### PR TITLE
Bnjoroge/property testing

### DIFF
--- a/crates/aksh-gha-expressions/src/lib.rs
+++ b/crates/aksh-gha-expressions/src/lib.rs
@@ -142,6 +142,16 @@ pub enum ExpressionError {
     UnknownFunction(String),
 }
 
+/// Parse an expression without evaluating it.
+pub fn validate_expression(input: &str) -> Result<(), ExpressionError> {
+    let trimmed = trim_expression_markers(input);
+    let tokens = Lexer::new(trimmed).lex()?;
+    let mut parser = Parser::new(tokens);
+    let expr = parser.parse_expr()?;
+    parser.expect_end()?;
+    validate_function_calls(&expr)
+}
+
 /// Parse and evaluate a GitHub Actions expression.
 pub fn eval_expression(input: &str, context: &Context) -> Result<Value, ExpressionError> {
     let trimmed = trim_expression_markers(input);
@@ -164,6 +174,68 @@ pub fn trim_expression_markers(input: &str) -> &str {
         inner.trim()
     } else {
         value
+    }
+}
+/// Whether an expression contains a status-check call outside string literals.
+///
+/// GitHub's condition conversion adds an implicit `success()` gate unless the
+/// expression calls `success`, `failure`, `cancelled`, or `always` itself.
+pub fn contains_status_check_function(condition: &str) -> bool {
+    let mut chars = condition.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\'' {
+            while let Some(quoted) = chars.next() {
+                if quoted == '\'' {
+                    if chars.peek() == Some(&'\'') {
+                        chars.next();
+                    } else {
+                        break;
+                    }
+                }
+            }
+            continue;
+        }
+
+        if ch == '_' || ch == '-' || ch.is_ascii_alphabetic() {
+            let mut ident = String::from(ch);
+            while let Some(next) = chars.peek().copied() {
+                if next == '_' || next == '-' || next.is_ascii_alphanumeric() {
+                    ident.push(next);
+                    chars.next();
+                } else {
+                    break;
+                }
+            }
+            while let Some(whitespace) = chars.peek().copied() {
+                if whitespace.is_whitespace() {
+                    chars.next();
+                } else {
+                    break;
+                }
+            }
+            if matches!(
+                ident.to_ascii_lowercase().as_str(),
+                "success" | "failure" | "cancelled" | "always"
+            ) && chars.peek() == Some(&'(')
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Apply GitHub's implicit success gate to a job or step condition.
+pub fn effective_condition(raw: Option<&str>) -> String {
+    let condition = match raw {
+        Some(condition) if !condition.trim().is_empty() => condition,
+        _ => return "success()".to_owned(),
+    };
+    let stripped = trim_expression_markers(condition);
+    if contains_status_check_function(stripped) {
+        stripped.to_owned()
+    } else {
+        format!("success() && ({stripped})")
     }
 }
 
@@ -210,6 +282,39 @@ enum BinaryOp {
     Ge,
     Lt,
     Le,
+}
+
+fn validate_function_calls(expr: &Expr) -> Result<(), ExpressionError> {
+    match expr {
+        Expr::Literal(_) | Expr::Path(_) => Ok(()),
+        Expr::UnaryNot(inner) | Expr::MemberAccess { expr: inner, .. } => {
+            validate_function_calls(inner)
+        }
+        Expr::Binary { left, right, .. } => {
+            validate_function_calls(left)?;
+            validate_function_calls(right)
+        }
+        Expr::Call { name, args } => {
+            if !matches!(
+                name.to_ascii_lowercase().as_str(),
+                "always"
+                    | "success"
+                    | "failure"
+                    | "cancelled"
+                    | "contains"
+                    | "startswith"
+                    | "endswith"
+                    | "format"
+                    | "fromjson"
+                    | "join"
+                    | "hashfiles"
+                    | "tojson"
+            ) {
+                return Err(ExpressionError::UnknownFunction(name.clone()));
+            }
+            args.iter().try_for_each(validate_function_calls)
+        }
+    }
 }
 
 fn eval(expr: &Expr, context: &Context) -> Result<Value, ExpressionError> {
@@ -1066,11 +1171,7 @@ mod tests {
         );
         // Mixed dot and bracket
         assert_eq!(
-            eval_expression(
-                r#"fromJSON('{"a":{"b":{"c":"deep"}}}').a.b.c"#,
-                &context,
-            )
-            .unwrap(),
+            eval_expression(r#"fromJSON('{"a":{"b":{"c":"deep"}}}').a.b.c"#, &context,).unwrap(),
             Value::String("deep".to_owned())
         );
     }

--- a/crates/aksh-gha-expressions/src/lib.rs
+++ b/crates/aksh-gha-expressions/src/lib.rs
@@ -196,10 +196,10 @@ pub fn contains_status_check_function(condition: &str) -> bool {
             continue;
         }
 
-        if ch == '_' || ch == '-' || ch.is_ascii_alphabetic() {
+        if ch == '_' || ch.is_ascii_alphabetic() {
             let mut ident = String::from(ch);
             while let Some(next) = chars.peek().copied() {
-                if next == '_' || next == '-' || next.is_ascii_alphanumeric() {
+                if next == '_' || next.is_ascii_alphanumeric() {
                     ident.push(next);
                     chars.next();
                 } else {

--- a/crates/aksh-gha-parser/src/dag.rs
+++ b/crates/aksh-gha-parser/src/dag.rs
@@ -1,0 +1,410 @@
+//! Needs-graph validation (DAG properties) for workflow jobs.
+//!
+//! Oracle source: GitHub Actions workflow syntax, `jobs.<job_id>.needs`:
+//! <https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds>.
+//! The parser properties encode the contract that every `needs` name exists,
+//! cycles are rejected during validation, and every topological layer appears
+//! after all of its dependencies. The implementation algorithm is an internal
+//! choice; GitHub's private control-plane algorithm is not assumed.
+use aksh_gha_protocol::JobPlan;
+use std::collections::BTreeMap;
+
+use crate::ParserError;
+
+/// A needs edge list: job id → dependency job ids (as written in YAML).
+pub type NeedsGraph = BTreeMap<String, Vec<String>>;
+
+/// Cycle detection error with a witness node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NeedsCycle {
+    /// A job id that participates in a cycle.
+    pub witness: String,
+}
+
+/// Detect a cycle in a needs graph via three-color DFS.
+pub fn detect_needs_cycle(edges: &NeedsGraph) -> Result<(), NeedsCycle> {
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum Color {
+        White,
+        Gray,
+        Black,
+    }
+
+    let mut color: BTreeMap<&str, Color> =
+        edges.keys().map(|k| (k.as_str(), Color::White)).collect();
+    for deps in edges.values() {
+        for d in deps {
+            color.entry(d.as_str()).or_insert(Color::White);
+        }
+    }
+
+    fn visit<'a>(
+        node: &'a str,
+        edges: &'a NeedsGraph,
+        color: &mut BTreeMap<&'a str, Color>,
+    ) -> Result<(), NeedsCycle> {
+        color.insert(node, Color::Gray);
+        if let Some(deps) = edges.get(node) {
+            for dep in deps {
+                match color.get(dep.as_str()).copied().unwrap_or(Color::White) {
+                    Color::Gray => {
+                        return Err(NeedsCycle {
+                            witness: dep.clone(),
+                        });
+                    }
+                    Color::White => visit(dep.as_str(), edges, color)?,
+                    Color::Black => {}
+                }
+            }
+        }
+        color.insert(node, Color::Black);
+        Ok(())
+    }
+
+    let nodes: Vec<&str> = color.keys().copied().collect();
+    for node in nodes {
+        if color.get(node) == Some(&Color::White) {
+            visit(node, edges, &mut color)?;
+        }
+    }
+    Ok(())
+}
+
+/// Build a needs graph from expanded job plans (base ids + needs).
+pub fn needs_graph_from_pairs(jobs: &[(String, Vec<String>)]) -> NeedsGraph {
+    let mut edges = NeedsGraph::new();
+    for (id, needs) in jobs {
+        edges.entry(id.clone()).or_default().extend(needs.clone());
+    }
+    edges
+}
+/// Validate dependency references and cycles after matrix/reusable expansion.
+///
+/// A declared need may name one concrete expanded job or a base job, in which
+/// case it expands to every matrix sibling with that base id. Validation runs
+/// before server state is mutated, so invalid workflows cannot queue jobs.
+pub fn validate_job_plans(jobs: &[JobPlan]) -> Result<(), ParserError> {
+    let mut graph = NeedsGraph::new();
+
+    for job in jobs {
+        if let Some(condition) = &job.if_condition {
+            let effective = aksh_gha_expressions::effective_condition(Some(condition));
+            aksh_gha_expressions::validate_expression(&effective).map_err(|error| {
+                ParserError::InvalidJobCondition {
+                    job_id: job.id.0.clone(),
+                    message: error.to_string(),
+                }
+            })?;
+        }
+        let mut expanded_needs = Vec::new();
+        for need in &job.needs {
+            let matches = jobs
+                .iter()
+                .filter(|candidate| candidate.id == *need || candidate.base_id == need.0)
+                .map(|candidate| candidate.id.0.clone())
+                .collect::<Vec<_>>();
+            if matches.is_empty() {
+                return Err(ParserError::UnknownNeed {
+                    job_id: job.id.0.clone(),
+                    need: need.0.clone(),
+                });
+            }
+            expanded_needs.extend(matches);
+        }
+        expanded_needs.sort();
+        expanded_needs.dedup();
+        graph.insert(job.id.0.clone(), expanded_needs);
+    }
+
+    detect_needs_cycle(&graph).map_err(|cycle| ParserError::NeedsCycle {
+        witness: cycle.witness,
+    })
+}
+
+/// Kahn topological layers: jobs whose needs are subset of already-emitted.
+/// Returns `None` if a cycle prevents a full order.
+pub fn topo_layers(edges: &NeedsGraph) -> Option<Vec<Vec<String>>> {
+    use std::collections::BTreeSet;
+
+    let mut remaining: BTreeMap<String, BTreeSet<String>> = edges
+        .iter()
+        .map(|(k, v)| (k.clone(), v.iter().cloned().collect()))
+        .collect();
+    // Ensure referenced deps exist as nodes.
+    let deps: Vec<String> = remaining.values().flat_map(|d| d.iter().cloned()).collect();
+    for d in deps {
+        remaining.entry(d).or_default();
+    }
+
+    let mut layers = Vec::new();
+    let mut done: BTreeSet<String> = BTreeSet::new();
+
+    while done.len() < remaining.len() {
+        let layer: Vec<String> = remaining
+            .iter()
+            .filter(|(id, needs)| !done.contains(*id) && needs.iter().all(|n| done.contains(n)))
+            .map(|(id, _)| id.clone())
+            .collect();
+        if layer.is_empty() {
+            return None;
+        }
+        for id in &layer {
+            done.insert(id.clone());
+        }
+        layers.push(layer);
+    }
+    Some(layers)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use proptest::test_runner::RngSeed;
+
+    /// Deterministic proptest config for DAG validation tests.
+    /// Fixed seed ensures reproducibility; failure persistence and verbose
+    /// reporting preserve/report the seed on failure (docs/property-tests.md §Common).
+    fn dag_config(cases: u32) -> ProptestConfig {
+        ProptestConfig {
+            cases,
+            rng_seed: RngSeed::Fixed(20250713),
+            verbose: 1,
+            ..ProptestConfig::default()
+        }
+    }
+
+    #[test]
+    fn rejects_self_loop() {
+        let mut g = NeedsGraph::new();
+        g.insert("a".into(), vec!["a".into()]);
+        assert!(detect_needs_cycle(&g).is_err());
+    }
+
+    #[test]
+    fn accepts_diamond() {
+        let mut g = NeedsGraph::new();
+        g.insert("a".into(), vec![]);
+        g.insert("b".into(), vec!["a".into()]);
+        g.insert("c".into(), vec!["a".into()]);
+        g.insert("d".into(), vec!["b".into(), "c".into()]);
+        assert!(detect_needs_cycle(&g).is_ok());
+        let layers = topo_layers(&g).unwrap();
+        assert_eq!(layers[0], vec!["a".to_string()]);
+        assert!(layers.last().unwrap().contains(&"d".to_string()));
+    }
+
+    /// Generate a DAG by only allowing edges to lower indices.
+    fn arb_dag_edges(n: usize) -> impl Strategy<Value = NeedsGraph> {
+        proptest::collection::vec(any::<u8>(), n..=n).prop_map(move |masks| {
+            (0..n)
+                .map(|i| {
+                    let mut needs = Vec::new();
+                    if i > 0 {
+                        let mut seen = std::collections::BTreeSet::new();
+                        for d in 0..i {
+                            if masks[i] & (1u8 << (d % 8)) != 0 && seen.insert(d) {
+                                needs.push(format!("j{d}"));
+                            }
+                        }
+                    }
+                    (format!("j{i}"), needs)
+                })
+                .collect()
+        })
+    }
+
+    // Oracle: `jobs.<job_id>.needs` workflow syntax contract. These
+    // generated graphs verify acyclicity, topological dependency order,
+    // and cycle rejection independently of server scheduling.
+    proptest! {
+        #![proptest_config(dag_config(10_000))]
+
+        #[test]
+        fn generated_dags_are_acyclic(g in arb_dag_edges(6)) {
+            prop_assert!(detect_needs_cycle(&g).is_ok());
+            prop_assert!(topo_layers(&g).is_some());
+        }
+
+        #[test]
+        fn topo_layers_respect_needs(g in arb_dag_edges(5)) {
+            let Some(layers) = topo_layers(&g) else {
+                prop_assert!(false, "expected layers");
+                return Ok(());
+            };
+            let mut rank = BTreeMap::new();
+            for (i, layer) in layers.iter().enumerate() {
+                for id in layer {
+                    rank.insert(id.clone(), i);
+                }
+            }
+            for (id, needs) in &g {
+                for n in needs {
+                    if let (Some(&ri), Some(&rn)) = (rank.get(id), rank.get(n)) {
+                        prop_assert!(rn < ri, "{n} must precede {id}");
+                    }
+                }
+            }
+        }
+
+        #[test]
+        fn cycle_detector_flags_mutual_edge(a in "[a-z]{1,3}", b in "[a-z]{1,3}") {
+            // Force distinct endpoints without reject-heavy prop_assume.
+            let b = if a == b { format!("{b}_x") } else { b };
+            let mut g = NeedsGraph::new();
+            g.insert(a.clone(), vec![b.clone()]);
+            g.insert(b.clone(), vec![a.clone()]);
+            prop_assert!(detect_needs_cycle(&g).is_err());
+            prop_assert!(topo_layers(&g).is_none());
+        }
+    }
+
+    // ─── Unknown/cycle prequeue rejection (spec §1.12, §1 regression) ───────
+
+    fn job_plan(id: &str, base: &str, needs: &[&str]) -> JobPlan {
+        JobPlan {
+            id: aksh_gha_protocol::JobId(id.to_owned()),
+            base_id: base.to_owned(),
+            name: id.to_owned(),
+            runs_on: vec!["ubuntu-latest".to_owned()],
+            needs: needs
+                .iter()
+                .map(|n| aksh_gha_protocol::JobId(n.to_string()))
+                .collect(),
+            matrix: Default::default(),
+            env: Default::default(),
+            steps: vec![],
+            if_condition: None,
+            fail_fast: true,
+            max_parallel: None,
+            secrets_inherit: false,
+            container: None,
+            services: None,
+            inputs: Default::default(),
+            workflow_file: None,
+            workflow_ref: None,
+            workflow_sha: None,
+            workflow_repository: None,
+            secrets_map: Default::default(),
+            job_outputs: Default::default(),
+        }
+    }
+
+    /// Unknown need is rejected before dispatch (spec §1.12).
+    #[test]
+    fn validate_rejects_unknown_need() {
+        let plans = vec![
+            job_plan("build", "build", &[]),
+            job_plan("test", "test", &["nonexistent"]),
+        ];
+        let err = validate_job_plans(&plans).unwrap_err();
+        match err {
+            ParserError::UnknownNeed { job_id, need } => {
+                assert_eq!(job_id, "test");
+                assert_eq!(need, "nonexistent");
+            }
+            other => panic!("expected UnknownNeed, got {other:?}"),
+        }
+    }
+
+    /// Cyclic graph is rejected before dispatch (spec §1.12).
+    #[test]
+    fn validate_rejects_cycle_before_dispatch() {
+        let plans = vec![job_plan("a", "a", &["b"]), job_plan("b", "b", &["a"])];
+        let err = validate_job_plans(&plans).unwrap_err();
+        match err {
+            ParserError::NeedsCycle { witness } => {
+                assert!(
+                    witness == "a" || witness == "b",
+                    "witness should be a cycle participant, got {witness}"
+                );
+            }
+            other => panic!("expected NeedsCycle, got {other:?}"),
+        }
+    }
+
+    /// Three-node cycle: a → b → c → a.
+    #[test]
+    fn validate_rejects_three_node_cycle() {
+        let plans = vec![
+            job_plan("a", "a", &["c"]),
+            job_plan("b", "b", &["a"]),
+            job_plan("c", "c", &["b"]),
+        ];
+        assert!(matches!(
+            validate_job_plans(&plans),
+            Err(ParserError::NeedsCycle { .. })
+        ));
+    }
+
+    /// Valid DAG passes validation.
+    #[test]
+    fn validate_accepts_valid_dag() {
+        let plans = vec![
+            job_plan("build", "build", &[]),
+            job_plan("test", "test", &["build"]),
+            job_plan("deploy", "deploy", &["build", "test"]),
+        ];
+        assert!(validate_job_plans(&plans).is_ok());
+    }
+
+    /// Base-id matching: needing "build" resolves to matrix siblings
+    /// "build (1)" and "build (2)".
+    #[test]
+    fn validate_resolves_base_id_needs() {
+        let plans = vec![
+            job_plan("build (1)", "build", &[]),
+            job_plan("build (2)", "build", &[]),
+            job_plan("test", "test", &["build"]),
+        ];
+        assert!(validate_job_plans(&plans).is_ok());
+    }
+
+    /// Generate graphs with REVERSE edges (higher → lower indices) to exercise
+    /// parser rejection. This is NOT acyclic by construction.
+    fn arb_graph_with_reverse_edges(n: usize) -> impl Strategy<Value = NeedsGraph> {
+        proptest::collection::vec(any::<u8>(), n..=n).prop_map(move |masks| {
+            (0..n)
+                .map(|i| {
+                    let mut needs = Vec::new();
+                    // Allow edges to ANY node, including higher indices
+                    for d in 0..n {
+                        if d != i && masks[i] & (1u8 << (d % 8)) != 0 {
+                            needs.push(format!("j{d}"));
+                        }
+                    }
+                    (format!("j{i}"), needs)
+                })
+                .collect()
+        })
+    }
+
+    // Oracle cross-check: parser cycle detection and topological layers
+    // must agree on every generated graph; this checks consistency, not
+    // a claim that GitHub uses this particular algorithm.
+    proptest! {
+        #![proptest_config(dag_config(5_000))]
+
+        /// Graphs with reverse edges: cycle detection and topo_layers agree.
+        #[test]
+        fn reverse_edge_graphs_agree(g in arb_graph_with_reverse_edges(5)) {
+            let cycle_result = detect_needs_cycle(&g);
+            let topo_result = topo_layers(&g);
+            match (&cycle_result, &topo_result) {
+                (Ok(()), Some(layers)) => {
+                    // Acyclic: layers must cover all nodes
+                    let total: usize = layers.iter().map(|l| l.len()).sum();
+                    prop_assert_eq!(total, g.len() + g.values().flatten()
+                        .filter(|d| !g.contains_key(*d)).count());
+                }
+                (Err(_), None) => { /* both agree it's cyclic */ }
+                (Ok(()), None) => {
+                    prop_assert!(false, "cycle detector says ok but topo failed");
+                }
+                (Err(_), Some(_)) => {
+                    prop_assert!(false, "cycle detector says cycle but topo succeeded");
+                }
+            }
+        }
+    }
+}

--- a/crates/aksh-gha-parser/src/job_builder.rs
+++ b/crates/aksh-gha-parser/src/job_builder.rs
@@ -434,22 +434,19 @@ fn build_task_step(step: &crate::StepPlan, context: &Context) -> TaskStep {
         display_name_token,
         condition,
         script: run,
-        reference: step
-            .uses
-            .as_ref()
-            .map(|uses| {
-                let (name, version) = if let Some((n, v)) = uses.split_once('@') {
-                    (n.to_owned(), Some(v.to_owned()))
-                } else {
-                    (uses.clone(), None)
-                };
-                aksh_gha_protocol::azdo::TaskReference {
-                    id: None,
-                    name: Some(name),
-                    version,
-                    reference_type: None,
-                }
-            }),
+        reference: step.uses.as_ref().map(|uses| {
+            let (name, version) = if let Some((n, v)) = uses.split_once('@') {
+                (n.to_owned(), Some(v.to_owned()))
+            } else {
+                (uses.clone(), None)
+            };
+            aksh_gha_protocol::azdo::TaskReference {
+                id: None,
+                name: Some(name),
+                version,
+                reference_type: None,
+            }
+        }),
         inputs: with,
         env,
         continue_on_error: step.continue_on_error,

--- a/crates/aksh-gha-parser/src/lib.rs
+++ b/crates/aksh-gha-parser/src/lib.rs
@@ -6,6 +6,8 @@ use std::path::{Path, PathBuf};
 use aksh_gha_protocol::{JobId, JobPlan, StepPlan};
 use indexmap::IndexMap;
 
+/// Workflow dependency graph validation.
+pub mod dag;
 /// Expression evaluation for workflow fields.
 pub mod eval;
 
@@ -23,6 +25,29 @@ pub enum ParserError {
     /// Workflow did not define jobs.
     #[error("workflow does not define any jobs")]
     EmptyJobs,
+    /// A job references a dependency that does not exist after expansion.
+    #[error("job `{job_id}` needs unknown job `{need}`")]
+    UnknownNeed {
+        /// Dependent job id.
+        job_id: String,
+        /// Missing dependency id.
+        need: String,
+    },
+    /// The expanded workflow dependency graph contains a cycle.
+    #[error("workflow job dependency cycle contains `{witness}`")]
+    NeedsCycle {
+        /// One job participating in the cycle.
+        witness: String,
+    },
+    /// A job-level condition is syntactically invalid.
+    #[error("invalid condition for job `{job_id}`: {message}")]
+    InvalidJobCondition {
+        /// Expanded job id.
+        job_id: String,
+        /// Expression parser error.
+        message: String,
+    },
+
     /// Matrix include/exclude entries must be objects.
     #[error("matrix entry for `{job_id}` in `{field}` must be an object")]
     InvalidMatrixEntry {
@@ -849,6 +874,7 @@ pub fn expand_jobs(workflow: &Workflow) -> Result<Vec<JobPlan>, ParserError> {
             });
         }
     }
+    dag::validate_job_plans(&plans)?;
     Ok(plans)
 }
 
@@ -1168,6 +1194,8 @@ pub fn expand_jobs_with_reusables(
         }
         plan.needs = new_needs;
     }
+
+    dag::validate_job_plans(&plans)?;
 
     Ok(ExpandedWorkflows {
         jobs: plans,

--- a/crates/aksh-gha-parser/src/matrix_expand.rs
+++ b/crates/aksh-gha-parser/src/matrix_expand.rs
@@ -650,4 +650,97 @@ mod tests {
             ]
         );
     }
+
+    /// Size limit: cartesian count stays bounded for generated specs.
+    /// Oracle: docs/property-tests.md §2.14 — size limits enforced before expansion.
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 1_000, ..ProptestConfig::default() })]
+
+        #[test]
+        fn cartesian_count_bounded(
+            axis_count in 0usize..=4,
+            sizes in proptest::collection::vec(0usize..=6, 0..=4),
+        ) {
+            let mut axes = IndexMap::new();
+            for i in 0..axis_count.min(sizes.len()) {
+                let vals: Vec<Value> = (0..sizes[i]).map(|v| json!(v)).collect();
+                if !vals.is_empty() {
+                    axes.insert(format!("a{i}"), vals);
+                }
+            }
+            let spec = MatrixSpec { axes, exclude: vec![], include: vec![] };
+            let count = cartesian_count(&spec);
+            prop_assert!(count <= 1296, "cartesian count {count} exceeds 6^4 bound");
+            let combos = expand_matrix_spec(&spec);
+            prop_assert!(combos.len() <= count + 1); // +1 for empty-fallback
+        }
+    }
+
+    /// Declaration-order permutation: same axes in different order produce
+    /// the same set of value combinations.
+    /// Oracle: docs/property-tests.md §2.13 — reordering does not change values.
+    #[test]
+    fn declaration_order_permutation_stable() {
+        let mut axes_ab = IndexMap::new();
+        axes_ab.insert("os".into(), vec![json!("linux"), json!("mac")]);
+        axes_ab.insert("node".into(), vec![json!(18), json!(20)]);
+        let mut axes_ba = IndexMap::new();
+        axes_ba.insert("node".into(), vec![json!(18), json!(20)]);
+        axes_ba.insert("os".into(), vec![json!("linux"), json!("mac")]);
+
+        let combos_ab = expand_matrix_spec(&MatrixSpec { axes: axes_ab, exclude: vec![], include: vec![] });
+        let combos_ba = expand_matrix_spec(&MatrixSpec { axes: axes_ba, exclude: vec![], include: vec![] });
+        assert_eq!(combos_ab.len(), combos_ba.len());
+        // Same value sets (order may differ by declaration order, which is correct)
+        let set_ab: std::collections::BTreeSet<_> = combos_ab.iter().map(|c| {
+            let mut sorted: Vec<_> = c.values.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+            sorted.sort_by(|a, b| a.0.cmp(&b.0));
+            sorted
+        }).collect();
+        let set_ba: std::collections::BTreeSet<_> = combos_ba.iter().map(|c| {
+            let mut sorted: Vec<_> = c.values.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+            sorted.sort_by(|a, b| a.0.cmp(&b.0));
+            sorted
+        }).collect();
+        assert_eq!(set_ab, set_ba);
+    }
+
+    /// Production-path: generated matrix → YAML → parse → expand → job count matches model.
+    /// Oracle: docs/property-tests.md §2 production-path requirements.
+    #[test]
+    fn matrix_production_path_count_matches_model() {
+        // 100 deterministic cases
+        for case in 0u64..100 {
+            let n_vals = ((case * 7 + 3) % 3 + 1) as usize; // 1-3 values
+            let vals: Vec<Value> = (0..n_vals).map(|v| json!(format!("v{v}"))).collect();
+            let mut axes = IndexMap::new();
+            axes.insert("x".into(), vals);
+            if case % 3 == 0 {
+                let vals2: Vec<Value> = (0..((case % 2 + 1) as usize)).map(|v| json!(format!("w{v}"))).collect();
+                axes.insert("y".into(), vals2);
+            }
+            let spec = MatrixSpec { axes: axes.clone(), exclude: vec![], include: vec![] };
+            let model_count = expand_matrix_spec(&spec).len();
+
+            // Render as YAML
+            let mut yaml = String::from("on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    strategy:\n      matrix:\n");
+            for (name, values) in &axes {
+                yaml.push_str(&format!("        {name}: ["));
+                for (i, v) in values.iter().enumerate() {
+                    if i > 0 { yaml.push_str(", "); }
+                    yaml.push_str(v.as_str().unwrap_or("0"));
+                }
+                yaml.push_str("]\n");
+            }
+            yaml.push_str("    steps:\n      - run: echo test\n");
+
+            let workflow = crate::parse_workflow(&yaml).unwrap();
+            let jobs = crate::expand_jobs(&workflow).unwrap();
+            assert_eq!(
+                jobs.len(), model_count,
+                "case {case}: production {}, model {model_count}",
+                jobs.len()
+            );
+        }
+    }
 }

