### PR TITLE
Test workflows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
 name = "aksh-runner-client"
 version = "0.1.0"
 dependencies = [
+ "aksh-gha-parser",
  "aksh-gha-protocol",
  "anyhow",
  "clap",

--- a/crates/aksh-gha-expressions/src/evaluator.rs
+++ b/crates/aksh-gha-expressions/src/evaluator.rs
@@ -32,6 +32,7 @@ pub(super) fn validate_function_calls(expr: &Expr) -> Result<(), ExpressionError
                     | "join"
                     | "hashfiles"
                     | "tojson"
+                    | "case"
             ) {
                 return Err(ExpressionError::UnknownFunction(name.clone()));
             }
@@ -238,6 +239,25 @@ fn eval_call(name: &str, args: &[Expr], context: &Context) -> Result<Value, Expr
         "tojson" => Ok(Value::String(
             serde_json::to_string(values.first().unwrap_or(&Value::Null)).unwrap_or_default(),
         )),
+        "case" => {
+            if values.len() < 2 {
+                return Err(ExpressionError::InvalidFormat(
+                    "case() requires at least 2 arguments".to_owned(),
+                ));
+            }
+            let num_pairs = values.len() / 2;
+            for i in 0..num_pairs {
+                let cond = &values[i * 2];
+                if is_truthy(cond) {
+                    return Ok(values[i * 2 + 1].clone());
+                }
+            }
+            if values.len() % 2 == 1 {
+                Ok(values.last().cloned().unwrap_or(Value::Null))
+            } else {
+                Ok(Value::Null)
+            }
+        }
         _ => Err(ExpressionError::UnknownFunction(name.to_owned())),
     }
 }

--- a/crates/aksh-gha-expressions/src/evaluator.rs
+++ b/crates/aksh-gha-expressions/src/evaluator.rs
@@ -36,7 +36,35 @@ pub(super) fn validate_function_calls(expr: &Expr) -> Result<(), ExpressionError
             ) {
                 return Err(ExpressionError::UnknownFunction(name.clone()));
             }
+            if name.eq_ignore_ascii_case("case") && (args.len() < 3 || args.len().is_multiple_of(2))
+            {
+                return Err(ExpressionError::EvenCaseParameters);
+            }
             args.iter().try_for_each(validate_function_calls)
+        }
+    }
+}
+
+/// Collect all top-level context names referenced in an expression AST.
+pub(super) fn collect_contexts_from_expr(expr: &Expr, out: &mut std::collections::HashSet<String>) {
+    match expr {
+        Expr::Path(path) => {
+            if let Some(first) = path.first() {
+                out.insert(first.to_ascii_lowercase());
+            }
+        }
+        Expr::Literal(_) => {}
+        Expr::UnaryNot(inner) | Expr::MemberAccess { expr: inner, .. } => {
+            collect_contexts_from_expr(inner, out);
+        }
+        Expr::Binary { left, right, .. } => {
+            collect_contexts_from_expr(left, out);
+            collect_contexts_from_expr(right, out);
+        }
+        Expr::Call { args, .. } => {
+            for arg in args {
+                collect_contexts_from_expr(arg, out);
+            }
         }
     }
 }
