### PR TITLE
ci-sync-e2e2

### DIFF
--- a/.github/workflows/e2e-sync.yml
+++ b/.github/workflows/e2e-sync.yml
@@ -1,0 +1,6 @@
+on: push
+jobs:
+  e2e:
+    runs-on: self-hosted
+    steps:
+      - run: echo "sync-e2e-ok"


### PR DESCRIPTION
CI run `8815399e-976a-4148-91c5-ca5f2198c9da` completed with `success`.

- Head: `69b4f5ae4c0ec5793a87bc559d3cc8978e68ed3f`
- Tested tree: `3e327b72f39f5ca5606f12dafa5843c39b2b78c2`
- Actor: `Bill Njoroge`
- Details: http://127.0.0.1:9093/runs/8815399e-976a-4148-91c5-ca5f2198c9da

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a minimal GitHub Actions workflow to check E2E sync on push. It runs an `e2e` job on a `self-hosted` runner and echoes `sync-e2e-ok` to confirm CI connectivity.

<sup>Written for commit 69b4f5ae4c0ec5793a87bc559d3cc8978e68ed3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