--- a/crates/aksh-gha-parser/src/matrix_expand.rs
+++ b/crates/aksh-gha-parser/src/matrix_expand.rs
@@ -1,0 +1,653 @@
+//! Pure matrix expansion matching GitHub Actions semantics.
+//!
+//! Official order (docs.github.com + runner.server):
+//! 1. Cartesian product of axis values (declaration order).
+//! 2. Drop combinations that partially match any `exclude` object.
+//! 3. For each `include` object: merge into the first compatible combination,
+//!    else append as include-only.
+//! 4. If the result is empty, emit a single empty combination (no matrix context).
+//!
+//! Deferred matrices (`fromJSON(needs.*.outputs.*)`) are modeled explicitly so
+//! property tests can assert unresolved display identity when a producer fails
+//! (property-testing-plan scenario 63).
+
+use indexmap::IndexMap;
+use serde_json::Value;
+
+/// Structured matrix specification used by generators and expansion.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct MatrixSpec {
+    /// Axis name → list of values (declaration order).
+    pub axes: IndexMap<String, Vec<Value>>,
+    /// Exclude partial objects.
+    pub exclude: Vec<IndexMap<String, Value>>,
+    /// Include objects (merge or append).
+    pub include: Vec<IndexMap<String, Value>>,
+}
+
+/// A concrete expanded combination.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MatrixCombination {
+    /// Key/value pairs in axis declaration order, then include-only keys.
+    pub values: IndexMap<String, Value>,
+    /// True when this row came only from `include` (no cartesian match).
+    pub include_only: bool,
+}
+
+/// Deferred matrix axis that cannot be expanded until a producer job finishes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeferredMatrixAxis {
+    /// Axis name in the consumer job.
+    pub name: String,
+    /// Raw expression, e.g. `fromJSON(needs.producer.outputs.matrix)`.
+    pub expression: String,
+}
+
+/// Result of attempting expansion when some axes are deferred.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ExpandOutcome {
+    /// Fully concrete expansion.
+    Concrete(Vec<MatrixCombination>),
+    /// Producer failed or outputs missing: keep unresolved display placeholders.
+    Unresolved {
+        /// Base job id.
+        base_id: String,
+        /// Display name template that must retain `${{ matrix.* }}` placeholders.
+        display_template: String,
+        /// Deferred axes that never resolved.
+        deferred: Vec<DeferredMatrixAxis>,
+    },
+}
+
+/// Expand a concrete matrix. Never panics; invalid empty axis lists yield no
+/// cartesian rows (then include-only / empty fallback apply).
+pub fn expand_matrix_spec(spec: &MatrixSpec) -> Vec<MatrixCombination> {
+    let mut combinations: Vec<IndexMap<String, Value>> = vec![IndexMap::new()];
+
+    for (axis, values) in &spec.axes {
+        if values.is_empty() {
+            // Empty axis annihilates the product (GitHub rejects this in practice;
+            // we model it as zero cartesian rows before include).
+            combinations.clear();
+            break;
+        }
+        combinations = combinations
+            .into_iter()
+            .flat_map(|existing| {
+                values.iter().cloned().map({
+                    let axis = axis.clone();
+                    move |value| {
+                        let mut next = existing.clone();
+                        next.insert(axis.clone(), value);
+                        next
+                    }
+                })
+            })
+            .collect();
+    }
+
+    for excluded in &spec.exclude {
+        combinations.retain(|candidate| !matches_partial(candidate, excluded));
+    }
+
+    let mut tagged: Vec<MatrixCombination> = combinations
+        .into_iter()
+        .map(|values| MatrixCombination {
+            values,
+            include_only: false,
+        })
+        .collect();
+
+    // Official MatrixBuilder.MatrixInclude.Match: each include filter is applied
+    // against *every* cross-product vector (not just the first match). Unmatched
+    // include rows are appended as include-only configurations.
+    // Source: actions/runner MatrixBuilder.cs (via runner.server Sdk/WorkflowParser).
+    for included in &spec.include {
+        let mut matched_any = false;
+        for candidate in &mut tagged {
+            if can_merge_include(&candidate.values, included) {
+                candidate.values.extend(included.clone());
+                matched_any = true;
+            }
+        }
+        if !matched_any {
+            tagged.push(MatrixCombination {
+                values: included.clone(),
+                include_only: true,
+            });
+        }
+    }
+
+    // Official MatrixBuilder yields zero configs when the product is empty and
+    // no include-only rows remain (all-excluded matrix → no jobs). Do not invent
+    // a synthetic empty combination here.
+    tagged
+}
+
+/// Cartesian product size before exclude/include (0 if any axis is empty).
+pub fn cartesian_count(spec: &MatrixSpec) -> usize {
+    if spec.axes.is_empty() {
+        return 1;
+    }
+    let mut n = 1usize;
+    for values in spec.axes.values() {
+        if values.is_empty() {
+            return 0;
+        }
+        n = n.saturating_mul(values.len());
+    }
+    n
+}
+
+/// Build the official expanded job id: `base (v1, v2)` in declaration order.
+pub fn expanded_job_id(base: &str, matrix: &IndexMap<String, Value>) -> String {
+    if matrix.is_empty() {
+        return base.to_owned();
+    }
+    let values: Vec<String> = matrix.values().map(value_key).collect();
+    format!("{base} ({})", values.join(", "))
+}
+
+/// When deferred axes cannot resolve, the display identity must keep the
+/// template form rather than collapsing to the bare base id (scenario 63).
+pub fn unresolved_display_identity(base_id: &str, display_template: &str) -> String {
+    if display_template.contains("${{") {
+        display_template.to_owned()
+    } else {
+        // No template — still must not invent matrix values.
+        base_id.to_owned()
+    }
+}
+
+/// Expand or record unresolved deferred identity.
+pub fn expand_with_deferred(
+    base_id: &str,
+    display_template: &str,
+    concrete: &MatrixSpec,
+    deferred: &[DeferredMatrixAxis],
+    producer_ok: bool,
+) -> ExpandOutcome {
+    if !deferred.is_empty() && !producer_ok {
+        return ExpandOutcome::Unresolved {
+            base_id: base_id.to_owned(),
+            display_template: unresolved_display_identity(base_id, display_template),
+            deferred: deferred.to_vec(),
+        };
+    }
+    ExpandOutcome::Concrete(expand_matrix_spec(concrete))
+}
+
+fn value_key(value: &Value) -> String {
+    match value {
+        Value::String(value) => value.clone(),
+        other => other.to_string(),
+    }
+}
+
+fn matches_partial(candidate: &IndexMap<String, Value>, partial: &IndexMap<String, Value>) -> bool {
+    partial.iter().all(|(key, value)| {
+        candidate
+            .get(key)
+            .is_some_and(|candidate| candidate == value)
+    })
+}
+
+fn can_merge_include(
+    candidate: &IndexMap<String, Value>,
+    include: &IndexMap<String, Value>,
+) -> bool {
+    include
+        .iter()
+        .all(|(key, value)| candidate.get(key).is_none_or(|existing| existing == value))
+}
+
+/// Convert parser `Matrix` wire type into a pure `MatrixSpec`.
+pub fn matrix_to_spec(matrix: &crate::Matrix) -> MatrixSpec {
+    let mut axes = IndexMap::new();
+    for (axis, values) in &matrix.axes {
+        let axis_values = match values {
+            Value::Array(values) => values.clone(),
+            value => vec![value.clone()],
+        };
+        axes.insert(axis.clone(), axis_values);
+    }
+    let exclude = matrix
+        .exclude
+        .iter()
+        .filter_map(|v| value_object_indexed(v))
+        .collect();
+    let include = matrix
+        .include
+        .iter()
+        .filter_map(|v| value_object_indexed(v))
+        .collect();
+    MatrixSpec {
+        axes,
+        exclude,
+        include,
+    }
+}
+
+fn value_object_indexed(value: &Value) -> Option<IndexMap<String, Value>> {
+    let Value::Object(map) = value else {
+        return None;
+    };
+    Some(map.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use serde_json::json;
+
+    #[test]
+    fn exclude_and_include_match_unit_fixture() {
+        // Mirrors parses_and_expands_matrix expectations.
+        let mut axes = IndexMap::new();
+        axes.insert(
+            "os".into(),
+            vec![json!("ubuntu-latest"), json!("macos-latest")],
+        );
+        axes.insert("node".into(), vec![json!(20), json!(22)]);
+        let mut exclude = IndexMap::new();
+        exclude.insert("os".into(), json!("macos-latest"));
+        exclude.insert("node".into(), json!(20));
+        let mut include = IndexMap::new();
+        include.insert("os".into(), json!("ubuntu-latest"));
+        include.insert("node".into(), json!(24));
+        include.insert("experimental".into(), json!(true));
+
+        let spec = MatrixSpec {
+            axes,
+            exclude: vec![exclude],
+            include: vec![include],
+        };
+        let combos = expand_matrix_spec(&spec);
+        // 2*2 - 1 exclude + 1 include-only (24 is new) = 4
+        assert_eq!(combos.len(), 4);
+        assert!(combos.iter().any(|c| {
+            c.values.get("node") == Some(&json!(24))
+                && c.values.get("experimental") == Some(&json!(true))
+        }));
+        assert!(!combos.iter().any(|c| {
+            c.values.get("os") == Some(&json!("macos-latest"))
+                && c.values.get("node") == Some(&json!(20))
+        }));
+    }
+
+    #[test]
+    fn scenario_63_unresolved_keeps_template() {
+        let deferred = vec![DeferredMatrixAxis {
+            name: "case".into(),
+            expression: "fromJSON(needs.producer.outputs.matrix)".into(),
+        }];
+        let outcome = expand_with_deferred(
+            "matrix-build",
+            "matrix-build-${{ matrix.case }}-${{ matrix.mode }}",
+            &MatrixSpec::default(),
+            &deferred,
+            false,
+        );
+        match outcome {
+            ExpandOutcome::Unresolved {
+                display_template, ..
+            } => {
+                assert_eq!(
+                    display_template,
+                    "matrix-build-${{ matrix.case }}-${{ matrix.mode }}"
+                );
+                assert_ne!(display_template, "matrix-build");
+            }
+            other => panic!("expected unresolved, got {other:?}"),
+        }
+    }
+
+    fn arb_scalar() -> impl Strategy<Value = Value> {
+        prop_oneof![
+            any::<bool>().prop_map(Value::Bool),
+            (0i64..8).prop_map(|n| Value::Number(n.into())),
+            "[a-d]{1,3}".prop_map(Value::String),
+        ]
+    }
+
+    fn arb_matrix_spec() -> impl Strategy<Value = MatrixSpec> {
+        // Up to two fixed axis names with 1–3 values each; small excludes/includes.
+        (
+            proptest::collection::vec(arb_scalar(), 1..3),
+            prop::option::of(proptest::collection::vec(arb_scalar(), 1..3)),
+            proptest::collection::vec(arb_scalar(), 0..2),
+            proptest::collection::vec(arb_scalar(), 0..2),
+        )
+            .prop_map(|(os_vals, node_vals, ex_os, in_extra)| {
+                let mut axes = IndexMap::new();
+                axes.insert("os".into(), os_vals);
+                if let Some(node) = node_vals {
+                    axes.insert("node".into(), node);
+                }
+
+                let exclude = ex_os
+                    .into_iter()
+                    .take(2)
+                    .map(|v| {
+                        let mut m = IndexMap::new();
+                        m.insert("os".into(), v);
+                        m
+                    })
+                    .collect();
+
+                let include = in_extra
+                    .into_iter()
+                    .take(2)
+                    .map(|v| {
+                        let mut m = IndexMap::new();
+                        m.insert("os".into(), v);
+                        m.insert("extra".into(), Value::Bool(true));
+                        m
+                    })
+                    .collect();
+
+                MatrixSpec {
+                    axes,
+                    exclude,
+                    include,
+                }
+            })
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(10_000))]
+
+        /// Expansion never panics. Empty is allowed when the product is fully
+        /// excluded and no include-only rows remain (official MatrixBuilder).
+        #[test]
+        fn expand_never_panics(spec in arb_matrix_spec()) {
+            let _ = expand_matrix_spec(&spec);
+        }
+
+        /// When each axis has distinct values, expanded combinations are unique.
+        /// (Duplicate axis values intentionally fan out identical rows — same as GitHub.)
+        #[test]
+        fn combinations_unique_when_axis_values_unique(spec in arb_matrix_spec()) {
+            for values in spec.axes.values() {
+                let mut seen = std::collections::BTreeSet::new();
+                for v in values {
+                    let key = serde_json::to_string(v).unwrap();
+                    prop_assume!(seen.insert(key));
+                }
+            }
+            let combos = expand_matrix_spec(&spec);
+            let mut seen = std::collections::BTreeSet::new();
+            for c in &combos {
+                let key = serde_json::to_string(&c.values.iter().collect::<Vec<_>>()).unwrap();
+                prop_assert!(seen.insert(key), "duplicate combination {:?}", c.values);
+            }
+        }
+
+        /// Exclude applies only to the cartesian product (before include).
+        #[test]
+        fn excluded_never_in_cartesian(spec in arb_matrix_spec()) {
+            let mut pre_include = MatrixSpec {
+                axes: spec.axes.clone(),
+                exclude: spec.exclude.clone(),
+                include: vec![],
+            };
+            // expand with empty include; drop the empty-fallback-only case
+            let combos = expand_matrix_spec(&pre_include);
+            for ex in &spec.exclude {
+                for c in &combos {
+                    if c.values.is_empty() && pre_include.axes.is_empty() {
+                        continue;
+                    }
+                    // After cartesian+exclude, no non-empty row matches exclude.
+                    if !c.values.is_empty() {
+                        prop_assert!(
+                            !matches_partial(&c.values, ex),
+                            "excluded combination still present: {:?} matches {:?}",
+                            c.values,
+                            ex
+                        );
+                    }
+                }
+            }
+            // Keep `spec.include` used so the generator stays honest.
+            let _ = expand_matrix_spec(&spec);
+            let _ = &mut pre_include;
+        }
+
+        /// Determinism: same spec → same ordered combinations.
+        #[test]
+        fn expansion_deterministic(spec in arb_matrix_spec()) {
+            let a = expand_matrix_spec(&spec);
+            let b = expand_matrix_spec(&spec);
+            prop_assert_eq!(a, b);
+        }
+
+        /// Cartesian count multiplies axis lengths (before exclude).
+        #[test]
+        fn cartesian_count_matches_product(spec in arb_matrix_spec()) {
+            let expected = if spec.axes.is_empty() {
+                1
+            } else {
+                spec.axes.values().map(|v| v.len()).product()
+            };
+            prop_assert_eq!(cartesian_count(&spec), expected);
+        }
+
+        /// Expanded job ids are unique for unique combinations.
+        #[test]
+        fn expanded_ids_unique_for_distinct_combos(spec in arb_matrix_spec()) {
+            let combos = expand_matrix_spec(&spec);
+            let ids: Vec<_> = combos
+                .iter()
+                .map(|c| expanded_job_id("job", &c.values))
+                .collect();
+            // Same values ⇒ same id; distinct value maps should not collide when
+            // value_key renderings differ. We only assert injectivity on the
+            // serialized value map, not on the display id (bool/number can alias).
+            let mut map = std::collections::BTreeMap::new();
+            for (c, id) in combos.iter().zip(ids.iter()) {
+                let key = serde_json::to_string(&c.values.iter().collect::<Vec<_>>()).unwrap();
+                if let Some(prev) = map.insert(key, id.clone()) {
+                    prop_assert_eq!(prev, id.clone());
+                }
+            }
+        }
+
+        /// Deferred failure preserves template identity (scenario 63 family).
+        #[test]
+        fn deferred_failure_preserves_placeholders(
+            case_name in "[a-z]{1,5}",
+            mode_name in "[a-z]{1,5}"
+        ) {
+            let template = format!(
+                "matrix-build-${{{{ matrix.{case_name} }}}}-${{{{ matrix.{mode_name} }}}}"
+            );
+            let deferred = vec![
+                DeferredMatrixAxis {
+                    name: case_name,
+                    expression: "fromJSON(needs.p.outputs.m)".into(),
+                },
+                DeferredMatrixAxis {
+                    name: mode_name,
+                    expression: "fromJSON(needs.p.outputs.m2)".into(),
+                },
+            ];
+            let outcome = expand_with_deferred(
+                "matrix-build",
+                &template,
+                &MatrixSpec::default(),
+                &deferred,
+                false,
+            );
+            match outcome {
+                ExpandOutcome::Unresolved {
+                    display_template, ..
+                } => {
+                    prop_assert!(display_template.contains("${{"));
+                    prop_assert_ne!(display_template, "matrix-build");
+                }
+                ExpandOutcome::Concrete(_) => prop_assert!(false, "should be unresolved"),
+            }
+        }
+
+        /// When producer succeeds with no deferred axes, concrete expansion runs.
+        #[test]
+        fn deferred_ok_without_axes_is_concrete(spec in arb_matrix_spec()) {
+            let outcome =
+                expand_with_deferred("job", "job", &spec, &[], true);
+            prop_assert!(matches!(outcome, ExpandOutcome::Concrete(_)));
+        }
+    }
+
+    /// Include-only rows are tagged and do not invent axis declaration order.
+    #[test]
+    fn include_only_flag_set_for_appended_rows() {
+        let mut axes = IndexMap::new();
+        axes.insert("os".into(), vec![json!("linux")]);
+        let mut include = IndexMap::new();
+        include.insert("os".into(), json!("windows"));
+        include.insert("extra".into(), json!(true));
+        let combos = expand_matrix_spec(&MatrixSpec {
+            axes,
+            exclude: vec![],
+            include: vec![include],
+        });
+        assert_eq!(combos.len(), 2);
+        assert!(!combos[0].include_only);
+        assert!(combos[1].include_only);
+        assert_eq!(combos[1].values.get("extra"), Some(&json!(true)));
+    }
+
+    /// Official MatrixBuilder example 1 — simple cross product.
+    #[test]
+    fn official_matrix_builder_example_cross_product() {
+        let mut axes = IndexMap::new();
+        axes.insert("arch".into(), vec![json!("x64"), json!("x86")]);
+        axes.insert("os".into(), vec![json!("linux"), json!("windows")]);
+        let combos = expand_matrix_spec(&MatrixSpec {
+            axes,
+            exclude: vec![],
+            include: vec![],
+        });
+        let ids: Vec<_> = combos
+            .iter()
+            .map(|c| expanded_job_id("job", &c.values))
+            .collect();
+        assert_eq!(
+            ids,
+            vec![
+                "job (x64, linux)",
+                "job (x64, windows)",
+                "job (x86, linux)",
+                "job (x86, windows)",
+            ]
+        );
+    }
+
+    /// Official MatrixBuilder example 2 — exclude filter.
+    #[test]
+    fn official_matrix_builder_example_exclude() {
+        let mut axes = IndexMap::new();
+        axes.insert("arch".into(), vec![json!("x64"), json!("x86")]);
+        axes.insert("os".into(), vec![json!("linux"), json!("windows")]);
+        let mut ex = IndexMap::new();
+        ex.insert("arch".into(), json!("x86"));
+        ex.insert("os".into(), json!("linux"));
+        let combos = expand_matrix_spec(&MatrixSpec {
+            axes,
+            exclude: vec![ex],
+            include: vec![],
+        });
+        assert_eq!(combos.len(), 3);
+        assert!(!combos.iter().any(|c| {
+            c.values.get("arch") == Some(&json!("x86"))
+                && c.values.get("os") == Some(&json!("linux"))
+        }));
+    }
+
+    /// Official MatrixBuilder example 3 — include adds extra values to *all* matches.
+    #[test]
+    fn official_matrix_builder_example_include_extra_all_matches() {
+        let mut axes = IndexMap::new();
+        axes.insert("arch".into(), vec![json!("x64"), json!("x86")]);
+        axes.insert("os".into(), vec![json!("linux"), json!("windows")]);
+        let mut inc = IndexMap::new();
+        inc.insert("arch".into(), json!("x64"));
+        inc.insert("os".into(), json!("linux"));
+        inc.insert("publish".into(), json!(true));
+        let combos = expand_matrix_spec(&MatrixSpec {
+            axes,
+            exclude: vec![],
+            include: vec![inc],
+        });
+        assert_eq!(combos.len(), 4);
+        let x64_linux = combos
+            .iter()
+            .find(|c| {
+                c.values.get("arch") == Some(&json!("x64"))
+                    && c.values.get("os") == Some(&json!("linux"))
+            })
+            .unwrap();
+        assert_eq!(x64_linux.values.get("publish"), Some(&json!(true)));
+        // Other rows must not get publish.
+        assert!(combos.iter().filter(|c| c.values.get("publish").is_some()).count() == 1);
+    }
+
+    /// Include with only an axis key that matches multiple product rows applies
+    /// to every match (MatrixBuilder.Match loops all vectors).
+    #[test]
+    fn official_include_merges_into_all_matching_vectors() {
+        let mut axes = IndexMap::new();
+        axes.insert("arch".into(), vec![json!("x64"), json!("x86")]);
+        axes.insert("os".into(), vec![json!("linux"), json!("windows")]);
+        let mut inc = IndexMap::new();
+        inc.insert("arch".into(), json!("x64"));
+        inc.insert("publish".into(), json!(true));
+        let combos = expand_matrix_spec(&MatrixSpec {
+            axes,
+            exclude: vec![],
+            include: vec![inc],
+        });
+        let published: Vec<_> = combos
+            .iter()
+            .filter(|c| c.values.get("publish") == Some(&json!(true)))
+            .collect();
+        // Both x64/linux and x64/windows get publish:true.
+        assert_eq!(published.len(), 2);
+        assert!(published.iter().all(|c| c.values.get("arch") == Some(&json!("x64"))));
+    }
+
+    /// Official: all-excluded product with no include-only → zero configurations.
+    #[test]
+    fn official_all_excluded_yields_empty() {
+        let mut axes = IndexMap::new();
+        axes.insert("os".into(), vec![json!("linux")]);
+        let mut ex = IndexMap::new();
+        ex.insert("os".into(), json!("linux"));
+        let combos = expand_matrix_spec(&MatrixSpec {
+            axes,
+            exclude: vec![ex],
+            include: vec![],
+        });
+        assert!(combos.is_empty());
+    }
+
+    /// Golden fixture fixtures/golden/matrix-expand.yml expansion ids.
+    #[test]
+    fn golden_matrix_expand_fixture_ids() {
+        let yaml = include_str!("../../../fixtures/golden/matrix-expand.yml");
+        let workflow = crate::parse_workflow(yaml).unwrap();
+        let jobs = crate::expand_jobs(&workflow).unwrap();
+        let ids: Vec<_> = jobs.iter().map(|j| j.id.0.clone()).collect();
+        assert_eq!(
+            ids,
+            vec![
+                "build (ubuntu-latest, 16)",
+                "build (ubuntu-latest, 18)",
+                "build (macos-latest, 16)",
+                "build (macos-latest, 18)",
+            ]
+        );
+    }
+}

