### PR TITLE
Fix cubic PR-2 feedback (9 findings) + runner registration unblock

### DIFF
--- a/crates/aksh-gha-parser/src/eval.rs
+++ b/crates/aksh-gha-parser/src/eval.rs
@@ -40,31 +40,28 @@ pub fn resolve_string(input: &str, context: &Context) -> Result<String, String> 
 }
 
 fn find_expression_end(input: &str) -> Option<usize> {
-    let mut quote = None;
-    let mut escaped = false;
-
-    for (index, ch) in input.char_indices() {
-        if escaped {
-            escaped = false;
-            continue;
-        }
-
-        if let Some(quote_ch) = quote {
-            if ch == '\\' {
-                escaped = true;
-            } else if ch == quote_ch {
-                quote = None;
+    // Mirror the single-quoted string rules of `aksh-gha-expressions`'s lexer:
+    // only `'` opens/closes a string, doubled `''` is an escaped quote, and
+    // backslash is treated as an ordinary character (no C-style escapes).
+    let mut chars = input.char_indices().peekable();
+    let mut in_string = false;
+    while let Some((index, ch)) = chars.next() {
+        if in_string {
+            if ch == '\'' {
+                if matches!(chars.peek(), Some(&(_, '\''))) {
+                    chars.next();
+                    continue;
+                }
+                in_string = false;
             }
             continue;
         }
-
         match ch {
-            '\'' | '"' => quote = Some(ch),
+            '\'' => in_string = true,
             '}' if input[index..].starts_with("}}") => return Some(index),
             _ => {}
         }
     }
-
     None
 }
 
@@ -216,6 +213,21 @@ mod tests {
     #[test]
     fn expression_end_ignores_braces_inside_string_literals() {
         let source = r#" format('value }} still inside') }}"#;
+        assert_eq!(find_expression_end(source), Some(source.len() - 2));
+    }
+
+    #[test]
+    fn expression_end_treats_backslash_as_literal_in_single_quotes() {
+        // Backslash is NOT an escape in the lexer's single-quoted strings.
+        // The first `'` closes the string, then `}}` should terminate.
+        let source = r"'C:\' }}";
+        assert_eq!(find_expression_end(source), Some(source.len() - 2));
+    }
+
+    #[test]
+    fn expression_end_handles_doubled_quote_escape() {
+        // `''` inside a single-quoted string is an escaped quote, not a close.
+        let source = r"'it''s fine' }}";
         assert_eq!(find_expression_end(source), Some(source.len() - 2));
     }
 

--- a/crates/aksh-gha-protocol/src/azdo.rs
+++ b/crates/aksh-gha-protocol/src/azdo.rs
@@ -315,6 +315,7 @@ impl Serialize for TaskStep {
             + usize::from(self.display_name.is_some())
             + usize::from(self.condition.is_some())
             + usize::from(self.continue_on_error.is_some())
+            + usize::from(self.working_directory.is_some())
             + usize::from(self.timeout_in_minutes.is_some());
         let mut map = serializer.serialize_map(Some(field_count))?;
         map.serialize_entry("type", "action")?;
@@ -333,6 +334,9 @@ impl Serialize for TaskStep {
         }
         if let Some(continue_on_error) = self.continue_on_error {
             map.serialize_entry("continueOnError", &continue_on_error)?;
+        }
+        if let Some(working_directory) = &self.working_directory {
+            map.serialize_entry("workingDirectory", working_directory)?;
         }
         if let Some(timeout_in_minutes) = self.timeout_in_minutes {
             map.serialize_entry("timeoutInMinutes", &timeout_in_minutes)?;

--- a/crates/aksh-runner-server/src/lib.rs
+++ b/crates/aksh-runner-server/src/lib.rs
@@ -176,37 +176,115 @@ pub fn app(state: AppState, shutdown: CancellationToken) -> Router {
         .route("/:org/_apis/connectionData", get(connection_data))
         .route("/:org/_apis/v1/oauth2/token", post(oauth2_token))
         .route("/:org/_apis/v1/AgentPools", get(runner_pools))
-        .route("/:org/_apis/v1/Agent/:pool_id/:agent_id", get(agent_lookup_by_id_org).post(register_runner_compat_org_2))
-        .route("/:org/_apis/v1/Agent/:pool_id", get(agent_lookup_org).post(register_runner_compat_org))
-        .route("/:org/_apis/v1/AgentSession/:pool_id/:session_id", post(create_session_compat_org))
-        .route("/:org/_apis/v1/AgentSession/:pool_id", post(create_session_compat_org_pool_only))
-        .route("/:org/_apis/v1/AgentSession/:pool_id/:session_id", delete(delete_session_org))
-        .route("/:org/_apis/v1/Message/:pool_id", get(next_message_compat_org))
-        .route("/:org/_apis/v1/Message/:pool_id/:message_id", delete(delete_pool_message_org))
-        .route("/:org/_apis/v1/AgentRequest/:pool_id/:request_id", patch(agent_request_patch_org))
-        .route("/:org/_apis/v1/Timeline/:scope/:hub/:plan_id/:timeline_id", patch(patch_timeline_records_org))
-        .route("/:org/_apis/v1/Logfiles/:scope/:hub/:plan_id/:log_id", post(create_log_org))
-        .route("/:org/_apis/v1/Logfiles/:scope/:hub/:plan_id/:log_id/:log_id2", post(append_log_org))
-        .route("/:org/_apis/v1/TimeLineWebConsoleLog/:scope/:hub/:plan_id/:timeline_id/:record_id", post(console_log_org))
-        .route("/:org/_apis/v1/FinishJob/:scope/:hub/:plan_id", post(finish_job_org))
-        .route("/:org/_apis/v1/ActionDownloadInfo/:scope/:hub/:plan_id", post(action_download_info_org))
+        .route(
+            "/:org/_apis/v1/Agent/:pool_id/:agent_id",
+            get(agent_lookup_by_id_org).post(register_runner_compat_org_2),
+        )
+        .route(
+            "/:org/_apis/v1/Agent/:pool_id",
+            get(agent_lookup_org).post(register_runner_compat_org),
+        )
+        .route(
+            "/:org/_apis/v1/AgentSession/:pool_id/:session_id",
+            post(create_session_compat_org),
+        )
+        .route(
+            "/:org/_apis/v1/AgentSession/:pool_id",
+            post(create_session_compat_org_pool_only),
+        )
+        .route(
+            "/:org/_apis/v1/AgentSession/:pool_id/:session_id",
+            delete(delete_session_org),
+        )
+        .route(
+            "/:org/_apis/v1/Message/:pool_id",
+            get(next_message_compat_org),
+        )
+        .route(
+            "/:org/_apis/v1/Message/:pool_id/:message_id",
+            delete(delete_pool_message_org),
+        )
+        .route(
+            "/:org/_apis/v1/AgentRequest/:pool_id/:request_id",
+            patch(agent_request_patch_org),
+        )
+        .route(
+            "/:org/_apis/v1/Timeline/:scope/:hub/:plan_id/:timeline_id",
+            patch(patch_timeline_records_org),
+        )
+        .route(
+            "/:org/_apis/v1/Logfiles/:scope/:hub/:plan_id/:log_id",
+            post(create_log_org),
+        )
+        .route(
+            "/:org/_apis/v1/Logfiles/:scope/:hub/:plan_id/:log_id/:log_id2",
+            post(append_log_org),
+        )
+        .route(
+            "/:org/_apis/v1/TimeLineWebConsoleLog/:scope/:hub/:plan_id/:timeline_id/:record_id",
+            post(console_log_org),
+        )
+        .route(
+            "/:org/_apis/v1/FinishJob/:scope/:hub/:plan_id",
+            post(finish_job_org),
+        )
+        .route(
+            "/:org/_apis/v1/ActionDownloadInfo/:scope/:hub/:plan_id",
+            post(action_download_info_org),
+        )
         .route("/_apis/v1/oauth2/token", post(oauth2_token))
-        .route("/api/v3/actions/runner-registration", post(github_registration_token))
-        .route("/api/v3/orgs/:org/actions/runners/registration-token", post(github_registration_token))
-        .route("/api/v3/repos/:owner/:repo/actions/runners/registration-token", post(github_registration_token))
+        .route(
+            "/api/v3/actions/runner-registration",
+            post(github_registration_token),
+        )
+        .route(
+            "/api/v3/orgs/:org/actions/runners/registration-token",
+            post(github_registration_token),
+        )
+        .route(
+            "/api/v3/repos/:owner/:repo/actions/runners/registration-token",
+            post(github_registration_token),
+        )
         .route("/runner/server/_apis/connectionData", get(connection_data))
         .route("/runner/server/_apis/v1/oauth2/token", post(oauth2_token))
         .route("/runner/server/_apis/v1/AgentPools", get(runner_pools))
-        .route("/runner/server/_apis/v1/Agent/:pool_id/:agent_id", get(agent_lookup_by_id).post(register_runner_compat))
-        .route("/runner/server/_apis/v1/Agent/:pool_id", get(agent_lookup).post(register_runner_compat_pool_only))
-        .route("/runner/server/_apis/v1/AgentSession/:pool_id/:session_id", post(create_session_compat))
-        .route("/runner/server/_apis/v1/AgentSession/:pool_id", post(create_session_compat_pool_only))
-        .route("/runner/server/_apis/v1/AgentSession/:pool_id/:session_id", delete(delete_session))
-        .route("/runner/server/_apis/v1/Message/:pool_id", get(next_message_compat))
-        .route("/runner/server/_apis/v1/Message/:pool_id/:message_id", delete(delete_pool_message))
-        .route("/runner/server/_apis/v1/AgentRequest/:pool_id/:request_id", patch(agent_request_patch))
+        .route(
+            "/runner/server/_apis/v1/Agent/:pool_id/:agent_id",
+            get(agent_lookup_by_id).post(register_runner_compat),
+        )
+        .route(
+            "/runner/server/_apis/v1/Agent/:pool_id",
+            get(agent_lookup).post(register_runner_compat_pool_only),
+        )
+        .route(
+            "/runner/server/_apis/v1/AgentSession/:pool_id/:session_id",
+            post(create_session_compat),
+        )
+        .route(
+            "/runner/server/_apis/v1/AgentSession/:pool_id",
+            post(create_session_compat_pool_only),
+        )
+        .route(
+            "/runner/server/_apis/v1/AgentSession/:pool_id/:session_id",
+            delete(delete_session),
+        )
+        .route(
+            "/runner/server/_apis/v1/Message/:pool_id",
+            get(next_message_compat),
+        )
+        .route(
+            "/runner/server/_apis/v1/Message/:pool_id/:message_id",
+            delete(delete_pool_message),
+        )
+        .route(
+            "/runner/server/_apis/v1/AgentRequest/:pool_id/:request_id",
+            patch(agent_request_patch),
+        )
         .route("/_apis/connectionData", get(connection_data))
-        .route("/_apis/", axum::routing::options(|| async { StatusCode::OK }))
+        .route(
+            "/_apis/",
+            axum::routing::options(|| async { StatusCode::OK }),
+        )
         .route("/api/v1/runs", post(submit_run))
         .route("/api/v1/runs/:run_id", get(get_run))
         .route("/api/v1/runs/:run_id/cancel", post(cancel_run))
@@ -229,13 +307,31 @@ pub fn app(state: AppState, shutdown: CancellationToken) -> Router {
         .route("/api/v1/artifacts/:artifact_id", get(artifact_get))
         // Runner lifecycle endpoints — public (runner may not have auth token yet)
         .route("/_apis/v1/AgentPools", get(runner_pools))
-        .route("/_apis/v1/Agent/:pool_id/:agent_id", get(agent_lookup_by_id).post(register_runner_compat))
-        .route("/_apis/v1/AgentSession/:pool_id/:session_id", post(create_session_compat))
-        .route("/_apis/v1/AgentSession/:pool_id", post(create_session_compat_pool_only))
-        .route("/_apis/v1/AgentSession/:pool_id/:session_id", delete(delete_session))
+        .route(
+            "/_apis/v1/Agent/:pool_id/:agent_id",
+            get(agent_lookup_by_id).post(register_runner_compat),
+        )
+        .route(
+            "/_apis/v1/AgentSession/:pool_id/:session_id",
+            post(create_session_compat),
+        )
+        .route(
+            "/_apis/v1/AgentSession/:pool_id",
+            post(create_session_compat_pool_only),
+        )
+        .route(
+            "/_apis/v1/AgentSession/:pool_id/:session_id",
+            delete(delete_session),
+        )
         .route("/_apis/v1/Message/:pool_id", get(next_message_compat))
-        .route("/_apis/v1/Message/:pool_id/:message_id", delete(delete_pool_message))
-        .route("/_apis/v1/AgentRequest/:pool_id/:request_id", patch(agent_request_patch))
+        .route(
+            "/_apis/v1/Message/:pool_id/:message_id",
+            delete(delete_pool_message),
+        )
+        .route(
+            "/_apis/v1/AgentRequest/:pool_id/:request_id",
+            patch(agent_request_patch),
+        )
         .merge(protected_apis)
         .layer(TraceLayer::new_for_http())
         .with_state(Arc::new(SharedState { state, shutdown }))
@@ -997,7 +1093,10 @@ async fn agent_request_patch(
                 }
             }
         } else {
-            info!(request_id, "no inflight job for request_id; ignoring result");
+            info!(
+                request_id,
+                "no inflight job for request_id; ignoring result"
+            );
         }
     }
     Json(json!({
@@ -1119,11 +1218,7 @@ fn under_max_parallel(inner: &InnerState, job: &QueuedJob) -> bool {
     active_in_queue + active_running < max_parallel
 }
 
-fn apply_matrix_fail_fast(
-    inner: &mut InnerState,
-    run_id: RunId,
-    failed_job: &JobId,
-) -> usize {
+fn apply_matrix_fail_fast(inner: &mut InnerState, run_id: RunId, failed_job: &JobId) -> usize {
     let Some(run) = inner.runs.get_mut(&run_id) else {
         return 0;
     };
@@ -2418,8 +2513,14 @@ jobs:
             Value::Null,
         )
         .await;
-        assert_eq!(first_msg["messageType"], azdo::message_type::PIPELINE_AGENT_JOB_REQUEST);
-        assert_eq!(second_msg["messageType"], azdo::message_type::PIPELINE_AGENT_JOB_REQUEST);
+        assert_eq!(
+            first_msg["messageType"],
+            azdo::message_type::PIPELINE_AGENT_JOB_REQUEST
+        );
+        assert_eq!(
+            second_msg["messageType"],
+            azdo::message_type::PIPELINE_AGENT_JOB_REQUEST
+        );
 
         // The mapping should have two entries — one per request_id.
         let (first_req_id, _) = state
@@ -2493,7 +2594,10 @@ jobs:
             Value::Null,
         )
         .await;
-        assert_eq!(first["messageType"], azdo::message_type::PIPELINE_AGENT_JOB_REQUEST);
+        assert_eq!(
+            first["messageType"],
+            azdo::message_type::PIPELINE_AGENT_JOB_REQUEST
+        );
         let second = request_json(
             &app,
             Method::GET,
@@ -2501,7 +2605,10 @@ jobs:
             Value::Null,
         )
         .await;
-        assert_eq!(second["messageType"], azdo::message_type::PIPELINE_AGENT_JOB_REQUEST);
+        assert_eq!(
+            second["messageType"],
+            azdo::message_type::PIPELINE_AGENT_JOB_REQUEST
+        );
 
         let failing_job = {
             let inner = state.inner.lock().await;
@@ -2859,9 +2966,15 @@ jobs:
             (Method::PATCH, "/runner/server/_apis/v1/Timeline/s/h/p/t"),
             (Method::POST, "/runner/server/_apis/v1/Logfiles/s/h/p/l"),
             (Method::POST, "/runner/server/_apis/v1/Logfiles/s/h/p/l/l2"),
-            (Method::POST, "/runner/server/_apis/v1/TimeLineWebConsoleLog/s/h/p/t/r"),
+            (
+                Method::POST,
+                "/runner/server/_apis/v1/TimeLineWebConsoleLog/s/h/p/t/r",
+            ),
             (Method::POST, "/runner/server/_apis/v1/FinishJob/s/h/p"),
-            (Method::POST, "/runner/server/_apis/v1/ActionDownloadInfo/s/h/p"),
+            (
+                Method::POST,
+                "/runner/server/_apis/v1/ActionDownloadInfo/s/h/p",
+            ),
         ];
         for (method, uri) in cases {
             let response = app
@@ -2960,7 +3073,9 @@ jobs:
             .oneshot(
                 Request::builder()
                     .method(Method::DELETE)
-                    .uri("/runner/server/_apis/distributedtask/pools/1/messages/1?sessionId=default")
+                    .uri(
+                        "/runner/server/_apis/distributedtask/pools/1/messages/1?sessionId=default",
+                    )
                     .header(header::AUTHORIZATION, "Bearer aksh-system-token")
                     .body(Body::empty())
                     .unwrap(),

--- a/crates/aksh-runner-server/src/lib.rs
+++ b/crates/aksh-runner-server/src/lib.rs
@@ -297,9 +297,11 @@ struct InnerState {
     artifacts: BTreeMap<String, ArtifactRecord>,
     logs: BTreeMap<String, Vec<u8>>,
     timeline_events: BTreeMap<RunId, Vec<NdjsonEvent>>,
+    inflight_requests: BTreeMap<i64, (RunId, JobId)>,
     next_runner_id: i64,
     next_cache_id: i64,
     next_message_id: i64,
+    next_request_id: i64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -463,7 +465,7 @@ async fn submit_run(
         let mut job_fail_fast = BTreeMap::new();
         let mut ready_by_base: BTreeMap<String, u64> = BTreeMap::new();
         for job in jobs {
-            let agent_msg = aksh_gha_parser::job_builder::build_agent_job_message(
+            let mut agent_msg = aksh_gha_parser::job_builder::build_agent_job_message(
                 &job,
                 &github,
                 &job.env,
@@ -475,6 +477,15 @@ async fn submit_run(
                 &submission.vars,
             )
             .map_err(|e| ApiError::bad_request(format!("failed to build job message: {e}")))?;
+
+            // Give every dispatched job a unique requestId so PATCH
+            // /AgentRequest/:request_id can target exactly one job.
+            inner.next_request_id += 1;
+            let request_id = inner.next_request_id;
+            agent_msg.request_id = request_id;
+            inner
+                .inflight_requests
+                .insert(request_id, (run_id, job.id.clone()));
 
             let queued_job = QueuedJob {
                 run_id,
@@ -945,31 +956,34 @@ async fn complete_job_compat(
 /// The runner sends this to renew the job lock or report completion.
 async fn agent_request_patch(
     State(shared): State<Arc<SharedState>>,
-    Path((_pool_id, _request_id)): Path<(i64, i64)>,
+    Path((_pool_id, request_id)): Path<(i64, i64)>,
     Json(body): Json<serde_json::Value>,
 ) -> Json<serde_json::Value> {
     info!(?body, "agent_request_patch received");
-    // Check if this is a completion event
     if let Some(result) = body.get("result").and_then(|v| v.as_str()) {
-        info!(result, "job request completed");
+        let new_status = match result {
+            "succeeded" => ExecutionStatus::Success,
+            "failed" => ExecutionStatus::Failure,
+            "cancelled" => ExecutionStatus::Cancelled,
+            _ => ExecutionStatus::Success,
+        };
         let mut inner = shared.state.inner.lock().await;
-        for run in inner.runs.values_mut() {
-            for (job_id, status) in run.jobs.iter_mut() {
-                if *status == ExecutionStatus::InProgress {
-                    *status = match result {
-                        "succeeded" => ExecutionStatus::Success,
-                        "failed" => ExecutionStatus::Failure,
-                        "cancelled" => ExecutionStatus::Cancelled,
-                        _ => ExecutionStatus::Success,
-                    };
-                    info!(job_id = %job_id, result, "updated job status");
+        // Look up the (run_id, job_id) this request_id was assigned to at
+        // dispatch time. Without this mapping we'd mutate every InProgress
+        // job in every run.
+        if let Some((run_id, job_id)) = inner.inflight_requests.remove(&request_id) {
+            if let Some(run) = inner.runs.get_mut(&run_id) {
+                if let Some(status) = run.jobs.get_mut(&job_id) {
+                    *status = new_status;
+                    info!(%run_id, %job_id, result, "updated job status");
                 }
             }
+        } else {
+            info!(request_id, "no inflight job for request_id; ignoring result");
         }
     }
-    // Return a valid TaskAgentJobRequest response
     Json(json!({
-        "requestId": _request_id,
+        "requestId": request_id,
         "lockedUntil": "2099-12-31T23:59:59Z",
         "result": body.get("result"),
     }))
@@ -2352,6 +2366,75 @@ jobs:
                 .count(),
             2
         );
+    }
+
+    #[tokio::test]
+    async fn agent_request_patch_targets_only_the_request_id() {
+        let temp = tempfile::tempdir().unwrap();
+        let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+        let app = app(state.clone(), CancellationToken::new());
+
+        // Two independent runs, both reach InProgress when their job is pulled.
+        let workflow = json!({
+            "workflow_yaml": "on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n",
+            "event": "push",
+            "repository": "owner/repo"
+        });
+        let first = request_json(&app, Method::POST, "/api/v1/runs", workflow.clone()).await;
+        let second = request_json(&app, Method::POST, "/api/v1/runs", workflow).await;
+        let first_run: RunId = first["run_id"].as_str().unwrap().parse().unwrap();
+        let second_run: RunId = second["run_id"].as_str().unwrap().parse().unwrap();
+
+        // Pull both jobs so they are InProgress and each has a distinct request_id.
+        let first_msg = request_json(
+            &app,
+            Method::GET,
+            "/runner/server/_apis/distributedtask/pools/1/messages?sessionId=s1",
+            Value::Null,
+        )
+        .await;
+        let second_msg = request_json(
+            &app,
+            Method::GET,
+            "/runner/server/_apis/distributedtask/pools/1/messages?sessionId=s2",
+            Value::Null,
+        )
+        .await;
+        assert_eq!(first_msg["messageType"], azdo::message_type::PIPELINE_AGENT_JOB_REQUEST);
+        assert_eq!(second_msg["messageType"], azdo::message_type::PIPELINE_AGENT_JOB_REQUEST);
+
+        // The mapping should have two entries — one per request_id.
+        let (first_req_id, _) = state
+            .inner
+            .lock()
+            .await
+            .inflight_requests
+            .iter()
+            .find(|(_, (rid, _))| *rid == first_run)
+            .map(|(k, v)| (*k, v.clone()))
+            .unwrap();
+
+        // PATCH only the first run's request_id.
+        request_json(
+            &app,
+            Method::PATCH,
+            &format!("/runner/server/_apis/v1/AgentRequest/1/{first_req_id}"),
+            json!({"result": "succeeded"}),
+        )
+        .await;
+
+        let inner = state.inner.lock().await;
+        let first = inner.runs.get(&first_run).unwrap();
+        let second = inner.runs.get(&second_run).unwrap();
+        assert!(first
+            .jobs
+            .values()
+            .all(|status| *status == ExecutionStatus::Success));
+        assert!(second
+            .jobs
+            .values()
+            .all(|status| *status == ExecutionStatus::InProgress));
+        assert!(!inner.inflight_requests.contains_key(&first_req_id));
     }
 
     #[tokio::test]

--- a/crates/aksh-runner-server/src/lib.rs
+++ b/crates/aksh-runner-server/src/lib.rs
@@ -291,7 +291,7 @@ struct InnerState {
     agent_keypair: Option<AgentRsaKeypair>,
     runner_public_keys: BTreeMap<i64, String>,
     runner_rsa_public_keys: BTreeMap<i64, AgentRsaPublicKey>,
-    inflight_messages: BTreeMap<i64, azdo::TaskAgentMessage>,
+    inflight_messages: BTreeMap<String, BTreeMap<i64, azdo::TaskAgentMessage>>,
     cancellation_queue: VecDeque<QueuedCancellation>,
     pending_caches: BTreeMap<i64, PendingCache>,
     artifacts: BTreeMap<String, ArtifactRecord>,
@@ -776,7 +776,11 @@ async fn next_message(
 
     loop {
         let mut inner = shared.state.inner.lock().await;
-        if let Some(message) = inner.inflight_messages.values().next().cloned() {
+        if let Some(message) = inner
+            .inflight_messages
+            .get(&session_id)
+            .and_then(|messages| messages.values().next().cloned())
+        {
             return Ok(Json(Some(message)));
         }
 
@@ -847,9 +851,9 @@ async fn next_message(
 
 async fn delete_session_message(
     State(shared): State<Arc<SharedState>>,
-    Path((_session_id, message_id)): Path<(String, i64)>,
+    Path((session_id, message_id)): Path<(String, i64)>,
 ) -> StatusCode {
-    ack_message(shared, message_id).await
+    ack_message(shared, &session_id, message_id).await
 }
 
 fn build_task_agent_message(
@@ -879,20 +883,31 @@ fn build_task_agent_message(
         body: BASE64_STANDARD.encode(&encrypted_body),
         iv: Some(iv),
     };
-    inner.inflight_messages.insert(message_id, message.clone());
+    inner
+        .inflight_messages
+        .entry(session_id.to_owned())
+        .or_default()
+        .insert(message_id, message.clone());
     Ok(message)
 }
 
 async fn delete_pool_message(
     State(shared): State<Arc<SharedState>>,
     Path((_pool_id, message_id)): Path<(i64, i64)>,
+    Query(params): Query<std::collections::HashMap<String, String>>,
 ) -> StatusCode {
-    ack_message(shared, message_id).await
+    let session_id = params.get("sessionId").map(String::as_str).unwrap_or("");
+    ack_message(shared, session_id, message_id).await
 }
 
-async fn ack_message(shared: Arc<SharedState>, message_id: i64) -> StatusCode {
+async fn ack_message(shared: Arc<SharedState>, session_id: &str, message_id: i64) -> StatusCode {
     let mut inner = shared.state.inner.lock().await;
-    inner.inflight_messages.remove(&message_id);
+    if let Some(messages) = inner.inflight_messages.get_mut(session_id) {
+        messages.remove(&message_id);
+        if messages.is_empty() {
+            inner.inflight_messages.remove(session_id);
+        }
+    }
     StatusCode::NO_CONTENT
 }
 
@@ -1717,8 +1732,9 @@ async fn next_message_compat_org(
 async fn delete_pool_message_org(
     State(shared): State<Arc<SharedState>>,
     Path((_org, pool_id, message_id)): Path<(String, i64, i64)>,
+    Query(params): Query<std::collections::HashMap<String, String>>,
 ) -> StatusCode {
-    delete_pool_message(State(shared), Path((pool_id, message_id))).await
+    delete_pool_message(State(shared), Path((pool_id, message_id)), Query(params)).await
 }
 
 #[allow(dead_code)]
@@ -2695,7 +2711,7 @@ jobs:
             .oneshot(
                 Request::builder()
                     .method(Method::DELETE)
-                    .uri("/runner/server/_apis/distributedtask/pools/1/messages/1")
+                    .uri("/runner/server/_apis/distributedtask/pools/1/messages/1?sessionId=default")
                     .header(header::AUTHORIZATION, "Bearer aksh-system-token")
                     .body(Body::empty())
                     .unwrap(),
@@ -2757,7 +2773,7 @@ jobs:
                 Request::builder()
                     .method(Method::DELETE)
                     .uri(format!(
-                        "/runner/server/_apis/distributedtask/pools/1/messages/{message_id}"
+                        "/runner/server/_apis/distributedtask/pools/1/messages/{message_id}?sessionId=default"
                     ))
                     .header(header::AUTHORIZATION, "Bearer aksh-system-token")
                     .body(Body::empty())

--- a/crates/aksh-runner-server/src/lib.rs
+++ b/crates/aksh-runner-server/src/lib.rs
@@ -144,6 +144,30 @@ pub fn app(state: AppState, shutdown: CancellationToken) -> Router {
             "/_apis/v1/ActionDownloadInfo/:scope/:hub/:plan_id",
             post(action_download_info),
         )
+        .route(
+            "/runner/server/_apis/v1/Timeline/:scope/:hub/:plan_id/:timeline_id",
+            patch(patch_timeline_records),
+        )
+        .route(
+            "/runner/server/_apis/v1/Logfiles/:scope/:hub/:plan_id/:log_id",
+            post(create_log),
+        )
+        .route(
+            "/runner/server/_apis/v1/Logfiles/:scope/:hub/:plan_id/:log_id/:log_id2",
+            post(append_log),
+        )
+        .route(
+            "/runner/server/_apis/v1/TimeLineWebConsoleLog/:scope/:hub/:plan_id/:timeline_id/:record_id",
+            post(console_log),
+        )
+        .route(
+            "/runner/server/_apis/v1/FinishJob/:scope/:hub/:plan_id",
+            post(finish_job),
+        )
+        .route(
+            "/runner/server/_apis/v1/ActionDownloadInfo/:scope/:hub/:plan_id",
+            post(action_download_info),
+        )
         .route_layer(middleware::from_fn(require_bearer));
 
     Router::new()
@@ -181,12 +205,6 @@ pub fn app(state: AppState, shutdown: CancellationToken) -> Router {
         .route("/runner/server/_apis/v1/Message/:pool_id", get(next_message_compat))
         .route("/runner/server/_apis/v1/Message/:pool_id/:message_id", delete(delete_pool_message))
         .route("/runner/server/_apis/v1/AgentRequest/:pool_id/:request_id", patch(agent_request_patch))
-        .route("/runner/server/_apis/v1/Timeline/:scope/:hub/:plan_id/:timeline_id", patch(patch_timeline_records))
-        .route("/runner/server/_apis/v1/Logfiles/:scope/:hub/:plan_id/:log_id", post(create_log))
-        .route("/runner/server/_apis/v1/Logfiles/:scope/:hub/:plan_id/:log_id/:log_id2", post(append_log))
-        .route("/runner/server/_apis/v1/TimeLineWebConsoleLog/:scope/:hub/:plan_id/:timeline_id/:record_id", post(console_log))
-        .route("/runner/server/_apis/v1/FinishJob/:scope/:hub/:plan_id", post(finish_job))
-        .route("/runner/server/_apis/v1/ActionDownloadInfo/:scope/:hub/:plan_id", post(action_download_info))
         .route("/_apis/connectionData", get(connection_data))
         .route("/_apis/", axum::routing::options(|| async { StatusCode::OK }))
         .route("/api/v1/runs", post(submit_run))
@@ -2824,6 +2842,46 @@ jobs:
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn runner_server_v1_sensitive_routes_require_bearer() {
+        let temp = tempfile::tempdir().unwrap();
+        let app = app(
+            AppState::new(temp.path().to_path_buf()).await.unwrap(),
+            CancellationToken::new(),
+        );
+
+        // These /runner/server/_apis/v1/* aliases were previously placed on
+        // the public router, letting unauthenticated callers mutate timelines,
+        // inject logs, and finish jobs. They MUST require a bearer token.
+        let cases = [
+            (Method::PATCH, "/runner/server/_apis/v1/Timeline/s/h/p/t"),
+            (Method::POST, "/runner/server/_apis/v1/Logfiles/s/h/p/l"),
+            (Method::POST, "/runner/server/_apis/v1/Logfiles/s/h/p/l/l2"),
+            (Method::POST, "/runner/server/_apis/v1/TimeLineWebConsoleLog/s/h/p/t/r"),
+            (Method::POST, "/runner/server/_apis/v1/FinishJob/s/h/p"),
+            (Method::POST, "/runner/server/_apis/v1/ActionDownloadInfo/s/h/p"),
+        ];
+        for (method, uri) in cases {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method(method.clone())
+                        .uri(uri)
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .body(Body::from("{}"))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                response.status(),
+                StatusCode::UNAUTHORIZED,
+                "{method} {uri} should require bearer auth"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/aksh-runner-server/src/lib.rs
+++ b/crates/aksh-runner-server/src/lib.rs
@@ -198,7 +198,7 @@ pub fn app(state: AppState, shutdown: CancellationToken) -> Router {
         .route("/runner/server/_apis/v1/oauth2/token", post(oauth2_token))
         .route("/runner/server/_apis/v1/AgentPools", get(runner_pools))
         .route("/runner/server/_apis/v1/Agent/:pool_id/:agent_id", get(agent_lookup_by_id).post(register_runner_compat))
-        .route("/runner/server/_apis/v1/Agent/:pool_id", get(agent_lookup).post(register_runner_compat))
+        .route("/runner/server/_apis/v1/Agent/:pool_id", get(agent_lookup).post(register_runner_compat_pool_only))
         .route("/runner/server/_apis/v1/AgentSession/:pool_id/:session_id", post(create_session_compat))
         .route("/runner/server/_apis/v1/AgentSession/:pool_id", post(create_session_compat_pool_only))
         .route("/runner/server/_apis/v1/AgentSession/:pool_id/:session_id", delete(delete_session))

--- a/crates/aksh-runner-server/src/lib.rs
+++ b/crates/aksh-runner-server/src/lib.rs
@@ -997,9 +997,11 @@ async fn complete_job_inner(
         );
         run.status = summarize_run(run.jobs.values().copied());
     }
-    if completion.status == ExecutionStatus::Failure {
-        apply_matrix_fail_fast(&mut inner, completion.run_id, &completion.job_id);
-    }
+    let cancelled_siblings = if completion.status == ExecutionStatus::Failure {
+        apply_matrix_fail_fast(&mut inner, completion.run_id, &completion.job_id)
+    } else {
+        0
+    };
     let promoted_jobs = promote_ready_jobs(&mut inner);
     let record = inner
         .runs
@@ -1007,7 +1009,7 @@ async fn complete_job_inner(
         .cloned()
         .ok_or_else(|| ApiError::not_found("run not found"))?;
     drop(inner);
-    if promoted_jobs > 0 {
+    if promoted_jobs > 0 || cancelled_siblings > 0 {
         shared.state.message_notify.notify_waiters();
     }
 
@@ -1085,17 +1087,25 @@ fn under_max_parallel(inner: &InnerState, job: &QueuedJob) -> bool {
     active_in_queue + active_running < max_parallel
 }
 
-fn apply_matrix_fail_fast(inner: &mut InnerState, run_id: RunId, failed_job: &JobId) {
+fn apply_matrix_fail_fast(
+    inner: &mut InnerState,
+    run_id: RunId,
+    failed_job: &JobId,
+) -> usize {
     let Some(run) = inner.runs.get_mut(&run_id) else {
-        return;
+        return 0;
     };
     let Some(base_id) = run.job_base_ids.get(failed_job).cloned() else {
-        return;
+        return 0;
     };
     if !run.job_fail_fast.get(&base_id).copied().unwrap_or(true) {
-        return;
+        return 0;
     }
 
+    // Track in-progress siblings: they need a JOB_CANCELLED message so the
+    // runner aborts the worker. Queued siblings only need their state flipped
+    // — they were never dispatched.
+    let mut cancellations = Vec::new();
     for (job_id, status) in &mut run.jobs {
         if job_id != failed_job
             && run.job_base_ids.get(job_id) == Some(&base_id)
@@ -1104,6 +1114,12 @@ fn apply_matrix_fail_fast(inner: &mut InnerState, run_id: RunId, failed_job: &Jo
                 ExecutionStatus::Queued | ExecutionStatus::InProgress
             )
         {
+            if matches!(status, ExecutionStatus::InProgress) {
+                cancellations.push(QueuedCancellation {
+                    run_id,
+                    job_id: job_id.clone(),
+                });
+            }
             *status = ExecutionStatus::Cancelled;
         }
     }
@@ -1114,6 +1130,9 @@ fn apply_matrix_fail_fast(inner: &mut InnerState, run_id: RunId, failed_job: &Jo
     inner
         .pending_jobs
         .retain(|job| !(job.run_id == run_id && job.base_id == base_id));
+    let count = cancellations.len();
+    inner.cancellation_queue.extend(cancellations);
+    count
 }
 
 fn hydrate_needs_context(job: &mut QueuedJob, run: &RunRecord) {
@@ -2332,6 +2351,95 @@ jobs:
                 .filter(|status| **status == ExecutionStatus::Cancelled)
                 .count(),
             2
+        );
+    }
+
+    #[tokio::test]
+    async fn matrix_fail_fast_cancels_in_progress_siblings_via_message() {
+        let temp = tempfile::tempdir().unwrap();
+        let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+        let app = app(state.clone(), CancellationToken::new());
+
+        let accepted = request_json(
+            &app,
+            Method::POST,
+            "/api/v1/runs",
+            json!({
+                "workflow_yaml": r#"
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu, macos]
+    steps:
+      - run: echo matrix
+"#,
+                "event": "push",
+                "repository": "owner/repo"
+            }),
+        )
+        .await;
+        let run_id: RunId = accepted["run_id"].as_str().unwrap().parse().unwrap();
+
+        // Dispatch both siblings — both move to InProgress.
+        let first = request_json(
+            &app,
+            Method::GET,
+            "/runner/server/_apis/distributedtask/pools/1/messages?sessionId=default",
+            Value::Null,
+        )
+        .await;
+        assert_eq!(first["messageType"], azdo::message_type::PIPELINE_AGENT_JOB_REQUEST);
+        let second = request_json(
+            &app,
+            Method::GET,
+            "/runner/server/_apis/distributedtask/pools/1/messages?sessionId=default",
+            Value::Null,
+        )
+        .await;
+        assert_eq!(second["messageType"], azdo::message_type::PIPELINE_AGENT_JOB_REQUEST);
+
+        let failing_job = {
+            let inner = state.inner.lock().await;
+            inner
+                .runs
+                .get(&run_id)
+                .unwrap()
+                .jobs
+                .keys()
+                .next()
+                .unwrap()
+                .clone()
+        };
+
+        request_json(
+            &app,
+            Method::POST,
+            "/api/v1/jobs/complete",
+            json!({
+                "run_id": run_id,
+                "job_id": failing_job,
+                "status": "failure"
+            }),
+        )
+        .await;
+
+        // The fix: in-progress siblings get a cancellation enqueued so the
+        // runner receives a JOB_CANCELLED message. Inspect the queue directly
+        // since the matched siblings still have unACKed in-flight job messages.
+        let inner = state.inner.lock().await;
+        assert_eq!(inner.cancellation_queue.len(), 1);
+        let cancellation = inner.cancellation_queue.front().unwrap();
+        assert_eq!(cancellation.run_id, run_id);
+        assert_ne!(cancellation.job_id, failing_job);
+        // The sibling is now Cancelled in the run state.
+        let run = inner.runs.get(&run_id).unwrap();
+        assert_eq!(
+            run.jobs.get(&cancellation.job_id),
+            Some(&ExecutionStatus::Cancelled)
         );
     }
 

--- a/scripts/e2e-setup.sh
+++ b/scripts/e2e-setup.sh
@@ -86,7 +86,11 @@ macos_teardown() {
 # ── Linux ────────────────────────────────────────────────────────────────────
 
 linux_status() {
-    if sudo iptables -t nat -L OUTPUT -n 2>/dev/null | grep -q "REDIRECT.*dpt:80.*:$AKSH_PORT"; then
+    # Check the exact rule the setup adds; -L output shows REDIRECT as
+    # "redir ports 9090" with no colon, so a grep for ":$AKSH_PORT" never
+    # matches. -C returns 0 iff an identical rule already exists.
+    if sudo iptables -t nat -C OUTPUT -p tcp -d 127.0.0.1 --dport 80 \
+        -j REDIRECT --to-port "$AKSH_PORT" 2>/dev/null; then
         green "✓ redirect active: 127.0.0.1:80 → 127.0.0.1:$AKSH_PORT"
         return 0
     fi

--- a/scripts/e2e-setup.sh
+++ b/scripts/e2e-setup.sh
@@ -52,7 +52,7 @@ macos_setup() {
     tmp=$(mktemp)
     trap "rm -f '$tmp'" RETURN
     {
-        sudo pfctl -sn 2>/dev/null | grep -vE "rdr .*lo0.*port [= ]*80\b" || true
+        sudo pfctl -sn 2>/dev/null | grep -vE "rdr .*lo0.*port [= ]*80\b.*port [= ]*$AKSH_PORT\b" || true
         echo "$rule"
     } > "$tmp"
 
@@ -77,7 +77,7 @@ macos_teardown() {
     trap "rm -f '$tmp'" RETURN
 
     # Reload nat rules without our redirect
-    sudo pfctl -sn 2>/dev/null | grep -vE "rdr .*lo0.*port [= ]*80\b" > "$tmp" 2>/dev/null || true
+    sudo pfctl -sn 2>/dev/null | grep -vE "rdr .*lo0.*port [= ]*80\b.*port [= ]*$AKSH_PORT\b" > "$tmp" 2>/dev/null || true
     sudo pfctl -N -f "$tmp" 2>&1 | grep -vE "ALTQ|flushing|main ruleset|pf\.conf|^$" || true
 
     green "✓ redirect removed"

--- a/scripts/e2e-start.sh
+++ b/scripts/e2e-start.sh
@@ -48,9 +48,13 @@ except Exception:
 }
 
 cleanup() {
-    pkill -f "aksh-runner-server serve" 2>/dev/null || true
-    pkill -f "Runner.Listener" 2>/dev/null || true
-    pkill -f socat 2>/dev/null || true
+    # Kill processes started by this script. Avoid broad `pkill -f` patterns
+    # that could match unrelated runners/servers on the same host.
+    if [[ -n "${AKSH_PID:-}" ]]; then
+        kill "$AKSH_PID" 2>/dev/null || true
+    fi
+    # Reap any remaining direct children (e.g. perl/run.sh) of this shell.
+    pkill -P $$ 2>/dev/null || true
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
Addresses every selected cubic-dev-ai comment on the now-merged PR #2 (https://github.com/preloopdev/aksh/pull/2), rebased onto current main.

## Cubic feedback addressed (one commit each)

| Severity | Topic | Commit |
|---|---|---|
| P1 | TaskStep Serialize dropped workingDirectory | `64ba782` |
| P2 | find_expression_end mis-handled single-quote escape rules | `7ed2f09` |
| P2 | e2e-start.sh used broad pkill -f patterns | `82ed271` |
| P2 | e2e-setup.sh Linux iptables status check always failed | `ca6f06b` |
| P2 | e2e-setup.sh macOS pf rdr removed all port-80 redirects | `8de2a78` |
| P1 | inflight_messages not scoped by session | `42f9ccc` |
| P1 | apply_matrix_fail_fast omitted cancellation_queue push | `d0e485a` |
| P1 | agent_request_patch mutated every InProgress job | `0058e3b` |
| P1 | /runner/server/_apis/v1/{Timeline,Logfiles,...} on public router | `b730ffe` |

## Out-of-cubic-scope (e2e unblock)

`495690c` rewires `/runner/server/_apis/v1/Agent/:pool_id` (1-segment) from `register_runner_compat` (expects 2 path args) to the existing `register_runner_compat_pool_only`. Pre-existing routing bug that returned 500 at runner registration and blocked every official-runner cycle. Included to make the cubic fixes validatable end-to-end.

## Validation

- `cargo test --workspace` — 69 passed (3 new behavior tests: per-session inflight, request-id scoping, fail-fast cancellation queue)
- `cargo clippy --workspace -- -D warnings` — clean
- Official `actions/runner` 2.335.1 cycles against patched aksh:
  - Server surface: full lifecycle, `Job build completed with result: Succeeded`
  - Protocol surface: `working-directory: /tmp` and `/var/tmp` both round-tripped, both succeeded
  - Parser surface: `\${{ 'C:\\\\' }}` and `\${{ 'it''s fine' }}` accepted, job succeeded
  - Scripts surface: `e2e-setup.sh --status` confirms scoped predicate

## Notes

- Each commit is independently revertable; the e2e-unblock commit is clearly labeled and can be split into its own PR if preferred.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nine findings from the PR‑2 review and unblocks runner registration by wiring the correct pool-only route. Hardens runner endpoints, corrects per-job/request handling, aligns expression parsing, restores `workingDirectory` serialization, and makes e2e scripts safer.

- **Bug Fixes**
  - Server: protect sensitive `/runner/server/_apis/v1/*` routes with bearer auth; scope inflight messages by `sessionId` and require it on DELETE; assign a unique `requestId` per job and PATCH only that job; enqueue JOB_CANCELLED for in‑progress matrix siblings on fail‑fast; fix `/runner/server/_apis/v1/Agent/:pool_id` to use `register_runner_compat_pool_only` to stop 500s during registration.
  - Parser/Protocol: `find_expression_end` now follows single‑quote rules (only `'`, `''` escapes, backslash literal); `TaskStep` serializes `workingDirectory`.
  - e2e: macOS `pf` changes only touch the aksh redirect; Linux status uses `iptables -C`; startup cleanup kills only script‑started processes.

<sup>Written for commit 1eecdcbe133b9bdffe368f59f19b4857f1bd9547. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/aksh/pull/3?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

