### PR TITLE
e2e-sync-1786060441

### DIFF
--- a/.github/workflows/e2e-sync.yml
+++ b/.github/workflows/e2e-sync.yml
@@ -1,0 +1,8 @@
+name: e2e-sync
+on: push
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "sync e2e ok"
+      - run: git log --oneline -1


### PR DESCRIPTION
CI run `3c9759be-10ca-49ed-9533-ac36addd9e56` completed with `failure`.

- Head: `41461287a508b6f0db48d7d589b0b47274906b6f`
- Tested tree: `fb18602bd0d0cb3d1334f396250a6693be02586d`
- Actor: ``
- Details: http://127.0.0.1:9092/runs/3c9759be-10ca-49ed-9533-ac36addd9e56

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a minimal `e2e-sync` GitHub Actions workflow that runs on push to verify CI wiring by echoing a sync marker and printing the latest commit. This provides a simple smoke check for e2e sync runs.

<sup>Written for commit 41461287a508b6f0db48d7d589b0b47274906b6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/22?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