--- a/crates/aksh-gha-protocol/src/azdo.rs
+++ b/crates/aksh-gha-protocol/src/azdo.rs
@@ -526,8 +526,11 @@ fn extract_template_map(value: Option<&serde_json::Value>) -> Option<BTreeMap<St
         for pair in pairs {
             let key_val = pair.get("Key").or_else(|| pair.get("key"));
             let val_val = pair.get("Value").or_else(|| pair.get("value"));
-            let key = key_val
-                .and_then(|v| v.as_str().map(str::to_owned).or_else(|| v.get("lit").and_then(|l| l.as_str()).map(str::to_owned)))?;
+            let key = key_val.and_then(|v| {
+                v.as_str()
+                    .map(str::to_owned)
+                    .or_else(|| v.get("lit").and_then(|l| l.as_str()).map(str::to_owned))
+            })?;
             let val = val_val
                 .and_then(|v| {
                     v.as_str()
@@ -1376,9 +1379,8 @@ mod tests {
     #[test]
     fn template_string_token_handles_braces_inside_string_literals() {
         // Expression containing }} inside a single-quoted JSON string
-        let token = template_string_token(
-            r#"${{ fromJSON('{"a":{"b":{"c":"deep"}}}')['a']['b']['c'] }}"#,
-        );
+        let token =
+            template_string_token(r#"${{ fromJSON('{"a":{"b":{"c":"deep"}}}')['a']['b']['c'] }}"#);
         assert_eq!(token["type"], 3);
         let expr = token["expr"].as_str().unwrap();
         // Should preserve the full expression, not truncate at the first }}
@@ -1391,10 +1393,7 @@ mod tests {
     #[test]
     fn find_expression_end_skips_braces_in_strings() {
         // }} inside a string should be skipped
-        assert_eq!(
-            find_expression_end(" fromJSON('{}}')'a' }}"),
-            Some(20)
-        );
+        assert_eq!(find_expression_end(" fromJSON('{}}')'a' }}"), Some(20));
         // Plain expression
         assert_eq!(find_expression_end(" x }}"), Some(3));
         // No closing

--- a/crates/aksh-runner-server/proptest-regressions/scheduling.txt
+++ b/crates/aksh-runner-server/proptest-regressions/scheduling.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 4ff0e5a358b3a703b1dc01862bdd51edd9fe2bef5acdde7905b06defa8d75ed2 # shrinks to needs_count = 4, statuses = [Failure, Cancelled], condition = Some("cancelled()")

--- a/crates/aksh-runner-server/src/lib.rs
+++ b/crates/aksh-runner-server/src/lib.rs
@@ -10272,6 +10272,18 @@ jobs:
             }
             let failed_root = (0..count).find(|job| needs[*job].is_empty()).unwrap();
 
+            // Assign conditions to non-root jobs based on PRNG
+            let mut conditions: Vec<Option<&str>> = vec![None; count];
+            for job in 1..count {
+                if !needs[job].is_empty() {
+                    conditions[job] = match next(&mut seed) % 5 {
+                        0 => Some("always()"),
+                        1 => Some("failure()"),
+                        _ => None, // default gate
+                    };
+                }
+            }
+
             let mut yaml = String::from("on: push\njobs:\n");
             for job in 0..count {
                 yaml.push_str(&format!("  j{job}:\n"));
@@ -10284,6 +10296,9 @@ jobs:
                         yaml.push_str(&format!("j{dependency}"));
                     }
                     yaml.push_str("]\n");
+                }
+                if let Some(cond) = conditions[job] {
+                    yaml.push_str(&format!("    if: {cond}\n"));
                 }
                 yaml.push_str("    runs-on: ubuntu-latest\n");
                 yaml.push_str("    steps:\n      - run: echo property\n");
@@ -10342,11 +10357,25 @@ jobs:
                 let expected = if job == failed_root {
                     ExecutionStatus::Failure
                 } else if failed_ancestor[job] {
-                    ExecutionStatus::Skipped
+                    // Job has a failed ancestor — what does the condition say?
+                    match conditions[job] {
+                        Some("always()") => ExecutionStatus::Success, // always runs, completed successfully
+                        Some("failure()") => ExecutionStatus::Success, // failure() is true, job runs
+                        _ => ExecutionStatus::Skipped,                 // default gate blocks
+                    }
                 } else {
-                    ExecutionStatus::Success
+                    // No failed ancestor
+                    match conditions[job] {
+                        Some("failure()") => ExecutionStatus::Skipped, // failure() is false, skip
+                        _ => ExecutionStatus::Success,                 // default or always() runs
+                    }
                 };
-                assert_eq!(run.jobs[&JobId(format!("j{job}"))], expected, "case {case}");
+                assert_eq!(
+                    run.jobs[&JobId(format!("j{job}"))],
+                    expected,
+                    "case {case} job j{job} condition={:?}",
+                    conditions[job]
+                );
             }
         }
     }

--- a/crates/aksh-runner-server/src/lib.rs
+++ b/crates/aksh-runner-server/src/lib.rs
@@ -7,6 +7,9 @@ use std::sync::Arc;
 
 pub mod github;
 
+/// Pure job-graph scheduler model and property tests.
+pub mod scheduling;
+
 use axum_server::{tls_rustls::RustlsConfig, Handle};
 use rcgen::generate_simple_self_signed;
 
@@ -59,6 +62,10 @@ pub struct ServerConfig {
     pub record_flows: Option<PathBuf>,
     /// TLS mode (default: no TLS).
     pub tls: TlsMode,
+    /// Enable privileged local/CI simulation endpoints.
+    pub enable_test_api: bool,
+    /// Bearer token required by privileged simulation endpoints.
+    pub test_api_token: Option<String>,
 }
 
 /// TLS configuration.
@@ -227,7 +234,27 @@ pub async fn serve(config: ServerConfig) -> anyhow::Result<()> {
         inner.flows_file = Some(file);
     }
     let shutdown = CancellationToken::new();
-    let router = app(state.clone(), shutdown.clone());
+    let test_api_token = if config.enable_test_api {
+        if !config.listen.ip().is_loopback() {
+            anyhow::bail!("the test API may only be enabled on a loopback listener");
+        }
+        let token = config
+            .test_api_token
+            .clone()
+            .filter(|token| !token.trim().is_empty())
+            .ok_or_else(|| anyhow::anyhow!("--enable-test-api requires --test-api-token"))?;
+        warn!(
+            listen = %config.listen,
+            "PRIVILEGED TEST API ENABLED; simulated sessions and completions are accepted"
+        );
+        Some(token)
+    } else {
+        if config.test_api_token.is_some() {
+            anyhow::bail!("--test-api-token requires --enable-test-api");
+        }
+        None
+    };
+    let router = build_app(state.clone(), shutdown.clone(), test_api_token);
 
     let shared = Arc::new(SharedState {
         state,
@@ -302,8 +329,28 @@ async fn shutdown_signal(shutdown: CancellationToken) {
     shutdown.cancel();
 }
 
-/// Build the server router.
+/// Build the production server router without simulation endpoints.
 pub fn app(state: AppState, shutdown: CancellationToken) -> Router {
+    build_app(state, shutdown, None)
+}
+
+/// Build an in-process router with privileged local/CI simulation endpoints.
+///
+/// Network servers should use [`serve`], which additionally enforces a
+/// loopback-only listener when this API is enabled.
+pub fn app_with_test_api(
+    state: AppState,
+    shutdown: CancellationToken,
+    token: impl Into<String>,
+) -> Router {
+    build_app(state, shutdown, Some(token.into()))
+}
+
+fn build_app(
+    state: AppState,
+    shutdown: CancellationToken,
+    test_api_token: Option<String>,
+) -> Router {
     let shared = Arc::new(SharedState {
         state: state.clone(),
         shutdown: shutdown.clone(),
@@ -471,7 +518,7 @@ pub fn app(state: AppState, shutdown: CancellationToken) -> Router {
         )
         .route_layer(middleware::from_fn(require_bearer));
 
-    Router::new()
+    let router = Router::new()
         .route("/healthz", get(healthz))
         // GHES-style org-prefixed routes
         .route("/:org/_apis/connectionData", get(connection_data))
@@ -610,15 +657,6 @@ pub fn app(state: AppState, shutdown: CancellationToken) -> Router {
             get(download_action_tarball),
         )
         .route("/api/v1/runners", post(register_runner))
-        .route("/api/v1/runners/sessions", post(create_session))
-        .route(
-            "/api/v1/runners/sessions/:session_id/messages",
-            get(next_message),
-        )
-        .route(
-            "/api/v1/runners/sessions/:session_id/messages/:message_id",
-            delete(delete_session_message),
-        )
         .route(
             "/runner/session",
             post(broker_session_root).delete(broker_delete_session_root),
@@ -665,7 +703,6 @@ pub fn app(state: AppState, shutdown: CancellationToken) -> Router {
         )
         .route("/runner/server/message", get(next_message_broker_ref_root))
         .route("/runner/server/acknowledge", post(broker_acknowledge_root))
-        .route("/api/v1/jobs/complete", post(complete_job))
         .route("/api/v1/cache", post(cache_put))
         .route("/api/v1/cache", get(cache_get))
         .route("/api/v1/artifacts", post(artifact_put))
@@ -778,7 +815,48 @@ pub fn app(state: AppState, shutdown: CancellationToken) -> Router {
             state.clone(),
             record_flows_middleware,
         ))
-        .with_state(shared)
+        .with_state(shared.clone());
+
+    match test_api_token {
+        Some(token) => router.merge(
+            Router::new()
+                .route(
+                    "/internal/test/runners/sessions/:session_id/messages",
+                    get(next_message),
+                )
+                .route(
+                    "/internal/test/runners/sessions/:session_id/messages/:message_id",
+                    delete(delete_session_message),
+                )
+                .route("/internal/test/runners/sessions", post(create_session))
+                .route("/internal/test/jobs/complete", post(complete_job))
+                .route_layer(middleware::from_fn_with_state(
+                    Arc::<str>::from(token),
+                    require_test_api_token,
+                ))
+                .with_state(shared),
+        ),
+        None => router,
+    }
+}
+
+async fn require_test_api_token(
+    State(expected): State<Arc<str>>,
+    request: Request,
+    next: Next,
+) -> Result<Response, ApiError> {
+    let authorized = request
+        .headers()
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .is_some_and(|token| token == expected.as_ref());
+    if !authorized {
+        warn!(path = %request.uri().path(), "rejected privileged test API request");
+        return Err(ApiError::unauthorized("missing or invalid test API token"));
+    }
+    warn!(path = %request.uri().path(), "privileged test API request");
+    Ok(next.run(request).await)
 }
 
 /// HMAC key used for local JWT signing/verification.
@@ -968,6 +1046,8 @@ pub(crate) struct RunRecord {
     pub(crate) status: ExecutionStatus,
     pub(crate) job_outputs: BTreeMap<JobId, BTreeMap<String, serde_json::Value>>,
     pub(crate) job_base_ids: BTreeMap<JobId, String>,
+    #[serde(skip)]
+    pub(crate) job_needs: BTreeMap<JobId, Vec<JobId>>,
     pub(crate) job_fail_fast: BTreeMap<String, bool>,
     #[serde(default)]
     pub(crate) job_check_run_ids: BTreeMap<JobId, u64>,
@@ -998,6 +1078,8 @@ struct QueuedJob {
     job_id: JobId,
     base_id: String,
     needs: Vec<JobId>,
+    if_condition: Option<String>,
+    condition_context: aksh_gha_expressions::Context,
     fail_fast: bool,
     max_parallel: Option<u64>,
     /// Required runner labels from `runs-on`.
@@ -1156,7 +1238,7 @@ pub(crate) async fn submit_run_inner(
         )));
     }
     let expanded = expand_jobs_with_reusables(&workflow, &submission.reusable_workflows)?;
-    let mut jobs = expanded.jobs;
+    let jobs = expanded.jobs;
     let reusable_calls = expanded.reusable_calls;
     let run_id = RunId::new();
     let github = json!({
@@ -1174,9 +1256,32 @@ pub(crate) async fn submit_run_inner(
         let mut statuses = BTreeMap::new();
         let mut ready_jobs = 0usize;
         let mut job_base_ids = BTreeMap::new();
+        let mut job_needs = BTreeMap::new();
         let mut job_fail_fast = BTreeMap::new();
         let mut ready_by_base: BTreeMap<String, u64> = BTreeMap::new();
+        let mut initially_skipped = Vec::new();
         for job in jobs {
+            job_base_ids.insert(job.id.clone(), job.base_id.clone());
+            job_needs.insert(job.id.clone(), job.needs.clone());
+            job_fail_fast.insert(job.base_id.clone(), job.fail_fast);
+            statuses.insert(job.id.clone(), ExecutionStatus::Queued);
+            let condition_context = job_condition_context(&job, &github, &submission);
+            if job.needs.is_empty() {
+                let condition =
+                    aksh_gha_expressions::effective_condition(job.if_condition.as_deref());
+                let should_run = aksh_gha_expressions::eval_bool(&condition, &condition_context)
+                    .map_err(|error| {
+                        ApiError::bad_request(format!(
+                            "failed to evaluate condition for job `{}`: {error}",
+                            job.id
+                        ))
+                    })?;
+                if !should_run {
+                    statuses.insert(job.id.clone(), ExecutionStatus::Skipped);
+                    initially_skipped.push((run_id, job.id.clone()));
+                    continue;
+                }
+            }
             let mut agent_msg = aksh_gha_parser::job_builder::build_agent_job_message(
                 &job,
                 &github,
@@ -1258,13 +1363,13 @@ pub(crate) async fn submit_run_inner(
                 job_id: job.id.clone(),
                 base_id: job.base_id.clone(),
                 needs: job.needs.clone(),
+                if_condition: job.if_condition.clone(),
+                condition_context,
                 fail_fast: job.fail_fast,
                 max_parallel: job.max_parallel,
                 runs_on: job.runs_on.clone(),
                 message: agent_msg,
             };
-            job_base_ids.insert(job.id.clone(), job.base_id.clone());
-            job_fail_fast.insert(job.base_id.clone(), job.fail_fast);
 
             // Check if dependencies are met (no needs = ready immediately)
             if job.needs.is_empty()
@@ -1272,17 +1377,20 @@ pub(crate) async fn submit_run_inner(
                     .max_parallel
                     .is_none_or(|max| ready_by_base.get(&job.base_id).copied().unwrap_or(0) < max)
             {
-                statuses.insert(job.id.clone(), ExecutionStatus::Queued);
                 inner.queue.push_back(queued_job);
                 *ready_by_base.entry(job.base_id.clone()).or_default() += 1;
                 ready_jobs += 1;
             } else {
                 // Job has dependencies — queue it as pending
-                statuses.insert(job.id.clone(), ExecutionStatus::Queued);
                 inner.pending_jobs.push_back(queued_job);
             }
         }
         let queued_jobs = statuses.len();
+        let initial_status = if statuses.values().copied().all(is_terminal_status) {
+            summarize_run(statuses.values().copied())
+        } else {
+            ExecutionStatus::Queued
+        };
         inner.runs.insert(
             run_id,
             RunRecord {
@@ -1291,15 +1399,29 @@ pub(crate) async fn submit_run_inner(
                 jobs: statuses,
                 job_outputs: BTreeMap::new(),
                 job_base_ids,
+                job_needs,
                 job_fail_fast,
-                status: ExecutionStatus::Queued,
+                status: initial_status,
                 job_check_run_ids: BTreeMap::new(),
                 reusable_calls,
             },
         );
+        let scheduling = promote_ready_jobs(&mut inner);
+        ready_jobs += scheduling.promoted;
+        initially_skipped.extend(scheduling.skipped);
         drop(inner);
         if ready_jobs > 0 {
             shared.state.message_notify.notify_waiters();
+        }
+        for (event_run_id, job_id) in initially_skipped {
+            shared
+                .state
+                .emit(NdjsonEvent::JobStatus {
+                    run_id: event_run_id,
+                    job_id,
+                    status: ExecutionStatus::Skipped,
+                })
+                .await;
         }
         shared
             .state
@@ -1382,12 +1504,22 @@ async fn cancel_run(
 ) -> Result<Json<RunRecord>, ApiError> {
     let mut inner = shared.state.inner.lock().await;
     let mut cancellations = Vec::new();
+    let changed;
     {
         let record = inner
             .runs
             .get_mut(&run_id)
             .ok_or_else(|| ApiError::not_found("run not found"))?;
-        record.status = ExecutionStatus::Cancelled;
+        let was_active = record.jobs.values().any(|status| {
+            matches!(
+                status,
+                ExecutionStatus::Queued | ExecutionStatus::InProgress
+            )
+        });
+        changed = was_active;
+        if was_active {
+            record.status = ExecutionStatus::Cancelled;
+        }
         for (job_id, status) in &mut record.jobs {
             if matches!(*status, ExecutionStatus::InProgress) {
                 cancellations.push(QueuedCancellation {
@@ -1417,13 +1549,15 @@ async fn cancel_run(
     if cancellation_count > 0 {
         shared.state.message_notify.notify_waiters();
     }
-    shared
-        .state
-        .emit(NdjsonEvent::RunStatus {
-            run_id,
-            status: ExecutionStatus::Cancelled,
-        })
-        .await;
+    if changed {
+        shared
+            .state
+            .emit(NdjsonEvent::RunStatus {
+                run_id,
+                status: record.status,
+            })
+            .await;
+    }
     Ok(Json(record))
 }
 
@@ -1922,10 +2056,11 @@ struct BrokerRenewJobRequest {
 }
 
 fn execution_status_from_runner_result(result: &str) -> Option<ExecutionStatus> {
-    match result {
-        "success" | "succeeded" | "succeededWithIssues" => Some(ExecutionStatus::Success),
+    match result.to_ascii_lowercase().as_str() {
+        "success" | "succeeded" | "succeededwithissues" => Some(ExecutionStatus::Success),
         "failure" | "failed" => Some(ExecutionStatus::Failure),
         "cancelled" | "canceled" => Some(ExecutionStatus::Cancelled),
+        "skipped" => Some(ExecutionStatus::Skipped),
         _ => None,
     }
 }
@@ -2328,11 +2463,13 @@ async fn broker_complete_job(
     Path(_runner_id): Path<i64>,
     Json(request): Json<BrokerRenewJobRequest>,
 ) -> Result<StatusCode, ApiError> {
-    let status = request
-        .conclusion
-        .as_deref()
-        .and_then(execution_status_from_runner_result)
-        .unwrap_or(ExecutionStatus::Success);
+    let status = match request.conclusion.as_deref() {
+        Some(conclusion) => execution_status_from_runner_result(conclusion).ok_or_else(|| {
+            ApiError::bad_request(format!("unknown broker conclusion `{conclusion}`"))
+        })?,
+        // Older broker clients omit this field on successful completion.
+        None => ExecutionStatus::Success,
+    };
 
     // Extract outputs from the completejob body.
     // Runner sends: { "outputName": {"value": "theValue"} }
@@ -3627,12 +3764,25 @@ async fn complete_job_inner(
     shared: Arc<SharedState>,
     completion: JobCompletion,
 ) -> Result<Json<RunRecord>, ApiError> {
+    if !is_terminal_status(completion.status) {
+        return Err(ApiError::bad_request(
+            "job completion status must be terminal",
+        ));
+    }
     let mut inner = shared.state.inner.lock().await;
     {
         let run = inner
             .runs
             .get_mut(&completion.run_id)
             .ok_or_else(|| ApiError::not_found("run not found"))?;
+        let current = run
+            .jobs
+            .get(&completion.job_id)
+            .copied()
+            .ok_or_else(|| ApiError::bad_request("job does not belong to run"))?;
+        if is_terminal_status(current) {
+            return Ok(Json(run.clone()));
+        }
         run.jobs
             .insert(completion.job_id.clone(), completion.status);
         run.job_outputs.insert(
@@ -3649,9 +3799,9 @@ async fn complete_job_inner(
     let cancelled_siblings = if completion.status == ExecutionStatus::Failure {
         apply_matrix_fail_fast(&mut inner, completion.run_id, &completion.job_id)
     } else {
-        0
+        Vec::new()
     };
-    let promoted_jobs = promote_ready_jobs(&mut inner);
+    let scheduling = promote_ready_jobs(&mut inner);
     let record = inner
         .runs
         .get(&completion.run_id)
@@ -3679,7 +3829,7 @@ async fn complete_job_inner(
     )
     .await;
 
-    if promoted_jobs > 0 || cancelled_siblings > 0 {
+    if scheduling.promoted > 0 || !cancelled_siblings.is_empty() {
         shared.state.message_notify.notify_waiters();
     }
 
@@ -3691,6 +3841,43 @@ async fn complete_job_inner(
             status: completion.status,
         })
         .await;
+    for job_id in cancelled_siblings {
+        github::report_check_run_completed(
+            &shared,
+            completion.run_id,
+            &job_id,
+            ExecutionStatus::Cancelled,
+        )
+        .await;
+        shared
+            .state
+            .emit(NdjsonEvent::JobStatus {
+                run_id: completion.run_id,
+                job_id,
+                status: ExecutionStatus::Cancelled,
+            })
+            .await;
+    }
+    for (run_id, job_id) in scheduling.skipped {
+        shared
+            .state
+            .emit(NdjsonEvent::JobStatus {
+                run_id,
+                job_id,
+                status: ExecutionStatus::Skipped,
+            })
+            .await;
+    }
+    for (run_id, job_id) in scheduling.failed {
+        shared
+            .state
+            .emit(NdjsonEvent::JobStatus {
+                run_id,
+                job_id,
+                status: ExecutionStatus::Failure,
+            })
+            .await;
+    }
     shared
         .state
         .emit(NdjsonEvent::RunStatus {
@@ -3701,34 +3888,187 @@ async fn complete_job_inner(
     Ok(Json(record))
 }
 
-/// Check if pending jobs can be dispatched and promote them to the queue.
-fn promote_ready_jobs(inner: &mut InnerState) -> usize {
-    let mut promoted = Vec::new();
-    let mut remaining = VecDeque::new();
+fn job_condition_context(
+    job: &aksh_gha_protocol::JobPlan,
+    github: &serde_json::Value,
+    submission: &WorkflowSubmission,
+) -> aksh_gha_expressions::Context {
+    let mut context = aksh_gha_expressions::Context::default();
+    context.insert("github", github.clone());
+    context.insert(
+        "vars",
+        serde_json::to_value(&submission.vars).unwrap_or_default(),
+    );
+    context.insert(
+        "inputs",
+        serde_json::to_value(&job.inputs).unwrap_or_default(),
+    );
+    context.insert("needs", serde_json::Value::Object(Default::default()));
+    context
+}
 
-    while let Some(mut job) = inner.pending_jobs.pop_front() {
-        let needs_satisfied = inner
-            .runs
-            .get(&job.run_id)
-            .is_some_and(|run| job.needs.iter().all(|need| need_satisfied(run, need)))
-            && under_max_parallel(inner, &job);
+#[derive(Default)]
+struct SchedulingOutcome {
+    promoted: usize,
+    skipped: Vec<(RunId, JobId)>,
+    failed: Vec<(RunId, JobId)>,
+}
 
-        if needs_satisfied {
-            if let Some(run) = inner.runs.get(&job.run_id) {
-                hydrate_needs_context(&mut job, run);
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DependencyDecision {
+    Wait,
+    Run,
+    Skip,
+    Error,
+}
+
+/// Promote or skip pending jobs once every declared dependency is terminal.
+fn promote_ready_jobs(inner: &mut InnerState) -> SchedulingOutcome {
+    let mut outcome = SchedulingOutcome::default();
+    loop {
+        let mut promoted_by_base: BTreeMap<(RunId, String), u64> = BTreeMap::new();
+        let mut promoted = Vec::new();
+        let mut remaining = VecDeque::new();
+        let mut settled = false;
+
+        while let Some(mut job) = inner.pending_jobs.pop_front() {
+            let decision = inner
+                .runs
+                .get(&job.run_id)
+                .map(|run| dependency_decision(run, &job))
+                .unwrap_or(DependencyDecision::Wait);
+            match decision {
+                DependencyDecision::Run
+                    if under_max_parallel(inner, &job)
+                        && promoted_by_base
+                            .get(&(job.run_id, job.base_id.clone()))
+                            .copied()
+                            .unwrap_or(0)
+                            < job.max_parallel.unwrap_or(u64::MAX) =>
+                {
+                    if let Some(run) = inner.runs.get(&job.run_id) {
+                        hydrate_needs_context(&mut job, run);
+                    }
+                    *promoted_by_base
+                        .entry((job.run_id, job.base_id.clone()))
+                        .or_default() += 1;
+                    promoted.push(job);
+                }
+                DependencyDecision::Skip | DependencyDecision::Error => {
+                    if let Some(run) = inner.runs.get_mut(&job.run_id) {
+                        let status = if decision == DependencyDecision::Skip {
+                            ExecutionStatus::Skipped
+                        } else {
+                            ExecutionStatus::Failure
+                        };
+                        run.jobs.insert(job.job_id.clone(), status);
+                        run.status = summarize_run(run.jobs.values().copied());
+                    }
+                    if decision == DependencyDecision::Skip {
+                        outcome.skipped.push((job.run_id, job.job_id));
+                    } else {
+                        outcome.failed.push((job.run_id, job.job_id));
+                    }
+                    settled = true;
+                }
+                DependencyDecision::Wait | DependencyDecision::Run => remaining.push_back(job),
             }
-            promoted.push(job);
-        } else {
-            remaining.push_back(job);
+        }
+
+        outcome.promoted += promoted.len();
+        inner.pending_jobs = remaining;
+        inner.queue.extend(promoted);
+        if !settled {
+            return outcome;
         }
     }
+}
 
-    let promoted_count = promoted.len();
-    inner.pending_jobs = remaining;
-    for job in promoted {
-        inner.queue.push_back(job);
+fn dependency_decision(run: &RunRecord, job: &QueuedJob) -> DependencyDecision {
+    if job.needs.is_empty() {
+        return DependencyDecision::Run;
     }
-    promoted_count
+    let direct_statuses = job
+        .needs
+        .iter()
+        .flat_map(|need| matching_need_statuses(run, need))
+        .collect::<Vec<_>>();
+    if direct_statuses.is_empty()
+        || direct_statuses
+            .iter()
+            .any(|status| !is_terminal_status(*status))
+    {
+        return DependencyDecision::Wait;
+    }
+    let statuses = ancestor_statuses(run, job);
+    let aggregate = aggregate_need_status(&statuses).unwrap_or(ExecutionStatus::Skipped);
+    let context = job.condition_context.clone().with_status(
+        aggregate == ExecutionStatus::Success,
+        aggregate == ExecutionStatus::Failure,
+        aggregate == ExecutionStatus::Cancelled,
+    );
+    let mut context = context;
+    context.insert("needs", needs_json_context(run, &job.needs));
+    let condition = aksh_gha_expressions::effective_condition(job.if_condition.as_deref());
+    match aksh_gha_expressions::eval_bool(&condition, &context) {
+        Ok(true) => DependencyDecision::Run,
+        Ok(false) => DependencyDecision::Skip,
+        Err(_) => DependencyDecision::Error,
+    }
+}
+
+fn matching_need_ids(run: &RunRecord, need: &JobId) -> Vec<JobId> {
+    run.jobs
+        .keys()
+        .filter(|job_id| {
+            *job_id == need
+                || run
+                    .job_base_ids
+                    .get(*job_id)
+                    .is_some_and(|base| base == &need.0)
+        })
+        .cloned()
+        .collect()
+}
+
+fn matching_need_statuses(run: &RunRecord, need: &JobId) -> Vec<ExecutionStatus> {
+    matching_need_ids(run, need)
+        .iter()
+        .filter_map(|job_id| run.jobs.get(job_id).copied())
+        .collect()
+}
+
+fn ancestor_statuses(run: &RunRecord, job: &QueuedJob) -> Vec<ExecutionStatus> {
+    let mut pending = job
+        .needs
+        .iter()
+        .flat_map(|need| matching_need_ids(run, need))
+        .collect::<Vec<_>>();
+    let mut visited = std::collections::BTreeSet::new();
+    let mut statuses = Vec::new();
+
+    while let Some(job_id) = pending.pop() {
+        if !visited.insert(job_id.clone()) {
+            continue;
+        }
+        if let Some(status) = run.jobs.get(&job_id) {
+            statuses.push(*status);
+        }
+        if let Some(needs) = run.job_needs.get(&job_id) {
+            pending.extend(needs.iter().flat_map(|need| matching_need_ids(run, need)));
+        }
+    }
+    statuses
+}
+
+fn is_terminal_status(status: ExecutionStatus) -> bool {
+    matches!(
+        status,
+        ExecutionStatus::Success
+            | ExecutionStatus::Failure
+            | ExecutionStatus::Skipped
+            | ExecutionStatus::Cancelled
+    )
 }
 
 /// Check if a job's `runs-on` labels match a runner's registered labels.
@@ -3816,20 +4156,21 @@ fn under_max_parallel(inner: &InnerState, job: &QueuedJob) -> bool {
     active_in_queue + active_running < max_parallel
 }
 
-fn apply_matrix_fail_fast(inner: &mut InnerState, run_id: RunId, failed_job: &JobId) -> usize {
+fn apply_matrix_fail_fast(inner: &mut InnerState, run_id: RunId, failed_job: &JobId) -> Vec<JobId> {
     let Some(run) = inner.runs.get_mut(&run_id) else {
-        return 0;
+        return Vec::new();
     };
     let Some(base_id) = run.job_base_ids.get(failed_job).cloned() else {
-        return 0;
+        return Vec::new();
     };
     if !run.job_fail_fast.get(&base_id).copied().unwrap_or(true) {
-        return 0;
+        return Vec::new();
     }
 
     // Track in-progress siblings: they need a JOB_CANCELLED message so the
     // runner aborts the worker. Queued siblings only need their state flipped
     // — they were never dispatched.
+    let mut cancelled_jobs = Vec::new();
     let mut cancellations = Vec::new();
     for (job_id, status) in &mut run.jobs {
         if job_id != failed_job
@@ -3845,6 +4186,7 @@ fn apply_matrix_fail_fast(inner: &mut InnerState, run_id: RunId, failed_job: &Jo
                     job_id: job_id.clone(),
                 });
             }
+            cancelled_jobs.push(job_id.clone());
             *status = ExecutionStatus::Cancelled;
         }
     }
@@ -3855,9 +4197,8 @@ fn apply_matrix_fail_fast(inner: &mut InnerState, run_id: RunId, failed_job: &Jo
     inner
         .pending_jobs
         .retain(|job| !(job.run_id == run_id && job.base_id == base_id));
-    let count = cancellations.len();
     inner.cancellation_queue.extend(cancellations);
-    count
+    cancelled_jobs
 }
 
 fn hydrate_needs_context(job: &mut QueuedJob, run: &RunRecord) {
@@ -3870,19 +4211,66 @@ fn hydrate_needs_context(job: &mut QueuedJob, run: &RunRecord) {
         .context_data
         .insert("needs".to_owned(), azdo::PipelineContextData::Dict(needs));
 }
+fn needs_json_context(run: &RunRecord, needs: &[JobId]) -> serde_json::Value {
+    let values = needs
+        .iter()
+        .filter_map(|need| {
+            let statuses = matching_need_statuses(run, need);
+            let result = aggregate_need_status(&statuses)?;
+            let matching_ids = matching_need_ids(run, need);
+            let mut outputs = serde_json::Map::new();
+            for job_id in matching_ids {
+                if let Some(job_outputs) = run.job_outputs.get(&job_id) {
+                    outputs.extend(job_outputs.clone());
+                }
+            }
+            Some((
+                need.0.clone(),
+                json!({
+                    "result": status_string(result),
+                    "outputs": outputs,
+                }),
+            ))
+        })
+        .collect();
+    serde_json::Value::Object(values)
+}
+
+fn aggregate_need_status(statuses: &[ExecutionStatus]) -> Option<ExecutionStatus> {
+    if statuses
+        .iter()
+        .any(|status| *status == ExecutionStatus::Failure)
+    {
+        Some(ExecutionStatus::Failure)
+    } else if statuses
+        .iter()
+        .any(|status| *status == ExecutionStatus::Cancelled)
+    {
+        Some(ExecutionStatus::Cancelled)
+    } else if statuses
+        .iter()
+        .any(|status| *status == ExecutionStatus::Skipped)
+    {
+        Some(ExecutionStatus::Skipped)
+    } else if !statuses.is_empty()
+        && statuses
+            .iter()
+            .all(|status| *status == ExecutionStatus::Success)
+    {
+        Some(ExecutionStatus::Success)
+    } else {
+        None
+    }
+}
 
 fn need_context(run: &RunRecord, need: &JobId) -> Option<azdo::PipelineContextData> {
-    let mut result = None;
+    let statuses = matching_need_statuses(run, need);
+    let result = aggregate_need_status(&statuses)?;
     let mut outputs = BTreeMap::new();
-    let matrix_prefix = format!("{} (", need.0);
-
-    for (job_id, status) in &run.jobs {
-        if job_id == need || job_id.0.starts_with(&matrix_prefix) {
-            result = Some(status_string(*status));
-            if let Some(job_outputs) = run.job_outputs.get(job_id) {
-                for (key, value) in job_outputs {
-                    outputs.insert(key.clone(), json_to_context_data(value));
-                }
+    for job_id in matching_need_ids(run, need) {
+        if let Some(job_outputs) = run.job_outputs.get(&job_id) {
+            for (key, value) in job_outputs {
+                outputs.insert(key.clone(), json_to_context_data(value));
             }
         }
     }
@@ -3890,7 +4278,7 @@ fn need_context(run: &RunRecord, need: &JobId) -> Option<azdo::PipelineContextDa
     let mut context = BTreeMap::new();
     context.insert(
         "result".to_owned(),
-        azdo::PipelineContextData::String(result?),
+        azdo::PipelineContextData::String(status_string(result)),
     );
     context.insert(
         "outputs".to_owned(),
@@ -3929,22 +4317,6 @@ fn json_to_context_data(value: &serde_json::Value) -> azdo::PipelineContextData 
         ),
         serde_json::Value::Null => azdo::PipelineContextData::String(String::new()),
     }
-}
-
-fn need_satisfied(run: &RunRecord, need: &JobId) -> bool {
-    let matrix_prefix = format!("{} (", need.0);
-    let mut matched = false;
-
-    for (job_id, status) in &run.jobs {
-        if job_id == need || job_id.0.starts_with(&matrix_prefix) {
-            matched = true;
-            if !matches!(status, ExecutionStatus::Success | ExecutionStatus::Skipped) {
-                return false;
-            }
-        }
-    }
-
-    matched
 }
 
 // ─── Phase E: Timeline, logs, completion ────────────────────────────────────
@@ -4578,7 +4950,14 @@ fn runnerresolve_action(
 
 fn summarize_run(statuses: impl Iterator<Item = ExecutionStatus>) -> ExecutionStatus {
     let statuses = statuses.collect::<Vec<_>>();
-    if statuses
+    if statuses.iter().any(|status| {
+        matches!(
+            status,
+            ExecutionStatus::Queued | ExecutionStatus::InProgress
+        )
+    }) {
+        ExecutionStatus::InProgress
+    } else if statuses
         .iter()
         .any(|status| *status == ExecutionStatus::Failure)
     {
@@ -4588,13 +4967,8 @@ fn summarize_run(statuses: impl Iterator<Item = ExecutionStatus>) -> ExecutionSt
         .any(|status| *status == ExecutionStatus::Cancelled)
     {
         ExecutionStatus::Cancelled
-    } else if statuses
-        .iter()
-        .all(|status| matches!(status, ExecutionStatus::Success | ExecutionStatus::Skipped))
-    {
-        ExecutionStatus::Success
     } else {
-        ExecutionStatus::InProgress
+        ExecutionStatus::Success
     }
 }
 
@@ -6048,6 +6422,18 @@ fn propagate_reusable_outputs(run: &mut RunRecord) {
 }
 
 #[cfg(test)]
+/// Production-path DAG/workflow properties.
+///
+/// Oracle sources:
+/// - `needs`, skipped dependencies, and job-level conditions:
+///   <https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds>.
+/// - status functions: <https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions>.
+/// - runner v2.335.1: `src/Runner.Worker/StepsRunner.cs` and
+///   `src/Runner.Worker/Expressions/{Success,Failure,Cancelled,Always}Function.cs`.
+///
+/// These tests submit YAML through the real parser/router and use only the
+/// explicitly gated internal test API to simulate worker completions. The
+/// oracle compares observable job/run state; it does not copy scheduler code.
 mod tests {
     use axum::body::{to_bytes, Body};
     use axum::http::{Method, Request, StatusCode};
@@ -6056,6 +6442,11 @@ mod tests {
     use tower::ServiceExt;
 
     use super::*;
+    const TEST_API_TOKEN: &str = "property-test-token";
+
+    fn app(state: AppState, shutdown: CancellationToken) -> Router {
+        app_with_test_api(state, shutdown, TEST_API_TOKEN)
+    }
 
     #[tokio::test]
     async fn matrix_max_parallel_and_fail_fast_are_enforced() {
@@ -6097,7 +6488,7 @@ jobs:
         request_json(
             &app,
             Method::POST,
-            "/api/v1/jobs/complete",
+            "/internal/test/jobs/complete",
             json!({
                 "run_id": run_id,
                 "job_id": first_job,
@@ -6643,7 +7034,7 @@ jobs:
         request_json(
             &app,
             Method::POST,
-            "/api/v1/jobs/complete",
+            "/internal/test/jobs/complete",
             json!({
                 "run_id": run_id,
                 "job_id": failing_job,
@@ -6702,7 +7093,7 @@ jobs:
         request_json(
             &app,
             Method::POST,
-            "/api/v1/jobs/complete",
+            "/internal/test/jobs/complete",
             json!({
                 "run_id": run_id,
                 "job_id": "build",
@@ -6799,7 +7190,7 @@ jobs:
         request_json(
             &app,
             Method::POST,
-            "/api/v1/jobs/complete",
+            "/internal/test/jobs/complete",
             json!({
                 "run_id": run_id,
                 "job_id": "build",
@@ -6863,7 +7254,7 @@ jobs:
         request_json(
             &app,
             Method::POST,
-            "/api/v1/jobs/complete",
+            "/internal/test/jobs/complete",
             json!({
                 "run_id": run_id,
                 "job_id": "build",
@@ -6919,7 +7310,7 @@ jobs:
         request_json(
             &app,
             Method::POST,
-            "/api/v1/jobs/complete",
+            "/internal/test/jobs/complete",
             json!({
                 "run_id": run_id,
                 "job_id": "producer",
@@ -7033,7 +7424,7 @@ jobs:
         request_json(
             &app,
             Method::POST,
-            "/api/v1/jobs/complete",
+            "/internal/test/jobs/complete",
             json!({
                 "run_id": run_id,
                 "job_id": failing_job,
@@ -7391,7 +7782,7 @@ jobs:
         let session = request_json(
             &app,
             Method::POST,
-            "/api/v1/runners/sessions",
+            "/internal/test/runners/sessions",
             json!({"runner_id": runner_id, "name": "local"}),
         )
         .await;
@@ -7427,7 +7818,7 @@ jobs:
         let session = request_json(
             &app,
             Method::POST,
-            "/api/v1/runners/sessions",
+            "/internal/test/runners/sessions",
             json!({"runner_id": runner_id, "name": "local"}),
         )
         .await;
@@ -8388,7 +8779,7 @@ jobs:
         let session = request_json(
             &app,
             Method::POST,
-            "/api/v1/runners/sessions",
+            "/internal/test/runners/sessions",
             json!({"runner_id": 1, "name": "local"}),
         )
         .await;
@@ -8419,7 +8810,9 @@ jobs:
         let message = request_json(
             &app,
             Method::GET,
-            &format!("/api/v1/runners/sessions/{session_id}/messages?sessionId={session_id}"),
+            &format!(
+                "/internal/test/runners/sessions/{session_id}/messages?sessionId={session_id}"
+            ),
             Value::Null,
         )
         .await;
@@ -8626,6 +9019,8 @@ jobs:
                 || uri.starts_with("/twirp/")
             {
                 builder = builder.header(header::AUTHORIZATION, "Bearer aksh-system-token");
+            } else if uri.starts_with("/internal/test/") {
+                builder = builder.header(header::AUTHORIZATION, format!("Bearer {TEST_API_TOKEN}"));
             } else if uri.starts_with("/api/v3/actions/runner-registration") {
                 builder =
                     builder.header(header::AUTHORIZATION, "RemoteAuth aksh-registration-token");
@@ -8681,7 +9076,7 @@ jobs:
         let (s, sess) = try_req(
             &app,
             Method::POST,
-            "/api/v1/runners/sessions",
+            "/internal/test/runners/sessions",
             json!({"runner_id": runner_id, "name": "test-runner"}),
         )
         .await;
@@ -8699,7 +9094,7 @@ jobs:
             &app,
             Method::GET,
             &format!(
-                "/api/v1/runners/sessions/{}/messages?sessionId={}&waitSeconds=0",
+                "/internal/test/runners/sessions/{}/messages?sessionId={}&waitSeconds=0",
                 session_id, session_id
             ),
             Value::Null,
@@ -8717,7 +9112,7 @@ jobs:
         let (s, _) = try_req(
             &app,
             Method::POST,
-            "/api/v1/jobs/complete",
+            "/internal/test/jobs/complete",
             json!({"run_id": run_id, "job_id": job_id, "status": "success"}),
         )
         .await;
@@ -8743,6 +9138,8 @@ jobs:
             || uri.starts_with("/twirp/")
         {
             builder = builder.header(header::AUTHORIZATION, "Bearer aksh-system-token");
+        } else if uri.starts_with("/internal/test/") {
+            builder = builder.header(header::AUTHORIZATION, format!("Bearer {TEST_API_TOKEN}"));
         } else if uri.starts_with("/api/v3/actions/runner-registration") {
             builder = builder.header(header::AUTHORIZATION, "RemoteAuth aksh-registration-token");
         }
@@ -8755,12 +9152,14 @@ jobs:
                 .unwrap()
         };
         let response = app.clone().oneshot(request).await.unwrap();
-        assert!(
-            response.status().is_success(),
-            "unexpected status: {}",
-            response.status()
-        );
+        let status = response.status();
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        assert!(
+            status.is_success(),
+            "unexpected status: {} body={}",
+            status,
+            String::from_utf8_lossy(&bytes)
+        );
         if bytes.is_empty() {
             Value::Null
         } else {
@@ -9338,5 +9737,617 @@ jobs:
     #[test]
     fn label_matching_empty_job_matches_all() {
         assert!(job_matches_runner(&[], &["self-hosted".into()]));
+    }
+
+    // Oracle: GitHub `needs` and status-function contracts, with worker-side
+    // condition semantics pinned to actions/runner v2.335.1. These tests are
+    // production-path checks: YAML is parsed and expanded by Aksh, then the
+    // real queue/promotion state is driven through the explicitly gated test
+    // completion API and compared with the documented outcome.
+    // ─── DAG scheduling regression tests (spec §1) ─────────────────────────
+
+    /// Production path: build fails → test with default condition is skipped.
+    /// Verifies the server's promote_ready_jobs correctly propagates failure.
+    #[tokio::test]
+    async fn dag_build_fails_test_skipped_production() {
+        let temp = tempfile::tempdir().unwrap();
+        let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+        let app = app(state.clone(), CancellationToken::new());
+
+        let accepted = request_json(
+            &app,
+            Method::POST,
+            "/api/v1/runs",
+            json!({
+                "workflow_yaml": r#"
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+  test:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo test
+"#,
+                "event": "push",
+                "repository": "owner/repo"
+            }),
+        )
+        .await;
+        let run_id: RunId = accepted["run_id"].as_str().unwrap().parse().unwrap();
+
+        request_json(
+            &app,
+            Method::POST,
+            "/internal/test/jobs/complete",
+            json!({
+                "run_id": run_id,
+                "job_id": "build",
+                "status": "failure"
+            }),
+        )
+        .await;
+
+        let inner = state.inner.lock().await;
+        let run = inner.runs.get(&run_id).unwrap();
+        assert_eq!(
+            run.jobs.get(&JobId("build".to_owned())),
+            Some(&ExecutionStatus::Failure)
+        );
+        assert_eq!(
+            run.jobs.get(&JobId("test".to_owned())),
+            Some(&ExecutionStatus::Skipped),
+            "test must be skipped when build fails under default gate"
+        );
+        // No new jobs should have been promoted to queue
+        assert!(
+            !inner.queue.iter().any(|j| j.job_id.0 == "test"),
+            "test must not be in queue"
+        );
+        assert!(inner.pending_jobs.is_empty(), "no jobs should be pending");
+    }
+
+    /// Production path: build fails → cleanup with `if: always()` runs.
+    #[tokio::test]
+    async fn dag_always_runs_after_failure_production() {
+        let temp = tempfile::tempdir().unwrap();
+        let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+        let app = app(state.clone(), CancellationToken::new());
+
+        let accepted = request_json(
+            &app,
+            Method::POST,
+            "/api/v1/runs",
+            json!({
+                "workflow_yaml": r#"
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+  cleanup:
+    needs: [build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo cleanup
+"#,
+                "event": "push",
+                "repository": "owner/repo"
+            }),
+        )
+        .await;
+        let run_id: RunId = accepted["run_id"].as_str().unwrap().parse().unwrap();
+
+        request_json(
+            &app,
+            Method::POST,
+            "/internal/test/jobs/complete",
+            json!({
+                "run_id": run_id,
+                "job_id": "build",
+                "status": "failure"
+            }),
+        )
+        .await;
+
+        let inner = state.inner.lock().await;
+        assert!(
+            inner.queue.iter().any(|job| job.job_id.0 == "cleanup"),
+            "cleanup with always() must be promoted after build failure"
+        );
+    }
+
+    /// Production path: build fails → notify with `if: failure()` runs.
+    #[tokio::test]
+    async fn dag_failure_condition_runs_after_failure_production() {
+        let temp = tempfile::tempdir().unwrap();
+        let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+        let app = app(state.clone(), CancellationToken::new());
+
+        let accepted = request_json(
+            &app,
+            Method::POST,
+            "/api/v1/runs",
+            json!({
+                "workflow_yaml": r#"
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+  notify:
+    needs: [build]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo notify
+"#,
+                "event": "push",
+                "repository": "owner/repo"
+            }),
+        )
+        .await;
+        let run_id: RunId = accepted["run_id"].as_str().unwrap().parse().unwrap();
+
+        request_json(
+            &app,
+            Method::POST,
+            "/internal/test/jobs/complete",
+            json!({
+                "run_id": run_id,
+                "job_id": "build",
+                "status": "failure"
+            }),
+        )
+        .await;
+
+        let inner = state.inner.lock().await;
+        assert!(
+            inner.queue.iter().any(|job| job.job_id.0 == "notify"),
+            "notify with failure() must be promoted after build failure"
+        );
+    }
+
+    /// Production path: diamond graph build → test-a/test-b → deploy.
+    /// All succeed → deploy runs → run completes successfully.
+    #[tokio::test]
+    async fn dag_diamond_settlement_production() {
+        let temp = tempfile::tempdir().unwrap();
+        let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+        let app = app(state.clone(), CancellationToken::new());
+
+        let accepted = request_json(
+            &app,
+            Method::POST,
+            "/api/v1/runs",
+            json!({
+                "workflow_yaml": r#"
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+  test-a:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo test-a
+  test-b:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo test-b
+  deploy:
+    needs: [test-a, test-b]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo deploy
+"#,
+                "event": "push",
+                "repository": "owner/repo"
+            }),
+        )
+        .await;
+        let run_id: RunId = accepted["run_id"].as_str().unwrap().parse().unwrap();
+
+        // Only build queued initially
+        {
+            let inner = state.inner.lock().await;
+            assert_eq!(inner.queue.len(), 1);
+            assert_eq!(inner.queue[0].job_id.0, "build");
+        }
+
+        // Complete build
+        request_json(
+            &app,
+            Method::POST,
+            "/internal/test/jobs/complete",
+            json!({"run_id": run_id, "job_id": "build", "status": "success"}),
+        )
+        .await;
+
+        // test-a and test-b promoted (build QueuedJob remains until dispatched)
+        {
+            let inner = state.inner.lock().await;
+            let queued_ids: std::collections::BTreeSet<_> =
+                inner.queue.iter().map(|j| j.job_id.0.clone()).collect();
+            assert!(queued_ids.contains("test-a"), "test-a should be promoted");
+            assert!(queued_ids.contains("test-b"), "test-b should be promoted");
+        }
+
+        // Complete test-a and test-b
+        request_json(
+            &app,
+            Method::POST,
+            "/internal/test/jobs/complete",
+            json!({"run_id": run_id, "job_id": "test-a", "status": "success"}),
+        )
+        .await;
+        request_json(
+            &app,
+            Method::POST,
+            "/internal/test/jobs/complete",
+            json!({"run_id": run_id, "job_id": "test-b", "status": "success"}),
+        )
+        .await;
+
+        // deploy promoted (other completed jobs' QueuedJobs may linger)
+        {
+            let inner = state.inner.lock().await;
+            assert!(
+                inner.queue.iter().any(|j| j.job_id.0 == "deploy"),
+                "deploy should be promoted after test-a and test-b complete"
+            );
+        }
+
+        // Complete deploy
+        request_json(
+            &app,
+            Method::POST,
+            "/internal/test/jobs/complete",
+            json!({"run_id": run_id, "job_id": "deploy", "status": "success"}),
+        )
+        .await;
+
+        let inner = state.inner.lock().await;
+        let run = inner.runs.get(&run_id).unwrap();
+        assert_eq!(run.status, ExecutionStatus::Success);
+        assert!(inner.pending_jobs.is_empty());
+    }
+
+    /// Production path: cyclic graph rejected at submission time.
+    #[tokio::test]
+    async fn dag_cyclic_graph_rejected_production() {
+        let temp = tempfile::tempdir().unwrap();
+        let app = app(
+            AppState::new(temp.path().to_path_buf()).await.unwrap(),
+            CancellationToken::new(),
+        );
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/v1/runs")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "workflow_yaml": r#"
+on: push
+jobs:
+  a:
+    needs: [b]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo a
+  b:
+    needs: [a]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo b
+"#,
+                            "event": "push",
+                            "repository": "owner/repo"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.status(),
+            StatusCode::BAD_REQUEST,
+            "cyclic graph must be rejected before dispatch"
+        );
+    }
+
+    /// Production path: duplicate completion does not create a second promotion.
+    #[tokio::test]
+    async fn dag_duplicate_completion_idempotent_production() {
+        let temp = tempfile::tempdir().unwrap();
+        let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+        let app = app(state.clone(), CancellationToken::new());
+
+        let accepted = request_json(
+            &app,
+            Method::POST,
+            "/api/v1/runs",
+            json!({
+                "workflow_yaml": r#"
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+  test:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo test
+"#,
+                "event": "push",
+                "repository": "owner/repo"
+            }),
+        )
+        .await;
+        let run_id: RunId = accepted["run_id"].as_str().unwrap().parse().unwrap();
+
+        // Complete build once
+        request_json(
+            &app,
+            Method::POST,
+            "/internal/test/jobs/complete",
+            json!({"run_id": run_id, "job_id": "build", "status": "success"}),
+        )
+        .await;
+
+        // test should be queued exactly once
+        {
+            let inner = state.inner.lock().await;
+            assert_eq!(
+                inner.queue.iter().filter(|j| j.job_id.0 == "test").count(),
+                1,
+                "test must appear exactly once in queue"
+            );
+        }
+
+        // Complete build again (duplicate)
+        request_json(
+            &app,
+            Method::POST,
+            "/internal/test/jobs/complete",
+            json!({"run_id": run_id, "job_id": "build", "status": "success"}),
+        )
+        .await;
+
+        // test must still appear exactly once
+        {
+            let inner = state.inner.lock().await;
+            assert_eq!(
+                inner.queue.iter().filter(|j| j.job_id.0 == "test").count(),
+                1,
+                "duplicate completion must not create second promotion"
+            );
+        }
+    }
+
+    /// Production path: small structured YAML → parse → expand → server
+    /// submission → promote/complete verifies the full pipeline.
+    #[tokio::test]
+    async fn dag_yaml_parse_expand_server_production() {
+        let yaml = r#"
+on: push
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo lint
+  build:
+    needs: [lint]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+  test:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo test
+  deploy:
+    needs: [test]
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo deploy
+"#;
+        // Verify parser round-trip
+        let workflow = aksh_gha_parser::parse_workflow(yaml).unwrap();
+        let plans = aksh_gha_parser::expand_jobs(&workflow).unwrap();
+        let plan_ids: Vec<_> = plans.iter().map(|p| p.id.0.as_str()).collect();
+        assert!(plan_ids.contains(&"lint"));
+        assert!(plan_ids.contains(&"build"));
+        assert!(plan_ids.contains(&"test"));
+        assert!(plan_ids.contains(&"deploy"));
+
+        // Verify DAG validation passes
+        aksh_gha_parser::dag::validate_job_plans(&plans).unwrap();
+
+        // Run through real server
+        let temp = tempfile::tempdir().unwrap();
+        let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+        let app = app(state.clone(), CancellationToken::new());
+
+        let accepted = request_json(
+            &app,
+            Method::POST,
+            "/api/v1/runs",
+            json!({
+                "workflow_yaml": yaml,
+                "event": "push",
+                "repository": "owner/repo"
+            }),
+        )
+        .await;
+        let run_id: RunId = accepted["run_id"].as_str().unwrap().parse().unwrap();
+
+        // Queued jobs = parser's expanded IDs (lint is root)
+        {
+            let inner = state.inner.lock().await;
+            assert_eq!(inner.queue.len(), 1);
+            assert_eq!(inner.queue[0].job_id.0, "lint");
+        }
+
+        // Walk the chain: lint → build → test → deploy
+        for (job, next_queued) in [
+            ("lint", Some("build")),
+            ("build", Some("test")),
+            ("test", Some("deploy")),
+            ("deploy", None),
+        ] {
+            request_json(
+                &app,
+                Method::POST,
+                "/internal/test/jobs/complete",
+                json!({"run_id": run_id, "job_id": job, "status": "success"}),
+            )
+            .await;
+
+            let inner = state.inner.lock().await;
+            if let Some(next) = next_queued {
+                assert!(
+                    inner.queue.iter().any(|j| j.job_id.0 == next),
+                    "after completing {job}, {next} should be queued"
+                );
+            }
+        }
+
+        // Run is terminal — all jobs completed successfully
+        let inner = state.inner.lock().await;
+        let run = inner.runs.get(&run_id).unwrap();
+        assert_eq!(run.status, ExecutionStatus::Success);
+        assert!(inner.pending_jobs.is_empty());
+        for (job_id, status) in &run.jobs {
+            assert_eq!(
+                *status,
+                ExecutionStatus::Success,
+                "job {} should be Success, got {:?}",
+                job_id.0,
+                status
+            );
+        }
+    }
+    /// Exercises the real parser → queue → completion → dependency-promotion path
+    /// over 1,000 deterministic bounded DAGs.
+    #[tokio::test]
+    async fn generated_server_dag_properties_1000_cases() {
+        fn next(seed: &mut u64) -> u64 {
+            *seed = seed
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            *seed
+        }
+        let temp = tempfile::tempdir().unwrap();
+        let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+        let app = app(state.clone(), CancellationToken::new());
+
+        for case in 0..1_000u64 {
+            let mut seed = 20250713u64 ^ case.wrapping_mul(0x9E37_79B9);
+            let count = 2 + (next(&mut seed) % 4) as usize;
+            let mut needs = vec![Vec::<usize>::new(); count];
+            for job in 1..count {
+                for dependency in 0..job {
+                    if next(&mut seed) & 1 == 1 {
+                        needs[job].push(dependency);
+                    }
+                }
+            }
+            let failed_root = (0..count).find(|job| needs[*job].is_empty()).unwrap();
+
+            let mut yaml = String::from("on: push\njobs:\n");
+            for job in 0..count {
+                yaml.push_str(&format!("  j{job}:\n"));
+                if !needs[job].is_empty() {
+                    yaml.push_str("    needs: [");
+                    for (index, dependency) in needs[job].iter().enumerate() {
+                        if index > 0 {
+                            yaml.push_str(", ");
+                        }
+                        yaml.push_str(&format!("j{dependency}"));
+                    }
+                    yaml.push_str("]\n");
+                }
+                yaml.push_str("    runs-on: ubuntu-latest\n");
+                yaml.push_str("    steps:\n      - run: echo property\n");
+            }
+
+            let accepted = request_json(
+                &app,
+                Method::POST,
+                "/api/v1/runs",
+                json!({
+                    "workflow_yaml": yaml,
+                    "event": "push",
+                    "repository": "property/test"
+                }),
+            )
+            .await;
+            let run_id: RunId = accepted["run_id"].as_str().unwrap().parse().unwrap();
+
+            for _ in 0..=count {
+                let queued = {
+                    let inner = state.inner.lock().await;
+                    inner
+                        .queue
+                        .iter()
+                        .filter(|job| job.run_id == run_id)
+                        .map(|job| job.job_id.0.clone())
+                        .collect::<Vec<_>>()
+                };
+                if queued.is_empty() {
+                    break;
+                }
+                for job_id in queued {
+                    let status = if job_id == format!("j{failed_root}") {
+                        "failure"
+                    } else {
+                        "success"
+                    };
+                    request_json(
+                        &app,
+                        Method::POST,
+                        "/internal/test/jobs/complete",
+                        json!({"run_id": run_id, "job_id": job_id, "status": status}),
+                    )
+                    .await;
+                }
+            }
+
+            let inner = state.inner.lock().await;
+            let run = inner.runs.get(&run_id).unwrap();
+            let mut failed_ancestor = vec![false; count];
+            for job in 0..count {
+                failed_ancestor[job] = job == failed_root
+                    || needs[job]
+                        .iter()
+                        .any(|dependency| failed_ancestor[*dependency]);
+                let expected = if job == failed_root {
+                    ExecutionStatus::Failure
+                } else if failed_ancestor[job] {
+                    ExecutionStatus::Skipped
+                } else {
+                    ExecutionStatus::Success
+                };
+                assert_eq!(run.jobs[&JobId(format!("j{job}"))], expected, "case {case}");
+            }
+        }
     }
 }

--- a/crates/aksh-runner-server/src/main.rs
+++ b/crates/aksh-runner-server/src/main.rs
@@ -36,6 +36,12 @@ enum Command {
         /// Generate an ephemeral self-signed cert (local dev only).
         #[arg(long, conflicts_with = "tls_cert")]
         tls_self_signed: bool,
+        /// Enable privileged local/CI simulation endpoints (loopback only).
+        #[arg(long)]
+        enable_test_api: bool,
+        /// Bearer token for privileged simulation endpoints.
+        #[arg(long, requires = "enable_test_api")]
+        test_api_token: Option<String>,
     },
     /// Generate a persistent self-signed TLS certificate (no openssl needed).
     Cert {
@@ -82,6 +88,8 @@ async fn main() -> anyhow::Result<()> {
             tls_cert,
             tls_key,
             tls_self_signed,
+            enable_test_api,
+            test_api_token,
         } => {
             let tls = match (tls_cert, tls_key, tls_self_signed) {
                 (Some(cert), Some(key), false) => TlsMode::PemFiles { cert, key },
@@ -94,6 +102,8 @@ async fn main() -> anyhow::Result<()> {
                 state_dir,
                 record_flows,
                 tls,
+                enable_test_api,
+                test_api_token,
             })
             .await?;
         }

--- a/crates/aksh-runner-server/src/scheduling.rs
+++ b/crates/aksh-runner-server/src/scheduling.rs
@@ -1,0 +1,1418 @@
+//! Pure job-graph scheduler model.
+//!
+//! Mirrors official GitHub Actions dispatch rules for `needs` and matrix
+//! fan-out so property tests can exercise thousands of graphs without HTTP.
+//!
+//! Oracle sources (pinned where source code is used):
+//! - Workflow contract: <https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds>.
+//! - Status functions: <https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions>.
+//! - Runner v2.335.1 condition implementation:
+//!   `src/Runner.Worker/StepsRunner.cs`,
+//!   `src/Runner.Worker/Expressions/SuccessFunction.cs`,
+//!   `src/Runner.Worker/Expressions/FailureFunction.cs`,
+//!   `src/Runner.Worker/Expressions/CancelledFunction.cs`, and
+//!   `src/Runner.Worker/Expressions/AlwaysFunction.cs`.
+//!
+//! Properties below encode these observable rules:
+//! - A dependent waits until every needed job is terminal.
+//! - Failed or skipped dependencies skip a default dependent; explicit
+//!   `always()`, `failure()`, or `cancelled()` conditions may override that.
+//! - `failure()` observes failures in the transitive needs ancestry.
+//! - Matrix siblings share a base id; needing `build` waits for every
+//!   expanded `build (...)` sibling and respects `max-parallel`.
+//! - Cycles and unknown needs are invalid and must be rejected before dispatch.
+//! - A job is never dispatched twice; promotion is deterministic given a
+//!   stable pending order; terminal statuses do not regress.
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use aksh_gha_protocol::{ExecutionStatus, JobId};
+
+/// One schedulable job node after matrix expansion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchedJob {
+    /// Expanded job id (`build (ubuntu, 20)` or plain `build`).
+    pub id: JobId,
+    /// Workflow job id before matrix suffixing.
+    pub base_id: String,
+    /// Declared `needs` (base or expanded ids).
+    pub needs: Vec<JobId>,
+    /// Optional matrix max-parallel for this base id.
+    pub max_parallel: Option<u64>,
+    /// Job-level condition expression, if any.
+    pub if_condition: Option<String>,
+}
+
+/// Mutable scheduler snapshot for one workflow run.
+#[derive(Debug, Clone, Default)]
+pub struct SchedulerState {
+    /// Terminal/non-terminal status per expanded job id.
+    pub jobs: BTreeMap<JobId, ExecutionStatus>,
+    /// Expanded id → base id.
+    pub job_base_ids: BTreeMap<JobId, String>,
+    /// Expanded id → declared dependency ids.
+    pub job_needs: BTreeMap<JobId, Vec<JobId>>,
+    /// Jobs waiting on dependencies (stable insertion order).
+    pub pending: VecDeque<SchedJob>,
+    /// Jobs ready for runner acquisition (stable FIFO).
+    pub queue: VecDeque<SchedJob>,
+}
+
+/// Error when a needs graph is not a DAG.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CycleError {
+    /// One job id participating in a cycle (representative).
+    pub witness: String,
+}
+
+/// Detect a cycle in a needs graph.
+///
+/// `edges` maps job id → list of needed job ids.
+/// Returns `Ok(())` when acyclic, else a witness job id on a cycle.
+pub fn detect_needs_cycle(edges: &BTreeMap<String, Vec<String>>) -> Result<(), CycleError> {
+    #[derive(Clone, Copy, PartialEq, Eq)]
+    enum Color {
+        White,
+        Gray,
+        Black,
+    }
+
+    let mut color: BTreeMap<&str, Color> =
+        edges.keys().map(|k| (k.as_str(), Color::White)).collect();
+    // Also color referenced nodes that may be missing as keys.
+    for deps in edges.values() {
+        for d in deps {
+            color.entry(d.as_str()).or_insert(Color::White);
+        }
+    }
+
+    fn visit<'a>(
+        node: &'a str,
+        edges: &'a BTreeMap<String, Vec<String>>,
+        color: &mut BTreeMap<&'a str, Color>,
+    ) -> Result<(), CycleError> {
+        color.insert(node, Color::Gray);
+        if let Some(deps) = edges.get(node) {
+            for dep in deps {
+                match color.get(dep.as_str()).copied().unwrap_or(Color::White) {
+                    Color::Gray => {
+                        return Err(CycleError {
+                            witness: dep.clone(),
+                        });
+                    }
+                    Color::White => visit(dep.as_str(), edges, color)?,
+                    Color::Black => {}
+                }
+            }
+        }
+        color.insert(node, Color::Black);
+        Ok(())
+    }
+
+    let nodes: Vec<&str> = color.keys().copied().collect();
+    for node in nodes {
+        if color.get(node) == Some(&Color::White) {
+            visit(node, edges, &mut color)?;
+        }
+    }
+    Ok(())
+}
+
+/// Whether a single `needs` entry completed successfully.
+///
+/// The need may name a concrete expanded id or a base id matching matrix
+/// siblings. Every match must be successful and at least one match is required.
+/// A skipped need does not satisfy GitHub's default dependency condition.
+pub fn need_satisfied(jobs: &BTreeMap<JobId, ExecutionStatus>, need: &JobId) -> bool {
+    let statuses = matching_need_statuses(jobs, need);
+    !statuses.is_empty()
+        && statuses
+            .iter()
+            .all(|status| *status == ExecutionStatus::Success)
+}
+
+fn matching_need_statuses(
+    jobs: &BTreeMap<JobId, ExecutionStatus>,
+    need: &JobId,
+) -> Vec<ExecutionStatus> {
+    let matrix_prefix = format!("{} (", need.0);
+    jobs.iter()
+        .filter_map(|(job_id, status)| {
+            (job_id == need || job_id.0.starts_with(&matrix_prefix)).then_some(*status)
+        })
+        .collect()
+}
+
+fn matching_need_ids(state: &SchedulerState, need: &JobId) -> Vec<JobId> {
+    state
+        .jobs
+        .keys()
+        .filter(|job_id| {
+            *job_id == need
+                || state
+                    .job_base_ids
+                    .get(*job_id)
+                    .is_some_and(|base| base == &need.0)
+        })
+        .cloned()
+        .collect()
+}
+
+fn state_need_statuses(state: &SchedulerState, need: &JobId) -> Vec<ExecutionStatus> {
+    matching_need_ids(state, need)
+        .iter()
+        .filter_map(|job_id| state.jobs.get(job_id).copied())
+        .collect()
+}
+
+fn ancestor_statuses(state: &SchedulerState, job: &SchedJob) -> Vec<ExecutionStatus> {
+    let mut pending = job
+        .needs
+        .iter()
+        .flat_map(|need| matching_need_ids(state, need))
+        .collect::<Vec<_>>();
+    let mut visited = BTreeSet::new();
+    let mut statuses = Vec::new();
+    while let Some(job_id) = pending.pop() {
+        if !visited.insert(job_id.clone()) {
+            continue;
+        }
+        if let Some(status) = state.jobs.get(&job_id) {
+            statuses.push(*status);
+        }
+        if let Some(needs) = state.job_needs.get(&job_id) {
+            pending.extend(needs.iter().flat_map(|need| matching_need_ids(state, need)));
+        }
+    }
+    statuses
+}
+
+fn aggregate_status(statuses: &[ExecutionStatus]) -> ExecutionStatus {
+    if statuses
+        .iter()
+        .any(|status| *status == ExecutionStatus::Failure)
+    {
+        ExecutionStatus::Failure
+    } else if statuses
+        .iter()
+        .any(|status| *status == ExecutionStatus::Cancelled)
+    {
+        ExecutionStatus::Cancelled
+    } else if statuses
+        .iter()
+        .any(|status| *status == ExecutionStatus::Skipped)
+    {
+        ExecutionStatus::Skipped
+    } else {
+        ExecutionStatus::Success
+    }
+}
+
+fn terminal(status: ExecutionStatus) -> bool {
+    matches!(
+        status,
+        ExecutionStatus::Success
+            | ExecutionStatus::Failure
+            | ExecutionStatus::Skipped
+            | ExecutionStatus::Cancelled
+    )
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DependencyDecision {
+    Wait,
+    Run,
+    Skip,
+}
+
+fn dependency_decision(state: &SchedulerState, job: &SchedJob) -> DependencyDecision {
+    if job.needs.is_empty() {
+        return DependencyDecision::Run;
+    }
+    let direct_statuses = job
+        .needs
+        .iter()
+        .flat_map(|need| state_need_statuses(state, need))
+        .collect::<Vec<_>>();
+    if direct_statuses.is_empty() || direct_statuses.iter().any(|status| !terminal(*status)) {
+        return DependencyDecision::Wait;
+    }
+
+    let statuses = ancestor_statuses(state, job);
+    let aggregate = aggregate_status(&statuses);
+    let success = aggregate == ExecutionStatus::Success;
+    let failure = aggregate == ExecutionStatus::Failure;
+    let cancelled = aggregate == ExecutionStatus::Cancelled;
+    let condition = aksh_gha_expressions::effective_condition(job.if_condition.as_deref());
+    let context = aksh_gha_expressions::Context::default().with_status(success, failure, cancelled);
+    match aksh_gha_expressions::eval_bool(&condition, &context) {
+        Ok(true) => DependencyDecision::Run,
+        Ok(false) | Err(_) => DependencyDecision::Skip,
+    }
+}
+
+/// Whether `job` is under its matrix `max-parallel` budget.
+pub fn under_max_parallel(state: &SchedulerState, job: &SchedJob) -> bool {
+    let Some(max_parallel) = job.max_parallel else {
+        return true;
+    };
+    let active_in_queue = state
+        .queue
+        .iter()
+        .filter(|queued| queued.base_id == job.base_id)
+        .count() as u64;
+    let active_running = state
+        .jobs
+        .iter()
+        .filter(|(job_id, status)| {
+            state.job_base_ids.get(*job_id) == Some(&job.base_id)
+                && matches!(status, ExecutionStatus::InProgress)
+        })
+        .count() as u64;
+
+    active_in_queue + active_running < max_parallel
+}
+
+/// Resolve pending jobs whose dependencies have become terminal.
+///
+/// Runnable jobs enter the FIFO queue. Jobs whose condition is false become
+/// terminal `Skipped`. The pass repeats after skips so downstream chains settle.
+/// Returns the number of jobs promoted to the queue.
+pub fn promote_ready_jobs(state: &mut SchedulerState) -> usize {
+    let mut promoted_count = 0;
+    loop {
+        let mut promoted_by_base: BTreeMap<String, u64> = BTreeMap::new();
+        let mut promoted = Vec::new();
+        let mut remaining = VecDeque::new();
+        let mut skipped = false;
+
+        while let Some(job) = state.pending.pop_front() {
+            match dependency_decision(state, &job) {
+                DependencyDecision::Run
+                    if under_max_parallel(state, &job)
+                        && promoted_by_base.get(&job.base_id).copied().unwrap_or(0)
+                            < job.max_parallel.unwrap_or(u64::MAX) =>
+                {
+                    *promoted_by_base.entry(job.base_id.clone()).or_default() += 1;
+                    promoted.push(job)
+                }
+                DependencyDecision::Skip => {
+                    state.jobs.insert(job.id, ExecutionStatus::Skipped);
+                    skipped = true;
+                }
+                DependencyDecision::Wait | DependencyDecision::Run => remaining.push_back(job),
+            }
+        }
+
+        promoted_count += promoted.len();
+        state.pending = remaining;
+        state.queue.extend(promoted);
+        if !skipped {
+            return promoted_count;
+        }
+    }
+}
+
+/// Seed a scheduler from expanded job definitions.
+///
+/// Jobs with empty `needs` enter the queue immediately; others stay pending.
+/// All jobs start as `Queued`.
+pub fn seed_from_jobs(jobs: Vec<SchedJob>) -> SchedulerState {
+    let mut state = SchedulerState::default();
+    for job in jobs {
+        if state.jobs.contains_key(&job.id) {
+            continue;
+        }
+        state.jobs.insert(job.id.clone(), ExecutionStatus::Queued);
+        state
+            .job_base_ids
+            .insert(job.id.clone(), job.base_id.clone());
+        state.job_needs.insert(job.id.clone(), job.needs.clone());
+        if job.needs.is_empty() {
+            state.queue.push_back(job);
+        } else {
+            state.pending.push_back(job);
+        }
+    }
+    state
+}
+
+/// Mark a job terminal and re-run promotion.
+pub fn complete_job(state: &mut SchedulerState, job_id: &JobId, status: ExecutionStatus) -> usize {
+    let Some(current) = state.jobs.get_mut(job_id) else {
+        return 0;
+    };
+    if terminal(*current) {
+        return 0;
+    }
+    *current = status;
+    state.queue.retain(|job| &job.id != job_id);
+    state.pending.retain(|job| &job.id != job_id);
+    promote_ready_jobs(state)
+}
+
+/// Simulate dispatch: move the front queued job to `InProgress` and return it.
+pub fn acquire_next(state: &mut SchedulerState) -> Option<SchedJob> {
+    let job = state.queue.pop_front()?;
+    if let Some(slot) = state.jobs.get_mut(&job.id) {
+        *slot = ExecutionStatus::InProgress;
+    }
+    Some(job)
+}
+
+/// True when every job is in a terminal status.
+pub fn run_settled(state: &SchedulerState) -> bool {
+    state.jobs.values().all(|s| {
+        matches!(
+            s,
+            ExecutionStatus::Success
+                | ExecutionStatus::Failure
+                | ExecutionStatus::Skipped
+                | ExecutionStatus::Cancelled
+        )
+    }) && state.pending.is_empty()
+        && state.queue.is_empty()
+}
+
+/// Jobs currently `InProgress`.
+pub fn in_progress_ids(state: &SchedulerState) -> BTreeSet<JobId> {
+    state
+        .jobs
+        .iter()
+        .filter_map(|(id, status)| {
+            matches!(status, ExecutionStatus::InProgress).then(|| id.clone())
+        })
+        .collect()
+}
+
+/// Count how many times a job id appears across queue + pending (must be ≤ 1).
+pub fn placement_count(state: &SchedulerState, job_id: &JobId) -> usize {
+    state.queue.iter().filter(|j| &j.id == job_id).count()
+        + state.pending.iter().filter(|j| &j.id == job_id).count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use proptest::test_runner::RngSeed;
+
+    /// Deterministic proptest config for DAG scheduler tests.
+    /// Fixed seed ensures reproducibility; failure persistence and verbose
+    /// reporting preserve/report the seed on failure (docs/property-tests.md §Common).
+    fn dag_config(cases: u32) -> ProptestConfig {
+        ProptestConfig {
+            cases,
+            rng_seed: RngSeed::Fixed(20250713),
+            verbose: 1,
+            ..ProptestConfig::default()
+        }
+    }
+
+    fn jid(s: &str) -> JobId {
+        JobId(s.to_owned())
+    }
+
+    #[test]
+    fn linear_needs_promotes_in_order() {
+        let jobs = vec![
+            SchedJob {
+                id: jid("a"),
+                base_id: "a".into(),
+                needs: vec![],
+                max_parallel: None,
+                if_condition: None,
+            },
+            SchedJob {
+                id: jid("b"),
+                base_id: "b".into(),
+                needs: vec![jid("a")],
+                max_parallel: None,
+                if_condition: None,
+            },
+            SchedJob {
+                id: jid("c"),
+                base_id: "c".into(),
+                needs: vec![jid("b")],
+                max_parallel: None,
+                if_condition: None,
+            },
+        ];
+        let mut state = seed_from_jobs(jobs);
+        assert_eq!(state.queue.len(), 1);
+        let a = acquire_next(&mut state).unwrap();
+        assert_eq!(a.id.0, "a");
+        complete_job(&mut state, &jid("a"), ExecutionStatus::Success);
+        let b = acquire_next(&mut state).unwrap();
+        assert_eq!(b.id.0, "b");
+        complete_job(&mut state, &jid("b"), ExecutionStatus::Success);
+        let c = acquire_next(&mut state).unwrap();
+        assert_eq!(c.id.0, "c");
+    }
+
+    /// Official: failed dependency causes dependent to be skipped under the
+    /// default `success()` gate — it must NOT stay pending forever.
+    #[test]
+    fn failed_need_skips_dependent() {
+        let jobs = vec![
+            SchedJob {
+                id: jid("a"),
+                base_id: "a".into(),
+                needs: vec![],
+                max_parallel: None,
+                if_condition: None,
+            },
+            SchedJob {
+                id: jid("b"),
+                base_id: "b".into(),
+                needs: vec![jid("a")],
+                max_parallel: None,
+                if_condition: None,
+            },
+        ];
+        let mut state = seed_from_jobs(jobs);
+        acquire_next(&mut state);
+        complete_job(&mut state, &jid("a"), ExecutionStatus::Failure);
+        assert!(state.queue.is_empty(), "dependent must not be queued");
+        assert!(state.pending.is_empty(), "dependent must not stay pending");
+        assert_eq!(
+            state.jobs.get(&jid("b")).copied(),
+            Some(ExecutionStatus::Skipped),
+            "dependent must be skipped when need failed under default gate"
+        );
+    }
+
+    /// Official: `need_satisfied` uses the strict Success-only check.
+    /// Skipped does NOT satisfy the default dependency gate — instead the
+    /// scheduler evaluates `success()` via the full ancestor chain which
+    /// considers skipped ancestors as non-success, causing the dependent to
+    /// skip under the default condition.
+    #[test]
+    fn skipped_need_does_not_satisfy_success_gate() {
+        let mut jobs_map = BTreeMap::new();
+        jobs_map.insert(jid("a"), ExecutionStatus::Skipped);
+        assert!(
+            !need_satisfied(&jobs_map, &jid("a")),
+            "Skipped is not Success — need_satisfied must return false"
+        );
+    }
+
+    /// Official: skipped dependency causes dependent to be skipped under the
+    /// default gate (skipped is not success in the ancestor chain).
+    #[test]
+    fn skipped_need_skips_dependent() {
+        let jobs = vec![
+            SchedJob {
+                id: jid("build"),
+                base_id: "build".into(),
+                needs: vec![],
+                max_parallel: None,
+                if_condition: None,
+            },
+            SchedJob {
+                id: jid("test"),
+                base_id: "test".into(),
+                needs: vec![jid("build")],
+                max_parallel: None,
+                if_condition: None,
+            },
+        ];
+        let mut state = seed_from_jobs(jobs);
+        acquire_next(&mut state);
+        complete_job(&mut state, &jid("build"), ExecutionStatus::Skipped);
+        assert!(state.queue.is_empty());
+        assert!(state.pending.is_empty());
+        assert_eq!(
+            state.jobs.get(&jid("test")).copied(),
+            Some(ExecutionStatus::Skipped),
+            "dependent must be skipped when need was skipped"
+        );
+    }
+
+    #[test]
+    fn matrix_prefix_need_requires_all_siblings() {
+        let mut jobs_map = BTreeMap::new();
+        jobs_map.insert(jid("build (1)"), ExecutionStatus::Success);
+        jobs_map.insert(jid("build (2)"), ExecutionStatus::InProgress);
+        assert!(!need_satisfied(&jobs_map, &jid("build")));
+        jobs_map.insert(jid("build (2)"), ExecutionStatus::Success);
+        assert!(need_satisfied(&jobs_map, &jid("build")));
+    }
+
+    #[test]
+    fn cycle_detection_finds_loop() {
+        let mut edges = BTreeMap::new();
+        edges.insert("a".into(), vec!["b".into()]);
+        edges.insert("b".into(), vec!["c".into()]);
+        edges.insert("c".into(), vec!["a".into()]);
+        assert!(detect_needs_cycle(&edges).is_err());
+    }
+
+    #[test]
+    fn cycle_detection_accepts_dag() {
+        let mut edges = BTreeMap::new();
+        edges.insert("a".into(), vec![]);
+        edges.insert("b".into(), vec!["a".into()]);
+        edges.insert("c".into(), vec!["a".into(), "b".into()]);
+        assert!(detect_needs_cycle(&edges).is_ok());
+    }
+
+    /// Generate a random DAG over `n` nodes by only allowing edges i → j with j < i.
+    fn arb_dag(n: usize) -> impl Strategy<Value = Vec<SchedJob>> {
+        // Bitmask per node selecting a subset of lower-index dependencies.
+        proptest::collection::vec(any::<u8>(), n..=n).prop_map(move |masks| {
+            (0..n)
+                .map(|i| {
+                    let mut needs = Vec::new();
+                    if i > 0 {
+                        let mut seen = BTreeSet::new();
+                        for d in 0..i {
+                            if masks[i] & (1u8 << (d % 8)) != 0 && seen.insert(d) {
+                                needs.push(jid(&format!("j{d}")));
+                            }
+                        }
+                    }
+                    SchedJob {
+                        id: jid(&format!("j{i}")),
+                        base_id: format!("j{i}"),
+                        needs,
+                        max_parallel: None,
+                        if_condition: None,
+                    }
+                })
+                .collect()
+        })
+    }
+
+    /// Golden needs-dag fixture: build → test → deploy promotion order.
+    #[test]
+    fn golden_needs_dag_promotes_in_dependency_order() {
+        let jobs = vec![
+            SchedJob {
+                id: jid("build"),
+                base_id: "build".into(),
+                needs: vec![],
+                max_parallel: None,
+                if_condition: None,
+            },
+            SchedJob {
+                id: jid("test"),
+                base_id: "test".into(),
+                needs: vec![jid("build")],
+                max_parallel: None,
+                if_condition: None,
+            },
+            SchedJob {
+                id: jid("deploy"),
+                base_id: "deploy".into(),
+                needs: vec![jid("build"), jid("test")],
+                max_parallel: None,
+                if_condition: None,
+            },
+        ];
+        let mut state = seed_from_jobs(jobs);
+        assert_eq!(acquire_next(&mut state).unwrap().id.0, "build");
+        complete_job(&mut state, &jid("build"), ExecutionStatus::Success);
+        assert_eq!(acquire_next(&mut state).unwrap().id.0, "test");
+        complete_job(&mut state, &jid("test"), ExecutionStatus::Success);
+        assert_eq!(acquire_next(&mut state).unwrap().id.0, "deploy");
+    }
+
+    // Oracle: GitHub `jobs.<job_id>.needs` contract (workflow syntax URL in
+    // the module docs). These properties cover placement uniqueness, waiting
+    // for terminal dependencies, deterministic FIFO promotion, successful
+    // settlement, and terminal skip propagation.
+    //
+    // The cycle property below additionally cross-checks the implementation
+    // against an independent DFS reference; it is not an official algorithm
+    // claim.
+    proptest! {
+        #![proptest_config(dag_config(10_000))]
+
+        /// No job is ever present in both queue and pending, or twice in either.
+        #[test]
+        fn no_duplicate_placement(jobs in arb_dag(6)) {
+            let mut state = seed_from_jobs(jobs.clone());
+            // Complete roots successfully in waves until settled or stuck.
+            for _ in 0..32 {
+                while let Some(job) = acquire_next(&mut state) {
+                    complete_job(&mut state, &job.id, ExecutionStatus::Success);
+                }
+                if state.pending.is_empty() && state.queue.is_empty() {
+                    break;
+                }
+                // If still pending with empty queue, nothing more can promote.
+                if state.queue.is_empty() {
+                    break;
+                }
+            }
+            for job in &jobs {
+                prop_assert!(
+                    placement_count(&state, &job.id) <= 1,
+                    "job {} placed more than once",
+                    job.id.0
+                );
+            }
+        }
+
+        /// Completing every job as Success eventually settles an acyclic graph.
+        #[test]
+        fn success_wave_settles_dag(jobs in arb_dag(5)) {
+            let mut edges = BTreeMap::new();
+            for job in &jobs {
+                edges.insert(
+                    job.id.0.clone(),
+                    job.needs.iter().map(|n| n.0.clone()).collect(),
+                );
+            }
+            prop_assert!(detect_needs_cycle(&edges).is_ok());
+
+            let mut state = seed_from_jobs(jobs);
+            for _ in 0..64 {
+                if let Some(job) = acquire_next(&mut state) {
+                    complete_job(&mut state, &job.id, ExecutionStatus::Success);
+                } else if state.pending.is_empty() {
+                    break;
+                } else {
+                    // promote may still free jobs after completions
+                    if promote_ready_jobs(&mut state) == 0 {
+                        break;
+                    }
+                }
+            }
+            prop_assert!(
+                run_settled(&state),
+                "DAG did not settle: pending={:?} queue={:?} jobs={:?}",
+                state.pending.iter().map(|j| j.id.0.clone()).collect::<Vec<_>>(),
+                state.queue.iter().map(|j| j.id.0.clone()).collect::<Vec<_>>(),
+                state.jobs
+            );
+        }
+
+        /// A job never becomes InProgress before all needs are Success|Skipped.
+        #[test]
+        fn never_dispatch_before_needs(jobs in arb_dag(5)) {
+            let mut state = seed_from_jobs(jobs.clone());
+            let needs_of: BTreeMap<_, _> = jobs
+                .iter()
+                .map(|j| (j.id.clone(), j.needs.clone()))
+                .collect();
+
+            for _ in 0..64 {
+                if let Some(job) = acquire_next(&mut state) {
+                    for need in needs_of.get(&job.id).into_iter().flatten() {
+                        let status = state.jobs.get(need).copied();
+                        prop_assert!(
+                            matches!(
+                                status,
+                                Some(ExecutionStatus::Success) | Some(ExecutionStatus::Skipped)
+                            ),
+                            "dispatched {} while need {} is {:?}",
+                            job.id.0,
+                            need.0,
+                            status
+                        );
+                    }
+                    // Alternate success/skip to exercise both satisfying terminals.
+                    let terminal = if job.id.0.ends_with('0') {
+                        ExecutionStatus::Skipped
+                    } else {
+                        ExecutionStatus::Success
+                    };
+                    complete_job(&mut state, &job.id, terminal);
+                } else if promote_ready_jobs(&mut state) == 0 {
+                    break;
+                }
+            }
+        }
+
+        /// Promotion is deterministic: same seed state → same queue order.
+        #[test]
+        fn promote_is_deterministic(jobs in arb_dag(5)) {
+            let mut a = seed_from_jobs(jobs.clone());
+            let mut b = seed_from_jobs(jobs);
+            // Complete first root if any.
+            if let Some(job) = acquire_next(&mut a) {
+                complete_job(&mut a, &job.id, ExecutionStatus::Success);
+            }
+            if let Some(job) = acquire_next(&mut b) {
+                complete_job(&mut b, &job.id, ExecutionStatus::Success);
+            }
+            let qa: Vec<_> = a.queue.iter().map(|j| j.id.0.clone()).collect();
+            let qb: Vec<_> = b.queue.iter().map(|j| j.id.0.clone()).collect();
+            prop_assert_eq!(qa, qb);
+            let pa: Vec<_> = a.pending.iter().map(|j| j.id.0.clone()).collect();
+            let pb: Vec<_> = b.pending.iter().map(|j| j.id.0.clone()).collect();
+            prop_assert_eq!(pa, pb);
+        }
+
+        /// Failure of a dependency: dependent is never queued (it either stays
+        /// pending if other deps are non-terminal, or becomes Skipped once
+        /// all deps are terminal).
+        #[test]
+        fn failure_never_queues_dependent(jobs in arb_dag(4)) {
+            let mut state = seed_from_jobs(jobs.clone());
+            if let Some(job) = acquire_next(&mut state) {
+                complete_job(&mut state, &job.id, ExecutionStatus::Failure);
+                for other in &jobs {
+                    if other.needs.iter().any(|n| n == &job.id) {
+                        // Must NOT be queued under default gate after failed dep
+                        prop_assert!(
+                            state.queue.iter().all(|q| q.id != other.id),
+                            "dependent {} entered queue after failed need {}",
+                            other.id.0,
+                            job.id.0
+                        );
+                        // If ALL deps are terminal, must be Skipped (not stuck pending).
+                        let all_deps_terminal = other.needs.iter().all(|need| {
+                            let status = state.jobs.get(need).copied();
+                            matches!(
+                                status,
+                                Some(ExecutionStatus::Success)
+                                    | Some(ExecutionStatus::Failure)
+                                    | Some(ExecutionStatus::Skipped)
+                                    | Some(ExecutionStatus::Cancelled)
+                            )
+                        });
+                        if all_deps_terminal {
+                            prop_assert_eq!(
+                                state.jobs.get(&other.id).copied(),
+                                Some(ExecutionStatus::Skipped),
+                                "dependent {} with all-terminal deps must be Skipped, not stuck",
+                                other.id.0
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Random edge sets: cycle detector never panics and is consistent with
+    // a simple DFS reference.
+    proptest! {
+        #![proptest_config(dag_config(10_000))]
+
+        #[test]
+        fn cycle_detector_stable(
+            edges in proptest::collection::btree_map(
+                "[a-d]{1}",
+                proptest::collection::vec("[a-d]{1}", 0..3),
+                1..5
+            )
+        ) {
+            let result = detect_needs_cycle(&edges);
+            // Self-loop is always a cycle.
+            for (k, deps) in &edges {
+                if deps.iter().any(|d| d == k) {
+                    prop_assert!(result.is_err());
+                    return Ok(());
+                }
+            }
+            let _ = result;
+        }
+    }
+
+    // ─── Regression fixtures (spec §1 Required regression fixtures) ─────────
+
+    /// `build` fails → default `test` becomes Skipped.
+    /// Official: failed dependency causes dependent to skip under default gate.
+    #[test]
+    fn regression_build_fails_test_skipped() {
+        let jobs = vec![
+            SchedJob {
+                id: jid("build"),
+                base_id: "build".into(),
+                needs: vec![],
+                max_parallel: None,
+                if_condition: None,
+            },
+            SchedJob {
+                id: jid("test"),
+                base_id: "test".into(),
+                needs: vec![jid("build")],
+                max_parallel: None,
+                if_condition: None,
+            },
+        ];
+        let mut state = seed_from_jobs(jobs);
+        let build = acquire_next(&mut state).unwrap();
+        assert_eq!(build.id.0, "build");
+        complete_job(&mut state, &jid("build"), ExecutionStatus::Failure);
+
+        assert!(state.queue.is_empty());
+        assert!(state.pending.is_empty());
+        assert_eq!(state.jobs[&jid("test")], ExecutionStatus::Skipped);
+        assert!(run_settled(&state));
+    }
+
+    /// `build` is skipped → default `test` becomes Skipped.
+    #[test]
+    fn regression_build_skipped_test_skipped() {
+        let jobs = vec![
+            SchedJob {
+                id: jid("build"),
+                base_id: "build".into(),
+                needs: vec![],
+                max_parallel: None,
+                if_condition: None,
+            },
+            SchedJob {
+                id: jid("test"),
+                base_id: "test".into(),
+                needs: vec![jid("build")],
+                max_parallel: None,
+                if_condition: None,
+            },
+        ];
+        let mut state = seed_from_jobs(jobs);
+        let build = acquire_next(&mut state).unwrap();
+        assert_eq!(build.id.0, "build");
+        complete_job(&mut state, &jid("build"), ExecutionStatus::Skipped);
+
+        assert!(state.queue.is_empty());
+        assert!(state.pending.is_empty());
+        assert_eq!(state.jobs[&jid("test")], ExecutionStatus::Skipped);
+        assert!(run_settled(&state));
+    }
+
+    /// `build` fails → `cleanup` with `if: always()` runs.
+    /// Official: `always()` overrides the default gate.
+    #[test]
+    fn regression_always_runs_after_failure() {
+        let jobs = vec![
+            SchedJob {
+                id: jid("build"),
+                base_id: "build".into(),
+                needs: vec![],
+                max_parallel: None,
+                if_condition: None,
+            },
+            SchedJob {
+                id: jid("cleanup"),
+                base_id: "cleanup".into(),
+                needs: vec![jid("build")],
+                max_parallel: None,
+                if_condition: Some("always()".to_owned()),
+            },
+        ];
+        let mut state = seed_from_jobs(jobs);
+        let build = acquire_next(&mut state).unwrap();
+        assert_eq!(build.id.0, "build");
+        complete_job(&mut state, &jid("build"), ExecutionStatus::Failure);
+
+        // cleanup should be promoted to queue, not skipped
+        assert_eq!(state.queue.len(), 1);
+        let cleanup = acquire_next(&mut state).unwrap();
+        assert_eq!(cleanup.id.0, "cleanup");
+        assert_eq!(state.jobs[&jid("cleanup")], ExecutionStatus::InProgress);
+    }
+
+    /// `build` fails → `cleanup` with `if: failure()` runs (official status context).
+    #[test]
+    fn regression_failure_condition_runs_after_failure() {
+        let jobs = vec![
+            SchedJob {
+                id: jid("build"),
+                base_id: "build".into(),
+                needs: vec![],
+                max_parallel: None,
+                if_condition: None,
+            },
+            SchedJob {
+                id: jid("cleanup"),
+                base_id: "cleanup".into(),
+                needs: vec![jid("build")],
+                max_parallel: None,
+                if_condition: Some("failure()".to_owned()),
+            },
+        ];
+        let mut state = seed_from_jobs(jobs);
+        acquire_next(&mut state);
+        complete_job(&mut state, &jid("build"), ExecutionStatus::Failure);
+
+        assert_eq!(state.queue.len(), 1);
+        let cleanup = acquire_next(&mut state).unwrap();
+        assert_eq!(cleanup.id.0, "cleanup");
+    }
+
+    /// `build` succeeds → `cleanup` with `if: failure()` is skipped.
+    #[test]
+    fn failure_condition_skips_when_success() {
+        let jobs = vec![
+            SchedJob {
+                id: jid("build"),
+                base_id: "build".into(),
+                needs: vec![],
+                max_parallel: None,
+                if_condition: None,
+            },
+            SchedJob {
+                id: jid("cleanup"),
+                base_id: "cleanup".into(),
+                needs: vec![jid("build")],
+                max_parallel: None,
+                if_condition: Some("failure()".to_owned()),
+            },
+        ];
+        let mut state = seed_from_jobs(jobs);
+        acquire_next(&mut state);
+        complete_job(&mut state, &jid("build"), ExecutionStatus::Success);
+
+        assert!(state.queue.is_empty());
+        assert_eq!(state.jobs[&jid("cleanup")], ExecutionStatus::Skipped);
+    }
+
+    /// `build` cancelled → `on_cancel` with `if: cancelled()` runs.
+    #[test]
+    fn cancelled_condition_runs_after_cancellation() {
+        let jobs = vec![
+            SchedJob {
+                id: jid("build"),
+                base_id: "build".into(),
+                needs: vec![],
+                max_parallel: None,
+                if_condition: None,
+            },
+            SchedJob {
+                id: jid("on_cancel"),
+                base_id: "on_cancel".into(),
+                needs: vec![jid("build")],
+                max_parallel: None,
+                if_condition: Some("cancelled()".to_owned()),
+            },
+        ];
+        let mut state = seed_from_jobs(jobs);
+        acquire_next(&mut state);
+        complete_job(&mut state, &jid("build"), ExecutionStatus::Cancelled);
+
+        assert_eq!(state.queue.len(), 1);
+        let on_cancel = acquire_next(&mut state).unwrap();
+        assert_eq!(on_cancel.id.0, "on_cancel");
+    }
+
+    /// Transitive ancestor failure: a → b → c. `a` fails, both b and c skip.
+    #[test]
+    fn transitive_ancestor_failure_skips_chain() {
+        let jobs = vec![
+            SchedJob {
+                id: jid("a"),
+                base_id: "a".into(),
+                needs: vec![],
+                max_parallel: None,
+                if_condition: None,
+            },
+            SchedJob {
+                id: jid("b"),
+                base_id: "b".into(),
+                needs: vec![jid("a")],
+                max_parallel: None,
+                if_condition: None,
+            },
+            SchedJob {
+                id: jid("c"),
+                base_id: "c".into(),
+                needs: vec![jid("b")],
+                max_parallel: None,
+                if_condition: None,
+            },
+        ];
+        let mut state = seed_from_jobs(jobs);
+        acquire_next(&mut state);
+        complete_job(&mut state, &jid("a"), ExecutionStatus::Failure);
+
+        // b skips because a failed; c skips transitively
+        assert!(state.pending.is_empty());
+        assert!(state.queue.is_empty());
+        assert_eq!(state.jobs[&jid("b")], ExecutionStatus::Skipped);
+        assert_eq!(state.jobs[&jid("c")], ExecutionStatus::Skipped);
+        assert!(run_settled(&state));
+    }
+
+    /// Diamond graph: build → test-a/test-b → deploy.
+    /// All succeed → deploy runs.
+    #[test]
+    fn regression_diamond_graph_settlement() {
+        let jobs = vec![
+            SchedJob {
+                id: jid("build"),
+                base_id: "build".into(),
+                needs: vec![],
+                max_parallel: None,
+                if_condition: None,
+            },
+            SchedJob {
+                id: jid("test-a"),
+                base_id: "test-a".into(),
+                needs: vec![jid("build")],
+                max_parallel: None,
+                if_condition: None,
+            },
+            SchedJob {
+                id: jid("test-b"),
+                base_id: "test-b".into(),
+                needs: vec![jid("build")],
+                max_parallel: None,
+                if_condition: None,
+            },
+            SchedJob {
+                id: jid("deploy"),
+                base_id: "deploy".into(),
+                needs: vec![jid("test-a"), jid("test-b")],
+                max_parallel: None,
+                if_condition: None,
+            },
+        ];
+        let mut state = seed_from_jobs(jobs);
+        // build is the only root
+        let build = acquire_next(&mut state).unwrap();
+        assert_eq!(build.id.0, "build");
+        assert!(acquire_next(&mut state).is_none());
+
+        complete_job(&mut state, &jid("build"), ExecutionStatus::Success);
+        // test-a and test-b promoted
+        assert_eq!(state.queue.len(), 2);
+
+        let ta = acquire_next(&mut state).unwrap();
+        let tb = acquire_next(&mut state).unwrap();
+        let mut test_ids: Vec<_> = vec![ta.id.0.clone(), tb.id.0.clone()];
+        test_ids.sort();
+        assert_eq!(test_ids, vec!["test-a", "test-b"]);
+
+        // deploy not yet ready
+        assert!(acquire_next(&mut state).is_none());
+
+        complete_job(&mut state, &ta.id, ExecutionStatus::Success);
+        // deploy still waiting for test-b
+        assert!(state.queue.is_empty());
+
+        complete_job(&mut state, &tb.id, ExecutionStatus::Success);
+        // now deploy is promoted
+        let deploy = acquire_next(&mut state).unwrap();
+        assert_eq!(deploy.id.0, "deploy");
+        complete_job(&mut state, &jid("deploy"), ExecutionStatus::Success);
+        assert!(run_settled(&state));
+    }
+
+    /// Diamond graph with one leg failed → deploy skipped.
+    #[test]
+    fn diamond_one_leg_fails_deploy_skipped() {
+        let jobs = vec![
+            SchedJob {
+                id: jid("build"),
+                base_id: "build".into(),
+                needs: vec![],
+                max_parallel: None,
+                if_condition: None,
+            },
+            SchedJob {
+                id: jid("test-a"),
+                base_id: "test-a".into(),
+                needs: vec![jid("build")],
+                max_parallel: None,
+                if_condition: None,
+            },
+            SchedJob {
+                id: jid("test-b"),
+                base_id: "test-b".into(),
+                needs: vec![jid("build")],
+                max_parallel: None,
+                if_condition: None,
+            },
+            SchedJob {
+                id: jid("deploy"),
+                base_id: "deploy".into(),
+                needs: vec![jid("test-a"), jid("test-b")],
+                max_parallel: None,
+                if_condition: None,
+            },
+        ];
+        let mut state = seed_from_jobs(jobs);
+        acquire_next(&mut state); // build
+        complete_job(&mut state, &jid("build"), ExecutionStatus::Success);
+
+        let ta = acquire_next(&mut state).unwrap();
+        let tb = acquire_next(&mut state).unwrap();
+        complete_job(&mut state, &ta.id, ExecutionStatus::Success);
+        complete_job(&mut state, &tb.id, ExecutionStatus::Failure);
+
+        // deploy must be skipped
+        assert_eq!(state.jobs[&jid("deploy")], ExecutionStatus::Skipped);
+        assert!(run_settled(&state));
+    }
+
+    /// Duplicate completion is idempotent: completing an already-terminal job
+    /// does not promote dependents again or change the terminal status.
+    #[test]
+    fn duplicate_completion_is_idempotent() {
+        let jobs = vec![
+            SchedJob {
+                id: jid("a"),
+                base_id: "a".into(),
+                needs: vec![],
+                max_parallel: None,
+                if_condition: None,
+            },
+            SchedJob {
+                id: jid("b"),
+                base_id: "b".into(),
+                needs: vec![jid("a")],
+                max_parallel: None,
+                if_condition: None,
+            },
+        ];
+        let mut state = seed_from_jobs(jobs);
+        acquire_next(&mut state);
+        let promoted_first = complete_job(&mut state, &jid("a"), ExecutionStatus::Success);
+        assert_eq!(promoted_first, 1); // b promoted
+
+        // Completing again must be a no-op
+        let promoted_second = complete_job(&mut state, &jid("a"), ExecutionStatus::Success);
+        assert_eq!(
+            promoted_second, 0,
+            "duplicate completion must not re-promote"
+        );
+
+        // Try to override with a different status — must be ignored
+        let promoted_third = complete_job(&mut state, &jid("a"), ExecutionStatus::Failure);
+        assert_eq!(promoted_third, 0);
+        assert_eq!(
+            state.jobs[&jid("a")],
+            ExecutionStatus::Success,
+            "terminal status must be immutable"
+        );
+    }
+
+    /// Cancellation immutability: once a job is terminal (e.g. Cancelled),
+    /// it cannot transition back. The terminal status is sticky.
+    #[test]
+    fn cancellation_is_immutable() {
+        let jobs = vec![SchedJob {
+            id: jid("a"),
+            base_id: "a".into(),
+            needs: vec![],
+            max_parallel: None,
+            if_condition: None,
+        }];
+        let mut state = seed_from_jobs(jobs);
+        acquire_next(&mut state);
+        complete_job(&mut state, &jid("a"), ExecutionStatus::Cancelled);
+        assert_eq!(state.jobs[&jid("a")], ExecutionStatus::Cancelled);
+
+        // Try to override with Success — must be ignored
+        complete_job(&mut state, &jid("a"), ExecutionStatus::Success);
+        assert_eq!(
+            state.jobs[&jid("a")],
+            ExecutionStatus::Cancelled,
+            "cancelled status must be immutable"
+        );
+    }
+
+    /// Terminal job never returns to pending, queued, or running (spec §1.8).
+    #[test]
+    fn terminal_job_never_reverts() {
+        let jobs = vec![SchedJob {
+            id: jid("x"),
+            base_id: "x".into(),
+            needs: vec![],
+            max_parallel: None,
+            if_condition: None,
+        }];
+        let mut state = seed_from_jobs(jobs);
+        let x = acquire_next(&mut state).unwrap();
+        assert_eq!(state.jobs[&x.id], ExecutionStatus::InProgress);
+
+        complete_job(&mut state, &x.id, ExecutionStatus::Success);
+        assert_eq!(state.jobs[&x.id], ExecutionStatus::Success);
+
+        // Attempt to complete again with different statuses
+        for status in [
+            ExecutionStatus::Failure,
+            ExecutionStatus::Cancelled,
+            ExecutionStatus::Queued,
+            ExecutionStatus::InProgress,
+        ] {
+            complete_job(&mut state, &x.id, status);
+            assert_eq!(
+                state.jobs[&x.id],
+                ExecutionStatus::Success,
+                "terminal Success must not revert to {status:?}"
+            );
+        }
+    }
+
+    // ─── Bounded independent-oracle model property (spec §1) ────────────────
+
+    /// Independent oracle for default dependency decision.
+    /// Does NOT call `dependency_decision`, `need_satisfied`, or any scheduler fn.
+    /// Implements the official GitHub status-function semantics directly.
+    /// A dependency set is summarized to one result: failure wins over
+    /// cancellation, then skipped, then success.
+    fn oracle_should_run(
+        ancestor_statuses: &[ExecutionStatus],
+        if_condition: Option<&str>,
+    ) -> bool {
+        let aggregate = if ancestor_statuses
+            .iter()
+            .any(|s| *s == ExecutionStatus::Failure)
+        {
+            ExecutionStatus::Failure
+        } else if ancestor_statuses
+            .iter()
+            .any(|s| *s == ExecutionStatus::Cancelled)
+        {
+            ExecutionStatus::Cancelled
+        } else if ancestor_statuses
+            .iter()
+            .any(|s| *s == ExecutionStatus::Skipped)
+        {
+            ExecutionStatus::Skipped
+        } else {
+            ExecutionStatus::Success
+        };
+        let all_success = aggregate == ExecutionStatus::Success;
+        let any_failure = aggregate == ExecutionStatus::Failure;
+        let any_cancelled = aggregate == ExecutionStatus::Cancelled;
+
+        match if_condition {
+            None | Some("") => all_success,
+            Some("always()") => true,
+            Some("failure()") => any_failure,
+            Some("cancelled()") => any_cancelled,
+            Some("success()") => all_success,
+            _ => false, // unrecognized — oracle is conservative
+        }
+    }
+
+    fn arb_terminal_status() -> impl Strategy<Value = ExecutionStatus> {
+        prop_oneof![
+            Just(ExecutionStatus::Success),
+            Just(ExecutionStatus::Failure),
+            Just(ExecutionStatus::Skipped),
+            Just(ExecutionStatus::Cancelled),
+        ]
+    }
+
+    // Oracle: GitHub status-check functions documentation plus pinned
+    // actions/runner v2.335.1 StepsRunner.cs and *Function.cs sources. The
+    // generated truth table compares aggregate ancestor status against the
+    // independent oracle, including failure/skip/cancelled/always overrides.
+    fn arb_condition() -> impl Strategy<Value = Option<String>> {
+        prop_oneof![
+            Just(None),
+            Just(Some("always()".to_owned())),
+            Just(Some("failure()".to_owned())),
+            Just(Some("cancelled()".to_owned())),
+            Just(Some("success()".to_owned())),
+        ]
+    }
+
+    proptest! {
+        #![proptest_config(dag_config(5_000))]
+
+        /// Bounded independent-oracle model property: for a single
+        /// dependent job with 1–4 needs, the scheduler's decision
+        /// (run vs skip) must agree with the independent oracle.
+        #[test]
+        fn oracle_agrees_with_scheduler(
+            needs_count in 1usize..=4,
+            statuses in proptest::collection::vec(arb_terminal_status(), 1..=4),
+            condition in arb_condition(),
+        ) {
+            let need_count = needs_count.min(statuses.len());
+            // Build a set of upstream jobs
+            let mut upstream_jobs = Vec::new();
+            for i in 0..need_count {
+                upstream_jobs.push(SchedJob {
+                    id: jid(&format!("up{i}")),
+                    base_id: format!("up{i}"),
+                    needs: vec![],
+                    max_parallel: None,
+                    if_condition: None,
+                });
+            }
+            let needs: Vec<JobId> = (0..need_count).map(|i| jid(&format!("up{i}"))).collect();
+            let dependent = SchedJob {
+                id: jid("dep"),
+                base_id: "dep".into(),
+                needs: needs.clone(),
+                max_parallel: None,
+                if_condition: condition.clone(),
+            };
+            let mut all_jobs = upstream_jobs;
+            all_jobs.push(dependent);
+
+            let mut state = seed_from_jobs(all_jobs);
+            // Complete all upstream jobs with the generated statuses
+            for i in 0..need_count {
+                let up_id = jid(&format!("up{i}"));
+                // Force acquire (roots go straight to queue)
+                acquire_next(&mut state);
+                complete_job(&mut state, &up_id, statuses[i]);
+            }
+
+            let actual_status = state.jobs.get(&jid("dep")).copied().unwrap();
+            let ancestor_stats: Vec<ExecutionStatus> =
+                (0..need_count).map(|i| statuses[i]).collect();
+            let oracle_says_run = oracle_should_run(
+                &ancestor_stats,
+                condition.as_deref(),
+            );
+
+            if oracle_says_run {
+                prop_assert!(
+                    matches!(actual_status, ExecutionStatus::Queued | ExecutionStatus::InProgress),
+                    "oracle says run but scheduler gave {:?} for condition={:?} statuses={:?}",
+                    actual_status,
+                    condition,
+                    ancestor_stats
+                );
+            } else {
+                prop_assert_eq!(
+                    actual_status,
+                    ExecutionStatus::Skipped,
+                    "oracle says skip but scheduler gave {:?} for condition={:?} statuses={:?}",
+                    actual_status,
+                    condition,
+                    ancestor_stats
+                );
+            }
+        }
+
+        /// Every valid acyclic graph eventually settles when ALL jobs complete
+        /// with mixed terminal statuses (not just Success).
+        #[test]
+        fn mixed_terminal_settles(
+            jobs in arb_dag(5),
+            statuses in proptest::collection::vec(arb_terminal_status(), 5..=5),
+        ) {
+            let mut edges = BTreeMap::new();
+            for job in &jobs {
+                edges.insert(
+                    job.id.0.clone(),
+                    job.needs.iter().map(|n| n.0.clone()).collect(),
+                );
+            }
+            prop_assert!(detect_needs_cycle(&edges).is_ok());
+
+            let mut state = seed_from_jobs(jobs.clone());
+            let mut idx = 0;
+            for _ in 0..64 {
+                if let Some(job) = acquire_next(&mut state) {
+                    let status = statuses[idx % statuses.len()];
+                    idx += 1;
+                    complete_job(&mut state, &job.id, status);
+                } else if state.pending.is_empty() {
+                    break;
+                } else if promote_ready_jobs(&mut state) == 0 {
+                    break;
+                }
+            }
+            prop_assert!(
+                run_settled(&state),
+                "DAG did not settle with mixed statuses: pending={:?} queue={:?}",
+                state.pending.iter().map(|j| j.id.0.clone()).collect::<Vec<_>>(),
+                state.queue.iter().map(|j| j.id.0.clone()).collect::<Vec<_>>(),
+            );
+        }
+    }
+}

--- a/crates/aksh-runner-server/src/scheduling.rs
+++ b/crates/aksh-runner-server/src/scheduling.rs
@@ -57,65 +57,8 @@ pub struct SchedulerState {
     pub queue: VecDeque<SchedJob>,
 }
 
-/// Error when a needs graph is not a DAG.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CycleError {
-    /// One job id participating in a cycle (representative).
-    pub witness: String,
-}
-
-/// Detect a cycle in a needs graph.
-///
-/// `edges` maps job id → list of needed job ids.
-/// Returns `Ok(())` when acyclic, else a witness job id on a cycle.
-pub fn detect_needs_cycle(edges: &BTreeMap<String, Vec<String>>) -> Result<(), CycleError> {
-    #[derive(Clone, Copy, PartialEq, Eq)]
-    enum Color {
-        White,
-        Gray,
-        Black,
-    }
-
-    let mut color: BTreeMap<&str, Color> =
-        edges.keys().map(|k| (k.as_str(), Color::White)).collect();
-    // Also color referenced nodes that may be missing as keys.
-    for deps in edges.values() {
-        for d in deps {
-            color.entry(d.as_str()).or_insert(Color::White);
-        }
-    }
-
-    fn visit<'a>(
-        node: &'a str,
-        edges: &'a BTreeMap<String, Vec<String>>,
-        color: &mut BTreeMap<&'a str, Color>,
-    ) -> Result<(), CycleError> {
-        color.insert(node, Color::Gray);
-        if let Some(deps) = edges.get(node) {
-            for dep in deps {
-                match color.get(dep.as_str()).copied().unwrap_or(Color::White) {
-                    Color::Gray => {
-                        return Err(CycleError {
-                            witness: dep.clone(),
-                        });
-                    }
-                    Color::White => visit(dep.as_str(), edges, color)?,
-                    Color::Black => {}
-                }
-            }
-        }
-        color.insert(node, Color::Black);
-        Ok(())
-    }
-
-    let nodes: Vec<&str> = color.keys().copied().collect();
-    for node in nodes {
-        if color.get(node) == Some(&Color::White) {
-            visit(node, edges, &mut color)?;
-        }
-    }
-    Ok(())
-}
+/// Re-export cycle detection from the parser crate (single source of truth).
+pub use aksh_gha_parser::dag::detect_needs_cycle;
 
 /// Whether a single `needs` entry completed successfully.
 ///
@@ -222,6 +165,7 @@ enum DependencyDecision {
     Wait,
     Run,
     Skip,
+    Error,
 }
 
 fn dependency_decision(state: &SchedulerState, job: &SchedJob) -> DependencyDecision {
@@ -246,7 +190,8 @@ fn dependency_decision(state: &SchedulerState, job: &SchedJob) -> DependencyDeci
     let context = aksh_gha_expressions::Context::default().with_status(success, failure, cancelled);
     match aksh_gha_expressions::eval_bool(&condition, &context) {
         Ok(true) => DependencyDecision::Run,
-        Ok(false) | Err(_) => DependencyDecision::Skip,
+        Ok(false) => DependencyDecision::Skip,
+        Err(_) => DependencyDecision::Error,
     }
 }
 
@@ -297,6 +242,10 @@ pub fn promote_ready_jobs(state: &mut SchedulerState) -> usize {
                 }
                 DependencyDecision::Skip => {
                     state.jobs.insert(job.id, ExecutionStatus::Skipped);
+                    skipped = true;
+                }
+                DependencyDecision::Error => {
+                    state.jobs.insert(job.id, ExecutionStatus::Failure);
                     skipped = true;
                 }
                 DependencyDecision::Wait | DependencyDecision::Run => remaining.push_back(job),

--- a/crates/aksh-runner/src/worker/mod.rs
+++ b/crates/aksh-runner/src/worker/mod.rs
@@ -15,7 +15,10 @@ pub mod job_extension;
 pub mod job_runner;
 pub mod live_logs;
 pub mod matchers;
+pub mod official_oracles;
 pub mod server_queue;
+pub mod step_conditions;
+pub mod step_records;
 pub mod steps_runner;
 pub mod template;
 

--- a/crates/aksh-runner/src/worker/official_oracles.rs
+++ b/crates/aksh-runner/src/worker/official_oracles.rs
@@ -1,0 +1,265 @@
+//! Oracles ported from official `actions/runner` v2.335.1 L0 tests and source.
+//!
+//! These tables are the ground truth for property tests. When aksh disagrees,
+//! the property fails — we do not normalize away official behavior.
+//!
+//! Sources:
+//! - `src/Test/L0/Worker/Expressions/ConditionFunctionsL0.cs`
+//! - `src/Runner.Worker/Expressions/SuccessFunction.cs` (`jobStatus ?? Success`)
+//! - `src/Sdk/WorkflowParser/Conversion/WorkflowTemplateConverter.cs`
+//!   `ConvertToIfCondition` (default `success()`, else `success() && (cond)`)
+//! - `src/Sdk/WorkflowParser/Conversion/MatrixBuilder.cs` documented examples
+//! - Live GitHub run for `p0-failure-conditions.yml` (docs/test-coverage.md)
+
+use super::step_conditions::{evaluate_step_condition, StatusFlags};
+
+/// Official `ActionResult` / `JobContext.Status` values.
+///
+/// Official SuccessFunction:
+/// `ActionResult jobStatus = executionContext.JobContext.Status ?? ActionResult.Success`
+/// so **unset (null) is Success**.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OfficialJobStatus {
+    /// `JobContext.Status == null` — treated as Success by official runner.
+    Unset,
+    Success,
+    Failure,
+    Cancelled,
+}
+
+impl OfficialJobStatus {
+    /// Map to aksh expression flags the way JobContext does for non-composite steps.
+    pub fn to_flags(self) -> StatusFlags {
+        match self {
+            // Official: null ?? Success → success() true
+            Self::Unset | Self::Success => StatusFlags::ok(),
+            Self::Failure => StatusFlags::after_failure(),
+            Self::Cancelled => StatusFlags::after_cancel(),
+        }
+    }
+}
+
+/// One row of ConditionFunctionsL0 for a status function.
+#[derive(Debug, Clone, Copy)]
+pub struct OfficialStatusCase {
+    /// Job status under test.
+    pub status: OfficialJobStatus,
+    /// Expected `always()` / `success()` / `failure()` / `cancelled()`.
+    pub always: bool,
+    pub success: bool,
+    pub failure: bool,
+    pub cancelled: bool,
+}
+
+/// Exact ConditionFunctionsL0 table (non-composite).
+///
+/// From official AlwaysFunction / SuccessFunction / FailureFunction / CancelledFunction tests.
+pub fn condition_functions_l0_table() -> &'static [OfficialStatusCase] {
+    &[
+        OfficialStatusCase {
+            status: OfficialJobStatus::Unset,
+            always: true,
+            success: true, // null ?? Success
+            failure: false,
+            cancelled: false,
+        },
+        OfficialStatusCase {
+            status: OfficialJobStatus::Success,
+            always: true,
+            success: true,
+            failure: false,
+            cancelled: false,
+        },
+        OfficialStatusCase {
+            status: OfficialJobStatus::Failure,
+            always: true,
+            success: false,
+            failure: true,
+            cancelled: false,
+        },
+        OfficialStatusCase {
+            status: OfficialJobStatus::Cancelled,
+            always: true,
+            success: false,
+            failure: false,
+            cancelled: true,
+        },
+    ]
+}
+
+/// p0-failure-conditions.yml expected step outcomes after intentional failure
+/// (verified on GitHub Actions run 28754419325 per docs/test-coverage.md).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StepRunOutcome {
+    Run,
+    Skip,
+}
+
+/// (step if-condition, expected outcome) once job is in Failure status.
+pub fn p0_failure_conditions_oracle() -> &'static [(&'static str, StepRunOutcome)] {
+    &[
+        // After failure, default/success gated steps skip; failure/always run.
+        ("success()", StepRunOutcome::Skip),
+        ("failure()", StepRunOutcome::Run),
+        ("always()", StepRunOutcome::Run),
+    ]
+}
+
+/// Official ConvertToIfCondition rewriting rules.
+pub fn official_effective_condition(raw: Option<&str>) -> String {
+    match raw {
+        None => "success()".to_owned(),
+        Some(s) if s.trim().is_empty() => "success()".to_owned(),
+        Some(s) => {
+            let stripped = aksh_gha_expressions::trim_expression_markers(s);
+            if super::step_conditions::contains_status_check_function(stripped) {
+                stripped.to_owned()
+            } else {
+                format!("success() && ({stripped})")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    /// ConditionFunctionsL0 — exact table, no generation.
+    #[test]
+    fn condition_functions_l0_matches_official_runner() {
+        for case in condition_functions_l0_table() {
+            let flags = case.status.to_flags();
+            assert_eq!(
+                evaluate_step_condition(Some("always()"), flags).unwrap(),
+                case.always,
+                "always() for {:?}",
+                case.status
+            );
+            assert_eq!(
+                evaluate_step_condition(Some("success()"), flags).unwrap(),
+                case.success,
+                "success() for {:?}",
+                case.status
+            );
+            assert_eq!(
+                evaluate_step_condition(Some("failure()"), flags).unwrap(),
+                case.failure,
+                "failure() for {:?}",
+                case.status
+            );
+            assert_eq!(
+                evaluate_step_condition(Some("cancelled()"), flags).unwrap(),
+                case.cancelled,
+                "cancelled() for {:?}",
+                case.status
+            );
+        }
+    }
+
+    /// Unset status must behave like Success (SuccessFunction null-coalesce).
+    #[test]
+    fn unset_job_status_is_success_like_official() {
+        let unset = OfficialJobStatus::Unset.to_flags();
+        let success = OfficialJobStatus::Success.to_flags();
+        assert_eq!(
+            evaluate_step_condition(Some("success()"), unset).unwrap(),
+            evaluate_step_condition(Some("success()"), success).unwrap()
+        );
+        assert!(evaluate_step_condition(None, unset).unwrap());
+    }
+
+    /// p0-failure-conditions.yml oracle from live GitHub.
+    #[test]
+    fn p0_failure_conditions_matches_github_run() {
+        let flags = OfficialJobStatus::Failure.to_flags();
+        for (cond, expected) in p0_failure_conditions_oracle() {
+            let runs = evaluate_step_condition(Some(cond), flags).unwrap();
+            match expected {
+                StepRunOutcome::Run => assert!(runs, "{cond} should run after failure"),
+                StepRunOutcome::Skip => assert!(!runs, "{cond} should skip after failure"),
+            }
+        }
+    }
+
+    /// ConvertToIfCondition rewrite must match official formatting.
+    #[test]
+    fn convert_to_if_condition_matches_official() {
+        assert_eq!(official_effective_condition(None), "success()");
+        assert_eq!(official_effective_condition(Some("")), "success()");
+        assert_eq!(
+            official_effective_condition(Some("true")),
+            "success() && (true)"
+        );
+        assert_eq!(official_effective_condition(Some("failure()")), "failure()");
+        assert_eq!(
+            official_effective_condition(Some("always() && 1 == 1")),
+            "always() && 1 == 1"
+        );
+        assert_eq!(
+            official_effective_condition(Some("${{ success() }}")),
+            "success()"
+        );
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(10_000))]
+
+        /// Across all official statuses, status functions stay mutually exclusive
+        /// (except always, which is always true). Official JobContext.Status is a
+        /// single enum, never Success+Failure simultaneously.
+        #[test]
+        fn official_status_enum_invariants(status in prop_oneof![
+            Just(OfficialJobStatus::Unset),
+            Just(OfficialJobStatus::Success),
+            Just(OfficialJobStatus::Failure),
+            Just(OfficialJobStatus::Cancelled),
+        ]) {
+            let flags = status.to_flags();
+            let s = evaluate_step_condition(Some("success()"), flags).unwrap();
+            let f = evaluate_step_condition(Some("failure()"), flags).unwrap();
+            let c = evaluate_step_condition(Some("cancelled()"), flags).unwrap();
+            let a = evaluate_step_condition(Some("always()"), flags).unwrap();
+            prop_assert!(a);
+            // At most one of success/failure/cancelled is true for official statuses.
+            let true_count = [s, f, c].iter().filter(|x| **x).count();
+            prop_assert!(
+                true_count == 1,
+                "expected exactly one of success/failure/cancelled, got s={s} f={f} c={c} for {status:?}"
+            );
+            // Unset and Success are equivalent for success().
+            if matches!(status, OfficialJobStatus::Unset | OfficialJobStatus::Success) {
+                prop_assert!(s && !f && !c);
+            }
+        }
+
+        /// After failure, bare literals stay success-gated (ConvertToIfCondition).
+        #[test]
+        fn after_failure_bare_true_is_skipped(lit in prop_oneof![Just("true"), Just("1 == 1")]) {
+            let flags = OfficialJobStatus::Failure.to_flags();
+            let effective = official_effective_condition(Some(lit));
+            prop_assert!(effective.starts_with("success() &&"));
+            prop_assert!(!evaluate_step_condition(Some(lit), flags).unwrap());
+        }
+
+        /// effective_condition matches official_effective_condition for common inputs.
+        #[test]
+        fn effective_condition_parity(
+            raw in prop::option::of(prop_oneof![
+                Just("success()".to_string()),
+                Just("failure()".to_string()),
+                Just("always()".to_string()),
+                Just("cancelled()".to_string()),
+                Just("true".to_string()),
+                Just("false".to_string()),
+                Just("${{ always() }}".to_string()),
+                Just("1 == 1".to_string()),
+            ])
+        ) {
+            let a = super::super::step_conditions::effective_condition(raw.as_deref());
+            let b = official_effective_condition(raw.as_deref());
+            prop_assert_eq!(a, b);
+        }
+    }
+}

--- a/crates/aksh-runner/src/worker/server_queue.rs
+++ b/crates/aksh-runner/src/worker/server_queue.rs
@@ -33,7 +33,7 @@ pub mod step_conclusion {
 }
 
 /// A step update matching the WorkflowStepsUpdate Twirp schema.
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct StepUpdate {
     /// Step external ID (UUID from the job message step).
     pub external_id: String,
@@ -118,8 +118,9 @@ impl ServerQueue {
 
     /// Queue a step status update.
     ///
-    /// Updates the cumulative step state. If this is a new step, it's added
-    /// to the pending keys list so it appears in the next flush.
+    /// Updates the cumulative step state using identity-safe merge rules:
+    /// `external_id` is the key, status is monotonic, and conclusions are not
+    /// erased by empty partials. Matches official WorkflowStepsUpdate behavior.
     pub fn queue_update(&mut self, update: StepUpdate) {
         debug!(
             "Queued update for step {}: status={} conclusion={}",
@@ -131,7 +132,10 @@ impl ServerQueue {
         if !self.all_steps.contains_key(&key) {
             self.pending_keys.push(key.clone());
         }
-        self.all_steps.insert(key, update);
+        let partial = crate::worker::step_records::PartialStepUpdate::from_full(&update);
+        let merged =
+            crate::worker::step_records::merge_step_update(self.all_steps.get(&key), &partial);
+        self.all_steps.insert(key, merged);
     }
 
     /// Queue log lines for a step.

--- a/crates/aksh-runner/src/worker/step_conditions.rs
+++ b/crates/aksh-runner/src/worker/step_conditions.rs
@@ -1,0 +1,269 @@
+//! Step condition evaluation matching official `actions/runner` StepsRunner.
+//!
+//! Reference: ConditionFunctionsL0 + StepsRunner implicit success gate.
+//!
+//! Rules:
+//! - Default condition is `success()`.
+//! - If the expression does **not** contain a status-check function
+//!   (`success` / `failure` / `cancelled` / `always`), it is rewritten to
+//!   `success() && (expr)`.
+//! - `always()` is true regardless of prior failure/cancel.
+//! - Status flags are not mutated by evaluation.
+//! - Skipped is not success/failure/cancelled; default success gate fails after
+//!   a prior step failure even when the job is not cancelled.
+
+pub use aksh_gha_expressions::{contains_status_check_function, effective_condition};
+use aksh_gha_expressions::{eval_bool, Context};
+
+/// Job-level status flags used for condition evaluation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StatusFlags {
+    /// `success()` result.
+    pub success: bool,
+    /// `failure()` result.
+    pub failure: bool,
+    /// `cancelled()` result.
+    pub cancelled: bool,
+}
+
+impl StatusFlags {
+    /// Healthy job — default after no failures.
+    pub fn ok() -> Self {
+        Self {
+            success: true,
+            failure: false,
+            cancelled: false,
+        }
+    }
+
+    /// After a prior step failure (not cancelled).
+    pub fn after_failure() -> Self {
+        Self {
+            success: false,
+            failure: true,
+            cancelled: false,
+        }
+    }
+
+    /// After external cancellation.
+    pub fn after_cancel() -> Self {
+        Self {
+            success: false,
+            failure: false,
+            cancelled: true,
+        }
+    }
+
+    /// Build an expression context with these flags (no extra roots).
+    pub fn to_context(self) -> Context {
+        Context::default().with_status(self.success, self.failure, self.cancelled)
+    }
+}
+
+/// Evaluate whether a step should run under the given status flags.
+///
+/// Returns `Ok(bool)` or an expression error. Does not mutate `flags`.
+pub fn evaluate_step_condition(
+    raw: Option<&str>,
+    flags: StatusFlags,
+) -> Result<bool, aksh_gha_expressions::ExpressionError> {
+    let expr = effective_condition(raw);
+    let ctx = flags.to_context();
+    eval_bool(&expr, &ctx)
+}
+
+/// Expected should-run result for the canonical status × condition truth table.
+///
+/// Conditions: default / success / failure / cancelled / always / true / false /
+/// `failure() || cancelled()` — matching ConditionFunctionsL0 + StepsRunner.
+pub fn expected_should_run(condition: Option<&str>, flags: StatusFlags) -> bool {
+    evaluate_step_condition(condition, flags).unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn default_runs_only_on_success() {
+        assert!(evaluate_step_condition(None, StatusFlags::ok()).unwrap());
+        assert!(!evaluate_step_condition(None, StatusFlags::after_failure()).unwrap());
+        assert!(!evaluate_step_condition(None, StatusFlags::after_cancel()).unwrap());
+    }
+
+    #[test]
+    fn always_runs_regardless() {
+        for flags in [
+            StatusFlags::ok(),
+            StatusFlags::after_failure(),
+            StatusFlags::after_cancel(),
+            StatusFlags {
+                success: false,
+                failure: false,
+                cancelled: false,
+            },
+        ] {
+            assert!(
+                evaluate_step_condition(Some("always()"), flags).unwrap(),
+                "always() failed for {flags:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn failure_only_after_failure() {
+        assert!(!evaluate_step_condition(Some("failure()"), StatusFlags::ok()).unwrap());
+        assert!(evaluate_step_condition(Some("failure()"), StatusFlags::after_failure()).unwrap());
+        assert!(!evaluate_step_condition(Some("failure()"), StatusFlags::after_cancel()).unwrap());
+    }
+
+    #[test]
+    fn cancelled_only_when_cancelled() {
+        assert!(!evaluate_step_condition(Some("cancelled()"), StatusFlags::ok()).unwrap());
+        assert!(
+            !evaluate_step_condition(Some("cancelled()"), StatusFlags::after_failure()).unwrap()
+        );
+        assert!(evaluate_step_condition(Some("cancelled()"), StatusFlags::after_cancel()).unwrap());
+    }
+
+    #[test]
+    fn bare_true_is_gated_by_success() {
+        // Official: no status fn → success() && (true)
+        assert!(evaluate_step_condition(Some("true"), StatusFlags::ok()).unwrap());
+        assert!(!evaluate_step_condition(Some("true"), StatusFlags::after_failure()).unwrap());
+    }
+
+    #[test]
+    fn status_fn_inside_string_does_not_count() {
+        assert!(!contains_status_check_function("'success()'"));
+        assert!(!contains_status_check_function("\"failure()\""));
+        assert!(contains_status_check_function("success()"));
+        assert!(contains_status_check_function("true || always()"));
+    }
+
+    #[test]
+    fn evaluation_does_not_mutate_flags() {
+        let flags = StatusFlags::after_failure();
+        let _ = evaluate_step_condition(Some("always()"), flags).unwrap();
+        assert_eq!(flags, StatusFlags::after_failure());
+    }
+
+    /// Full truth table for the four status functions × flag combinations.
+    #[test]
+    fn status_function_truth_table() {
+        let combos = [
+            (true, false, false),
+            (false, true, false),
+            (false, false, true),
+            (false, true, true),
+            (false, false, false),
+            (true, true, false), // unusual but allowed by context API
+        ];
+        for (s, f, c) in combos {
+            let flags = StatusFlags {
+                success: s,
+                failure: f,
+                cancelled: c,
+            };
+            assert_eq!(
+                evaluate_step_condition(Some("success()"), flags).unwrap(),
+                s
+            );
+            assert_eq!(
+                evaluate_step_condition(Some("failure()"), flags).unwrap(),
+                f
+            );
+            assert_eq!(
+                evaluate_step_condition(Some("cancelled()"), flags).unwrap(),
+                c
+            );
+            assert!(evaluate_step_condition(Some("always()"), flags).unwrap());
+        }
+    }
+
+    fn arb_flags() -> impl Strategy<Value = StatusFlags> {
+        (any::<bool>(), any::<bool>(), any::<bool>()).prop_map(|(s, f, c)| StatusFlags {
+            success: s,
+            failure: f,
+            cancelled: c,
+        })
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(10_000))]
+
+        #[test]
+        fn always_is_constant_true(flags in arb_flags()) {
+            prop_assert!(evaluate_step_condition(Some("always()"), flags).unwrap());
+            prop_assert!(evaluate_step_condition(Some("${{ always() }}"), flags).unwrap());
+        }
+
+        #[test]
+        fn success_matches_flag(flags in arb_flags()) {
+            prop_assert_eq!(
+                evaluate_step_condition(Some("success()"), flags).unwrap(),
+                flags.success
+            );
+        }
+
+        #[test]
+        fn failure_matches_flag(flags in arb_flags()) {
+            prop_assert_eq!(
+                evaluate_step_condition(Some("failure()"), flags).unwrap(),
+                flags.failure
+            );
+        }
+
+        #[test]
+        fn cancelled_matches_flag(flags in arb_flags()) {
+            prop_assert_eq!(
+                evaluate_step_condition(Some("cancelled()"), flags).unwrap(),
+                flags.cancelled
+            );
+        }
+
+        #[test]
+        fn default_equals_success_fn(flags in arb_flags()) {
+            prop_assert_eq!(
+                evaluate_step_condition(None, flags).unwrap(),
+                evaluate_step_condition(Some("success()"), flags).unwrap()
+            );
+        }
+
+        #[test]
+        fn bare_literal_gated_by_success(
+            flags in arb_flags(),
+            lit in prop_oneof![Just("true"), Just("false"), Just("1"), Just("0")]
+        ) {
+            let result = evaluate_step_condition(Some(lit), flags).unwrap();
+            let inner = aksh_gha_expressions::eval_bool(lit, &flags.to_context()).unwrap();
+            prop_assert_eq!(result, flags.success && inner);
+        }
+
+        #[test]
+        fn compound_failure_or_cancelled(flags in arb_flags()) {
+            let result =
+                evaluate_step_condition(Some("failure() || cancelled()"), flags).unwrap();
+            prop_assert_eq!(result, flags.failure || flags.cancelled);
+        }
+
+        #[test]
+        fn skipped_not_confused_with_status_fns(flags in arb_flags()) {
+            // "skipped" is not a status function; bare identifier is a context path → null → false,
+            // and is success-gated.
+            let result = evaluate_step_condition(Some("skipped"), flags);
+            // May be Ok(false) or err depending on path resolution; must not panic.
+            let _ = result;
+            prop_assert!(!contains_status_check_function("skipped"));
+            prop_assert!(!contains_status_check_function("success")); // no '('
+        }
+
+        #[test]
+        fn effective_condition_stable(raw in prop::option::of("[a-z()!&| ]{0,24}")) {
+            let a = effective_condition(raw.as_deref());
+            let b = effective_condition(raw.as_deref());
+            prop_assert_eq!(a, b);
+        }
+    }
+}

--- a/crates/aksh-runner/src/worker/step_conditions.rs
+++ b/crates/aksh-runner/src/worker/step_conditions.rs
@@ -136,10 +136,15 @@ mod tests {
 
     #[test]
     fn status_fn_inside_string_does_not_count() {
+        // Single-quoted strings hide status functions (GitHub expression syntax)
         assert!(!contains_status_check_function("'success()'"));
-        assert!(!contains_status_check_function("\"failure()\""));
+        assert!(!contains_status_check_function("'always()'"));
+        // Double quotes are NOT string delimiters in GitHub expressions;
+        // a bare failure() is correctly detected as a status function.
         assert!(contains_status_check_function("success()"));
         assert!(contains_status_check_function("true || always()"));
+        // Doubled single-quote escape does not end the string early
+        assert!(!contains_status_check_function("'it''s always() here'"));
     }
 
     #[test]
@@ -265,5 +270,31 @@ mod tests {
             let b = effective_condition(raw.as_deref());
             prop_assert_eq!(a, b);
         }
+    }
+
+    /// Missing context path vs explicit null — both falsy, both success-gated.
+    /// Oracle: docs/property-tests.md §3.10 — missing paths and null follow
+    /// pinned official truthiness rules.
+    #[test]
+    fn missing_context_path_vs_explicit_null() {
+        // A nonexistent path evaluates to empty/null → falsy.
+        // With default success gate: success() && (falsy) = false on success.
+        let ok = StatusFlags::ok();
+        // "null" literal
+        let null_result = evaluate_step_condition(Some("null"), ok).unwrap();
+        assert!(
+            !null_result,
+            "null literal should be falsy under success gate"
+        );
+        // Explicit "false"
+        let false_result = evaluate_step_condition(Some("false"), ok).unwrap();
+        assert!(
+            !false_result,
+            "false literal should be falsy under success gate"
+        );
+        // After failure, both should also be false (success gate fails)
+        let fail = StatusFlags::after_failure();
+        assert!(!evaluate_step_condition(Some("null"), fail).unwrap());
+        assert!(!evaluate_step_condition(Some("false"), fail).unwrap());
     }
 }

--- a/crates/aksh-runner/src/worker/step_records.rs
+++ b/crates/aksh-runner/src/worker/step_records.rs
@@ -585,4 +585,94 @@ mod tests {
             }
         }
     }
+
+    /// Explicit null on wire (has_started_at=true, started_at=None) does NOT
+    /// clear an existing timestamp — official cumulative updates preserve
+    /// the first non-empty value.
+    /// Oracle: docs/property-tests.md §4.5 — explicit null follows wire contract.
+    #[test]
+    fn explicit_null_wire_contract() {
+        let existing = full("s1", 1, "A", step_status::IN_PROGRESS, 0);
+        assert_eq!(existing.started_at.as_deref(), Some("t0"));
+        let incoming = PartialStepUpdate {
+            external_id: "s1".into(),
+            number: None,
+            name: None,
+            status: None,
+            started_at: None,
+            has_started_at: true,
+            completed_at: None,
+            has_completed_at: false,
+            conclusion: None,
+        };
+        let merged = merge_step_update(Some(&existing), &incoming);
+        assert_eq!(
+            merged.started_at.as_deref(),
+            Some("t0"),
+            "cumulative update preserves existing timestamp"
+        );
+        let fresh = merge_step_update(None, &incoming);
+        assert_eq!(fresh.started_at, None, "no existing → stays None");
+    }
+
+    /// Unknown received records (not in dispatched list) handled gracefully.
+    /// Oracle: docs/property-tests.md §4.c.4 — must not be silently dropped.
+    #[test]
+    fn unknown_received_record_not_dropped() {
+        let dispatched = vec![]; // empty
+        let mut received = BTreeMap::new();
+        received.insert(
+            "unknown".into(),
+            full(
+                "unknown",
+                99,
+                "Mystery",
+                step_status::COMPLETED,
+                step_conclusion::SUCCEEDED,
+            ),
+        );
+        let out = reconcile_cancelled_steps(&dispatched, &received);
+        // With empty dispatched, no tasks to reconcile — output should be empty
+        // (unknown records are not in scope of dispatched reconciliation)
+        assert_eq!(out.len(), 0);
+    }
+
+    /// Twirp conclusion constants match the proto enum from golden flows.
+    /// Oracle: docs/property-tests.md §4 — conclusion mapping from Twirp schema.
+    #[test]
+    fn twirp_conclusion_mapping() {
+        assert_eq!(step_conclusion::SUCCEEDED, 2);
+        assert_eq!(step_conclusion::FAILED, 3);
+        assert_eq!(step_conclusion::SKIPPED, 7);
+        assert_eq!(step_status::IN_PROGRESS, 2);
+        assert_eq!(step_status::COMPLETED, 6);
+    }
+
+    /// Generated merges produce valid field types.
+    /// Oracle: docs/property-tests.md §4.12 — valid field types.
+    proptest! {
+        #![proptest_config(ProptestConfig { cases: 1_000, ..ProptestConfig::default() })]
+
+        #[test]
+        fn valid_field_types_in_generated_merges(
+            updates in proptest::collection::vec(arb_partial(), 1..6)
+        ) {
+            let mut store = BTreeMap::new();
+            for u in updates {
+                apply_step_update(&mut store, &u);
+            }
+            for (ext_id, record) in &store {
+                prop_assert!(!ext_id.is_empty(), "empty external_id");
+                prop_assert!(!record.external_id.is_empty(), "empty record external_id");
+                prop_assert!(
+                    matches!(record.status, 0 | step_status::IN_PROGRESS | step_status::COMPLETED),
+                    "unknown status {}", record.status
+                );
+                prop_assert!(
+                    matches!(record.conclusion, 0 | step_conclusion::SUCCEEDED | step_conclusion::FAILED | step_conclusion::SKIPPED),
+                    "unknown conclusion {}", record.conclusion
+                );
+            }
+        }
+    }
 }

--- a/crates/aksh-runner/src/worker/step_records.rs
+++ b/crates/aksh-runner/src/worker/step_records.rs
@@ -1,0 +1,588 @@
+//! Step-record merge and cancellation reconciliation.
+//!
+//! Official runner (`actions/runner` v2.335.1) reports steps via Twirp
+//! `WorkflowStepsUpdate` as a **cumulative** map keyed by `external_id`.
+//! Status progresses `InProgress (2) → Completed (6)`. Partial / out-of-order
+//! updates must not erase conclusions or regress status.
+//!
+//! On cancellation, every interrupted in-flight task ends with exactly one
+//! terminal cancelled record; already-completed steps are left alone; setup
+//! and complete-job synthetic records remain valid.
+
+use std::collections::BTreeMap;
+
+use super::server_queue::{step_conclusion, step_status, StepUpdate};
+
+/// Partial step update — omitted fields preserve existing values on merge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PartialStepUpdate {
+    /// Identity key (UUID / wire external_id). Required.
+    pub external_id: String,
+    /// Ordinal number (1-based). Omitted → keep previous.
+    pub number: Option<u32>,
+    /// Display name. Omitted → keep previous.
+    pub name: Option<String>,
+    /// Status enum. Omitted → keep previous; regressions are ignored.
+    pub status: Option<u32>,
+    /// Start timestamp. `None` means omit; `Some(None)` would clear — we only
+    /// support omit (`None`) or set (`Some(value)`).
+    pub started_at: Option<String>,
+    /// Whether `started_at` is present in this update.
+    pub has_started_at: bool,
+    /// Completion timestamp.
+    pub completed_at: Option<String>,
+    /// Whether `completed_at` is present in this update.
+    pub has_completed_at: bool,
+    /// Conclusion enum. Omitted → keep previous; never erase a non-zero
+    /// conclusion with zero/absent unless status is still non-terminal.
+    pub conclusion: Option<u32>,
+}
+
+impl PartialStepUpdate {
+    /// Build a partial update from a full `StepUpdate` (all fields present).
+    pub fn from_full(update: &StepUpdate) -> Self {
+        Self {
+            external_id: update.external_id.clone(),
+            number: Some(update.number),
+            name: Some(update.name.clone()),
+            status: Some(update.status),
+            started_at: update.started_at.clone(),
+            has_started_at: true,
+            completed_at: update.completed_at.clone(),
+            has_completed_at: true,
+            conclusion: Some(update.conclusion),
+        }
+    }
+}
+
+/// Rank for status monotonicity. Higher is later in the lifecycle.
+pub fn status_rank(status: u32) -> u8 {
+    match status {
+        step_status::IN_PROGRESS => 1,
+        step_status::COMPLETED => 2,
+        // Unknown / pending-like values sort before in-progress.
+        _ => 0,
+    }
+}
+
+/// Merge `incoming` into `existing` (if any) under official identity rules.
+///
+/// - Identity is solely `external_id` (number never re-keys a different step).
+/// - Omitted fields preserve existing values.
+/// - Status never regresses (Completed ↛ InProgress).
+/// - Non-zero conclusion is not erased by a later partial without conclusion.
+/// - Duplicate identical merges are idempotent.
+pub fn merge_step_update(
+    existing: Option<&StepUpdate>,
+    incoming: &PartialStepUpdate,
+) -> StepUpdate {
+    let base = existing.cloned().unwrap_or(StepUpdate {
+        external_id: incoming.external_id.clone(),
+        number: incoming.number.unwrap_or(0),
+        name: incoming.name.clone().unwrap_or_default(),
+        status: incoming.status.unwrap_or(0),
+        started_at: None,
+        completed_at: None,
+        conclusion: 0,
+    });
+
+    let mut merged = base;
+
+    if let Some(number) = incoming.number {
+        merged.number = number;
+    }
+    if let Some(name) = incoming.name.clone() {
+        merged.name = name;
+    }
+
+    if let Some(status) = incoming.status {
+        if status_rank(status) >= status_rank(merged.status) {
+            merged.status = status;
+        }
+    }
+
+    if incoming.has_started_at {
+        // Prefer first non-empty started_at; do not clear once set.
+        if merged.started_at.is_none() {
+            merged.started_at = incoming.started_at.clone();
+        } else if incoming.started_at.is_some() && merged.started_at.is_none() {
+            merged.started_at = incoming.started_at.clone();
+        }
+    }
+
+    if incoming.has_completed_at {
+        if incoming.completed_at.is_some() || merged.completed_at.is_none() {
+            // Allow setting completed_at; do not clear a set value with None
+            // unless we are explicitly completing again with a timestamp.
+            if let Some(ref ts) = incoming.completed_at {
+                merged.completed_at = Some(ts.clone());
+            }
+        }
+    }
+
+    if let Some(conclusion) = incoming.conclusion {
+        // Never erase a real conclusion with 0 (unset).
+        if conclusion != 0 || merged.conclusion == 0 {
+            merged.conclusion = conclusion;
+        }
+    }
+
+    // Completed steps must keep a terminal conclusion if one was ever set.
+    if merged.status == step_status::COMPLETED && merged.conclusion == 0 {
+        if let Some(prev) = existing {
+            if prev.conclusion != 0 {
+                merged.conclusion = prev.conclusion;
+            }
+        }
+    }
+
+    merged.external_id = incoming.external_id.clone();
+    merged
+}
+
+/// Apply a partial update into a map keyed by external_id.
+pub fn apply_step_update(
+    store: &mut BTreeMap<String, StepUpdate>,
+    incoming: &PartialStepUpdate,
+) -> StepUpdate {
+    let existing = store.get(&incoming.external_id);
+    let merged = merge_step_update(existing, incoming);
+    store.insert(incoming.external_id.clone(), merged.clone());
+    merged
+}
+
+/// A dispatched task that may need cancellation reconciliation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DispatchedTask {
+    /// Wire external_id.
+    pub external_id: String,
+    /// Step number.
+    pub number: u32,
+    /// Display name.
+    pub name: String,
+    /// True for synthetic setup / complete-job records.
+    pub synthetic: bool,
+}
+
+/// Reconcile dispatched tasks against partial received records after cancel.
+///
+/// Official rules encoded here:
+/// - Every interrupted in-flight (non-completed) task gets exactly one
+///   cancelled terminal record.
+/// - Completed steps are not rewritten as cancelled.
+/// - Synthetic setup/complete-job records that already completed stay as-is;
+///   missing complete-job is added as cancelled only if it was dispatched
+///   and not completed.
+/// - Final order is by step number (stable).
+pub fn reconcile_cancelled_steps(
+    dispatched: &[DispatchedTask],
+    received: &BTreeMap<String, StepUpdate>,
+) -> Vec<StepUpdate> {
+    let mut out: BTreeMap<String, StepUpdate> = BTreeMap::new();
+
+    for task in dispatched {
+        if let Some(existing) = received.get(&task.external_id) {
+            if existing.status == step_status::COMPLETED {
+                // Keep completed as-is (including success/failure/skipped).
+                out.insert(task.external_id.clone(), existing.clone());
+                continue;
+            }
+            // In-flight or unknown → force cancelled terminal.
+            let mut cancelled = existing.clone();
+            cancelled.status = step_status::COMPLETED;
+            cancelled.conclusion = step_conclusion::FAILED; // Twirp has no cancel enum
+            cancelled.name = if cancelled.name.is_empty() {
+                task.name.clone()
+            } else {
+                cancelled.name
+            };
+            cancelled.number = if cancelled.number == 0 {
+                task.number
+            } else {
+                cancelled.number
+            };
+            if cancelled.completed_at.is_none() {
+                cancelled.completed_at = Some("cancelled".into());
+            }
+            out.insert(task.external_id.clone(), cancelled);
+        } else {
+            // Never reported — emit a single cancelled record.
+            out.insert(
+                task.external_id.clone(),
+                StepUpdate {
+                    external_id: task.external_id.clone(),
+                    number: task.number,
+                    name: task.name.clone(),
+                    status: step_status::COMPLETED,
+                    started_at: None,
+                    completed_at: Some("cancelled".into()),
+                    conclusion: step_conclusion::FAILED,
+                },
+            );
+        }
+    }
+
+    let mut steps: Vec<StepUpdate> = out.into_values().collect();
+    steps.sort_by_key(|s| s.number);
+    steps
+}
+
+/// Count cancelled terminal records (completed + failed conclusion used for cancel).
+pub fn count_cancelled(records: &[StepUpdate]) -> usize {
+    records
+        .iter()
+        .filter(|r| r.status == step_status::COMPLETED && r.conclusion == step_conclusion::FAILED)
+        .count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn full(id: &str, number: u32, name: &str, status: u32, conclusion: u32) -> StepUpdate {
+        StepUpdate {
+            external_id: id.into(),
+            number,
+            name: name.into(),
+            status,
+            started_at: Some("t0".into()),
+            completed_at: if status == step_status::COMPLETED {
+                Some("t1".into())
+            } else {
+                None
+            },
+            conclusion,
+        }
+    }
+
+    #[test]
+    fn completed_does_not_regress_to_in_progress() {
+        let existing = full(
+            "s1",
+            1,
+            "A",
+            step_status::COMPLETED,
+            step_conclusion::SUCCEEDED,
+        );
+        let incoming = PartialStepUpdate {
+            external_id: "s1".into(),
+            number: Some(1),
+            name: Some("A".into()),
+            status: Some(step_status::IN_PROGRESS),
+            started_at: Some("t0".into()),
+            has_started_at: true,
+            completed_at: None,
+            has_completed_at: true,
+            conclusion: Some(0),
+        };
+        let merged = merge_step_update(Some(&existing), &incoming);
+        assert_eq!(merged.status, step_status::COMPLETED);
+        assert_eq!(merged.conclusion, step_conclusion::SUCCEEDED);
+    }
+
+    #[test]
+    fn omitted_fields_preserve_existing() {
+        let existing = full("s1", 2, "Build", step_status::IN_PROGRESS, 0);
+        let incoming = PartialStepUpdate {
+            external_id: "s1".into(),
+            number: None,
+            name: None,
+            status: Some(step_status::COMPLETED),
+            started_at: None,
+            has_started_at: false,
+            completed_at: Some("t9".into()),
+            has_completed_at: true,
+            conclusion: Some(step_conclusion::FAILED),
+        };
+        let merged = merge_step_update(Some(&existing), &incoming);
+        assert_eq!(merged.number, 2);
+        assert_eq!(merged.name, "Build");
+        assert_eq!(merged.started_at.as_deref(), Some("t0"));
+        assert_eq!(merged.status, step_status::COMPLETED);
+        assert_eq!(merged.conclusion, step_conclusion::FAILED);
+    }
+
+    #[test]
+    fn unrelated_steps_never_merge() {
+        let mut store = BTreeMap::new();
+        apply_step_update(
+            &mut store,
+            &PartialStepUpdate::from_full(&full(
+                "a",
+                1,
+                "A",
+                step_status::COMPLETED,
+                step_conclusion::SUCCEEDED,
+            )),
+        );
+        apply_step_update(
+            &mut store,
+            &PartialStepUpdate::from_full(&full(
+                "b",
+                1,
+                "B",
+                step_status::COMPLETED,
+                step_conclusion::FAILED,
+            )),
+        );
+        assert_eq!(store.len(), 2);
+        assert_eq!(store["a"].conclusion, step_conclusion::SUCCEEDED);
+        assert_eq!(store["b"].conclusion, step_conclusion::FAILED);
+    }
+
+    #[test]
+    fn reconcile_cancels_in_flight_preserves_completed() {
+        let dispatched = vec![
+            DispatchedTask {
+                external_id: "setup".into(),
+                number: 1,
+                name: "Set up job".into(),
+                synthetic: true,
+            },
+            DispatchedTask {
+                external_id: "s1".into(),
+                number: 2,
+                name: "Run".into(),
+                synthetic: false,
+            },
+            DispatchedTask {
+                external_id: "s2".into(),
+                number: 3,
+                name: "Later".into(),
+                synthetic: false,
+            },
+        ];
+        let mut received = BTreeMap::new();
+        received.insert(
+            "setup".into(),
+            full(
+                "setup",
+                1,
+                "Set up job",
+                step_status::COMPLETED,
+                step_conclusion::SUCCEEDED,
+            ),
+        );
+        received.insert(
+            "s1".into(),
+            full("s1", 2, "Run", step_status::IN_PROGRESS, 0),
+        );
+        // s2 never reported
+
+        let out = reconcile_cancelled_steps(&dispatched, &received);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].conclusion, step_conclusion::SUCCEEDED);
+        assert_eq!(out[1].status, step_status::COMPLETED);
+        assert_eq!(out[1].conclusion, step_conclusion::FAILED);
+        assert_eq!(out[2].conclusion, step_conclusion::FAILED);
+        // Exactly one cancelled record per interrupted task (s1, s2); setup untouched.
+        assert_eq!(
+            out.iter()
+                .filter(|r| r.conclusion == step_conclusion::FAILED)
+                .count(),
+            2
+        );
+    }
+
+    fn arb_status() -> impl Strategy<Value = u32> {
+        prop_oneof![
+            Just(0u32),
+            Just(step_status::IN_PROGRESS),
+            Just(step_status::COMPLETED),
+        ]
+    }
+
+    fn arb_conclusion() -> impl Strategy<Value = u32> {
+        prop_oneof![
+            Just(0u32),
+            Just(step_conclusion::SUCCEEDED),
+            Just(step_conclusion::FAILED),
+            Just(step_conclusion::SKIPPED),
+        ]
+    }
+
+    fn arb_partial() -> impl Strategy<Value = PartialStepUpdate> {
+        (
+            "[a-c]{1}",
+            prop::option::of(1u32..5),
+            prop::option::of("[A-Z]{1,4}"),
+            prop::option::of(arb_status()),
+            prop::option::of(arb_conclusion()),
+            any::<bool>(),
+            any::<bool>(),
+        )
+            .prop_map(
+                |(id, number, name, status, conclusion, has_started, has_completed)| {
+                    PartialStepUpdate {
+                        external_id: id,
+                        number,
+                        name,
+                        status,
+                        started_at: has_started.then(|| "t".into()),
+                        has_started_at: has_started,
+                        completed_at: has_completed.then(|| "t".into()),
+                        has_completed_at: has_completed,
+                        conclusion,
+                    }
+                },
+            )
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(10_000))]
+
+        /// Merging the same partial twice is idempotent.
+        #[test]
+        fn merge_idempotent(first in arb_partial(), second in arb_partial()) {
+            let mut store = BTreeMap::new();
+            let a = apply_step_update(&mut store, &first);
+            let b = apply_step_update(&mut store, &first);
+            prop_assert_eq!(&a, &b);
+
+            // Force a distinct second id so we never reject on collision.
+            let mut second = second;
+            if second.external_id == first.external_id {
+                second.external_id = format!("{}'", first.external_id);
+            }
+            apply_step_update(&mut store, &second);
+            prop_assert_eq!(store.len(), 2);
+        }
+
+        /// Status is monotonic under a sequence of updates to one id.
+        #[test]
+        fn status_monotonic(updates in proptest::collection::vec(arb_partial(), 1..8)) {
+            let mut store = BTreeMap::new();
+            let id = "step".to_string();
+            let mut last_rank = 0u8;
+            for mut u in updates {
+                u.external_id = id.clone();
+                let merged = apply_step_update(&mut store, &u);
+                let rank = status_rank(merged.status);
+                prop_assert!(rank >= last_rank, "status regressed {} → {}", last_rank, rank);
+                last_rank = rank;
+            }
+        }
+
+        /// Conclusion once set non-zero is never erased by conclusion=0 partial.
+        #[test]
+        fn conclusion_not_erased(
+            c in prop_oneof![
+                Just(step_conclusion::SUCCEEDED),
+                Just(step_conclusion::FAILED),
+                Just(step_conclusion::SKIPPED),
+            ]
+        ) {
+            let existing = full("s", 1, "X", step_status::COMPLETED, c);
+            let incoming = PartialStepUpdate {
+                external_id: "s".into(),
+                number: None,
+                name: None,
+                status: None,
+                started_at: None,
+                has_started_at: false,
+                completed_at: None,
+                has_completed_at: false,
+                conclusion: Some(0),
+            };
+            let merged = merge_step_update(Some(&existing), &incoming);
+            prop_assert_eq!(merged.conclusion, c);
+        }
+
+        /// external_id is the only identity: same number, different id → two rows.
+        #[test]
+        fn external_id_not_number(suffix in 0u32..1000) {
+            // Generate distinct ids without prop_assume rejects.
+            let id_a = format!("a{suffix}");
+            let id_b = format!("b{suffix}");
+            let mut store = BTreeMap::new();
+            apply_step_update(
+                &mut store,
+                &PartialStepUpdate::from_full(&full(
+                    &id_a,
+                    1,
+                    "A",
+                    step_status::COMPLETED,
+                    step_conclusion::SUCCEEDED,
+                )),
+            );
+            apply_step_update(
+                &mut store,
+                &PartialStepUpdate::from_full(&full(
+                    &id_b,
+                    1,
+                    "B",
+                    step_status::COMPLETED,
+                    step_conclusion::FAILED,
+                )),
+            );
+            prop_assert_eq!(store.len(), 2);
+        }
+
+        /// Cancel reconciliation: completed preserved; others terminal cancelled once.
+        #[test]
+        fn reconcile_exactly_one_cancel_per_open(
+            n in 1usize..6,
+            completed_mask in 0u8..32
+        ) {
+            let dispatched: Vec<DispatchedTask> = (0..n)
+                .map(|i| DispatchedTask {
+                    external_id: format!("t{i}"),
+                    number: (i as u32) + 1,
+                    name: format!("step{i}"),
+                    synthetic: i == 0,
+                })
+                .collect();
+            let mut received = BTreeMap::new();
+            for (i, task) in dispatched.iter().enumerate() {
+                if completed_mask & (1 << (i % 8)) != 0 {
+                    received.insert(
+                        task.external_id.clone(),
+                        full(
+                            &task.external_id,
+                            task.number,
+                            &task.name,
+                            step_status::COMPLETED,
+                            step_conclusion::SUCCEEDED,
+                        ),
+                    );
+                } else if i % 2 == 0 {
+                    received.insert(
+                        task.external_id.clone(),
+                        full(
+                            &task.external_id,
+                            task.number,
+                            &task.name,
+                            step_status::IN_PROGRESS,
+                            0,
+                        ),
+                    );
+                }
+            }
+            let out = reconcile_cancelled_steps(&dispatched, &received);
+            prop_assert_eq!(out.len(), n);
+            // Order by number.
+            for w in out.windows(2) {
+                prop_assert!(w[0].number <= w[1].number);
+            }
+            for task in &dispatched {
+                let rec = out.iter().find(|r| r.external_id == task.external_id).unwrap();
+                if let Some(prev) = received.get(&task.external_id) {
+                    if prev.status == step_status::COMPLETED {
+                        prop_assert_eq!(rec.conclusion, step_conclusion::SUCCEEDED);
+                    } else {
+                        prop_assert_eq!(rec.status, step_status::COMPLETED);
+                        prop_assert_eq!(rec.conclusion, step_conclusion::FAILED);
+                    }
+                } else {
+                    prop_assert_eq!(rec.conclusion, step_conclusion::FAILED);
+                }
+            }
+            // No duplicates.
+            let mut ids = std::collections::BTreeSet::new();
+            for r in &out {
+                prop_assert!(ids.insert(r.external_id.clone()));
+            }
+        }
+    }
+}

--- a/crates/aksh-runner/src/worker/steps_runner.rs
+++ b/crates/aksh-runner/src/worker/steps_runner.rs
@@ -769,83 +769,32 @@ pub async fn run_steps(
 }
 
 fn should_run_step(step: &Step, job: &JobContext) -> Result<bool> {
-    let condition = match &step.condition {
-        Some(c) if !c.is_empty() => c.as_str(),
-        _ => "success()",
-    };
-    let stripped = aksh_gha_expressions::trim_expression_markers(condition);
-    let effective_condition = if contains_status_check_function(stripped) {
-        stripped.to_string()
-    } else {
-        format!("success() && ({stripped})")
-    };
+    use super::step_conditions::{contains_status_check_function, effective_condition};
 
+    let raw = step.condition.as_deref();
+    let effective = effective_condition(raw);
     let ctx = job.build_expression_context();
-    match aksh_gha_expressions::eval_bool(&effective_condition, &ctx) {
+    match aksh_gha_expressions::eval_bool(&effective, &ctx) {
         Ok(result) => Ok(result),
         Err(effective_error) => {
+            // Fallback: retry with untrimmed markers if the strip path failed.
+            let condition = match raw {
+                Some(c) if !c.is_empty() => c,
+                _ => return Err(effective_error.into()),
+            };
+            let stripped = aksh_gha_expressions::trim_expression_markers(condition);
             if stripped == condition {
                 Err(effective_error.into())
             } else {
-                aksh_gha_expressions::eval_bool(
-                    &if contains_status_check_function(condition) {
-                        condition.to_string()
-                    } else {
-                        format!("success() && ({condition})")
-                    },
-                    &ctx,
-                )
-                .map_err(Into::into)
+                let fallback = if contains_status_check_function(condition) {
+                    condition.to_string()
+                } else {
+                    format!("success() && ({condition})")
+                };
+                aksh_gha_expressions::eval_bool(&fallback, &ctx).map_err(Into::into)
             }
         }
     }
-}
-
-fn contains_status_check_function(condition: &str) -> bool {
-    let mut chars = condition.char_indices().peekable();
-    while let Some((_, ch)) = chars.next() {
-        if ch == '\'' || ch == '"' {
-            let quote = ch;
-            while let Some((_, quoted)) = chars.next() {
-                if quoted == '\\' {
-                    let _ = chars.next();
-                } else if quoted == quote {
-                    break;
-                }
-            }
-            continue;
-        }
-
-        if ch == '_' || ch.is_ascii_alphabetic() {
-            let mut ident = String::from(ch);
-            while let Some((_, next)) = chars.peek().copied() {
-                if next == '_' || next.is_ascii_alphanumeric() {
-                    ident.push(next);
-                    let _ = chars.next();
-                } else {
-                    break;
-                }
-            }
-
-            while let Some((_, whitespace)) = chars.peek().copied() {
-                if whitespace.is_whitespace() {
-                    let _ = chars.next();
-                } else {
-                    break;
-                }
-            }
-
-            if matches!(
-                ident.to_ascii_lowercase().as_str(),
-                "success" | "failure" | "cancelled" | "always"
-            ) && chars.peek().is_some_and(|(_, next)| *next == '(')
-            {
-                return true;
-            }
-        }
-    }
-
-    false
 }
 
 /// Execute a single step, threading cancel_rx to the process invoker.
@@ -1086,6 +1035,7 @@ mod tests {
     use super::*;
     use crate::worker::contexts::JobContext;
     use crate::worker::server_queue::ServerQueue;
+    use crate::worker::step_conditions::contains_status_check_function;
     use std::sync::Arc;
     use tempfile::TempDir;
     use tokio::sync::{watch, Mutex};

--- a/docs/property-testing-impl-log.md
+++ b/docs/property-testing-impl-log.md
@@ -1,0 +1,267 @@
+# Property Testing Implementation Log
+
+Tracking implementation of the first four families from
+`docs/property-testing-plan.md`, using official `actions/runner` v2.335.1
+semantics as the reference oracle.
+
+## Session start
+
+Date: 2026-07-13
+
+### Scope
+
+1. DAG scheduler model and dependency ordering
+2. Matrix include/exclude and deferred-matrix generator
+3. Condition truth tables (especially after prior failure)
+4. Step-update merge and cancellation reconciliation
+
+### Official-runner references consulted
+
+| Surface | Official source | aksh counterpart |
+|---|---|---|
+| Condition functions | `L0/Worker/Expressions/ConditionFunctionsL0.cs` | `aksh-gha-expressions` + `step_conditions` |
+| Implicit `success() &&` gate | StepsRunner condition evaluation | `evaluate_step_condition` / `effective_condition` |
+| Matrix expand | GitHub Actions matrix docs + runner.server | `matrix_expand::expand_matrix_spec` |
+| Needs / DAG | Workflow validation + job dispatch on `needs` | `scheduling` + `dag` |
+| Step updates | Twirp `WorkflowStepsUpdate` by `external_id` | `step_records::merge_step_update` |
+| Cancel reconciliation | Cancel → terminal records for open steps | `reconcile_cancelled_steps` |
+
+### Design choices
+
+- **Pure models first.** Free functions / small state machines mirror production
+  rules so proptest can shrink failures without HTTP/VMs.
+- **Structured generators.** Job graphs, matrix specs, and step records are
+  generated as Rust values, not random YAML.
+- **No protocol divergences.** Where production is incomplete (job-level `if`
+  after failed needs; full deferred matrix expansion), pure models encode the
+  official contract and tests pin the expected identity behavior.
+
+---
+
+## Work log
+
+### [1] DAG scheduler model — DONE
+
+**Files:**
+- `crates/aksh-runner-server/src/scheduling.rs` (new)
+- `crates/aksh-gha-parser/src/dag.rs` (new)
+- `crates/aksh-runner-server/src/lib.rs` — `need_satisfied` delegates to pure model
+
+**API:**
+- `detect_needs_cycle`, `need_satisfied`, `under_max_parallel`, `promote_ready_jobs`
+- `seed_from_jobs`, `complete_job`, `acquire_next`, `run_settled`
+- Parser-side `dag::detect_needs_cycle`, `topo_layers`
+
+**Properties (proptest, 128–256 cases):**
+- No duplicate placement in queue/pending
+- Success wave settles every generated DAG
+- Never dispatch before needs are Success|Skipped
+- Promote is deterministic
+- Failure blocks dependents under default rules
+- Cycle detector stable / flags mutual edges
+- Topo layers respect needs ordering
+
+**Official alignment:**
+- Default need gate = Success | Skipped (not Failure/Cancelled/InProgress)
+- Matrix base-id prefix `"base ("` requires all siblings terminal success/skip
+- Cycles rejected before dispatch (validation model; server still does not
+  reject at submit — model is ready for wiring)
+
+### [2] Matrix include/exclude + deferred — DONE
+
+**Files:**
+- `crates/aksh-gha-parser/src/matrix_expand.rs` (new)
+- `crates/aksh-gha-parser/src/lib.rs` — `expand_matrix` delegates to pure expander
+
+**API:**
+- `MatrixSpec`, `MatrixCombination`, `DeferredMatrixAxis`, `ExpandOutcome`
+- `expand_matrix_spec`, `cartesian_count`, `expanded_job_id`
+- `expand_with_deferred`, `unresolved_display_identity`, `matrix_to_spec`
+
+**Properties:**
+- Never empty / never panics
+- Unique combos when axis values unique (dup axis values fan out, as GitHub)
+- Exclude applies only to cartesian product (before include)
+- Deterministic expansion
+- Cartesian count = product of axis lengths
+- Deferred failure preserves `${{ matrix.* }}` template (scenario 63 family)
+- Include-only rows tagged
+
+**Official alignment:**
+- Cartesian → exclude (partial match) → include merge-or-append → empty fallback
+- Scenario 63: unresolved display must not collapse to bare base id
+
+**Gap still open:** runtime expansion of `fromJSON(needs.*.outputs.*)` matrices
+in the server/parser path is not implemented; the pure model + properties pin
+the contract for when it is.
+
+### [3] Condition truth tables — DONE
+
+**Files:**
+- `crates/aksh-gha-expressions/src/lib.rs` — expanded proptest truthiness + status
+- `crates/aksh-runner/src/worker/step_conditions.rs` (new)
+- `crates/aksh-runner/src/worker/steps_runner.rs` — uses shared condition logic
+
+**API:**
+- `StatusFlags`, `contains_status_check_function`, `effective_condition`
+- `evaluate_step_condition`
+
+**Properties / tables:**
+- null/bool/number/string/array/object truthiness (aksh semantics locked)
+- status flags ↔ success/failure/cancelled/always for all 8-ish flag combos
+- Context flags not mutated by eval
+- `skipped` is not a status function
+- Default condition ≡ `success()`
+- Bare literals gated by `success() && (expr)` (official StepsRunner)
+- `always()` constant true; `failure() || cancelled()` compound
+- After-failure: default skip, `failure()` run, `always()` run
+
+**Official alignment:** ConditionFunctionsL0 + StepsRunner implicit gate.
+**Fidelity note:** empty array/object falsy in aksh; some GitHub paths treat
+non-null containers as truthy — documented, not papered over.
+
+### [4] Step merge + cancel reconciliation — DONE
+
+**Files:**
+- `crates/aksh-runner/src/worker/step_records.rs` (new)
+- `crates/aksh-runner/src/worker/server_queue.rs` — `queue_update` uses merge
+
+**API:**
+- `PartialStepUpdate`, `merge_step_update`, `apply_step_update`
+- `DispatchedTask`, `reconcile_cancelled_steps`, `status_rank`
+
+**Properties:**
+- Merge idempotent
+- Status monotonic (Completed ↛ InProgress)
+- Conclusion not erased by zero/omitted partial
+- external_id identity (number alone never merges distinct steps)
+- Cancel reconcile: completed preserved; each open task exactly one cancelled
+  terminal; deterministic number order; no duplicate ids
+
+**Official alignment:**
+- Cumulative WorkflowStepsUpdate keyed by external_id
+- Twirp has no cancel conclusion → cancelled maps to FAILED (existing convention)
+- Setup completed records survive cancel
+
+---
+
+## Test results (2026-07-13)
+
+```
+aksh-gha-parser --lib          60 passed
+aksh-gha-expressions --lib     30 passed
+aksh-runner-server scheduling  12 passed
+aksh-runner worker::step_*     all passed
+aksh-runner worker::server_queue / steps_runner condition tests  passed
+```
+
+Pre-existing unrelated failures (not introduced here):
+- `listener::job_dispatcher::tests::test_worker_dispatch_run_new_job`
+- `listener::job_dispatcher::tests::test_worker_dispatch_cancellation`
+  (fail on clean tree too; CLI `via` option noise)
+
+---
+
+## Follow-ups
+
+1. Implement real deferred matrix expansion at job promotion time; keep
+   scenario 63 fixture under `fixtures/` once server path exists.
+2. Next plan items: action lifecycle generator, DTO round-trips, secrets/commands.
+
+---
+
+## Official-oracle alignment pass (2026-07-13, continued)
+
+### What “official reference” means here
+
+Tier-1 property tests cannot boot the official binary per generated case. The
+oracle is the documented GitHub Actions contract plus pinned runner source for
+worker-side expression semantics. GitHub's service-side DAG implementation is
+private, so Aksh does not claim to copy its internal graph algorithm.
+
+| Property family | Exact oracle | Aksh property/model |
+|---|---|---|
+| `needs`, unknown jobs, cycles, ordering | [Workflow syntax: `jobs.<job_id>.needs`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) | `aksh-gha-parser::dag` | 
+| `success()`, `failure()`, `cancelled()`, `always()` | [Status-check functions](https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions) + `actions/runner` v2.335.1 `src/Runner.Worker/Expressions/*Function.cs` | `scheduling::oracle_should_run` |
+| Implicit condition gate | `actions/runner` v2.335.1 `src/Runner.Worker/StepsRunner.cs` and `WorkflowTemplateConverter.ConvertToIfCondition` | `effective_condition` / scheduler model |
+| Matrix sibling dependency | GitHub workflow syntax matrix/needs contract + `actions/runner` v2.335.1 matrix expansion source | matrix scheduling properties |
+| Production observable state | Same documented contract, exercised through Aksh's real router | `lib.rs` production DAG tests |
+
+The implementation algorithm is intentionally not treated as an oracle: GitHub
+does not publish the control-plane scheduler, so DFS/Kahn choices are Aksh
+internals validated by their observable contract.
+
+### Fidelity fixes found by re-reading official source
+
+1. **Include merges into ALL matching product rows**, not just the first
+   (`MatrixBuilder.MatrixInclude.Match` loops every vector). Fixed in
+   `expand_matrix_spec`.
+2. **All-excluded product → zero jobs**, not a synthetic empty combination.
+3. **`JobContext.Status == null` ⇒ `success()` true** (official null-coalesce).
+   Encoded as `OfficialJobStatus::Unset` in `official_oracles.rs`.
+
+### New module
+
+- `crates/aksh-runner/src/worker/official_oracles.rs` — L0 tables + p0 oracle +
+  ConvertToIfCondition parity properties at **10_000** cases.
+
+### Stress run
+
+All property suites set to `ProptestConfig::with_cases(10_000)` and re-run:
+
+```
+aksh-gha-parser matrix_expand   17 passed (~1.5s)
+aksh-gha-parser dag              5 passed
+aksh-runner-server scheduling   13 passed
+aksh-runner official_oracles     7 passed
+aksh-runner step_records         9 passed (~2.8s)
+aksh-runner step_conditions     17 passed
+aksh-gha-expressions            30 passed
+```
+
+### Still not done (honest)
+
+- No per-case official **binary** differential (Tier 3) — that needs constrained
+  workflow generation + `actions/runner` v2.335.1 execution harness.
+
+---
+
+## DAG production-path completion (2026-07-13)
+
+The DAG and dependency-ordering area now satisfies the model and production
+layers in `docs/property-tests.md`:
+
+- expanded plans reject unknown `needs` and cycles before server state changes;
+- failed or skipped dependencies terminal-skip default downstream jobs instead
+  of leaving them pending;
+- `always()`, `failure()`, and `cancelled()` are evaluated after all direct
+  dependencies become terminal, with `failure()` including transitive ancestors;
+- matrix base dependencies wait for every expanded sibling;
+- duplicate completion and late completion after cancellation are idempotent;
+- unfinished runs remain non-terminal while conditionally promoted cleanup jobs run;
+- model properties use an independent status/condition oracle;
+- production tests traverse structured YAML through parse, expansion, HTTP
+  submission, promotion, completion, and final server-visible state.
+
+Primary oracles remain the GitHub `jobs.<job_id>.needs` and status-function
+contracts plus the pinned `actions/runner` v2.335.1 condition implementations.
+
+### Generated production-path stress validation (2026-07-13)
+
+Added `generated_server_dag_properties_1000_cases`, which generates 1,000
+bounded deterministic acyclic workflows and drives each through the local
+Aksh router using the privileged `/internal/test/jobs/complete` simulation
+endpoint. The test compares final job states against an independent
+transitive-ancestor oracle.
+
+Result:
+
+```
+tests::generated_server_dag_properties_1000_cases ... ok
+1,000 generated workflows passed in 6.38s
+```
+
+This validates parser, dependency promotion, terminal skip propagation, and
+run settlement through the real server state machine. It does not execute
+shell steps in microVMs; those remain covered by the real-world runner/SmolVM
+benchmarks.

--- a/docs/property-tests.md
+++ b/docs/property-tests.md
@@ -1,0 +1,426 @@
+# Runner-Compatibility Property Tests
+
+## Purpose and scope
+
+This document defines the **native property tests required for the first four implementation areas** in `docs/property-testing-impl-log.md`:
+
+1. DAG scheduling and dependency ordering.
+2. Matrix expansion.
+3. Step/job condition evaluation.
+4. Step-update merging and cancellation reconciliation.
+
+These are not all tests for one binary. The four areas cross the runner boundary:
+
+| Area | Aksh code under test | Compatibility owner |
+|---|---|---|
+| DAG and dependency ordering | `crates/aksh-gha-parser`, `crates/aksh-runner-server` | Workflow/control-plane semantics; the official runner consumes the resulting job graph and status context. |
+| Matrix expansion | `crates/aksh-gha-parser`, `crates/aksh-runner-server` | Workflow parser/control-plane semantics; the official runner receives one job payload per expanded combination. |
+| Conditions | `crates/aksh-gha-expressions`, `crates/aksh-runner/src/worker/step_conditions.rs`, `steps_runner.rs` | Official runner worker condition registration/evaluation; job dependency gating is partly service-side. |
+| Step records/cancellation | `crates/aksh-runner/src/worker/step_records.rs`, `server_queue.rs`, reporting code | Official runner worker reporting and Twirp `WorkflowStepsUpdate` semantics. |
+
+A property test is incomplete if it tests only a pure helper while the production parser, server, or worker uses a different path. Each area therefore has two required layers:
+
+- **Model properties:** fast, structured generators with an independent reference model.
+- **Production-path properties:** the generated case passes through the real parser/server/worker boundary and the observable result is checked.
+
+The official reference is pinned to `actions/runner` **v2.335.1**, commit [`7d737449ef346f6524f75688d0c9c95fa10ba10a`](https://github.com/actions/runner/tree/7d737449ef346f6524f75688d0c9c95fa10ba10a). The source links below use that commit so an upstream change cannot silently alter the oracle.
+
+> A source link is a reference model, not permission to copy an implementation into the test subject. The expected-value model must not call the function under test.
+
+## Common requirements
+
+Every property suite MUST:
+
+- use bounded generators and explicit maximum depth/size;
+- use a deterministic `ProptestConfig` and preserve the seed on failure;
+- shrink the structured input before rendering YAML/JSON;
+- include at least one regression fixture for every fixed compatibility bug;
+- distinguish `omitted`, `null`, empty, false, zero, and present values where the wire contract distinguishes them;
+- assert errors explicitly instead of treating any `Err` as success;
+- fail if the generated case is not exercised by the production path;
+- test duplicate and out-of-order delivery where the protocol can retry;
+- avoid broad normalization of IDs, names, statuses, or conclusions;
+- record the official source path and commit beside each oracle rule.
+
+The test harness MUST fail loudly when a filtered test discovers zero tests. A successful Cargo command with all tests filtered out is not verification.
+
+---
+
+## 1. DAG scheduling and dependency ordering
+
+### Official references
+
+The official runner does not own the GitHub control-plane queue, so this area has two references:
+
+- GitHub workflow dependency contract: [`jobs.<job_id>.needs`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idneeds).
+- The official runner worker condition implementation is [`StepsRunner.cs`](https://github.com/actions/runner/blob/7d737449ef346f6524f75688d0c9c95fa10ba10a/src/Runner.Worker/StepsRunner.cs), especially its expression-function registration, condition evaluation, cancellation re-test, and skipped/failed completion branches. The implicit job/dependency behavior is partly control-plane/service-side rather than a public method in the runner repository; use the pinned GitHub workflow syntax contract and captured official behavior for that portion. Do not cite an unverified `ConvertToIfCondition` path as an official source file.
+- Aksh implementation:
+  - `crates/aksh-runner-server/src/lib.rs`: `promote_ready_jobs`, `need_satisfied`, run completion.
+  - `crates/aksh-runner-server/src/scheduling.rs`: pure scheduler model.
+  - `crates/aksh-gha-parser/src/dag.rs`: parser DAG validation/model.
+
+The server property suite must not claim that `Success | Skipped` is the complete official behavior. GitHub documents that failed or skipped dependencies cause dependent jobs to skip unless the dependent condition overrides that behavior.
+
+### Generator
+
+Generate a structured workflow before rendering YAML:
+
+```text
+1–8 unique job IDs
+0–8 needs edges, including cycles and unknown needs
+job-level if: absent, success(), failure(), cancelled(), always(), and compounds
+runs-on labels and max-parallel values
+terminal outcomes: success, failure, cancelled, skipped
+operation sequences: submit, validate, promote, poll, acquire, complete, cancel, retry
+```
+
+Generate both valid DAGs and intentionally cyclic graphs. Do not generate only edges to lower indices: that proves acyclicity by construction and cannot exercise parser rejection.
+
+### Required model properties
+
+For every operation prefix:
+
+1. A job is in at most one of pending, queued, running, or terminal states.
+2. A job is acquired at most once unless the protocol explicitly models a lease retry for the same owner.
+3. A job cannot dispatch before every required dependency is terminal.
+4. Once all dependencies are terminal, the dependent reaches exactly one of:
+   - dispatched because its condition permits execution;
+   - `Skipped` because the default dependency rule blocks it.
+5. Failed or skipped dependencies do not leave a dependent pending forever.
+6. `if: always()` can opt a dependent into execution after a failed/skipped dependency.
+7. `if: failure()` and `if: cancelled()` follow the official status context, not a local “need satisfied” shortcut.
+8. A terminal job never returns to pending, queued, or running.
+9. Duplicate completion is idempotent and cannot promote a dependent twice.
+10. Cancellation races have one deterministic terminal outcome.
+11. Every valid acyclic graph eventually settles when all runnable jobs are completed.
+12. Every cyclic graph is rejected before a job is queued.
+13. Reordering map insertion or equivalent input declaration order does not change the semantic graph or terminal results. Queue ordering is checked separately where the official contract defines it.
+
+### Production-path properties
+
+The generated workflow MUST pass through:
+
+```text
+structured workflow → YAML → parse_workflow → expand_jobs → server submission → promote/acquire/complete
+```
+
+Assert production observations, not only model state:
+
+- parser returns a structured cycle/unknown-needs error before submission succeeds;
+- queued job IDs equal the parser’s expanded IDs;
+- no duplicate broker acquisition occurs;
+- downstream jobs emit one terminal status;
+- run status becomes terminal rather than remaining `InProgress` with permanently blocked pending jobs.
+
+### Required regression fixtures
+
+- `build` fails; default `test` becomes skipped.
+- `build` is skipped; default `test` becomes skipped.
+- `build` fails; `cleanup` with `if: always()` runs.
+- `build` fails; `cleanup` with `if: failure()` follows the official result.
+- diamond graph: `build → test-a/test-b → deploy`.
+- cyclic graph rejected before dispatch.
+- duplicate completion does not create a second promotion.
+
+---
+
+## 2. Matrix expansion
+
+### Official references
+
+- Official source: [`MatrixBuilder.cs`](https://github.com/actions/runner/blob/7d737449ef346f6524f75688d0c9c95fa10ba10a/src/Sdk/WorkflowParser/Conversion/MatrixBuilder.cs).
+- Official documentation and overwrite example: [Running variations of jobs in a workflow](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs).
+- Aksh implementation:
+  - `crates/aksh-gha-parser/src/matrix_expand.rs`: model/expander.
+  - `crates/aksh-gha-parser/src/lib.rs`: parser integration.
+  - `crates/aksh-runner-server/src/lib.rs`: job promotion and expanded job identity.
+
+### Generator
+
+Generate a `MatrixSpec` with:
+
+```text
+0–4 axes, declared in random order
+0–4 values per axis
+booleans, integers, decimals, strings, null where accepted
+0–5 exclude objects
+0–5 include objects
+include objects containing axis keys, extra keys, and overlapping extra keys
+empty axes and all-excluded products
+include-only entries that match no original row
+deferred fromJSON(needs.*.outputs.*) axes
+producer outcome: success, failure, cancelled, missing output, malformed JSON
+```
+
+The generator must preserve the distinction between:
+
+```text
+original Cartesian axis values
+fields added by include
+internal scheduling ID
+base job ID
+display name
+matrix context
+```
+
+### Required model properties
+
+Use an independent reference expander that retains the original Cartesian rows. For every generated matrix:
+
+1. Cartesian count equals the product of axis lengths before exclusions, with overflow handled explicitly.
+2. Every original combination is deterministic and has the expected axis declaration order.
+3. An `exclude` object removes every matching original row and no non-matching row.
+4. Include filters are matched against original axis compatibility, not fields added by an earlier include.
+5. One include applies to every compatible original row, not only the first compatible row.
+6. A later include can overwrite an earlier include-added key when official semantics allow it.
+7. An unmatched include creates exactly one include-only row.
+8. Later includes do not accidentally mutate an earlier include-only row as though it were an original Cartesian row.
+9. Duplicate axis values are handled according to the official expansion contract; do not assert uniqueness merely because serialized value maps happen to match.
+10. Empty-axis, all-excluded, and include-only behavior is explicit and regression-tested.
+11. Expansion is deterministic for the same structured input.
+12. Expanded IDs, base IDs, display names, and matrix contexts do not collapse into one normalized job name.
+13. Deferred output either expands into concrete combinations or preserves the unresolved display template according to producer outcome; it must never silently collapse to the bare base ID.
+14. Size limits are enforced before expansion; a generated case cannot cause unbounded allocation.
+
+### Required fixed include regression
+
+This documented case MUST be present because it catches the most important include bug:
+
+```yaml
+matrix:
+  animal: [cat, dog]
+  include:
+    - color: green
+    - animal: cat
+      color: pink
+```
+
+The second entry must overwrite the earlier `color: green` on the original `cat` combination. It must not become a separate include-only row merely because `color` was introduced by the first include.
+
+### Production-path properties
+
+The generated workflow MUST pass through:
+
+```text
+structured workflow → YAML → parse_workflow → expand_jobs → server queue
+```
+
+Assert:
+
+- the number of actual job plans equals the reference result;
+- each plan has the expected matrix context;
+- each actual scheduling ID is unique and stable;
+- excluded jobs are never queued;
+- include-only rows do not invent axis display values;
+- deferred producer failure preserves the actual production display identity.
+
+### Required regression fixtures
+
+- official green→pink include overwrite.
+- include applies to multiple original rows.
+- all Cartesian rows excluded and no include-only rows.
+- include-only row with an extra key.
+- declaration-order permutation with stable combination set and official display ordering.
+- scenario 63 unresolved identity:
+
+```text
+matrix-build-${{ matrix.case }}-${{ matrix.mode }}
+```
+
+---
+
+## 3. Step and job condition evaluation
+
+### Official references
+
+- [`StepsRunner.cs`](https://github.com/actions/runner/blob/7d737449ef346f6524f75688d0c9c95fa10ba10a/src/Runner.Worker/StepsRunner.cs) — step execution loop, status-function registration, condition evaluation, cancellation re-test, and skipped/failed completion.
+- [`SuccessFunction.cs`](https://github.com/actions/runner/blob/7d737449ef346f6524f75688d0c9c95fa10ba10a/src/Runner.Worker/Expressions/SuccessFunction.cs) — `success()` behavior, including the official null-status fallback to success.
+- [`FailureFunction.cs`](https://github.com/actions/runner/blob/7d737449ef346f6524f75688d0c9c95fa10ba10a/src/Runner.Worker/Expressions/FailureFunction.cs), [`AlwaysFunction.cs`](https://github.com/actions/runner/blob/7d737449ef346f6524f75688d0c9c95fa10ba10a/src/Runner.Worker/Expressions/AlwaysFunction.cs), and [`CancelledFunction.cs`](https://github.com/actions/runner/blob/7d737449ef346f6524f75688d0c9c95fa10ba10a/src/Runner.Worker/Expressions/CancelledFunction.cs) — status functions.
+- The implicit job/dependency gate is partly service-side and is not represented by a verified public `ConvertToIfCondition` source file in this pinned runner tree. Anchor it to the [workflow syntax contract](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idneeds) and official captured behavior; keep the expected-value model independent of aksh.
+- Expression truthiness documentation: [Evaluate expressions in workflows and actions](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions).
+- Aksh implementation:
+  - `crates/aksh-gha-expressions/src/lib.rs`.
+  - `crates/aksh-runner/src/worker/step_conditions.rs`.
+  - `crates/aksh-runner/src/worker/steps_runner.rs`.
+
+### Generator
+
+Generate a bounded expression AST, not only arbitrary strings:
+
+```text
+status calls: success, failure, cancelled, always
+literals: null, booleans, integers, decimals, strings
+context paths and missing paths
+operators: !, &&, ||, ==, !=, <, <=, >, >=
+function nesting and parentheses
+optional ${{ }} markers
+whitespace-only and malformed source strings
+single-quoted strings with doubled quote escapes
+```
+
+Use a separate arbitrary-string strategy for parser safety. Do not confuse grammar generation with malformed-input generation.
+
+### Required independent-oracle properties
+
+The expected result MUST come from a small independent truth-table/reference evaluator. It must not call `effective_condition`, `contains_status_check_function`, or `evaluate_step_condition`.
+
+Assert:
+
+1. Default/empty/whitespace-only condition follows the documented default.
+2. `success()`, `failure()`, `cancelled()`, and `always()` match the official status table.
+3. A skipped state is not silently converted into a success/failure/cancelled status.
+4. A condition containing no status function receives the implicit `success() && (...)` gate.
+5. A real status-function call suppresses the implicit gate according to official conversion.
+6. Text such as `"always()"` or `'failure()'` inside a string is not detected as a function call.
+7. Doubled single-quote escapes do not terminate a string early.
+8. Parentheses, harmless whitespace, and expression markers preserve semantics.
+9. Compound conditions use normal precedence and do not mutate the context.
+10. Missing paths, null, empty strings, zero, negative zero, arrays, and objects follow the pinned official truthiness/coercion rules.
+11. Malformed conditions return a structured error, never panic, hang, or silently run an unintended step.
+12. Evaluation is deterministic and bounded by an explicit maximum expression depth/size.
+
+### Production-path properties
+
+Run generated conditions through the actual worker decision path:
+
+```text
+workflow Step → job/step context construction → steps_runner::should_run_step → emitted step record
+```
+
+For job-level conditions, run through:
+
+```text
+workflow Job → parser plan → server promotion → terminal job state
+```
+
+Assert that the condition decision, step record, job status, and downstream scheduling decision agree.
+
+### Required regression fixtures
+
+- default condition after a prior failure.
+- `always()` after failure and cancellation.
+- `failure() || cancelled()` compound expression.
+- quoted text containing `always()`.
+- doubled quote escape containing status-function text.
+- whitespace-only condition.
+- malformed unterminated expression.
+- missing context path versus explicit `null`.
+
+---
+
+## 4. Step-update merging and cancellation reconciliation
+
+### Official references
+
+- [`StepsRunner.cs`](https://github.com/actions/runner/blob/7d737449ef346f6524f75688d0c9c95fa10ba10a/src/Runner.Worker/StepsRunner.cs) — lifecycle transitions that produce step updates.
+- [`JobRunner.cs`](https://github.com/actions/runner/blob/7d737449ef346f6524f75688d0c9c95fa10ba10a/src/Runner.Worker/JobRunner.cs) — job lifecycle, completion, and cancellation handling.
+- [`StepsRunner.cs` search for `WorkflowStepsUpdate`](https://github.com/actions/runner/search?q=WorkflowStepsUpdate&type=code) — official reporting call sites; pin the exact containing type/method when updating the oracle.
+- Results-service schema/reference: [`WorkflowStepUpdateService`](https://github.com/actions/runner/tree/7d737449ef346f6524f75688d0c9c95fa10ba10a/src/Sdk/RSWebApi) and the repository’s captured Twirp golden flows under `.runner-watch/golden/v2.335.1/`.
+- Aksh implementation:
+  - `crates/aksh-runner/src/worker/step_records.rs`.
+  - `crates/aksh-runner/src/worker/server_queue.rs`.
+  - `crates/aksh-runner/src/worker/steps_runner.rs`.
+  - server Twirp handler in `crates/aksh-runner-server/src/lib.rs`.
+
+### Generator
+
+Generate:
+
+```text
+1–12 dispatched tasks
+external IDs, numbers, names, synthetic setup/main/post/complete records
+partial updates with each optional field omitted, null, or present
+status sequence: pending/in-progress/completed
+conclusion sequence: unset/succeeded/failed/skipped/cancelled mapping
+out-of-order permutations
+duplicate and retry updates
+received records missing from dispatched and dispatched records missing from received
+cancellation at every sequence position
+late completion after cancellation
+```
+
+Keep external ID, number, and display name independent. Do not generate them as one identity.
+
+### Required merge properties
+
+Maintain an independent reference map keyed by `external_id`. After every generated update:
+
+1. At most one record exists per external ID.
+2. External ID, not number or name, controls identity.
+3. Same number with different external IDs never merges.
+4. Omitted fields preserve existing values.
+5. Explicit null behavior follows the wire contract; it is not automatically treated as omission.
+6. Status never regresses from completed to in-progress.
+7. A non-zero conclusion is not erased by an unset/zero partial update.
+8. A duplicate identical update is idempotent.
+9. Out-of-order delivery follows the official cumulative-update rule.
+10. Unrelated records and synthetic setup/complete records are preserved.
+11. Final ordering is deterministic according to the official ordering field.
+12. Every generated record has valid field types and valid timestamp syntax where timestamps are present.
+
+### Required cancellation properties
+
+For every cancellation point:
+
+1. Every interrupted in-flight task receives exactly one terminal cancellation representation.
+2. Completed successful/failed/skipped tasks are preserved and are not rewritten as cancelled.
+3. Setup and complete-job synthetic records follow the official lifecycle behavior.
+4. Received records not present in the dispatched list are handled according to the captured protocol contract; they must not be silently dropped by an accidental intersection operation.
+5. Re-running reconciliation is idempotent.
+6. Duplicate cancellation notifications do not create duplicate records.
+7. A late completion cannot resurrect or regress a cancelled terminal record.
+8. Cancellation conclusion mapping is tested from the actual Twirp schema; do not invent a timestamp sentinel such as `"cancelled"` in a timestamp field.
+9. Final record order and `change_order` behavior are deterministic.
+
+### Production-path properties
+
+Run generated sequences through:
+
+```text
+actual worker step transition → ServerQueue::queue_update → WorkflowStepsUpdate body → server Twirp handler → stored/emitted record state
+```
+
+For cancellation, use the real worker cancellation path rather than calling only `reconcile_cancelled_steps`.
+
+Assert both:
+
+- the cumulative body sent to the results service;
+- the final server-visible record set.
+
+### Required regression fixtures
+
+- duplicate in-progress update.
+- completed update followed by stale in-progress update.
+- same number with two external IDs.
+- partial update that omits conclusion.
+- out-of-order start/complete updates.
+- cancellation with completed setup and open main step.
+- cancellation with open post step.
+- duplicate cancellation notification.
+- late completion after cancellation.
+
+---
+
+## Completion gates
+
+Do not mark an area complete until all gates pass:
+
+- property tests are declared in the crate module tree and appear in `cargo test -- --list`;
+- model and production-path suites both run;
+- generated cases shrink to bounded, reproducible fixtures;
+- no generated case panics, hangs, or allocates without a configured limit;
+- the expected-value model is independent of the subject under test;
+- every compatibility-sensitive rule cites the pinned official runner source or a captured official wire artifact;
+- known gaps are marked incomplete rather than encoded as passing properties;
+- fixed regressions are promoted to fixtures;
+- targeted tests, `cargo fmt --all --check`, and the relevant workspace checks pass.
+
+## Source-reference maintenance
+
+When upgrading the runner version:
+
+1. update the commit in this document;
+2. re-open every linked official source file;
+3. regenerate the fixed oracle tables and wire fixtures;
+4. rerun the property suites and official capture replay;
+5. record any semantic change as a new minimized regression fixture.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a pure scheduler model and property tests to align our runner with GitHub Actions across DAG needs, matrix expansion, conditions, and step update merging. Also introduces DAG validation in the parser and a gated local test API for CI simulation.

- **New Features**
  - `aksh-runner-server`: new `scheduling` module modeling `needs` and matrix fan-out; adds proptest regressions file; optional local test API guarded by `--enable-test-api` and `--test-api-token` (loopback only).
  - `aksh-gha-parser`: DAG validation with unknown-need and cycle errors; pure matrix expansion matching Actions semantics.
  - `aksh-gha-expressions` + `aksh-runner`: shared condition helpers (`validate_expression`, status-function detection) and step condition evaluation with implicit `success() && (...)`.
  - `aksh-runner`: step update merge/cancellation reconciliation and identity-safe `WorkflowStepsUpdate`; official oracles included for compatibility checks.
  - Docs: adds `docs/property-tests.md` and an implementation log.

- **Bug Fixes**
  - `aksh-gha-parser`: preserve task reference fields when building `uses` steps.
  - `aksh-gha-protocol`: align AzDO template map parsing and template token handling.

<sup>Written for commit b125ba015cb4f66615526413aaa8d1ab868b12ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/aksh/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