@@ -120,14 +148,28 @@ fn abstract_equal(left: &Value, right: &Value) -> bool {
 }
 
 fn compare_values(
-    left: &Value,
-    right: &Value,
+    left_value: &Value,
+    right_value: &Value,
     predicate: impl FnOnce(std::cmp::Ordering) -> bool,
 ) -> bool {
-    if let (Some(left), Some(right)) = (numeric_value(left), numeric_value(right)) {
-        return left.partial_cmp(&right).is_some_and(predicate);
+    if let (Some(left), Some(right)) = (numeric_value(left_value), numeric_value(right_value)) {
+        if let Some(ordering) = left.partial_cmp(&right) {
+            return predicate(ordering);
+        }
+        // A failed numeric conversion for mixed values is not a string
+        // comparison; preserve the runner's false result for NaN.
+        if !matches!(
+            (left_value, right_value),
+            (Value::String(_), Value::String(_))
+        ) {
+            return false;
+        }
     }
-    predicate(string_value(left).cmp(&string_value(right)))
+    predicate(
+        string_value(left_value)
+            .to_ascii_lowercase()
+            .cmp(&string_value(right_value).to_ascii_lowercase()),
+    )
 }
 
 fn numeric_value(value: &Value) -> Option<f64> {
@@ -204,6 +246,24 @@ fn is_decimal_number(value: &str) -> bool {
 
 fn eval_call(name: &str, args: &[Expr], context: &Context) -> Result<Value, ExpressionError> {
     let lower = name.to_ascii_lowercase();
+    // case() uses lazy evaluation — handle before eager collect
+    if lower == "case" {
+        if args.len() < 3 || args.len().is_multiple_of(2) {
+            return Err(ExpressionError::EvenCaseParameters);
+        }
+        // Evaluate predicate-result pairs lazily
+        for i in (0..args.len() - 1).step_by(2) {
+            let predicate = eval(&args[i], context)?;
+            if !predicate.is_boolean() {
+                return Err(ExpressionError::NonBooleanCasePredicate);
+            }
+            if predicate.as_bool().unwrap_or(false) {
+                return eval(&args[i + 1], context);
+            }
+        }
+        // No predicate matched — return default (last arg)
+        return eval(&args[args.len() - 1], context);
+    }
     let values = args
         .iter()
         .map(|arg| eval(arg, context))
@@ -239,25 +299,6 @@ fn eval_call(name: &str, args: &[Expr], context: &Context) -> Result<Value, Expr
         "tojson" => Ok(Value::String(
             serde_json::to_string(values.first().unwrap_or(&Value::Null)).unwrap_or_default(),
         )),
-        "case" => {
-            if values.len() < 2 {
-                return Err(ExpressionError::InvalidFormat(
-                    "case() requires at least 2 arguments".to_owned(),
-                ));
-            }
-            let num_pairs = values.len() / 2;
-            for i in 0..num_pairs {
-                let cond = &values[i * 2];
-                if is_truthy(cond) {
-                    return Ok(values[i * 2 + 1].clone());
-                }
-            }
-            if values.len() % 2 == 1 {
-                Ok(values.last().cloned().unwrap_or(Value::Null))
-            } else {
-                Ok(Value::Null)
-            }
-        }
         _ => Err(ExpressionError::UnknownFunction(name.to_owned())),
     }
 }

--- a/crates/aksh-gha-expressions/src/lib.rs
+++ b/crates/aksh-gha-expressions/src/lib.rs
@@ -12,7 +12,7 @@ mod lexer;
 pub use conditions::{contains_status_check_function, effective_condition, is_truthy};
 pub use context::Context;
 
-use evaluator::{eval, validate_function_calls};
+use evaluator::{collect_contexts_from_expr, eval, validate_function_calls};
 use expr_parser::Parser;
 use lexer::Lexer;
 
@@ -28,6 +28,12 @@ pub enum ExpressionError {
     /// Unknown function.
     #[error("unknown function `{0}`")]
     UnknownFunction(String),
+    /// `case()` must have predicate/result pairs followed by a default.
+    #[error("case() requires an odd number of arguments (at least 3)")]
+    EvenCaseParameters,
+    /// `case()` predicates must evaluate to booleans.
+    #[error("case() predicate must evaluate to a boolean value")]
+    NonBooleanCasePredicate,
     /// Invalid `format()` template or argument reference.
     #[error("invalid format string: {0}")]
     InvalidFormat(String),
@@ -44,6 +50,18 @@ pub fn validate_expression(input: &str) -> Result<(), ExpressionError> {
     let expr = parser.parse_expr()?;
     parser.expect_end()?;
     validate_function_calls(&expr)
+}
+
+/// Collect top-level context names (e.g. "github", "matrix") from an expression string.
+pub fn collect_contexts(input: &str) -> Result<std::collections::HashSet<String>, ExpressionError> {
+    let trimmed = trim_expression_markers(input);
+    let tokens = Lexer::new(trimmed).lex()?;
+    let mut parser = Parser::new(tokens);
+    let expr = parser.parse_expr()?;
+    parser.expect_end()?;
+    let mut contexts = std::collections::HashSet::new();
+    collect_contexts_from_expr(&expr, &mut contexts);
+    Ok(contexts)
 }
 
 /// Parse and evaluate a GitHub Actions expression.

--- a/crates/aksh-gha-expressions/src/lib_tests.rs
+++ b/crates/aksh-gha-expressions/src/lib_tests.rs
@@ -43,6 +43,23 @@ fn evaluates_json_join_and_comparisons() {
     let context = Context::default();
 
     assert_eq!(
+        eval_expression("case(true, 'first', 'second')", &context).unwrap(),
+        Value::String("first".to_owned())
+    );
+    assert_eq!(
+        eval_expression("case(false, 'first', true, 'second', 'third')", &context).unwrap(),
+        Value::String("second".to_owned())
+    );
+    assert_eq!(
+        eval_expression("case(false, 'first', 'default')", &context).unwrap(),
+        Value::String("default".to_owned())
+    );
+    assert_eq!(
+        eval_expression("case(false, 'first')", &context).unwrap(),
+        Value::Null
+    );
+    assert!(validate_expression("case(github.ref == 'refs/heads/dev', format('{0}-{1}', github.workflow, github.run_id), 'default')").is_ok());
+    assert_eq!(
         eval_expression("fromJson('[\"a\",\"b\"]')", &context).unwrap(),
         json!(["a", "b"])
     );

--- a/crates/aksh-gha-expressions/src/lib_tests.rs
+++ b/crates/aksh-gha-expressions/src/lib_tests.rs
@@ -54,10 +54,8 @@ fn evaluates_json_join_and_comparisons() {
         eval_expression("case(false, 'first', 'default')", &context).unwrap(),
         Value::String("default".to_owned())
     );
-    assert_eq!(
-        eval_expression("case(false, 'first')", &context).unwrap(),
-        Value::Null
-    );
+    assert!(validate_expression("case(true, 'a')").is_err());
+    assert!(validate_expression("case(true, 'a', false, 'b')").is_err());
     assert!(validate_expression("case(github.ref == 'refs/heads/dev', format('{0}-{1}', github.workflow, github.run_id), 'default')").is_ok());
     assert_eq!(
         eval_expression("fromJson('[\"a\",\"b\"]')", &context).unwrap(),
@@ -73,6 +71,22 @@ fn evaluates_json_join_and_comparisons() {
     );
     assert_eq!(
         eval_expression("2 <= 2", &context).unwrap(),
+        Value::Bool(true)
+    );
+    assert_eq!(
+        eval_expression("'B' > 'a'", &context).unwrap(),
+        Value::Bool(true)
+    );
+    assert_eq!(
+        eval_expression("'a' < 'B'", &context).unwrap(),
+        Value::Bool(true)
+    );
+    assert_eq!(
+        eval_expression("'ABC' >= 'abc'", &context).unwrap(),
+        Value::Bool(true)
+    );
+    assert_eq!(
+        eval_expression("'abc' <= 'ABC'", &context).unwrap(),
         Value::Bool(true)
     );
     assert_eq!(

--- a/crates/aksh-gha-parser/src/eval.rs
+++ b/crates/aksh-gha-parser/src/eval.rs
@@ -10,6 +10,7 @@
 
 use std::collections::BTreeMap;
 
+use crate::models::{EnvValue, JobContinueOnError, ParserError, RunsOn, Workflow};
 use aksh_gha_expressions::{eval_expression, Context};
 use indexmap::IndexMap;
 use serde_json::{Map, Value};
@@ -135,6 +136,172 @@ fn stringify_value(value: &Value) -> String {
         Value::Array(a) => serde_json::to_string(a).unwrap_or_default(),
         Value::Object(o) => serde_json::to_string(o).unwrap_or_default(),
     }
+}
+
+/// Validate expressions in a string.
+pub fn validate_expressions_in_string(input: &str, is_condition: bool) -> Result<(), String> {
+    if is_condition && !input.contains("${{") {
+        let effective = aksh_gha_expressions::effective_condition(Some(input));
+        return aksh_gha_expressions::validate_expression(&effective)
+            .map_err(|e| format!("invalid condition `{input}`: {e}"));
+    }
+
+    let mut remaining = input;
+    while let Some(start) = remaining.find("${{") {
+        remaining = &remaining[start + 3..];
+        let end = find_expression_end(remaining)
+            .ok_or_else(|| format!("unclosed ${{ expression in `{input}`"))?;
+        let expr = remaining[..end].trim();
+        remaining = &remaining[end + 2..];
+
+        aksh_gha_expressions::validate_expression(expr)
+            .map_err(|e| format!("invalid expression `${{{{ {expr} }}}}` in `{input}`: {e}"))?;
+    }
+    Ok(())
+}
+
+/// Recursively validate expressions inside a serde_json::Value.
+pub fn validate_value_expressions(value: &Value) -> Result<(), String> {
+    match value {
+        Value::String(s) => validate_expressions_in_string(s, false),
+        Value::Array(arr) => {
+            for item in arr {
+                validate_value_expressions(item)?;
+            }
+            Ok(())
+        }
+        Value::Object(map) => {
+            for val in map.values() {
+                validate_value_expressions(val)?;
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
+fn validate_env_expressions(env: &crate::models::Env) -> Result<(), String> {
+    match env {
+        crate::models::Env::Empty => Ok(()),
+        crate::models::Env::Expression(expr) => validate_expressions_in_string(expr, false),
+        crate::models::Env::Map(map) => {
+            for val in map.values() {
+                if let EnvValue::String(s) = val {
+                    validate_expressions_in_string(s, false)?;
+                }
+            }
+            Ok(())
+        }
+    }
+}
+
+/// Validate all `${{ }}` expressions in a workflow.
+pub fn validate_workflow_expressions(workflow: &Workflow) -> Result<(), ParserError> {
+    if let Some(run_name) = &workflow.run_name {
+        validate_expressions_in_string(run_name, false).map_err(ParserError::InvalidExpression)?;
+    }
+    validate_env_expressions(&workflow.env).map_err(ParserError::InvalidExpression)?;
+
+    if let Some(concurrency) = &workflow.concurrency {
+        validate_expressions_in_string(&concurrency.group, false)
+            .map_err(ParserError::InvalidExpression)?;
+        if let Some(expr) = &concurrency.cancel_in_progress {
+            validate_expressions_in_string(expr, false).map_err(ParserError::InvalidExpression)?;
+        }
+    }
+
+    for (job_id, job) in &workflow.jobs {
+        if let Some(name) = &job.name {
+            validate_expressions_in_string(name, false)
+                .map_err(|e| ParserError::InvalidExpression(format!("job `{job_id}`: {e}")))?;
+        }
+        match &job.runs_on {
+            RunsOn::Single(s) => {
+                validate_expressions_in_string(s, false).map_err(|e| {
+                    ParserError::InvalidExpression(format!("job `{job_id}` runs-on: {e}"))
+                })?;
+            }
+            RunsOn::Many(list) => {
+                for s in list {
+                    validate_expressions_in_string(s, false).map_err(|e| {
+                        ParserError::InvalidExpression(format!("job `{job_id}` runs-on: {e}"))
+                    })?;
+                }
+            }
+            RunsOn::Dynamic(v) => {
+                validate_value_expressions(v).map_err(|e| {
+                    ParserError::InvalidExpression(format!("job `{job_id}` runs-on: {e}"))
+                })?;
+            }
+        }
+        if let Some(cond) = &job.if_condition {
+            validate_expressions_in_string(cond, true).map_err(|e| {
+                ParserError::InvalidExpression(format!("job `{job_id}` if condition: {e}"))
+            })?;
+        }
+        validate_env_expressions(&job.env)
+            .map_err(|e| ParserError::InvalidExpression(format!("job `{job_id}` env: {e}")))?;
+
+        if let Some(concurrency) = &job.concurrency {
+            validate_expressions_in_string(&concurrency.group, false).map_err(|e| {
+                ParserError::InvalidExpression(format!("job `{job_id}` concurrency: {e}"))
+            })?;
+            if let Some(expr) = &concurrency.cancel_in_progress {
+                validate_expressions_in_string(expr, false).map_err(|e| {
+                    ParserError::InvalidExpression(format!(
+                        "job `{job_id}` concurrency cancel-in-progress: {e}"
+                    ))
+                })?;
+            }
+        }
+        if let Some(JobContinueOnError::Expression(expr)) = &job.continue_on_error {
+            validate_expressions_in_string(expr, false).map_err(|e| {
+                ParserError::InvalidExpression(format!("job `{job_id}` continue-on-error: {e}"))
+            })?;
+        }
+
+        for (step_idx, step) in job.steps.iter().enumerate() {
+            let step_ref = step
+                .name
+                .as_deref()
+                .map(|n| format!("step `{n}`"))
+                .unwrap_or_else(|| format!("step #{step_idx}"));
+            if let Some(name) = &step.name {
+                validate_expressions_in_string(name, false).map_err(|e| {
+                    ParserError::InvalidExpression(format!("job `{job_id}` {step_ref}: {e}"))
+                })?;
+            }
+            if let Some(cond) = &step.if_condition {
+                validate_expressions_in_string(cond, true).map_err(|e| {
+                    ParserError::InvalidExpression(format!(
+                        "job `{job_id}` {step_ref} if condition: {e}"
+                    ))
+                })?;
+            }
+            validate_env_expressions(&step.env).map_err(|e| {
+                ParserError::InvalidExpression(format!("job `{job_id}` {step_ref} env: {e}"))
+            })?;
+            for val in step.with.values() {
+                validate_value_expressions(val).map_err(|e| {
+                    ParserError::InvalidExpression(format!("job `{job_id}` {step_ref} with: {e}"))
+                })?;
+            }
+            if let Some(run) = &step.run {
+                validate_expressions_in_string(run, false).map_err(|e| {
+                    ParserError::InvalidExpression(format!("job `{job_id}` {step_ref} run: {e}"))
+                })?;
+            }
+            if let Some(wd) = &step.working_directory {
+                validate_expressions_in_string(wd, false).map_err(|e| {
+                    ParserError::InvalidExpression(format!(
+                        "job `{job_id}` {step_ref} working-directory: {e}"
+                    ))
+                })?;
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Build an expression evaluation context from workflow data.

--- a/crates/aksh-gha-parser/src/eval.rs
+++ b/crates/aksh-gha-parser/src/eval.rs
@@ -139,11 +139,17 @@ fn stringify_value(value: &Value) -> String {
 }
 
 /// Validate expressions in a string.
-pub fn validate_expressions_in_string(input: &str, is_condition: bool) -> Result<(), String> {
+pub fn validate_expressions_in_string(
+    input: &str,
+    is_condition: bool,
+    allowed_contexts: Option<&[&str]>,
+) -> Result<(), String> {
     if is_condition && !input.contains("${{") {
         let effective = aksh_gha_expressions::effective_condition(Some(input));
-        return aksh_gha_expressions::validate_expression(&effective)
-            .map_err(|e| format!("invalid condition `{input}`: {e}"));
+        aksh_gha_expressions::validate_expression(&effective)
+            .map_err(|e| format!("invalid condition `{input}`: {e}"))?;
+        validate_contexts(&effective, allowed_contexts, input)?;
+        return Ok(());
     }
 
     let mut remaining = input;
@@ -156,23 +162,52 @@ pub fn validate_expressions_in_string(input: &str, is_condition: bool) -> Result
 
         aksh_gha_expressions::validate_expression(expr)
             .map_err(|e| format!("invalid expression `${{{{ {expr} }}}}` in `{input}`: {e}"))?;
+        validate_contexts(expr, allowed_contexts, input)?;
+    }
+    Ok(())
+}
+
+fn validate_contexts(
+    expr: &str,
+    allowed_contexts: Option<&[&str]>,
+    input: &str,
+) -> Result<(), String> {
+    let Some(allowed) = allowed_contexts else {
+        return Ok(());
+    };
+    let contexts = aksh_gha_expressions::collect_contexts(expr)
+        .map_err(|e| format!("invalid expression in `{input}`: {e}"))?;
+    for ctx in &contexts {
+        if !allowed.iter().any(|a| a.eq_ignore_ascii_case(ctx)) {
+            return Err(format!(
+                "context \"{ctx}\" is not allowed here. available contexts are {}.",
+                allowed
+                    .iter()
+                    .map(|a| format!("\"{a}\""))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
     }
     Ok(())
 }
 
 /// Recursively validate expressions inside a serde_json::Value.
-pub fn validate_value_expressions(value: &Value) -> Result<(), String> {
+pub fn validate_value_expressions(
+    value: &Value,
+    allowed_contexts: Option<&[&str]>,
+) -> Result<(), String> {
     match value {
-        Value::String(s) => validate_expressions_in_string(s, false),
+        Value::String(s) => validate_expressions_in_string(s, false, allowed_contexts),
         Value::Array(arr) => {
             for item in arr {
-                validate_value_expressions(item)?;
+                validate_value_expressions(item, allowed_contexts)?;
             }
             Ok(())
         }
         Value::Object(map) => {
             for val in map.values() {
-                validate_value_expressions(val)?;
+                validate_value_expressions(val, allowed_contexts)?;
             }
             Ok(())
         }
@@ -180,14 +215,19 @@ pub fn validate_value_expressions(value: &Value) -> Result<(), String> {
     }
 }
 
-fn validate_env_expressions(env: &crate::models::Env) -> Result<(), String> {
+fn validate_env_expressions(
+    env: &crate::models::Env,
+    allowed_contexts: Option<&[&str]>,
+) -> Result<(), String> {
     match env {
         crate::models::Env::Empty => Ok(()),
-        crate::models::Env::Expression(expr) => validate_expressions_in_string(expr, false),
+        crate::models::Env::Expression(expr) => {
+            validate_expressions_in_string(expr, false, allowed_contexts)
+        }
         crate::models::Env::Map(map) => {
             for val in map.values() {
                 if let EnvValue::String(s) = val {
-                    validate_expressions_in_string(s, false)?;
+                    validate_expressions_in_string(s, false, allowed_contexts)?;
                 }
             }
             Ok(())
@@ -195,67 +235,128 @@ fn validate_env_expressions(env: &crate::models::Env) -> Result<(), String> {
     }
 }
 
+const CTX_RUN_NAME: &[&str] = &["github", "inputs", "vars"];
+const CTX_WORKFLOW_ENV: &[&str] = &["github", "inputs", "vars", "secrets"];
+const CTX_WORKFLOW_CONCURRENCY: &[&str] = &["github", "inputs", "vars"];
+const CTX_JOB_IF: &[&str] = &[
+    "github",
+    "inputs",
+    "vars",
+    "needs",
+    "always",
+    "failure",
+    "cancelled",
+    "success",
+];
+const CTX_JOB_RUNS_ON: &[&str] = &["github", "inputs", "vars", "needs", "matrix", "strategy"];
+const CTX_JOB_ENV: &[&str] = &[
+    "github", "inputs", "vars", "needs", "strategy", "matrix", "secrets", "env",
+];
+const CTX_JOB_CONCURRENCY: &[&str] = &["github", "inputs", "vars", "needs", "strategy", "matrix"];
+const CTX_STEP_IF: &[&str] = &[
+    "github",
+    "inputs",
+    "vars",
+    "needs",
+    "strategy",
+    "matrix",
+    "secrets",
+    "steps",
+    "job",
+    "runner",
+    "env",
+    "always",
+    "failure",
+    "cancelled",
+    "success",
+    "hashfiles",
+];
+const CTX_STEP_ENV: &[&str] = &[
+    "github",
+    "inputs",
+    "vars",
+    "needs",
+    "strategy",
+    "matrix",
+    "secrets",
+    "steps",
+    "job",
+    "runner",
+    "env",
+    "hashfiles",
+];
+const CTX_STEP_WITH: &[&str] = CTX_STEP_ENV;
+const CTX_STEP_RUN: &[&str] = CTX_STEP_ENV;
+const CTX_STEP_NAME: &[&str] = CTX_STEP_ENV;
+const CTX_STEP_WORKING_DIR: &[&str] = CTX_STEP_ENV;
+
 /// Validate all `${{ }}` expressions in a workflow.
 pub fn validate_workflow_expressions(workflow: &Workflow) -> Result<(), ParserError> {
     if let Some(run_name) = &workflow.run_name {
-        validate_expressions_in_string(run_name, false).map_err(ParserError::InvalidExpression)?;
+        validate_expressions_in_string(run_name, false, Some(CTX_RUN_NAME))
+            .map_err(ParserError::InvalidExpression)?;
     }
-    validate_env_expressions(&workflow.env).map_err(ParserError::InvalidExpression)?;
+    validate_env_expressions(&workflow.env, Some(CTX_WORKFLOW_ENV))
+        .map_err(ParserError::InvalidExpression)?;
 
     if let Some(concurrency) = &workflow.concurrency {
-        validate_expressions_in_string(&concurrency.group, false)
+        validate_expressions_in_string(&concurrency.group, false, Some(CTX_WORKFLOW_CONCURRENCY))
             .map_err(ParserError::InvalidExpression)?;
         if let Some(expr) = &concurrency.cancel_in_progress {
-            validate_expressions_in_string(expr, false).map_err(ParserError::InvalidExpression)?;
+            validate_expressions_in_string(expr, false, Some(CTX_WORKFLOW_CONCURRENCY))
+                .map_err(ParserError::InvalidExpression)?;
         }
     }
 
     for (job_id, job) in &workflow.jobs {
         if let Some(name) = &job.name {
-            validate_expressions_in_string(name, false)
+            validate_expressions_in_string(name, false, Some(CTX_JOB_RUNS_ON))
                 .map_err(|e| ParserError::InvalidExpression(format!("job `{job_id}`: {e}")))?;
         }
         match &job.runs_on {
             RunsOn::Single(s) => {
-                validate_expressions_in_string(s, false).map_err(|e| {
+                validate_expressions_in_string(s, false, Some(CTX_JOB_RUNS_ON)).map_err(|e| {
                     ParserError::InvalidExpression(format!("job `{job_id}` runs-on: {e}"))
                 })?;
             }
             RunsOn::Many(list) => {
                 for s in list {
-                    validate_expressions_in_string(s, false).map_err(|e| {
-                        ParserError::InvalidExpression(format!("job `{job_id}` runs-on: {e}"))
-                    })?;
+                    validate_expressions_in_string(s, false, Some(CTX_JOB_RUNS_ON)).map_err(
+                        |e| ParserError::InvalidExpression(format!("job `{job_id}` runs-on: {e}")),
+                    )?;
                 }
             }
             RunsOn::Dynamic(v) => {
-                validate_value_expressions(v).map_err(|e| {
+                validate_value_expressions(v, Some(CTX_JOB_RUNS_ON)).map_err(|e| {
                     ParserError::InvalidExpression(format!("job `{job_id}` runs-on: {e}"))
                 })?;
             }
         }
         if let Some(cond) = &job.if_condition {
-            validate_expressions_in_string(cond, true).map_err(|e| {
+            validate_expressions_in_string(cond, true, Some(CTX_JOB_IF)).map_err(|e| {
                 ParserError::InvalidExpression(format!("job `{job_id}` if condition: {e}"))
             })?;
         }
-        validate_env_expressions(&job.env)
+        validate_env_expressions(&job.env, Some(CTX_JOB_ENV))
             .map_err(|e| ParserError::InvalidExpression(format!("job `{job_id}` env: {e}")))?;
 
         if let Some(concurrency) = &job.concurrency {
-            validate_expressions_in_string(&concurrency.group, false).map_err(|e| {
-                ParserError::InvalidExpression(format!("job `{job_id}` concurrency: {e}"))
-            })?;
-            if let Some(expr) = &concurrency.cancel_in_progress {
-                validate_expressions_in_string(expr, false).map_err(|e| {
-                    ParserError::InvalidExpression(format!(
-                        "job `{job_id}` concurrency cancel-in-progress: {e}"
-                    ))
+            validate_expressions_in_string(&concurrency.group, false, Some(CTX_JOB_CONCURRENCY))
+                .map_err(|e| {
+                    ParserError::InvalidExpression(format!("job `{job_id}` concurrency: {e}"))
                 })?;
+            if let Some(expr) = &concurrency.cancel_in_progress {
+                validate_expressions_in_string(expr, false, Some(CTX_JOB_CONCURRENCY)).map_err(
+                    |e| {
+                        ParserError::InvalidExpression(format!(
+                            "job `{job_id}` concurrency cancel-in-progress: {e}"
+                        ))
+                    },
+                )?;
             }
         }
         if let Some(JobContinueOnError::Expression(expr)) = &job.continue_on_error {
-            validate_expressions_in_string(expr, false).map_err(|e| {
+            validate_expressions_in_string(expr, false, Some(CTX_JOB_RUNS_ON)).map_err(|e| {
                 ParserError::InvalidExpression(format!("job `{job_id}` continue-on-error: {e}"))
             })?;
         }
@@ -267,36 +368,38 @@ pub fn validate_workflow_expressions(workflow: &Workflow) -> Result<(), ParserEr
                 .map(|n| format!("step `{n}`"))
                 .unwrap_or_else(|| format!("step #{step_idx}"));
             if let Some(name) = &step.name {
-                validate_expressions_in_string(name, false).map_err(|e| {
+                validate_expressions_in_string(name, false, Some(CTX_STEP_NAME)).map_err(|e| {
                     ParserError::InvalidExpression(format!("job `{job_id}` {step_ref}: {e}"))
                 })?;
             }
             if let Some(cond) = &step.if_condition {
-                validate_expressions_in_string(cond, true).map_err(|e| {
+                validate_expressions_in_string(cond, true, Some(CTX_STEP_IF)).map_err(|e| {
                     ParserError::InvalidExpression(format!(
                         "job `{job_id}` {step_ref} if condition: {e}"
                     ))
                 })?;
             }
-            validate_env_expressions(&step.env).map_err(|e| {
+            validate_env_expressions(&step.env, Some(CTX_STEP_ENV)).map_err(|e| {
                 ParserError::InvalidExpression(format!("job `{job_id}` {step_ref} env: {e}"))
             })?;
             for val in step.with.values() {
-                validate_value_expressions(val).map_err(|e| {
+                validate_value_expressions(val, Some(CTX_STEP_WITH)).map_err(|e| {
                     ParserError::InvalidExpression(format!("job `{job_id}` {step_ref} with: {e}"))
                 })?;
             }
             if let Some(run) = &step.run {
-                validate_expressions_in_string(run, false).map_err(|e| {
+                validate_expressions_in_string(run, false, Some(CTX_STEP_RUN)).map_err(|e| {
                     ParserError::InvalidExpression(format!("job `{job_id}` {step_ref} run: {e}"))
                 })?;
             }
             if let Some(wd) = &step.working_directory {
-                validate_expressions_in_string(wd, false).map_err(|e| {
-                    ParserError::InvalidExpression(format!(
-                        "job `{job_id}` {step_ref} working-directory: {e}"
-                    ))
-                })?;
+                validate_expressions_in_string(wd, false, Some(CTX_STEP_WORKING_DIR)).map_err(
+                    |e| {
+                        ParserError::InvalidExpression(format!(
+                            "job `{job_id}` {step_ref} working-directory: {e}"
+                        ))
+                    },
+                )?;
             }
         }
     }

--- a/crates/aksh-gha-parser/src/eval.rs
+++ b/crates/aksh-gha-parser/src/eval.rs
@@ -253,6 +253,12 @@ const CTX_JOB_ENV: &[&str] = &[
     "github", "inputs", "vars", "needs", "strategy", "matrix", "secrets", "env",
 ];
 const CTX_JOB_CONCURRENCY: &[&str] = &["github", "inputs", "vars", "needs", "strategy", "matrix"];
+const CTX_JOB_DEFAULTS_RUN: &[&str] = &["github", "strategy", "matrix", "needs", "env", "vars"];
+const CTX_JOB_CONTAINER: &[&str] = &["github", "needs", "strategy", "matrix", "vars"];
+const CTX_CONTAINER_CREDENTIALS: &[&str] = &["secrets", "env", "github", "vars"];
+const CTX_RUNNER: &[&str] = &[
+    "github", "needs", "strategy", "matrix", "secrets", "steps", "job", "runner", "env", "vars",
+];
 const CTX_STEP_IF: &[&str] = &[
     "github",
     "inputs",
@@ -289,6 +295,25 @@ const CTX_STEP_WITH: &[&str] = CTX_STEP_ENV;
 const CTX_STEP_RUN: &[&str] = CTX_STEP_ENV;
 const CTX_STEP_NAME: &[&str] = CTX_STEP_ENV;
 const CTX_STEP_WORKING_DIR: &[&str] = CTX_STEP_ENV;
+
+/// Validate a job container or service value. Container images/options inherit
+/// the job-container context, while `credentials` and `env` have their own
+/// narrower schema-defined contexts.
+fn validate_container_expressions(value: &Value) -> Result<(), String> {
+    let Value::Object(map) = value else {
+        return validate_value_expressions(value, Some(CTX_JOB_CONTAINER));
+    };
+
+    for (key, value) in map {
+        let allowed = match key.as_str() {
+            "credentials" => CTX_CONTAINER_CREDENTIALS,
+            "env" => CTX_RUNNER,
+            _ => CTX_JOB_CONTAINER,
+        };
+        validate_value_expressions(value, Some(allowed))?;
+    }
+    Ok(())
+}
 
 /// Validate all `${{ }}` expressions in a workflow.
 pub fn validate_workflow_expressions(workflow: &Workflow) -> Result<(), ParserError> {
@@ -358,6 +383,58 @@ pub fn validate_workflow_expressions(workflow: &Workflow) -> Result<(), ParserEr
         if let Some(JobContinueOnError::Expression(expr)) = &job.continue_on_error {
             validate_expressions_in_string(expr, false, Some(CTX_JOB_RUNS_ON)).map_err(|e| {
                 ParserError::InvalidExpression(format!("job `{job_id}` continue-on-error: {e}"))
+            })?;
+        }
+
+        if let Some(container) = &job.container {
+            validate_container_expressions(container).map_err(|e| {
+                ParserError::InvalidExpression(format!("job `{job_id}` container: {e}"))
+            })?;
+        }
+        if let Some(services) = &job.services {
+            if let Value::Object(services) = services {
+                for (service_name, service) in services {
+                    validate_container_expressions(service).map_err(|e| {
+                        ParserError::InvalidExpression(format!(
+                            "job `{job_id}` service `{service_name}`: {e}"
+                        ))
+                    })?;
+                }
+            } else {
+                validate_value_expressions(services, Some(CTX_JOB_CONTAINER)).map_err(|e| {
+                    ParserError::InvalidExpression(format!("job `{job_id}` services: {e}"))
+                })?;
+            }
+        }
+        if let Some(defaults) = &job.defaults {
+            if let Some(run) = &defaults.run {
+                if let Some(shell) = &run.shell {
+                    validate_expressions_in_string(shell, false, Some(CTX_JOB_DEFAULTS_RUN))
+                        .map_err(|e| {
+                            ParserError::InvalidExpression(format!(
+                                "job `{job_id}` defaults.run.shell: {e}"
+                            ))
+                        })?;
+                }
+                if let Some(working_directory) = &run.working_directory {
+                    validate_expressions_in_string(
+                        working_directory,
+                        false,
+                        Some(CTX_JOB_DEFAULTS_RUN),
+                    )
+                    .map_err(|e| {
+                        ParserError::InvalidExpression(format!(
+                            "job `{job_id}` defaults.run.working-directory: {e}"
+                        ))
+                    })?;
+                }
+            }
+        }
+        for (output_name, output) in &job.outputs {
+            validate_value_expressions(output, Some(CTX_RUNNER)).map_err(|e| {
+                ParserError::InvalidExpression(format!(
+                    "job `{job_id}` output `{output_name}`: {e}"
+                ))
             })?;
         }
 

--- a/crates/aksh-gha-parser/src/eval.rs
+++ b/crates/aksh-gha-parser/src/eval.rs
@@ -249,12 +249,13 @@ const CTX_JOB_IF: &[&str] = &[
     "success",
 ];
 const CTX_JOB_RUNS_ON: &[&str] = &["github", "inputs", "vars", "needs", "matrix", "strategy"];
+const CTX_STRATEGY: &[&str] = &["github", "inputs", "vars", "needs", "matrix", "strategy"];
 const CTX_JOB_ENV: &[&str] = &[
     "github", "inputs", "vars", "needs", "strategy", "matrix", "secrets", "env",
 ];
 const CTX_JOB_CONCURRENCY: &[&str] = &["github", "inputs", "vars", "needs", "strategy", "matrix"];
 const CTX_JOB_DEFAULTS_RUN: &[&str] = &["github", "strategy", "matrix", "needs", "env", "vars"];
-const CTX_JOB_CONTAINER: &[&str] = &["github", "needs", "strategy", "matrix", "vars"];
+const CTX_JOB_CONTAINER: &[&str] = &["github", "inputs", "needs", "strategy", "matrix", "vars"];
 const CTX_CONTAINER_CREDENTIALS: &[&str] = &["secrets", "env", "github", "vars"];
 const CTX_RUNNER: &[&str] = &[
     "github", "needs", "strategy", "matrix", "secrets", "steps", "job", "runner", "env", "vars",
@@ -334,6 +335,23 @@ pub fn validate_workflow_expressions(workflow: &Workflow) -> Result<(), ParserEr
     }
 
     for (job_id, job) in &workflow.jobs {
+        if let Some(crate::models::MatrixValue::Expression(expression)) = &job.strategy.matrix {
+            validate_expressions_in_string(expression, false, Some(CTX_STRATEGY)).map_err(|e| {
+                ParserError::InvalidExpression(format!("job `{job_id}` strategy.matrix: {e}"))
+            })?;
+        }
+        if let Some(crate::models::DeferredBool::Expression(expression)) = &job.strategy.fail_fast {
+            validate_expressions_in_string(expression, false, Some(CTX_STRATEGY)).map_err(|e| {
+                ParserError::InvalidExpression(format!("job `{job_id}` strategy.fail-fast: {e}"))
+            })?;
+        }
+        if let Some(crate::models::DeferredNumber::Expression(expression)) =
+            &job.strategy.max_parallel
+        {
+            validate_expressions_in_string(expression, false, Some(CTX_STRATEGY)).map_err(|e| {
+                ParserError::InvalidExpression(format!("job `{job_id}` strategy.max-parallel: {e}"))
+            })?;
+        }
         if let Some(name) = &job.name {
             validate_expressions_in_string(name, false, Some(CTX_JOB_RUNS_ON))
                 .map_err(|e| ParserError::InvalidExpression(format!("job `{job_id}`: {e}")))?;
@@ -455,6 +473,17 @@ pub fn validate_workflow_expressions(workflow: &Workflow) -> Result<(), ParserEr
                         "job `{job_id}` {step_ref} if condition: {e}"
                     ))
                 })?;
+            }
+            if let Some(crate::models::DeferredBool::Expression(expression)) =
+                &step.continue_on_error
+            {
+                validate_expressions_in_string(expression, false, Some(CTX_STEP_IF)).map_err(
+                    |e| {
+                        ParserError::InvalidExpression(format!(
+                            "job `{job_id}` {step_ref} continue-on-error: {e}"
+                        ))
+                    },
+                )?;
             }
             validate_env_expressions(&step.env, Some(CTX_STEP_ENV)).map_err(|e| {
                 ParserError::InvalidExpression(format!("job `{job_id}` {step_ref} env: {e}"))

--- a/crates/aksh-gha-parser/src/expand.rs
+++ b/crates/aksh-gha-parser/src/expand.rs
@@ -380,6 +380,7 @@ pub(crate) fn coerce_value(
 fn expand_jobs_with_reusables_internal(
     workflow: &Workflow,
     reusable_workflows: &BTreeMap<String, String>,
+    reusable_workflow_shas: &BTreeMap<String, String>,
     depth: usize,
     reusable_calls: &mut BTreeMap<String, ReusableCallMetadata>,
     inputs: Option<&BTreeMap<String, Value>>,
@@ -502,6 +503,7 @@ fn expand_jobs_with_reusables_internal(
                 let mut called_plans = expand_jobs_with_reusables_internal(
                     &called,
                     reusable_workflows,
+                    reusable_workflow_shas,
                     depth + 1,
                     reusable_calls,
                     Some(&resolved_inputs),
@@ -532,6 +534,12 @@ fn expand_jobs_with_reusables_internal(
                     called_plan.secrets_map.extend(secrets_map.clone());
                     called_plan.workflow_file = Some(path.clone());
                     called_plan.workflow_ref = Some(uses.clone());
+                    called_plan.workflow_sha = reusable_workflow_shas.get(uses).cloned();
+                    called_plan.workflow_repository =
+                        uses.split_once('/').and_then(|(owner, rest)| {
+                            rest.split_once('/')
+                                .map(|(repo, _)| format!("{owner}/{repo}"))
+                        });
                     called_plan.oidc_id_token_granted &= id_token_granted(
                         job.permissions.as_ref().or(workflow.permissions.as_ref()),
                     );
@@ -549,6 +557,11 @@ fn expand_jobs_with_reusables_internal(
                         caller_concurrency: job.concurrency.clone(),
                         embedded_concurrency: called.concurrency.clone(),
                         matrix: matrix.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
+                        workflow_sha: reusable_workflow_shas.get(uses).cloned(),
+                        workflow_repository: uses.split_once('/').and_then(|(owner, rest)| {
+                            rest.split_once('/')
+                                .map(|(repo, _)| format!("{owner}/{repo}"))
+                        }),
                     },
                 );
 
@@ -582,10 +595,20 @@ pub fn expand_jobs_with_reusables(
     workflow: &Workflow,
     reusable_workflows: &BTreeMap<String, String>,
 ) -> Result<ExpandedWorkflows, ParserError> {
+    expand_jobs_with_reusables_and_shas(workflow, reusable_workflows, &BTreeMap::new())
+}
+
+/// Expand jobs and inline reusable workflows with resolved remote metadata.
+pub fn expand_jobs_with_reusables_and_shas(
+    workflow: &Workflow,
+    reusable_workflows: &BTreeMap<String, String>,
+    reusable_workflow_shas: &BTreeMap<String, String>,
+) -> Result<ExpandedWorkflows, ParserError> {
     let mut reusable_calls = BTreeMap::new();
     let mut plans = expand_jobs_with_reusables_internal(
         workflow,
         reusable_workflows,
+        reusable_workflow_shas,
         0,
         &mut reusable_calls,
         None,

--- a/crates/aksh-gha-parser/src/expand.rs
+++ b/crates/aksh-gha-parser/src/expand.rs
@@ -624,9 +624,10 @@ pub fn expand_jobs_with_reusables_and_shas(
                 new_needs.push(need.clone());
             } else {
                 let prefix = format!("{}/", need.0);
+                let prefix_matrix = format!("{} (", need.0);
                 let mut matched = false;
                 for id in &expanded_ids {
-                    if id.starts_with(&prefix) {
+                    if id.starts_with(&prefix) || id.starts_with(&prefix_matrix) {
                         new_needs.push(JobId(id.clone()));
                         matched = true;
                     }

--- a/crates/aksh-gha-parser/src/expand.rs
+++ b/crates/aksh-gha-parser/src/expand.rs
@@ -9,9 +9,9 @@ use indexmap::IndexMap;
 use serde_json::Value;
 
 use crate::{
-    dag, matrix_expand, parse_workflow, Concurrency, ConcurrencyQueue, ExpandedWorkflows,
-    InputType, Job, JobContinueOnError, JobDefaults, Matrix, ParserError, ReusableCallMetadata,
-    Step, Workflow,
+    dag, matrix_expand, parse_workflow, Concurrency, ConcurrencyQueue, DeferredBool,
+    DeferredNumber, ExpandedWorkflows, InputType, Job, JobContinueOnError, JobDefaults,
+    MatrixValue, ParserError, ReusableCallMetadata, Step, Workflow,
 };
 
 fn resolved_continue_on_error(
@@ -62,6 +62,77 @@ fn resolved_continue_on_error(
                     job_id: job_id.to_owned(),
                     message: format!("expression returned {result}, expected a boolean"),
                 })
+        }
+    }
+}
+
+fn expression_context(
+    matrix: &IndexMap<String, Value>,
+    inputs: Option<&BTreeMap<String, Value>>,
+) -> Context {
+    let mut context = Context::default();
+    context.insert(
+        "matrix",
+        Value::Object(
+            matrix
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect(),
+        ),
+    );
+    if let Some(inputs) = inputs {
+        context.insert(
+            "inputs",
+            Value::Object(
+                inputs
+                    .iter()
+                    .map(|(key, value)| (key.clone(), value.clone()))
+                    .collect(),
+            ),
+        );
+    }
+    context
+}
+
+fn resolve_deferred_bool(
+    value: Option<&DeferredBool>,
+    matrix: &IndexMap<String, Value>,
+    inputs: Option<&BTreeMap<String, Value>>,
+    default: bool,
+) -> Result<bool, ParserError> {
+    let Some(value) = value else {
+        return Ok(default);
+    };
+    match value {
+        DeferredBool::Literal(value) => Ok(*value),
+        DeferredBool::Expression(expression) => {
+            let result = eval_expression(expression, &expression_context(matrix, inputs))
+                .map_err(|error| ParserError::InvalidExpression(error.to_string()))?;
+            result.as_bool().ok_or_else(|| {
+                ParserError::InvalidExpression(format!(
+                    "expression returned {result}, expected a boolean"
+                ))
+            })
+        }
+    }
+}
+
+fn resolve_deferred_number(
+    value: Option<&DeferredNumber>,
+    matrix: &IndexMap<String, Value>,
+    inputs: Option<&BTreeMap<String, Value>>,
+) -> Result<Option<u64>, ParserError> {
+    let Some(value) = value else { return Ok(None) };
+    match value {
+        DeferredNumber::Literal(value) => Ok(Some(*value)),
+        DeferredNumber::Expression(expression) => {
+            let result = eval_expression(expression, &expression_context(matrix, inputs))
+                .map_err(|error| ParserError::InvalidExpression(error.to_string()))?;
+            result.as_u64().map(Some).ok_or_else(|| {
+                ParserError::InvalidExpression(format!(
+                    "expression returned {result}, expected a number"
+                ))
+            })
         }
     }
 }
@@ -125,7 +196,7 @@ pub fn expand_jobs(workflow: &Workflow) -> Result<Vec<JobPlan>, ParserError> {
     let mut plans = Vec::new();
     let global_env = workflow.env.clone().into_strings();
     for (job_id, job) in &workflow.jobs {
-        for matrix in expand_matrix(job_id, job.strategy.matrix.as_ref())? {
+        for matrix in expand_matrix(job_id, job.strategy.matrix.as_ref(), None)? {
             let oidc_environment = oidc_environment(job.environment.as_ref(), &matrix);
             let expanded_id = matrix_expand::expanded_job_id(job_id, &matrix);
             let mut env = global_env.clone();
@@ -138,6 +209,7 @@ pub fn expand_jobs(workflow: &Workflow) -> Result<Vec<JobPlan>, ParserError> {
                 env,
                 oidc_environment,
                 workflow.permissions.as_ref(),
+                None,
             )?);
         }
     }
@@ -145,6 +217,7 @@ pub fn expand_jobs(workflow: &Workflow) -> Result<Vec<JobPlan>, ParserError> {
     Ok(plans)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn job_plan_from_job(
     job_id: &str,
     job: &Job,
@@ -153,11 +226,21 @@ fn job_plan_from_job(
     env: BTreeMap<String, String>,
     oidc_environment: Option<String>,
     workflow_permissions: Option<&Value>,
+    inputs: Option<&BTreeMap<String, Value>>,
 ) -> Result<JobPlan, ParserError> {
     let (concurrency_group, concurrency_cancel_in_progress, concurrency_queue) =
         concurrency_fields(job.concurrency.as_ref());
     let continue_on_error =
         resolved_continue_on_error(job_id, job.continue_on_error.as_ref(), &matrix)?;
+    let fail_fast = resolve_deferred_bool(job.strategy.fail_fast.as_ref(), &matrix, inputs, true)?;
+    let max_parallel =
+        resolve_deferred_number(job.strategy.max_parallel.as_ref(), &matrix, inputs)?;
+    let steps = job
+        .steps
+        .iter()
+        .cloned()
+        .map(|step| step_plan(step, &job.defaults, &matrix, inputs))
+        .collect::<Result<Vec<_>, _>>()?;
     Ok(JobPlan {
         id: JobId(expanded_id),
         base_id: job_id.to_owned(),
@@ -167,16 +250,11 @@ fn job_plan_from_job(
         needs: job.needs.ids(),
         matrix,
         env,
-        steps: job
-            .steps
-            .iter()
-            .cloned()
-            .map(|s| step_plan(s, &job.defaults))
-            .collect(),
+        steps,
         if_condition: job.if_condition.clone(),
         continue_on_error,
-        fail_fast: job.strategy.fail_fast.unwrap_or(true),
-        max_parallel: job.strategy.max_parallel,
+        fail_fast,
+        max_parallel,
         secrets_inherit: false,
         container: job.container.clone(),
         services: non_empty_services(job.services.clone()),
@@ -304,6 +382,7 @@ fn expand_jobs_with_reusables_internal(
     reusable_workflows: &BTreeMap<String, String>,
     depth: usize,
     reusable_calls: &mut BTreeMap<String, ReusableCallMetadata>,
+    inputs: Option<&BTreeMap<String, Value>>,
 ) -> Result<Vec<JobPlan>, ParserError> {
     let mut plans = Vec::new();
     let global_env = workflow.env.clone().into_strings();
@@ -416,7 +495,8 @@ fn expand_jobs_with_reusables_internal(
                 .map(|(k, v)| (k.clone(), v.value.clone()))
                 .collect();
 
-            let matrices = expand_matrix(job_id, job.strategy.matrix.as_ref())?;
+            let matrices =
+                expand_matrix(job_id, job.strategy.matrix.as_ref(), Some(&resolved_inputs))?;
             for matrix in matrices {
                 let expanded_job_id = matrix_expand::expanded_job_id(job_id, &matrix);
                 let mut called_plans = expand_jobs_with_reusables_internal(
@@ -424,6 +504,7 @@ fn expand_jobs_with_reusables_internal(
                     reusable_workflows,
                     depth + 1,
                     reusable_calls,
+                    Some(&resolved_inputs),
                 )?;
 
                 let mut inner_job_ids = Vec::new();
@@ -476,7 +557,7 @@ fn expand_jobs_with_reusables_internal(
             continue;
         }
 
-        for matrix in expand_matrix(job_id, job.strategy.matrix.as_ref())? {
+        for matrix in expand_matrix(job_id, job.strategy.matrix.as_ref(), inputs)? {
             let oidc_environment = oidc_environment(job.environment.as_ref(), &matrix);
             let expanded_id = matrix_expand::expanded_job_id(job_id, &matrix);
             let mut env = global_env.clone();
@@ -489,6 +570,7 @@ fn expand_jobs_with_reusables_internal(
                 env,
                 oidc_environment,
                 workflow.permissions.as_ref(),
+                inputs,
             )?);
         }
     }
@@ -501,8 +583,13 @@ pub fn expand_jobs_with_reusables(
     reusable_workflows: &BTreeMap<String, String>,
 ) -> Result<ExpandedWorkflows, ParserError> {
     let mut reusable_calls = BTreeMap::new();
-    let mut plans =
-        expand_jobs_with_reusables_internal(workflow, reusable_workflows, 0, &mut reusable_calls)?;
+    let mut plans = expand_jobs_with_reusables_internal(
+        workflow,
+        reusable_workflows,
+        0,
+        &mut reusable_calls,
+        None,
+    )?;
 
     // Post-process: Rewrite needs to replace base job IDs of reusable calls with their expanded inner job IDs.
     let expanded_ids: std::collections::HashSet<String> =
@@ -553,7 +640,12 @@ fn normalize_reusable_path(uses: &str) -> String {
         .into_owned()
 }
 
-fn step_plan(step: Step, defaults: &Option<JobDefaults>) -> StepPlan {
+fn step_plan(
+    step: Step,
+    defaults: &Option<JobDefaults>,
+    matrix: &IndexMap<String, Value>,
+    inputs: Option<&BTreeMap<String, Value>>,
+) -> Result<StepPlan, ParserError> {
     // Merge job-level defaults into step — step values take precedence.
     let working_directory = step.working_directory.or_else(|| {
         defaults
@@ -567,7 +659,7 @@ fn step_plan(step: Step, defaults: &Option<JobDefaults>) -> StepPlan {
             .and_then(|d| d.run.as_ref())
             .and_then(|r| r.shell.clone())
     });
-    StepPlan {
+    Ok(StepPlan {
         id: step.id,
         name: step.name,
         run: step.run,
@@ -577,19 +669,57 @@ fn step_plan(step: Step, defaults: &Option<JobDefaults>) -> StepPlan {
         if_condition: step.if_condition,
         working_directory,
         shell,
-        continue_on_error: step.continue_on_error,
-    }
+        continue_on_error: step.continue_on_error.as_ref().map_or(Ok(None), |value| {
+            resolve_deferred_bool(Some(value), matrix, inputs, false).map(Some)
+        })?,
+    })
 }
 
 fn expand_matrix(
     job_id: &str,
-    matrix: Option<&Matrix>,
+    matrix: Option<&MatrixValue>,
+    inputs: Option<&BTreeMap<String, Value>>,
 ) -> Result<Vec<IndexMap<String, Value>>, ParserError> {
     let Some(matrix) = matrix else {
         return Ok(vec![IndexMap::new()]);
     };
 
-    let spec = matrix_expand::matrix_to_spec(job_id, matrix)?;
+    let mut matrix = match matrix {
+        MatrixValue::Static(matrix) => matrix.clone(),
+        MatrixValue::Expression(expression) => {
+            let value = eval_expression(expression, &expression_context(&IndexMap::new(), inputs))
+                .map_err(|error| ParserError::InvalidExpression(error.to_string()))?;
+            if value.is_null() {
+                return Ok(vec![IndexMap::new()]);
+            }
+            serde_json::from_value(value).map_err(|error| {
+                ParserError::InvalidExpression(format!(
+                    "matrix expression did not return a matrix object: {error}"
+                ))
+            })?
+        }
+    };
+    for (field, values) in [
+        ("include", &mut matrix.include),
+        ("exclude", &mut matrix.exclude),
+    ] {
+        if values.len() == 1 {
+            if let Value::String(expression) = &values[0] {
+                let resolved =
+                    eval_expression(expression, &expression_context(&IndexMap::new(), inputs))
+                        .map_err(|error| ParserError::InvalidExpression(error.to_string()))?;
+                if resolved.is_null() {
+                    return Ok(vec![IndexMap::new()]);
+                }
+                *values = resolved.as_array().cloned().ok_or_else(|| {
+                    ParserError::InvalidExpression(format!(
+                        "matrix {field} expression did not return an array"
+                    ))
+                })?;
+            }
+        }
+    }
+    let spec = matrix_expand::matrix_to_spec(job_id, &matrix)?;
     Ok(matrix_expand::expand_matrix_spec(&spec)
         .into_iter()
         .map(|combination| combination.values)

--- a/crates/aksh-gha-parser/src/lib.rs
+++ b/crates/aksh-gha-parser/src/lib.rs
@@ -15,7 +15,7 @@ mod models;
 mod trigger;
 mod yaml;
 
-pub use expand::{expand_jobs, expand_jobs_with_reusables};
+pub use expand::{expand_jobs, expand_jobs_with_reusables, expand_jobs_with_reusables_and_shas};
 pub use models::*;
 pub use yaml::{parse_action_metadata, parse_workflow};
 

--- a/crates/aksh-gha-parser/src/lib_tests.rs
+++ b/crates/aksh-gha-parser/src/lib_tests.rs
@@ -1051,3 +1051,70 @@ jobs:
         Some("false")
     );
 }
+
+#[test]
+fn reusable_workflow_expression_matrix_uses_caller_inputs() {
+    let caller = parse_workflow(
+        r#"
+on: push
+jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+    with:
+      test-matrix: '{"os":["ubuntu-latest","windows-latest"]}'
+    secrets: inherit
+"#,
+    )
+    .unwrap();
+    let called = r#"
+on:
+  workflow_call:
+    inputs:
+      test-matrix:
+        required: true
+        type: string
+jobs:
+  test:
+    strategy:
+      matrix: ${{ fromJSON(inputs.test-matrix) }}
+      fail-fast: ${{ matrix.os == 'ubuntu-latest' }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - run: echo ${{ matrix.os }}
+"#;
+    let mut reusable = std::collections::BTreeMap::new();
+    reusable.insert(".github/workflows/test.yml".to_owned(), called.to_owned());
+
+    let expanded = expand_jobs_with_reusables(&caller, &reusable).unwrap();
+    assert_eq!(expanded.jobs.len(), 2);
+    assert!(expanded
+        .jobs
+        .iter()
+        .all(|job| job.matrix.get("os").is_some()));
+}
+
+#[test]
+fn strategy_expression_scalars_are_preserved_and_resolved() {
+    let workflow = parse_workflow(
+        r#"
+on: push
+jobs:
+  build:
+    strategy:
+      fail-fast: ${{ matrix.experimental }}
+      max-parallel: ${{ matrix.parallelism }}
+      matrix:
+        include:
+          - experimental: true
+            parallelism: 3
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+"#,
+    )
+    .unwrap();
+    let plans = expand_jobs(&workflow).unwrap();
+    assert_eq!(plans.len(), 1);
+    assert!(plans[0].fail_fast);
+    assert_eq!(plans[0].max_parallel, Some(3));
+}

--- a/crates/aksh-gha-parser/src/lib_tests.rs
+++ b/crates/aksh-gha-parser/src/lib_tests.rs
@@ -1118,3 +1118,49 @@ jobs:
     assert!(plans[0].fail_fast);
     assert_eq!(plans[0].max_parallel, Some(3));
 }
+
+#[test]
+fn reusable_workflow_sha_propagates_to_plans_and_call_metadata() {
+    let caller = parse_workflow(
+        r#"
+on: push
+jobs:
+  call:
+    uses: octo/demo/.github/workflows/build.yml@v1
+"#,
+    )
+    .unwrap();
+    let called = r#"
+on:
+  workflow_call:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+"#;
+    let mut reusable = BTreeMap::new();
+    reusable.insert(
+        "octo/demo/.github/workflows/build.yml@v1".to_owned(),
+        called.to_owned(),
+    );
+    let mut shas = BTreeMap::new();
+    shas.insert(
+        "octo/demo/.github/workflows/build.yml@v1".to_owned(),
+        "0123456789abcdef".to_owned(),
+    );
+
+    let expanded = expand_jobs_with_reusables_and_shas(&caller, &reusable, &shas).unwrap();
+    assert_eq!(
+        expanded.jobs[0].workflow_sha.as_deref(),
+        Some("0123456789abcdef")
+    );
+    assert_eq!(
+        expanded.jobs[0].workflow_repository.as_deref(),
+        Some("octo/demo")
+    );
+    assert_eq!(
+        expanded.reusable_calls["call"].workflow_sha.as_deref(),
+        Some("0123456789abcdef")
+    );
+}

--- a/crates/aksh-gha-parser/src/lib_tests.rs
+++ b/crates/aksh-gha-parser/src/lib_tests.rs
@@ -102,6 +102,23 @@ jobs:
 }
 
 #[test]
+fn parses_and_expands_opencode_test_workflow_fixture() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
+    let fixture_path = root
+        .join("fixtures")
+        .join("workflows")
+        .join("opencode-test.yml");
+    let yaml = std::fs::read_to_string(&fixture_path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", fixture_path.display()));
+    let parsed = parse_workflow(&yaml).expect("parse_workflow failed for opencode-test.yml");
+    let expanded = expand_jobs(&parsed).expect("expand_jobs failed for opencode-test.yml");
+    assert_eq!(expanded.len(), 4);
+}
+#[test]
 fn schedule_trigger_matches_event_name() {
     let workflow = parse_workflow(
         r#"

--- a/crates/aksh-gha-parser/src/lib_tests.rs
+++ b/crates/aksh-gha-parser/src/lib_tests.rs
@@ -805,6 +805,140 @@ fn preserves_job_output_expressions() {
         Some("${{ steps.gen.outputs.value }}")
     );
 }
+
+#[test]
+fn job_outputs_reject_unknown_function_expression() {
+    let result = parse_workflow(
+        r#"on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      value: ${{ notARealFunction() }}
+    steps:
+      - run: echo ok
+"#,
+    );
+
+    match result {
+        Err(ParserError::InvalidExpression(message)) => {
+            assert!(
+                message.contains("output `value`"),
+                "output field context missing from error: {message}"
+            );
+        }
+        other => panic!("expected invalid output expression, got {other:?}"),
+    }
+}
+
+#[test]
+fn job_outputs_accept_steps_context_expression() {
+    let workflow = parse_workflow(
+        r#"on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      value: ${{ steps.build.outputs.value }}
+    steps:
+      - id: build
+        run: echo ok
+"#,
+    )
+    .expect("steps context is allowed in job outputs");
+
+    assert_eq!(
+        workflow.jobs["build"].outputs["value"]
+            .as_str()
+            .expect("job output expression should remain a string"),
+        "${{ steps.build.outputs.value }}"
+    );
+}
+
+#[test]
+fn job_container_rejects_secrets_context_expression() {
+    let result = parse_workflow(
+        r#"on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: ${{ secrets.IMAGE }}
+    steps:
+      - run: echo ok
+"#,
+    );
+
+    match result {
+        Err(ParserError::InvalidExpression(message)) => {
+            assert!(
+                message.contains("container"),
+                "container field context missing from error: {message}"
+            );
+            assert!(
+                message.contains("secrets"),
+                "forbidden context missing from error: {message}"
+            );
+        }
+        other => panic!("expected invalid container expression, got {other:?}"),
+    }
+}
+
+#[test]
+fn job_defaults_run_working_directory_rejects_secrets_and_accepts_matrix() {
+    let invalid = parse_workflow(
+        r#"on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ secrets.WORKING_DIR }}
+    steps:
+      - run: echo ok
+"#,
+    );
+
+    match invalid {
+        Err(ParserError::InvalidExpression(message)) => {
+            assert!(
+                message.contains("working-directory"),
+                "working-directory field context missing from error: {message}"
+            );
+            assert!(
+                message.contains("secrets"),
+                "forbidden context missing from error: {message}"
+            );
+        }
+        other => panic!("expected invalid defaults expression, got {other:?}"),
+    }
+
+    let workflow = parse_workflow(
+        r#"on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        directory: [workspace]
+    defaults:
+      run:
+        working-directory: ${{ matrix.directory }}
+    steps:
+      - run: echo ok
+"#,
+    )
+    .expect("matrix context is allowed in job defaults.run.working-directory");
+
+    assert_eq!(
+        workflow.jobs["build"]
+            .defaults
+            .as_ref()
+            .and_then(|defaults| defaults.run.as_ref())
+            .and_then(|run| run.working_directory.as_deref()),
+        Some("${{ matrix.directory }}")
+    );
+}
+
 #[test]
 fn concurrency_bare_string_shorthand() {
     let wf = parse_workflow(

--- a/crates/aksh-gha-parser/src/lib_tests.rs
+++ b/crates/aksh-gha-parser/src/lib_tests.rs
@@ -1164,3 +1164,71 @@ jobs:
         Some("0123456789abcdef")
     );
 }
+
+#[test]
+fn matrix_expanded_reusable_workflow_needs_resolution() {
+    let caller = parse_workflow(
+        r#"
+on: push
+jobs:
+  build:
+    uses: octo/demo/.github/workflows/build.yml@v1
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+  package:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+"#,
+    )
+    .unwrap();
+    let called = r#"
+on:
+  workflow_call:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo test
+"#;
+    let mut reusable = BTreeMap::new();
+    reusable.insert(
+        "octo/demo/.github/workflows/build.yml@v1".to_owned(),
+        called.to_owned(),
+    );
+    let shas = BTreeMap::new();
+
+    let expanded = expand_jobs_with_reusables_and_shas(&caller, &reusable, &shas).unwrap();
+    // We expect package to depend on both matrix instances of the reusable workflow call
+    let package_job = expanded
+        .jobs
+        .iter()
+        .find(|j| j.base_id == "package")
+        .unwrap();
+    assert_eq!(package_job.needs.len(), 2);
+    let needs_ids: Vec<String> = package_job.needs.iter().map(|n| n.0.clone()).collect();
+    assert!(needs_ids.contains(&"build (ubuntu-latest)/test".to_owned()));
+    assert!(needs_ids.contains(&"build (windows-latest)/test".to_owned()));
+}
+
+#[test]
+fn parses_step_with_boolean_input() {
+    let yaml = r#"
+on: push
+jobs:
+  test:
+    if: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        if: true
+        with:
+          persist-credentials: false
+          fetch-depth: 25
+"#;
+    let parsed = parse_workflow(yaml).unwrap();
+    let expanded = expand_jobs(&parsed).unwrap();
+    assert_eq!(expanded.len(), 1);
+}

--- a/crates/aksh-gha-parser/src/models.rs
+++ b/crates/aksh-gha-parser/src/models.rs
@@ -14,6 +14,9 @@ pub enum ParserError {
     /// YAML deserialization failed.
     #[error("workflow yaml error: {0}")]
     Yaml(#[from] serde_yaml::Error),
+    /// Expression syntax or function error.
+    #[error("invalid expression in workflow: {0}")]
+    InvalidExpression(String),
     /// Workflow did not define jobs.
     #[error("workflow does not define any jobs")]
     EmptyJobs,

--- a/crates/aksh-gha-parser/src/models.rs
+++ b/crates/aksh-gha-parser/src/models.rs
@@ -662,13 +662,81 @@ impl Needs {
 pub struct Strategy {
     /// Matrix block.
     #[serde(default)]
-    pub matrix: Option<Matrix>,
+    pub matrix: Option<MatrixValue>,
     /// Fail-fast flag.
     #[serde(default, rename = "fail-fast")]
-    pub fail_fast: Option<bool>,
+    pub fail_fast: Option<DeferredBool>,
     /// Max parallel jobs.
     #[serde(default, rename = "max-parallel")]
-    pub max_parallel: Option<u64>,
+    pub max_parallel: Option<DeferredNumber>,
+}
+
+/// A workflow scalar that may be deferred as a GitHub Actions expression.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum DeferredBool {
+    /// Literal boolean value.
+    Literal(bool),
+    /// Expression evaluated when the job is expanded.
+    Expression(String),
+}
+
+/// A workflow number that may be deferred as a GitHub Actions expression.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum DeferredNumber {
+    /// Literal unsigned integer value.
+    Literal(u64),
+    /// Expression evaluated when the job is expanded.
+    Expression(String),
+}
+
+/// A static matrix or an expression producing a matrix object.
+#[derive(Debug, Clone)]
+pub enum MatrixValue {
+    /// Structured matrix axes, includes, and excludes.
+    Static(Matrix),
+    /// Expression that evaluates to a matrix object.
+    Expression(String),
+}
+
+impl Serialize for MatrixValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Static(matrix) => matrix.serialize(serializer),
+            Self::Expression(expression) => expression.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for MatrixValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_yaml::Value::deserialize(deserializer)?;
+        if let serde_yaml::Value::String(expression) = value {
+            return Ok(Self::Expression(expression));
+        }
+        let mut value = value;
+        if let serde_yaml::Value::Mapping(mapping) = &mut value {
+            for field in ["include", "exclude"] {
+                let key = serde_yaml::Value::String(field.to_owned());
+                if let Some(serde_yaml::Value::String(expression)) = mapping.get(&key).cloned() {
+                    mapping.insert(
+                        key,
+                        serde_yaml::Value::Sequence(vec![serde_yaml::Value::String(expression)]),
+                    );
+                }
+            }
+        }
+        serde_yaml::from_value(value)
+            .map(Self::Static)
+            .map_err(serde::de::Error::custom)
+    }
 }
 
 /// Concurrency queue mode for a group.
@@ -804,7 +872,7 @@ pub struct Step {
     pub shell: Option<String>,
     /// Whether to continue on error.
     #[serde(default, rename = "continue-on-error")]
-    pub continue_on_error: Option<bool>,
+    pub continue_on_error: Option<DeferredBool>,
 }
 
 /// Action metadata from `action.yml` or `action.yaml`.

--- a/crates/aksh-gha-parser/src/models.rs
+++ b/crates/aksh-gha-parser/src/models.rs
@@ -420,6 +420,12 @@ pub struct ReusableCallMetadata {
     /// Caller strategy matrix values.
     #[serde(default)]
     pub matrix: BTreeMap<String, Value>,
+    /// Resolved called-workflow commit SHA.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_sha: Option<String>,
+    /// Resolved called-workflow repository.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_repository: Option<String>,
 }
 
 /// Trigger syntax.

--- a/crates/aksh-gha-parser/src/models.rs
+++ b/crates/aksh-gha-parser/src/models.rs
@@ -509,6 +509,23 @@ impl EnvValue {
     }
 }
 
+fn deserialize_if_condition<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    match value {
+        None => Ok(None),
+        Some(serde_json::Value::Bool(b)) => Ok(Some(b.to_string())),
+        Some(serde_json::Value::Number(n)) => Ok(Some(n.to_string())),
+        Some(serde_json::Value::String(s)) => Ok(Some(s)),
+        Some(serde_json::Value::Null) => Ok(None),
+        Some(_) => Err(serde::de::Error::custom(
+            "expected a string, boolean, or number for `if` condition",
+        )),
+    }
+}
+
 /// Workflow job.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Job {
@@ -522,7 +539,7 @@ pub struct Job {
     #[serde(default)]
     pub needs: Needs,
     /// Optional if condition.
-    #[serde(default, rename = "if")]
+    #[serde(default, deserialize_with = "deserialize_if_condition", rename = "if")]
     pub if_condition: Option<String>,
     /// Job-level failure tolerance.
     #[serde(default, rename = "continue-on-error")]
@@ -868,7 +885,7 @@ pub struct Step {
     #[serde(default)]
     pub with: BTreeMap<String, Value>,
     /// Optional if condition.
-    #[serde(default, rename = "if")]
+    #[serde(default, deserialize_with = "deserialize_if_condition", rename = "if")]
     pub if_condition: Option<String>,
     /// Working directory override.
     #[serde(default, rename = "working-directory")]

--- a/crates/aksh-gha-parser/src/yaml.rs
+++ b/crates/aksh-gha-parser/src/yaml.rs
@@ -10,6 +10,7 @@ pub fn parse_workflow(input: &str) -> Result<Workflow, ParserError> {
     if workflow.jobs.is_empty() {
         return Err(ParserError::EmptyJobs);
     }
+    crate::eval::validate_workflow_expressions(&workflow)?;
     Ok(workflow)
 }
 

--- a/crates/aksh-gha-parser/src/yaml.rs
+++ b/crates/aksh-gha-parser/src/yaml.rs
@@ -21,7 +21,7 @@ pub fn parse_action_metadata(input: &str) -> Result<ActionMetadata, ParserError>
     Ok(serde_yaml::from_value(value)?)
 }
 
-fn normalize_yaml_keys(value: &mut serde_yaml::Value) {
+pub(crate) fn normalize_yaml_keys(value: &mut serde_yaml::Value) {
     match value {
         serde_yaml::Value::Mapping(map) => {
             if let Some(on_value) = map.remove(serde_yaml::Value::Bool(true)) {

--- a/crates/aksh-gha-protocol/src/lib.rs
+++ b/crates/aksh-gha-protocol/src/lib.rs
@@ -161,6 +161,9 @@ pub struct WorkflowSubmission {
     /// Local reusable workflow YAML keyed by repository-relative path.
     #[serde(default)]
     pub reusable_workflows: BTreeMap<String, String>,
+    /// Resolved commit SHA for each remote reusable workflow reference.
+    #[serde(default)]
+    pub reusable_workflow_shas: BTreeMap<String, String>,
     /// Enable DAP debugger for the run's jobs.
     #[serde(default)]
     pub enable_debugger: bool,

--- a/crates/aksh-runner-client/Cargo.toml
+++ b/crates/aksh-runner-client/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 anyhow.workspace = true
 clap.workspace = true
 aksh-gha-protocol = { path = "../aksh-gha-protocol" }
+aksh-gha-parser = { path = "../aksh-gha-parser" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/aksh-runner-client/src/main.rs
+++ b/crates/aksh-runner-client/src/main.rs
@@ -10,11 +10,12 @@ use clap::{Parser, Subcommand};
 use reqwest::Url;
 use serde_json::Value;
 
+const MAX_REUSABLE_WORKFLOW_DEPTH: usize = 4;
+
 #[derive(Debug, Parser)]
 #[command(name = "aksh")]
 #[command(about = "Submit and manage local Preloop GitHub Actions runs")]
 struct Cli {
-    /// Server base URL.
     #[arg(long, env = "PRELOOP_SERVER", default_value = "http://127.0.0.1:8080")]
     server: Url,
     #[command(subcommand)]
@@ -41,7 +42,6 @@ enum Command {
         /// Repository slug or local id.
         #[arg(long, default_value = "local/aksh")]
         repository: String,
-        /// Git ref.
         #[arg(long, default_value = "refs/heads/main")]
         git_ref: String,
         /// Variable in KEY=VALUE form.
@@ -60,29 +60,22 @@ enum Command {
         #[arg(long)]
         debugger_welcome_message: Option<String>,
     },
-    /// Show a run.
     Run {
-        /// Run id.
+        /// Run d.
         run_id: RunId,
     },
-    /// Cancel a run.
     Cancel {
-        /// Run id.
         run_id: RunId,
     },
-    /// Rerun a previous submission.
     Rerun {
-        /// Run id.
         run_id: RunId,
     },
-    /// Print current NDJSON events for a run.
     Events {
         /// Run id.
         run_id: RunId,
     },
     /// Lint and dry-run workflow parsing and job expansion without running it.
     Lint {
-        /// Workflow YAML path.
         #[arg(short = 'W', long)]
         workflow: PathBuf,
         /// Repository workspace root used to collect local reusable workflows.
@@ -218,6 +211,8 @@ async fn main() -> anyhow::Result<()> {
                 .with_context(|| format!("parse workflow {}", workflow.display()))?;
             let reusable_workflows =
                 collect_reusable_workflows(workspace_root.as_deref(), &workflow).await?;
+            let reusable_workflows =
+                resolve_remote_workflows(reusable_workflows, &workflow_yaml).await?;
             let expanded =
                 aksh_gha_parser::expand_jobs_with_reusables(&parsed, &reusable_workflows)
                     .with_context(|| format!("expand workflow {}", workflow.display()))?;
@@ -309,6 +304,62 @@ fn same_file_path(left: &std::path::Path, right: &std::path::Path) -> bool {
         (Ok(left), Ok(right)) => left == right,
         _ => left == right,
     }
+}
+
+async fn resolve_remote_workflows(
+    mut workflows: BTreeMap<String, String>,
+    root_yaml: &str,
+) -> anyhow::Result<BTreeMap<String, String>> {
+    let client = reqwest::Client::builder()
+        .user_agent("aksh-runner-client")
+        .build()?;
+    let token = std::env::var("AKSH_GITHUB_TOKEN").ok();
+    let mut queue = vec![(root_yaml.to_owned(), 0usize)];
+    let mut visited = std::collections::BTreeSet::new();
+    while let Some((yaml, depth)) = queue.pop() {
+        if depth >= MAX_REUSABLE_WORKFLOW_DEPTH {
+            anyhow::bail!("nested reusable workflow depth exceeded");
+        }
+        let workflow = aksh_gha_parser::parse_workflow(&yaml)?;
+        for job in workflow.jobs.values() {
+            let Some(reference) = job.uses.as_deref() else {
+                continue;
+            };
+            if reference.starts_with("./") || workflows.contains_key(reference) {
+                continue;
+            }
+            let Some((owner, repo, path, git_ref)) = parse_remote_reference(reference) else {
+                anyhow::bail!("unsupported reusable workflow reference `{reference}`");
+            };
+            if !visited.insert(reference.to_owned()) {
+                continue;
+            }
+            let mut request = client
+                .get(format!(
+                    "https://api.github.com/repos/{owner}/{repo}/contents/{path}?ref={git_ref}"
+                ))
+                .header(reqwest::header::ACCEPT, "application/vnd.github.raw+json");
+            if let Some(token) = token.as_deref() {
+                request = request.bearer_auth(token);
+            }
+            let contents = request.send().await?.error_for_status()?.text().await?;
+            workflows.insert(reference.to_owned(), contents.clone());
+            queue.push((contents, depth + 1));
+        }
+    }
+    Ok(workflows)
+}
+
+fn parse_remote_reference(reference: &str) -> Option<(&str, &str, &str, &str)> {
+    let (repository_path, git_ref) = reference.rsplit_once('@')?;
+    let mut parts = repository_path.splitn(3, '/');
+    let owner = parts.next()?;
+    let repo = parts.next()?;
+    let path = parts.next()?;
+    if owner.is_empty() || repo.is_empty() || !path.starts_with(".github/workflows/") {
+        return None;
+    }
+    Some((owner, repo, path, git_ref))
 }
 
 async fn print_response(response: reqwest::Response) -> anyhow::Result<()> {

--- a/crates/aksh-runner-client/src/main.rs
+++ b/crates/aksh-runner-client/src/main.rs
@@ -80,6 +80,15 @@ enum Command {
         /// Run id.
         run_id: RunId,
     },
+    /// Lint and dry-run workflow parsing and job expansion without running it.
+    Lint {
+        /// Workflow YAML path.
+        #[arg(short = 'W', long)]
+        workflow: PathBuf,
+        /// Repository workspace root used to collect local reusable workflows.
+        #[arg(long)]
+        workspace_root: Option<PathBuf>,
+    },
 }
 
 #[tokio::main]
@@ -197,6 +206,32 @@ async fn main() -> anyhow::Result<()> {
                 .await?,
             )
             .await?;
+        }
+        Command::Lint {
+            workflow,
+            workspace_root,
+        } => {
+            let workflow_yaml = tokio::fs::read_to_string(&workflow)
+                .await
+                .with_context(|| format!("read workflow {}", workflow.display()))?;
+            let parsed = aksh_gha_parser::parse_workflow(&workflow_yaml)
+                .with_context(|| format!("parse workflow {}", workflow.display()))?;
+            let reusable_workflows =
+                collect_reusable_workflows(workspace_root.as_deref(), &workflow).await?;
+            let expanded =
+                aksh_gha_parser::expand_jobs_with_reusables(&parsed, &reusable_workflows)
+                    .with_context(|| format!("expand workflow {}", workflow.display()))?;
+
+            let step_count: usize = expanded.jobs.iter().map(|j| j.steps.len()).sum();
+            println!(
+                "✓ Workflow {} is valid: parsed {} job plan(s) and {} total step(s).",
+                workflow.display(),
+                expanded.jobs.len(),
+                step_count
+            );
+            for job in &expanded.jobs {
+                println!("  - Job: {} ({})", job.id.0, job.name);
+            }
         }
     }
 

--- a/crates/aksh-runner-server/src/concurrency_http_properties.rs
+++ b/crates/aksh-runner-server/src/concurrency_http_properties.rs
@@ -861,6 +861,7 @@ pub(crate) mod http_sequences {
         })]
 
         #[test]
+        #[ignore = "expensive generated HTTP state-machine run; use just test-properties-full"]
         fn generated_http_sequence_invariants(case in arb_case()) {
             run_generated_sequence(case);
         }

--- a/crates/aksh-runner-server/src/concurrency_properties.rs
+++ b/crates/aksh-runner-server/src/concurrency_properties.rs
@@ -363,6 +363,7 @@ impl ProdState {
                 inputs: BTreeMap::new(),
                 secrets: BTreeMap::new(),
                 reusable_workflows: BTreeMap::new(),
+                reusable_workflow_shas: BTreeMap::new(),
                 enable_debugger: false,
                 debugger_welcome_message: None,
                 ..Default::default()

--- a/crates/aksh-runner-server/src/errors.rs
+++ b/crates/aksh-runner-server/src/errors.rs
@@ -179,6 +179,13 @@ impl ApiError {
             message: message.into(),
         }
     }
+
+    pub(crate) fn bad_gateway(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_GATEWAY,
+            message: message.into(),
+        }
+    }
 }
 
 impl From<aksh_gha_parser::ParserError> for ApiError {

--- a/crates/aksh-runner-server/src/github.rs
+++ b/crates/aksh-runner-server/src/github.rs
@@ -795,6 +795,7 @@ pub(crate) async fn handle_github_webhook(
                 vars: BTreeMap::new(),
                 secrets: BTreeMap::new(),
                 reusable_workflows: BTreeMap::new(),
+                reusable_workflow_shas: BTreeMap::new(),
                 enable_debugger: false,
                 debugger_welcome_message: None,
                 sha: resolved_sha.clone(),

--- a/crates/aksh-runner-server/src/lib.rs
+++ b/crates/aksh-runner-server/src/lib.rs
@@ -19,6 +19,7 @@ mod actions;
 use actions::*;
 mod reusable_workflows;
 use reusable_workflows::*;
+mod remote_workflows;
 mod runs;
 use runs::*;
 mod runtime_scheduling;

--- a/crates/aksh-runner-server/src/lib.rs
+++ b/crates/aksh-runner-server/src/lib.rs
@@ -87,7 +87,7 @@ use rcgen::generate_simple_self_signed;
 use aksh_artifacts::{validate_artifact_name, ArtifactStore};
 use aksh_cache::CacheStore;
 use aksh_gha_parser::eval::build_context;
-use aksh_gha_parser::{expand_jobs_with_reusables, parse_workflow};
+use aksh_gha_parser::parse_workflow;
 use aksh_gha_protocol::{
     azdo,
     crypto::{AgentRsaKeypair, AgentRsaPublicKey, SessionEncryption},

--- a/crates/aksh-runner-server/src/oidc.rs
+++ b/crates/aksh-runner-server/src/oidc.rs
@@ -969,6 +969,7 @@ jobs:
         }
 
         #[test]
+        #[ignore = "expensive RSA generation; use just test-properties-full"]
         fn prop_signed_jwt_verifies(
             _ in 0..4u32,
         ) {
@@ -994,6 +995,7 @@ jobs:
         }
 
         #[test]
+        #[ignore = "expensive RSA generation; use just test-properties-full"]
         fn prop_kid_matches_thumbprint(
             _ in 0..4u32,
         ) {

--- a/crates/aksh-runner-server/src/oidc_handlers.rs
+++ b/crates/aksh-runner-server/src/oidc_handlers.rs
@@ -211,21 +211,23 @@ pub(crate) async fn oidc_token(
     let job_workflow_ref = oidc_context.job_workflow_ref.as_deref().map(|reference| {
         format_reusable_workflow_ref(&submission.repository, reference, &submission.git_ref)
     });
-    let job_workflow_sha = job_workflow_ref
-        .as_ref()
-        .and_then(|reference| {
-            reference
-                .rsplit_once('@')
-                .map(|(_, git_ref)| git_ref)
-                .filter(|git_ref| {
-                    git_ref.len() == 40
-                        && git_ref
-                            .chars()
-                            .all(|character| character.is_ascii_hexdigit())
-                })
-                .map(str::to_owned)
-        })
-        .or_else(|| job_workflow_ref.as_ref().map(|_| sha.clone()));
+    let job_workflow_sha = oidc_context.job_workflow_sha.clone().or_else(|| {
+        job_workflow_ref
+            .as_ref()
+            .and_then(|reference| {
+                reference
+                    .rsplit_once('@')
+                    .map(|(_, git_ref)| git_ref)
+                    .filter(|git_ref| {
+                        git_ref.len() == 40
+                            && git_ref
+                                .chars()
+                                .all(|character| character.is_ascii_hexdigit())
+                    })
+                    .map(str::to_owned)
+            })
+            .or_else(|| job_workflow_ref.as_ref().map(|_| sha.clone()))
+    });
 
     let claims_input = oidc::OidcClaimsInput {
         repository: submission.repository.clone(),

--- a/crates/aksh-runner-server/src/remote_workflows.rs
+++ b/crates/aksh-runner-server/src/remote_workflows.rs
@@ -1,0 +1,102 @@
+use super::*;
+
+const MAX_REUSABLE_WORKFLOW_DEPTH: usize = 4;
+
+/// Populate the submission's reusable-workflow table with remote references.
+///
+/// GitHub resolves these references before handing the expanded workflow to
+/// the runner. The server performs the equivalent resolution for references
+/// not already supplied by a caller (local workflows and test fixtures).
+pub(crate) async fn resolve_remote_workflows(
+    submission: &mut WorkflowSubmission,
+) -> Result<(), ApiError> {
+    let client = reqwest::Client::builder()
+        .user_agent("aksh-runner-server")
+        .build()
+        .map_err(|error| ApiError::internal(format!("build GitHub client: {error}")))?;
+    let token = std::env::var("AKSH_GITHUB_TOKEN").ok();
+    let mut queue = vec![(submission.workflow_yaml.clone(), 0usize)];
+    let mut visited = std::collections::BTreeSet::new();
+    while let Some((workflow_yaml, depth)) = queue.pop() {
+        if depth > MAX_REUSABLE_WORKFLOW_DEPTH {
+            return Err(ApiError::bad_request(
+                "nested reusable workflow depth exceeded",
+            ));
+        }
+        let workflow = aksh_gha_parser::parse_workflow(&workflow_yaml)?;
+        for job in workflow.jobs.values() {
+            let Some(reference) = job.uses.as_deref() else {
+                continue;
+            };
+            if reference.starts_with("./") || submission.reusable_workflows.contains_key(reference)
+            {
+                continue;
+            }
+            let Some((owner, repo, path, git_ref)) = parse_remote_reference(reference) else {
+                return Err(ApiError::bad_request(format!(
+                    "unsupported reusable workflow reference `{reference}`"
+                )));
+            };
+            if !visited.insert(reference.to_owned()) {
+                continue;
+            }
+            let mut request = client
+                .get(format!(
+                    "https://api.github.com/repos/{owner}/{repo}/contents/{path}?ref={git_ref}"
+                ))
+                .header(reqwest::header::ACCEPT, "application/vnd.github.raw+json");
+            if let Some(token) = token.as_deref() {
+                request = request.bearer_auth(token);
+            }
+            let response = request.send().await.map_err(|error| {
+                ApiError::bad_gateway(format!("fetch reusable workflow `{reference}`: {error}"))
+            })?;
+            let status = response.status();
+            if !status.is_success() {
+                return Err(ApiError::bad_gateway(format!(
+                    "GitHub returned {status} for reusable workflow `{reference}`"
+                )));
+            }
+            let contents = response.text().await.map_err(|error| {
+                ApiError::bad_gateway(format!("read reusable workflow `{reference}`: {error}"))
+            })?;
+            submission
+                .reusable_workflows
+                .insert(reference.to_owned(), contents.clone());
+            queue.push((contents, depth + 1));
+        }
+    }
+    Ok(())
+}
+
+fn parse_remote_reference(reference: &str) -> Option<(&str, &str, &str, &str)> {
+    let (repository_path, git_ref) = reference.rsplit_once('@')?;
+    let mut parts = repository_path.splitn(3, '/');
+    let owner = parts.next()?;
+    let repo = parts.next()?;
+    let path = parts.next()?;
+    if owner.is_empty() || repo.is_empty() || !path.starts_with(".github/workflows/") {
+        return None;
+    }
+    Some((owner, repo, path, git_ref))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_remote_reference;
+
+    #[test]
+    fn parses_remote_workflow_reference() {
+        assert_eq!(
+            parse_remote_reference("octo/demo/.github/workflows/build.yml@v1"),
+            Some(("octo", "demo", ".github/workflows/build.yml", "v1"))
+        );
+    }
+
+    #[test]
+    fn rejects_local_and_non_workflow_references() {
+        assert!(parse_remote_reference("./.github/workflows/build.yml").is_none());
+        assert!(parse_remote_reference("octo/demo/action.yml@v1").is_none());
+        assert!(parse_remote_reference("octo/demo/.github/workflows/build.yml").is_none());
+    }
+}

--- a/crates/aksh-runner-server/src/remote_workflows.rs
+++ b/crates/aksh-runner-server/src/remote_workflows.rs
@@ -1,6 +1,20 @@
 use super::*;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
+use serde::Deserialize;
 
 const MAX_REUSABLE_WORKFLOW_DEPTH: usize = 4;
+
+#[derive(Debug, Deserialize)]
+struct GithubContentResponse {
+    content: String,
+    encoding: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubCommitResponse {
+    sha: String,
+}
 
 /// Populate the submission's reusable-workflow table with remote references.
 ///
@@ -28,8 +42,13 @@ pub(crate) async fn resolve_remote_workflows(
             let Some(reference) = job.uses.as_deref() else {
                 continue;
             };
-            if reference.starts_with("./") || submission.reusable_workflows.contains_key(reference)
-            {
+            if reference.starts_with("./") {
+                continue;
+            }
+            if let Some(contents) = submission.reusable_workflows.get(reference).cloned() {
+                if visited.insert(reference.to_owned()) {
+                    queue.push((contents, depth + 1));
+                }
                 continue;
             }
             let Some((owner, repo, path, git_ref)) = parse_remote_reference(reference) else {
@@ -44,7 +63,7 @@ pub(crate) async fn resolve_remote_workflows(
                 .get(format!(
                     "https://api.github.com/repos/{owner}/{repo}/contents/{path}?ref={git_ref}"
                 ))
-                .header(reqwest::header::ACCEPT, "application/vnd.github.raw+json");
+                .header(reqwest::header::ACCEPT, "application/vnd.github+json");
             if let Some(token) = token.as_deref() {
                 request = request.bearer_auth(token);
             }
@@ -57,16 +76,58 @@ pub(crate) async fn resolve_remote_workflows(
                     "GitHub returned {status} for reusable workflow `{reference}`"
                 )));
             }
-            let contents = response.text().await.map_err(|error| {
-                ApiError::bad_gateway(format!("read reusable workflow `{reference}`: {error}"))
+            let content_response: GithubContentResponse =
+                response.json().await.map_err(|error| {
+                    ApiError::bad_gateway(format!("read reusable workflow `{reference}`: {error}"))
+                })?;
+            let contents = decode_github_contents(&content_response).map_err(|error| {
+                ApiError::bad_gateway(format!("decode reusable workflow `{reference}`: {error}"))
+            })?;
+
+            let mut commit_request = client.get(format!(
+                "https://api.github.com/repos/{owner}/{repo}/commits/{git_ref}"
+            ));
+            if let Some(token) = token.as_deref() {
+                commit_request = commit_request.bearer_auth(token);
+            }
+            let commit_response = commit_request.send().await.map_err(|error| {
+                ApiError::bad_gateway(format!(
+                    "resolve reusable workflow `{reference}` SHA: {error}"
+                ))
+            })?;
+            let commit_status = commit_response.status();
+            if !commit_status.is_success() {
+                return Err(ApiError::bad_gateway(format!(
+                    "GitHub returned {commit_status} while resolving reusable workflow `{reference}` SHA"
+                )));
+            }
+            let commit: GithubCommitResponse = commit_response.json().await.map_err(|error| {
+                ApiError::bad_gateway(format!("read reusable workflow `{reference}` SHA: {error}"))
             })?;
             submission
                 .reusable_workflows
                 .insert(reference.to_owned(), contents.clone());
+            submission
+                .reusable_workflow_shas
+                .insert(reference.to_owned(), commit.sha);
             queue.push((contents, depth + 1));
         }
     }
     Ok(())
+}
+
+fn decode_github_contents(response: &GithubContentResponse) -> Result<String, String> {
+    if response.encoding != "base64" {
+        return Err(format!(
+            "unsupported GitHub content encoding `{}`",
+            response.encoding
+        ));
+    }
+    let encoded = response.content.lines().collect::<String>();
+    let bytes = BASE64_STANDARD
+        .decode(encoded)
+        .map_err(|error| format!("invalid base64 content: {error}"))?;
+    String::from_utf8(bytes).map_err(|error| format!("workflow is not UTF-8: {error}"))
 }
 
 fn parse_remote_reference(reference: &str) -> Option<(&str, &str, &str, &str)> {
@@ -83,7 +144,7 @@ fn parse_remote_reference(reference: &str) -> Option<(&str, &str, &str, &str)> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_remote_reference;
+    use super::{decode_github_contents, parse_remote_reference, GithubContentResponse};
 
     #[test]
     fn parses_remote_workflow_reference() {
@@ -98,5 +159,14 @@ mod tests {
         assert!(parse_remote_reference("./.github/workflows/build.yml").is_none());
         assert!(parse_remote_reference("octo/demo/action.yml@v1").is_none());
         assert!(parse_remote_reference("octo/demo/.github/workflows/build.yml").is_none());
+    }
+
+    #[test]
+    fn decodes_github_contents_response() {
+        let response = GithubContentResponse {
+            content: "bmFtZTogQ0kK\n".to_owned(),
+            encoding: "base64".to_owned(),
+        };
+        assert_eq!(decode_github_contents(&response).unwrap(), "name: CI\n");
     }
 }

--- a/crates/aksh-runner-server/src/remote_workflows.rs
+++ b/crates/aksh-runner-server/src/remote_workflows.rs
@@ -32,7 +32,7 @@ pub(crate) async fn resolve_remote_workflows(
     let mut queue = vec![(submission.workflow_yaml.clone(), 0usize)];
     let mut visited = std::collections::BTreeSet::new();
     while let Some((workflow_yaml, depth)) = queue.pop() {
-        if depth > MAX_REUSABLE_WORKFLOW_DEPTH {
+        if depth >= MAX_REUSABLE_WORKFLOW_DEPTH {
             return Err(ApiError::bad_request(
                 "nested reusable workflow depth exceeded",
             ));

--- a/crates/aksh-runner-server/src/runs.rs
+++ b/crates/aksh-runner-server/src/runs.rs
@@ -176,7 +176,11 @@ pub(crate) async fn submit_run_inner(
             submission.event
         )));
     }
-    let expanded = expand_jobs_with_reusables(&workflow, &submission.reusable_workflows)?;
+    let expanded = aksh_gha_parser::expand_jobs_with_reusables_and_shas(
+        &workflow,
+        &submission.reusable_workflows,
+        &submission.reusable_workflow_shas,
+    )?;
     let mut jobs = expanded.jobs;
     if !submission.dispatch_inputs.is_empty() {
         for job in &mut jobs {

--- a/crates/aksh-runner-server/src/runs.rs
+++ b/crates/aksh-runner-server/src/runs.rs
@@ -449,6 +449,7 @@ pub(crate) async fn submit_run_inner(
                 OidcJobContext {
                     environment: job.oidc_environment.clone(),
                     job_workflow_ref: job.oidc_job_workflow_ref.clone(),
+                    job_workflow_sha: job.workflow_sha.clone(),
                 },
             );
             inner.next_request_id += 1;

--- a/crates/aksh-runner-server/src/runs.rs
+++ b/crates/aksh-runner-server/src/runs.rs
@@ -74,6 +74,7 @@ pub(crate) async fn submit_run_inner(
     mut submission: WorkflowSubmission,
 ) -> Result<RunAccepted, ApiError> {
     let workflow = parse_workflow(&submission.workflow_yaml)?;
+    crate::remote_workflows::resolve_remote_workflows(&mut submission).await?;
     if submission.event == "workflow_dispatch" {
         workflow.apply_workflow_dispatch_inputs(&mut submission.payload)?;
         if submission.dispatch_inputs.is_empty() {

--- a/crates/aksh-runner-server/src/scheduler.rs
+++ b/crates/aksh-runner-server/src/scheduler.rs
@@ -704,6 +704,7 @@ async fn cron_loop(
             vars: Default::default(),
             secrets: Default::default(),
             reusable_workflows: Default::default(),
+            reusable_workflow_shas: Default::default(),
             enable_debugger: false,
             debugger_welcome_message: None,
             sha: resolved_sha.clone().unwrap_or_else(|| "0".repeat(40)),

--- a/crates/aksh-runner-server/src/scheduling_tests.rs
+++ b/crates/aksh-runner-server/src/scheduling_tests.rs
@@ -7,7 +7,11 @@ use proptest::test_runner::RngSeed;
 /// Deterministic proptest config for DAG scheduler tests.
 /// Fixed seed ensures reproducibility; failure persistence and verbose
 /// reporting preserve/report the seed on failure (docs/property-tests.md §Common).
-fn dag_config(cases: u32) -> ProptestConfig {
+fn dag_config(default_cases: u32) -> ProptestConfig {
+    let cases = std::env::var("PROPTEST_CASES")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default_cases);
     ProptestConfig {
         cases,
         rng_seed: RngSeed::Fixed(20250713),
@@ -234,7 +238,7 @@ fn golden_needs_dag_promotes_in_dependency_order() {
 // against an independent DFS reference; it is not an official algorithm
 // claim.
 proptest! {
-    #![proptest_config(dag_config(10_000))]
+    #![proptest_config(dag_config(512))]
 
     /// No job is ever present in both queue and pending, or twice in either.
     #[test]
@@ -398,7 +402,7 @@ proptest! {
 // Random edge sets: cycle detector never panics and is consistent with
 // a simple DFS reference.
 proptest! {
-    #![proptest_config(dag_config(10_000))]
+    #![proptest_config(dag_config(512))]
 
     #[test]
     fn cycle_detector_stable(
@@ -903,7 +907,7 @@ fn arb_condition() -> impl Strategy<Value = Option<String>> {
 }
 
 proptest! {
-    #![proptest_config(dag_config(5_000))]
+    #![proptest_config(dag_config(256))]
 
     /// Bounded independent-oracle model property: for a single
     /// dependent job with 1–4 needs, the scheduler's decision

--- a/crates/aksh-runner-server/src/state.rs
+++ b/crates/aksh-runner-server/src/state.rs
@@ -130,6 +130,8 @@ pub struct AppState {
 pub(crate) struct OidcJobContext {
     pub(crate) environment: Option<String>,
     pub(crate) job_workflow_ref: Option<String>,
+    /// Immutable commit SHA of the called reusable workflow, when resolved.
+    pub(crate) job_workflow_sha: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/aksh-runner/src/cli.rs
+++ b/crates/aksh-runner/src/cli.rs
@@ -48,6 +48,9 @@ pub enum Commands {
     /// Start the runner listener (polls for jobs, spawns workers).
     Run(RunArgs),
 
+    /// Lint and dry-run workflow parsing and job expansion without running it.
+    Lint(LintArgs),
+
     /// Internal: worker process spawned per job (reads NDJSON on stdin).
     #[command(hide = true)]
     Worker(WorkerArgs),
@@ -115,6 +118,18 @@ pub struct RunArgs {
     /// Protocol path to use.
     #[arg(long, default_value = "broker")]
     pub via: ProtocolPath,
+}
+
+/// Arguments for `lint`.
+#[derive(Debug, Clone, clap::Args)]
+pub struct LintArgs {
+    /// Workflow YAML path.
+    #[arg(short = 'W', long)]
+    pub workflow: PathBuf,
+
+    /// Repository workspace root used to collect local reusable workflows.
+    #[arg(long)]
+    pub workspace_root: Option<PathBuf>,
 }
 
 /// Protocol path selection.

--- a/crates/aksh-runner/src/main.rs
+++ b/crates/aksh-runner/src/main.rs
@@ -4,6 +4,7 @@
 
 use anyhow::Result;
 use clap::Parser;
+use std::collections::BTreeMap;
 
 use aksh_runner::cli::{Cli, Commands};
 
@@ -23,5 +24,29 @@ async fn main() -> Result<()> {
         Commands::Remove(args) => aksh_runner::configure::run_remove(args, &cli.global).await,
         Commands::Run(args) => aksh_runner::listener::run_listener(args, &cli.global).await,
         Commands::Worker(args) => aksh_runner::worker::run_worker(args).await,
+        Commands::Lint(args) => {
+            let workflow_yaml = tokio::fs::read_to_string(&args.workflow)
+                .await
+                .map_err(|e| anyhow::anyhow!("read workflow {}: {e}", args.workflow.display()))?;
+            let parsed = aksh_gha_parser::parse_workflow(&workflow_yaml)
+                .map_err(|e| anyhow::anyhow!("parse workflow {}: {e}", args.workflow.display()))?;
+            let reusable_workflows = BTreeMap::new();
+            let expanded =
+                aksh_gha_parser::expand_jobs_with_reusables(&parsed, &reusable_workflows).map_err(
+                    |e| anyhow::anyhow!("expand workflow {}: {e}", args.workflow.display()),
+                )?;
+
+            let step_count: usize = expanded.jobs.iter().map(|j| j.steps.len()).sum();
+            println!(
+                "✓ Workflow {} is valid: parsed {} job plan(s) and {} total step(s).",
+                args.workflow.display(),
+                expanded.jobs.len(),
+                step_count
+            );
+            for job in &expanded.jobs {
+                println!("  - Job: {} ({})", job.id.0, job.name);
+            }
+            Ok(())
+        }
     }
 }

--- a/crates/aksh-runner/src/main.rs
+++ b/crates/aksh-runner/src/main.rs
@@ -8,6 +8,8 @@ use std::collections::BTreeMap;
 
 use aksh_runner::cli::{Cli, Commands};
 
+const MAX_REUSABLE_WORKFLOW_DEPTH: usize = 4;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -113,9 +115,12 @@ async fn resolve_remote_workflows(
         .user_agent("aksh-runner")
         .build()?;
     let token = std::env::var("AKSH_GITHUB_TOKEN").ok();
-    let mut queue = vec![root_yaml.to_owned()];
+    let mut queue = vec![(root_yaml.to_owned(), 0usize)];
     let mut visited = std::collections::BTreeSet::new();
-    while let Some(yaml) = queue.pop() {
+    while let Some((yaml, depth)) = queue.pop() {
+        if depth >= MAX_REUSABLE_WORKFLOW_DEPTH {
+            anyhow::bail!("nested reusable workflow depth exceeded");
+        }
         let workflow = aksh_gha_parser::parse_workflow(&yaml)?;
         for job in workflow.jobs.values() {
             let Some(reference) = job.uses.as_deref() else {
@@ -140,7 +145,7 @@ async fn resolve_remote_workflows(
             }
             let contents = request.send().await?.error_for_status()?.text().await?;
             workflows.insert(reference.to_owned(), contents.clone());
-            queue.push(contents);
+            queue.push((contents, depth + 1));
         }
     }
     Ok(workflows)

--- a/crates/aksh-runner/src/main.rs
+++ b/crates/aksh-runner/src/main.rs
@@ -32,6 +32,8 @@ async fn main() -> Result<()> {
                 .map_err(|e| anyhow::anyhow!("parse workflow {}: {e}", args.workflow.display()))?;
             let reusable_workflows =
                 collect_reusable_workflows(args.workspace_root.as_deref(), &args.workflow).await?;
+            let reusable_workflows =
+                resolve_remote_workflows(reusable_workflows, &workflow_yaml).await?;
             let expanded =
                 aksh_gha_parser::expand_jobs_with_reusables(&parsed, &reusable_workflows).map_err(
                     |e| anyhow::anyhow!("expand workflow {}: {e}", args.workflow.display()),
@@ -101,4 +103,57 @@ fn same_file_path(left: &std::path::Path, right: &std::path::Path) -> bool {
         (Ok(left), Ok(right)) => left == right,
         _ => left == right,
     }
+}
+
+async fn resolve_remote_workflows(
+    mut workflows: BTreeMap<String, String>,
+    root_yaml: &str,
+) -> Result<BTreeMap<String, String>> {
+    let client = reqwest::Client::builder()
+        .user_agent("aksh-runner")
+        .build()?;
+    let token = std::env::var("AKSH_GITHUB_TOKEN").ok();
+    let mut queue = vec![root_yaml.to_owned()];
+    let mut visited = std::collections::BTreeSet::new();
+    while let Some(yaml) = queue.pop() {
+        let workflow = aksh_gha_parser::parse_workflow(&yaml)?;
+        for job in workflow.jobs.values() {
+            let Some(reference) = job.uses.as_deref() else {
+                continue;
+            };
+            if reference.starts_with("./") || workflows.contains_key(reference) {
+                continue;
+            }
+            let Some((owner, repo, path, git_ref)) = parse_remote_reference(reference) else {
+                anyhow::bail!("unsupported reusable workflow reference `{reference}`");
+            };
+            if !visited.insert(reference.to_owned()) {
+                continue;
+            }
+            let mut request = client
+                .get(format!(
+                    "https://api.github.com/repos/{owner}/{repo}/contents/{path}?ref={git_ref}"
+                ))
+                .header(reqwest::header::ACCEPT, "application/vnd.github.raw+json");
+            if let Some(token) = token.as_deref() {
+                request = request.bearer_auth(token);
+            }
+            let contents = request.send().await?.error_for_status()?.text().await?;
+            workflows.insert(reference.to_owned(), contents.clone());
+            queue.push(contents);
+        }
+    }
+    Ok(workflows)
+}
+
+fn parse_remote_reference(reference: &str) -> Option<(&str, &str, &str, &str)> {
+    let (repository_path, git_ref) = reference.rsplit_once('@')?;
+    let mut parts = repository_path.splitn(3, '/');
+    let owner = parts.next()?;
+    let repo = parts.next()?;
+    let path = parts.next()?;
+    if owner.is_empty() || repo.is_empty() || !path.starts_with(".github/workflows/") {
+        return None;
+    }
+    Some((owner, repo, path, git_ref))
 }

--- a/crates/aksh-runner/src/main.rs
+++ b/crates/aksh-runner/src/main.rs
@@ -30,7 +30,8 @@ async fn main() -> Result<()> {
                 .map_err(|e| anyhow::anyhow!("read workflow {}: {e}", args.workflow.display()))?;
             let parsed = aksh_gha_parser::parse_workflow(&workflow_yaml)
                 .map_err(|e| anyhow::anyhow!("parse workflow {}: {e}", args.workflow.display()))?;
-            let reusable_workflows = BTreeMap::new();
+            let reusable_workflows =
+                collect_reusable_workflows(args.workspace_root.as_deref(), &args.workflow).await?;
             let expanded =
                 aksh_gha_parser::expand_jobs_with_reusables(&parsed, &reusable_workflows).map_err(
                     |e| anyhow::anyhow!("expand workflow {}: {e}", args.workflow.display()),
@@ -48,5 +49,56 @@ async fn main() -> Result<()> {
             }
             Ok(())
         }
+    }
+}
+
+async fn collect_reusable_workflows(
+    workspace_root: Option<&std::path::Path>,
+    submitted_workflow: &std::path::Path,
+) -> Result<BTreeMap<String, String>> {
+    let Some(root) = workspace_root else {
+        return Ok(BTreeMap::new());
+    };
+    let workflow_dir = root.join(".github").join("workflows");
+    let mut out = BTreeMap::new();
+    let mut entries = match tokio::fs::read_dir(&workflow_dir).await {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+        Err(error) => {
+            return Err(anyhow::anyhow!("read {}: {error}", workflow_dir.display()));
+        }
+    };
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+        if !matches!(
+            path.extension().and_then(|extension| extension.to_str()),
+            Some("yml" | "yaml")
+        ) || same_file_path(&path, submitted_workflow)
+        {
+            continue;
+        }
+        let relative = path
+            .strip_prefix(root)
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "make {} relative to {}: {error}",
+                    path.display(),
+                    root.display()
+                )
+            })?
+            .to_string_lossy()
+            .into_owned();
+        let yaml = tokio::fs::read_to_string(&path).await.map_err(|error| {
+            anyhow::anyhow!("read reusable workflow {}: {error}", path.display())
+        })?;
+        out.insert(relative, yaml);
+    }
+    Ok(out)
+}
+
+fn same_file_path(left: &std::path::Path, right: &std::path::Path) -> bool {
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => left == right,
     }
 }

--- a/docs/workflow-lint-parser-report.md
+++ b/docs/workflow-lint-parser-report.md
@@ -4,6 +4,11 @@
 **aksh command:** `cargo run -p aksh-runner -- lint -W <workflow>`  
 **Reference linter:** `actionlint`
 
+Remote reusable workflows are resolved through GitHub's Contents API when the
+server or standalone lint command encounters `owner/repo/.github/workflows/x.yml@ref`.
+Set `AKSH_GITHUB_TOKEN` for private repositories; public repositories can use
+unauthenticated requests subject to GitHub API rate limits.
+
 This document tracks real public GitHub Actions workflows exercised against `aksh` and `actionlint`. Results are from the current default branches at the time of each run; workflows can change upstream.
 
 ## Current results
@@ -93,6 +98,19 @@ uses: ./.github/workflows/test_windows.yml
 
 The lint CLI now accepts `--workspace-root`, loads local workflow files, and passes them to the same reusable-workflow expander used by server submissions.
 
+### 4. Remote reusable workflow resolution — implemented
+
+Remote references are fetched from:
+
+```text
+https://api.github.com/repos/{owner}/{repo}/contents/{path}?ref={ref}
+```
+
+Fetched workflows are inserted into the reusable-workflow table and scanned
+for nested remote references up to the same depth limit used by the parser.
+The server resolves these before job expansion, matching the official runner's
+server-side `ReusableWorkflowsLoader` architecture.
+
 ### 4. Custom runner labels
 
 Some repositories use organization-specific labels, for example TypeScript's `1ES.Pool=...` and `1ES.ImageOverride=...`. These are valid in GitHub's environment but may not be known to `actionlint` or local runner configuration. They should not be treated as generic parser failures.
@@ -102,4 +120,4 @@ Some repositories use organization-specific labels, for example TypeScript's `1E
 1. Add deferred handling for remaining scalar fields such as `timeout-minutes`.
 2. Run Neovim and Kubernetes workflows from full sparse checkouts to exercise local reusable workflow expansion.
 3. Run the full Deno generated workflow periodically; it currently provides the largest successful expansion observed here.
-4. Keep this table updated with the workflow commit SHA when recording long-lived comparisons.
+5. Keep this table updated with the workflow commit SHA when recording long-lived comparisons.

--- a/docs/workflow-lint-parser-report.md
+++ b/docs/workflow-lint-parser-report.md
@@ -26,6 +26,53 @@ This document tracks real public GitHub Actions workflows exercised against `aks
 | [pytorch/pytorch](https://github.com/pytorch/pytorch/blob/main/.github/workflows/_linux-test.yml) | `_linux-test.yml` | **pass** — 1 deferred-input job plan, 17 steps | shellcheck findings | Standalone called workflow has no caller inputs; matrix expansion is deferred to a placeholder. |
 | [preloopdev/aksh](https://github.com/preloopdev/aksh/blob/907db62fa1b294f76bb041c55586394dba517fa7/.github/workflows/ci.yml) | `ci.yml` | **pass** | not recorded | Repository's own CI workflow. |
 
+### Apache projects
+
+Ten Apache repositories were exercised against `aksh` lint and `actionlint` to validate
+parser/evaluator coverage across diverse workflow patterns (reusable workflows, large
+matrices, expression-valued fields, multi-OS matrices). All ten pass `aksh` lint.
+
+| Repository | Workflow | `aksh` result | `actionlint` result | Notes |
+|---|---:|---:|---:|---|
+| [apache/superset](https://github.com/apache/superset/blob/master/.github/workflows/superset-python-unittest.yml) | `superset-python-unittest.yml` | **pass** — 3 job plans, 8 steps | exit 1 — unknown runner label `ubuntu-26.04` | Uses expression-valued `if` conditions for matrix selection. |
+| [apache/echarts](https://github.com/apache/echarts/blob/master/.github/workflows/ci.yml) | `ci.yml` | **pass** — 2 job plans, 16 steps | exit 1 — shellcheck findings | Simple matrix with Node.js version strategy. |
+| [apache/airflow](https://github.com/apache/airflow/blob/main/.github/workflows/basic-tests.yml) | `basic-tests.yml` | **pass** — 10 job plans, 56 steps | exit 1 — shellcheck findings | Uses `fromJSON` expressions in job names and matrix includes. |
+| [apache/spark](https://github.com/apache/spark/blob/master/.github/workflows/build_main.yml) | `build_main.yml` | **pass** — 32 job plans, 450 steps | exit 0 — clean | Local reusable workflow `./.github/workflows/build_and_test.yml`; requires `--workspace-root`. |
+| [apache/kafka](https://github.com/apache/kafka/blob/trunk/.github/workflows/ci.yml) | `ci.yml` | **pass** — 12 job plans, 87 steps | exit 0 — clean | Local reusable workflow `./.github/workflows/build.yml`; requires `--workspace-root`. |
+| [apache/flink](https://github.com/apache/flink/blob/master/.github/workflows/ci.yml) | `ci.yml` | **pass** — 13 job plans, 189 steps | exit 0 — clean | Local reusable workflow `./.github/workflows/template.pre-compile-checks.yml`; requires `--workspace-root`. |
+| [apache/dubbo](https://github.com/apache/dubbo/blob/3.3/.github/workflows/build-and-test-pr.yml) | `build-and-test-pr.yml` | **pass** — 32 job plans, 302 steps | exit 1 — shellcheck + expression type issues + old action versions | Large matrix with `include` entries; uses `actions/cache@v3`. |
+| [apache/skywalking](https://github.com/apache/skywalking/blob/master/.github/workflows/skywalking.yaml) | `skywalking.yaml` | **pass** — 221 job plans, 2,760 steps | exit 1 — shellcheck + expression type issues | Largest expansion in this set; matrix `include` with complex objects (docker configs, e2e test cases). |
+| [apache/rocketmq](https://github.com/apache/rocketmq/blob/develop/.github/workflows/maven.yaml) | `maven.yaml` | **pass** — 3 job plans, 15 steps | exit 1 — old action version `actions/checkout@v2` | Simple multi-OS matrix. |
+| [apache/apisix](https://github.com/apache/apisix/blob/master/.github/workflows/build.yml) | `build.yml` | **pass** — 4 job plans, 68 steps | exit 1 — shellcheck findings | Matrix with glob patterns in step names. |
+
+### Wider validation set (20 projects)
+
+Twenty additional repositories were tested to exercise large generated workflows,
+deep reusable workflow chaining, complex matrix expansion, and YAML edge cases.
+
+| Repository | Workflow | `aksh` result | `actionlint` result | Notes |
+|---|---:|---:|---:|---|
+| [denoland/deno](https://github.com/denoland/deno/blob/main/.github/workflows/ci.generated.yml) | `ci.generated.yml` | **pass** — 134 job plans, 3,041 steps | shellcheck findings | 405 KB generated workflow; repeated for regression. |
+| [cilium/cilium](https://github.com/cilium/cilium/blob/main/.github/workflows/tests-clustermesh-upgrade.yaml) | `tests-clustermesh-upgrade.yaml` | **pass** — 10 job plans, 137 steps | shellcheck findings + expression type issues | 43 KB; requires `--workspace-root` (101 workflow files). |
+| [bytecodealliance/wasmtime](https://github.com/bytecodealliance/wasmtime/blob/main/.github/workflows/main.yml) | `main.yml` | **pass** — 44 job plans, 542 steps | shellcheck findings | 62 KB; deep reusable workflow calls. |
+| [home-assistant/core](https://github.com/home-assistant/core/blob/dev/.github/workflows/ci.yaml) | `ci.yaml` | **pass** — 42 job plans, 331 steps | shellcheck findings | 53 KB; large matrix with multi-stage dependencies. |
+| [astral-sh/ruff](https://github.com/astral-sh/ruff/blob/main/.github/workflows/ci.yaml) | `ci.yaml` | **pass** — 55 job plans, 507 steps | shellcheck findings + custom runner label `codspeed-macro` | 52 KB; extensive job graph. |
+| [pytorch/pytorch](https://github.com/pytorch/pytorch/blob/main/.github/workflows/generated-linux-binary-manywheel-nightly.yml) | `generated-linux-binary-manywheel-nightly.yml` | **pass** — 59 job plans, 502 steps | custom runner label + shellcheck findings | 81 KB generated; some remote refs hit API rate limit. |
+| [vercel/next.js](https://github.com/vercel/next.js/blob/canary/.github/workflows/build_and_test.yml) | `build_and_test.yml` | **pass** — 162 job plans | shellcheck + `if: false` warning | Coerces boolean job-level `if` conditions to strings (finding #6). |
+| [hashicorp/terraform](https://github.com/hashicorp/terraform/blob/main/.github/workflows/build.yml) | `build.yml` | **pass** — 40 job plans, 241 steps | shellcheck findings | Resolves bare `needs` references to all matrix-expanded instances (finding #7). |
+| [microsoft/vscode](https://github.com/microsoft/vscode/blob/main/.github/workflows/component-fixtures.yml) | `component-fixtures.yml` | **pass** — 4 job plans, 47 steps | shellcheck findings | Screenshot-based testing. |
+| [angular/angular](https://github.com/angular/angular/blob/main/.github/workflows/ci.yml) | `ci.yml` | **pass** — 13 job plans, 176 steps | custom runner label + shellcheck | Multi-stage CI. |
+| [godotengine/godot](https://github.com/godotengine/godot/blob/master/.github/workflows/linux_builds.yml) | `linux_builds.yml` | **pass** — 41 job plans, 154 steps | shellcheck findings | Platform matrix with feature-flags. |
+| [nodejs/node](https://github.com/nodejs/node/blob/main/.github/workflows/benchmark.yml) | `benchmark.yml` | **pass** — 2 job plans, 21 steps | shellcheck findings | Benchmark comparison. |
+| [apache/arrow](https://github.com/apache/arrow/blob/main/.github/workflows/cpp_extra.yml) | `cpp_extra.yml` | **pass** — 54 job plans, 485 steps | shellcheck findings | C++ cross-build matrix; requires `--workspace-root`. |
+| [nixos/nixpkgs](https://github.com/nixos/nixpkgs/blob/master/.github/workflows/check.yml) | `check.yml` | **pass** — 2 job plans, 9 steps | exit 0 — clean | Ownership checker. |
+| [n8n-io/n8n](https://github.com/n8n-io/n8n/blob/master/.github/workflows/docker-build-push.yml) | `docker-build-push.yml` | **pass** — 6 job plans, 19 steps | exit 0 — clean | Docker build/push. Remote ref hit rate limit. |
+| [charmbracelet/gum](https://github.com/charmbracelet/gum/blob/main/.github/workflows/build.yml) | `build.yml` | **pass** — 1 job plan, 13 steps | exit 0 — clean | Goreleaser build. Remote ref hit rate limit. |
+| [elastic/kibana](https://github.com/elastic/kibana/blob/main/.github/workflows/trigger-chromium-build.yml) | `trigger-chromium-build.yml` | **pass** — 1 job plan, 8 steps | shellcheck findings | Trigger workflow. |
+| [mozilla/gecko-dev](https://github.com/mozilla/gecko-dev/blob/master/.github/workflows/close-pr.yml) | `close-pr.yml` | **pass** — 1 job plan, 4 steps | exit 0 — clean | Minimal (640 bytes). |
+| [rails/rails](https://github.com/rails/rails/blob/main/.github/workflows/rails_releaser_tests.yml) | `rails_releaser_tests.yml` | **pass** — 1 job plan, 11 steps | exit 0 — clean | Simple test. |
+| [apache/pulsar](https://github.com/apache/pulsar/blob/master/.github/workflows/ci-pulsarbot.yaml) | `ci-pulsarbot.yaml` | **pass** — 1 job plan, 10 steps | exit 0 — clean | Pulsar bot CI. |
+
 `actionlint` exit status is nonzero for the listed shellcheck findings even when YAML and workflow schema validation succeeds. Treat those separately from parser/schema failures.
 
 ## Reproduction
@@ -115,13 +162,55 @@ for nested remote references up to the same depth limit used by the parser.
 The server resolves these before job expansion, matching the official runner's
 server-side `ReusableWorkflowsLoader` architecture.
 
-### 4. Custom runner labels
+### 5. Custom runner labels
 
 Some repositories use organization-specific labels, for example TypeScript's `1ES.Pool=...` and `1ES.ImageOverride=...`. These are valid in GitHub's environment but may not be known to `actionlint` or local runner configuration. They should not be treated as generic parser failures.
+
+### 6. Boolean/numeric job/step `if` conditions — implemented
+
+Real workflows use plain YAML booleans and numbers in `if` blocks:
+
+```yaml
+test-next-napi-bindings-wasi:
+  if: false
+```
+
+The parser previously deserialized `if` as `Option<String>`, which failed on
+literal YAML booleans (`false`, `true`) or numbers, raising:
+
+```text
+invalid type: boolean `false`, expected a string
+```
+
+Resolved: implemented custom deserializer coercion to accept any scalar value and deserialize it to `Option<String>` for both job-level and step-level `if` conditions. Action `with` values already deserialize to `serde_json::Value` (which natively permits booleans/numbers) and are coerced to string during job building.
+
+### 7. Dependency on matrix-expanded reusable workflow call — implemented
+
+When a job depends on a reusable workflow call that uses a matrix, other jobs
+may reference the call by its unexpanded job id:
+
+```yaml
+build:
+  uses: ./.github/workflows/build-terraform-cli.yml
+  strategy:
+    matrix:
+      include:
+        - {goos: "linux", goarch: "amd64"}
+        - {goos: "darwin", goarch: "arm64"}
+
+package-docker:
+  needs: [build]
+```
+
+The expander creates suffixed job ids (`build (linux, amd64)`, `build (darwin, arm64)`)
+but `package-docker` references the bare `build`. GitHub's runner interprets
+`needs: [build]` as a dependency on all matrix instances of job `build`. The
+parser now resolves bare needed job names to the set of all matrix-expanded instances (both reusable workflow calls and regular matrix jobs).
 
 ## Suggested next validation set
 
 1. Add deferred handling for remaining scalar fields such as `timeout-minutes`.
 2. Run Neovim and Kubernetes workflows from full sparse checkouts to exercise local reusable workflow expansion.
 3. Run the full Deno generated workflow periodically; it currently provides the largest successful expansion observed here.
+4. Expand the Apache validation set to include more workflows per repository (e.g. Superset's `superset-frontend.yml`, Spark's `build_branch42.yml`, Airflow's `ci-amd.yml`) to stress matrix expansion and reusable-workflow chaining further.
 5. Keep this table updated with the workflow commit SHA when recording long-lived comparisons.

--- a/docs/workflow-lint-parser-report.md
+++ b/docs/workflow-lint-parser-report.md
@@ -9,6 +9,10 @@ server or standalone lint command encounters `owner/repo/.github/workflows/x.yml
 Set `AKSH_GITHUB_TOKEN` for private repositories; public repositories can use
 unauthenticated requests subject to GitHub API rate limits.
 
+The server also resolves each remote reference to its immutable commit SHA and
+propagates the repository, ref, and SHA into expanded job plans and reusable-call
+metadata.
+
 This document tracks real public GitHub Actions workflows exercised against `aksh` and `actionlint`. Results are from the current default branches at the time of each run; workflows can change upstream.
 
 ## Current results

--- a/docs/workflow-lint-parser-report.md
+++ b/docs/workflow-lint-parser-report.md
@@ -1,0 +1,105 @@
+# Real-World Workflow Lint/Parser Report
+
+**Last updated:** 2026-07-21  
+**aksh command:** `cargo run -p aksh-runner -- lint -W <workflow>`  
+**Reference linter:** `actionlint`
+
+This document tracks real public GitHub Actions workflows exercised against `aksh` and `actionlint`. Results are from the current default branches at the time of each run; workflows can change upstream.
+
+## Current results
+
+| Repository | Workflow | `aksh` result | `actionlint` result | Notes |
+|---|---|---:|---:|---|
+| [denoland/deno](https://github.com/denoland/deno/blob/main/.github/workflows/ci.generated.yml) | `ci.generated.yml` | **pass** — 134 expanded job plans, 3,041 steps | shellcheck findings | Large generated workflow; useful parser/matrix stress test. |
+| [rust-lang/rust](https://github.com/rust-lang/rust/blob/master/.github/workflows/ci.yml) | `ci.yml` | **pass** — 3 job plans, 38 steps | shellcheck findings | Expression-valued strategy booleans and matrix `include` are preserved; unresolved runtime output uses a lint placeholder. |
+| [microsoft/TypeScript](https://github.com/microsoft/TypeScript/blob/main/.github/workflows/ci.yml) | `ci.yml` | **pass** — 26 job plans, 135 steps | custom runner labels plus shellcheck findings | `runs-on` includes Azure/1ES-specific labels. |
+| [neovim/neovim](https://github.com/neovim/neovim/blob/master/.github/workflows/test.yml) | `test.yml` | **pass** — 30 job plans, 322 steps | shellcheck findings | Requires `--workspace-root` with a checkout so local reusable workflows can be loaded. |
+| [pytorch/pytorch](https://github.com/pytorch/pytorch/blob/main/.github/workflows/_linux-test.yml) | `_linux-test.yml` | **pass** — 1 deferred-input job plan, 17 steps | shellcheck findings | Standalone called workflow has no caller inputs; matrix expansion is deferred to a placeholder. |
+| [preloopdev/aksh](https://github.com/preloopdev/aksh/blob/907db62fa1b294f76bb041c55586394dba517fa7/.github/workflows/ci.yml) | `ci.yml` | **pass** | not recorded | Repository's own CI workflow. |
+
+`actionlint` exit status is nonzero for the listed shellcheck findings even when YAML and workflow schema validation succeeds. Treat those separately from parser/schema failures.
+
+## Reproduction
+
+Fetch individual workflows:
+
+```sh
+curl -L --fail \
+  https://raw.githubusercontent.com/rust-lang/rust/master/.github/workflows/ci.yml \
+  -o /tmp/rust-ci.yml
+```
+
+Run `aksh`:
+
+```sh
+cargo run -p aksh-runner -- lint -W /tmp/rust-ci.yml
+```
+
+Run `actionlint`:
+
+```sh
+actionlint /tmp/rust-ci.yml
+```
+
+For local reusable workflows, use a checkout instead of downloading one YAML file:
+
+```sh
+git clone --filter=blob:none --no-checkout https://github.com/neovim/neovim.git /tmp/neovim
+cd /tmp/neovim
+git sparse-checkout set .github/workflows
+git checkout master
+find .github/workflows -type f \( -name '*.yml' -o -name '*.yaml' \) -print
+cargo run -p aksh-runner -- lint -W .github/workflows/test.yml
+```
+
+## Findings to track
+
+### 1. Expression-valued typed scalar fields — implemented
+
+Real workflows use expressions in fields represented by typed YAML values, for example:
+
+```yaml
+continue-on-error: ${{ matrix.continue_on_error || false }}
+```
+
+The parser now preserves these values as deferred scalars and resolves them when a matrix/input context is available. The current `JobPlan` protocol remains concrete, so unresolved runtime expressions use a conservative lint placeholder rather than pretending to produce the final matrix.
+
+Previously, the parser attempted to deserialize that string directly into `bool`, producing errors such as:
+
+```text
+invalid type: string "${{ ... }}", expected a boolean
+```
+
+The expression-aware representation is implemented for strategy booleans/numbers and step continuation flags. Additional scalar fields can use the same pattern as they are encountered.
+
+### 2. Expression-valued matrices — implemented with deferred lint behavior
+
+Reusable workflows may define matrices from JSON expressions:
+
+```yaml
+strategy:
+  matrix: ${{ fromJSON(inputs.test-matrix) }}
+```
+
+The parser now preserves expression-valued matrices and evaluates them with reusable-workflow inputs. A standalone called workflow without caller inputs cannot produce concrete combinations; lint preserves the workflow and emits one deferred placeholder plan. Server submissions with resolved caller inputs expand concrete combinations.
+
+### 3. Local reusable workflow resolution — implemented for lint
+
+A single downloaded workflow is insufficient when it references a local reusable workflow:
+
+```yaml
+uses: ./.github/workflows/test_windows.yml
+```
+
+The lint CLI now accepts `--workspace-root`, loads local workflow files, and passes them to the same reusable-workflow expander used by server submissions.
+
+### 4. Custom runner labels
+
+Some repositories use organization-specific labels, for example TypeScript's `1ES.Pool=...` and `1ES.ImageOverride=...`. These are valid in GitHub's environment but may not be known to `actionlint` or local runner configuration. They should not be treated as generic parser failures.
+
+## Suggested next validation set
+
+1. Add deferred handling for remaining scalar fields such as `timeout-minutes`.
+2. Run Neovim and Kubernetes workflows from full sparse checkouts to exercise local reusable workflow expansion.
+3. Run the full Deno generated workflow periodically; it currently provides the largest successful expansion observed here.
+4. Keep this table updated with the workflow commit SHA when recording long-lived comparisons.

--- a/fixtures/workflows/opencode-test.yml
+++ b/fixtures/workflows/opencode-test.yml
@@ -1,0 +1,151 @@
+name: test
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  # Keep every run on dev so cancelled checks do not pollute the default branch
+  # commit history. PRs and other branches still share a group and cancel stale runs.
+  group: ${{ case(github.ref == 'refs/heads/dev', format('{0}-{1}', github.workflow, github.run_id), format('{0}-{1}', github.workflow, github.event.pull_request.number || github.ref)) }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  checks: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  unit:
+    name: unit (${{ matrix.settings.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - name: linux
+            host: blacksmith-4vcpu-ubuntu-2404
+          - name: windows
+            host: blacksmith-4vcpu-windows-2025
+    runs-on: ${{ matrix.settings.host }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "24"
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      - name: Configure git identity
+        run: |
+          git config --global user.email "bot@opencode.ai"
+          git config --global user.name "opencode"
+
+      - name: Cache Turbo
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: node_modules/.cache/turbo
+          key: turbo-${{ runner.os }}-${{ hashFiles('turbo.json', '**/package.json') }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-${{ hashFiles('turbo.json', '**/package.json') }}-
+            turbo-${{ runner.os }}-
+
+      - name: Run unit tests
+        timeout-minutes: 20
+        run: GITHUB_ACTIONS=false bun turbo test
+        env:
+          OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER: ${{ runner.os == 'Windows' && 'true' || 'false' }}
+
+      - name: Check generated client
+        if: runner.os == 'Linux'
+        working-directory: packages/client
+        run: bun run check:generated
+
+      - name: Run HttpApi exerciser gates
+        if: runner.os == 'Linux'
+        working-directory: packages/opencode
+        run: bun run test:httpapi
+
+  e2e:
+    name: e2e (${{ matrix.settings.name }})
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - name: linux
+            host: blacksmith-4vcpu-ubuntu-2404
+          - name: windows
+            host: blacksmith-4vcpu-windows-2025
+    runs-on: ${{ matrix.settings.host }}
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          # Playwright 1.59 hangs while extracting Chromium with Node 24.16.
+          node-version: "24.15"
+
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+
+      - name: Read Playwright version
+        id: playwright-version
+        run: |
+          version=$(node -e 'console.log(require("./package.json").workspaces.catalog["@playwright/test"])')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ github.workspace }}/.playwright-browsers
+          key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ steps.playwright-version.outputs.version }}-chromium
+
+      - name: Install Playwright system dependencies
+        if: runner.os == 'Linux'
+        working-directory: packages/app
+        run: bunx playwright install-deps chromium
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: packages/app
+        run: bunx playwright install chromium
+
+      - name: Run app e2e tests
+        run: bun --cwd packages/app test:e2e:local
+        env:
+          CI: true
+        timeout-minutes: 30
+
+      - name: Upload Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: playwright-${{ matrix.settings.name }}-${{ github.run_attempt }}
+          if-no-files-found: ignore
+          retention-days: 7
+          path: |
+            packages/app/e2e/test-results
+            packages/app/e2e/playwright-report

--- a/justfile
+++ b/justfile
@@ -26,7 +26,12 @@ clippy:
 test:
     cargo test --workspace --quiet
 
-test-ci: fmt-check clippy test
+test-properties-full:
+    PROPTEST_CASES=10000 cargo test -p aksh-runner-server --quiet
+    PROPTEST_CASES=10000 cargo test -p aksh-runner-server --quiet -- --ignored
+
+test-ci: fmt-check clippy
+    PROPTEST_CASES=8 cargo test --workspace --quiet
     @echo CI: all checks passed
 
 #lint (ast-grep structural rules)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `case()` and stricter expression validation, support expression-valued matrices/scalars, and resolve local/remote reusable workflows with SHA metadata. Also adds a `lint` subcommand to `aksh` and `aksh-runner` to parse and expand workflows without running them.

- **New Features**
  - `aksh-gha-expressions`: add `case()` (lazy eval, boolean predicates) and case-insensitive relational string comparisons; expose context collection for validation.
  - `aksh-gha-parser`: validate expressions with schema-scoped contexts; support expression-valued matrices and deferred scalars (`strategy.fail-fast`, `strategy.max-parallel`, step `continue-on-error`) evaluated against matrix/inputs; new `expand_jobs_with_reusables_and_shas`.
  - Reusable workflows: resolve local and remote references; propagate called-workflow commit SHA and repository to job plans and reusable-call metadata; server populates these and OIDC now prefers the resolved SHA.
  - Protocol: add `reusable_workflow_shas` to `WorkflowSubmission` (optional, defaults empty).
  - CLI: add `lint` to `aksh` and `aksh-runner` to parse/expand without running; resolves reusables (set `AKSH_GITHUB_TOKEN` for private repos); `--workspace-root` loads local reusables.
  - Docs/fixtures: add real-world lint report and an `opencode` workflow fixture.

- **Bug Fixes**
  - Match official runner semantics for `case()` validation and case-insensitive string comparisons.
  - Enforce context restrictions per field with clear errors; tighten tests and skip expensive property tests by default.

<sup>Written for commit b4f3f081e668c3fc4efb9c3d5cae1b4ab18df2ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/aksh/pull/14?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

