### PR TITLE
fix(pool): keep node externals readable by the non-root guest runner

### DIFF
--- a/.github/workflows/release-linux-runner.yml
+++ b/.github/workflows/release-linux-runner.yml
@@ -1,0 +1,74 @@
+name: release-linux-runner
+
+# macOS installs execute workflows inside Linux microVMs, so every release
+# must carry the Linux `preloop-runner` binary. cargo-dist cannot cross-build
+# it, so this workflow zigbuilds the bundle for both Linux guest triples and
+# uploads it to the release; `install.sh` and `preloop update` place it where
+# the engine looks (<prefix>/lib/preloop/runner/<triple>/).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build-and-upload-runner-bundles:
+    name: Build Linux runner bundle ${{ matrix.triple }}
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - triple: x86_64-unknown-linux-gnu
+          - triple: aarch64-unknown-linux-gnu
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+        with:
+          targets: ${{ matrix.triple }}
+
+      - name: Set up Zig cross toolchain
+        uses: goto-bus-stop/setup-zig@abea47f85e598557f500fa1fd2ab7464fcb39406
+        with:
+          version: 0.14.1
+
+      - name: Install cargo-zigbuild
+        uses: taiki-e/install-action@6c6fd71fe4fb72c3697d269963d0e15df8adedad
+        with:
+          tool: cargo-zigbuild@0.23.0
+
+      - name: Build runner bundle
+        run: |
+          cargo zigbuild --release \
+            --target ${{ matrix.triple }} \
+            -p preloop-runner
+          mkdir -p dist
+          cp "target/${{ matrix.triple }}/release/preloop-runner" \
+            "dist/preloop-runner-${{ matrix.triple }}"
+          sha256sum "dist/preloop-runner-${{ matrix.triple }}" \
+            > "dist/preloop-runner-${{ matrix.triple }}.sha256"
+
+      - name: Upload runner bundle to release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "dist/preloop-runner-${{ matrix.triple }}" \
+            "dist/preloop-runner-${{ matrix.triple }}.sha256" \
+            --clobber
+
+      - name: Retain runner bundle for non-release builds
+        if: github.event_name != 'release'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: preloop-runner-${{ matrix.triple }}
+          path: |
+            dist/preloop-runner-${{ matrix.triple }}
+            dist/preloop-runner-${{ matrix.triple }}.sha256
+          if-no-files-found: error

--- a/.runner-watch/state.json
+++ b/.runner-watch/state.json
@@ -3,5 +3,5 @@
   "phase": "conformed",
   "from": "v2.322.0",
   "to": "v2.335.1",
-  "updated_at_unix": 1786104266
+  "updated_at_unix": 1786147669
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,6 +1852,7 @@ name = "preloop-cli"
 version = "0.27.0"
 dependencies = [
  "anyhow",
+ "axum",
  "base64",
  "clap",
  "flate2",

--- a/README.md
+++ b/README.md
@@ -2,10 +2,8 @@
 
 [![Watch the demo](docs/demo/poster.png)](docs/demo/debug.mp4)
 
-> Watch: [debug.mp4](docs/demo/debug.mp4) — a failed step, a fix in another
-> pane, and a re-run. All local, no push required.
 
-> A failed step, a fix in another pane, and a re-run — all local, no push required.
+> A failed step, a fix in another pane, and a re-run, all local, with no push required.
 
 ---
 

--- a/benchmarks/conformance/run.sh
+++ b/benchmarks/conformance/run.sh
@@ -40,8 +40,13 @@ cargo build --quiet -p preloop-runner-server
 # startup, failing the run for reasons that have nothing to do with protocol
 # fidelity. The path intentionally does not exist: a missing file loads the
 # default (unconfigured) engine config.
+# The goldens carry real GitHub-issued registration tokens this control plane
+# cannot verify, so the replay server opts into the permissive registration
+# policy — the same sanctioned exception `preloop-conformance` uses. Without
+# it every scenario 401s on /api/v3/actions/runner-registration.
 PRELOOP_PUBLIC_URL="$REPLAY_URL" \
   PRELOOP_CONFIG="$STATE_DIR/config.toml" \
+  PRELOOP_REGISTRATION_POLICY="permissive" \
   ./target/debug/preloop-server serve --listen "127.0.0.1:$REPLAY_PORT" \
   --state-dir "$STATE_DIR/server-state" >"$SERVER_LOG" 2>&1 &
 SERVER_PID=$!

--- a/crates/preloop-cli/Cargo.toml
+++ b/crates/preloop-cli/Cargo.toml
@@ -20,6 +20,7 @@ preloop-vm = { path = "../preloop-vm" }
 preloop-runner-server = { path = "../preloop-runner-server" }
 preloop-gha-parser = { path = "../preloop-gha-parser" }
 anyhow = { workspace = true }
+axum = { workspace = true }
 base64 = { workspace = true }
 clap = { workspace = true }
 tokio = { workspace = true }

--- a/crates/preloop-cli/src/app_manifest.rs
+++ b/crates/preloop-cli/src/app_manifest.rs
@@ -1,0 +1,762 @@
+//! Browser-driven GitHub App creation (`preloop setup github --via app`).
+//!
+//! GitHub's App-manifest flow turns App creation into a redirect dance: a
+//! form POST hands GitHub a manifest, the operator clicks *Create*, and
+//! GitHub redirects back with a one-time code that converts into the App id,
+//! private key, and webhook secret. Doing that by hand means creating the App
+//! in the web UI, downloading a PEM, and re-running the CLI with two flags —
+//! four steps in which the only interesting decision is "yes, create it".
+//!
+//! This module collapses that into one command by binding a single-use HTTP
+//! listener on loopback and using it as the manifest's `redirect_url`. The
+//! listener is the security boundary: the private key never leaves the
+//! machine (unlike the server-side `/api/v1/github/register` page, which can
+//! only display it), and the callback is reachable only from this host.
+//!
+//! Three routes, one shot each:
+//!
+//! | Route        | Purpose                                                   |
+//! |--------------|-----------------------------------------------------------|
+//! | `/`          | auto-submitting form POST to GitHub's App-creation page    |
+//! | `/callback`  | manifest code → credentials, then redirect to the install  |
+//! | `/installed` | GitHub's post-install redirect; reports the installation   |
+
+use anyhow::{Context, Result};
+use axum::extract::{Query, State};
+use axum::response::{Html, IntoResponse, Redirect};
+use axum::routing::get;
+use axum::Router;
+use serde::Deserialize;
+use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use tokio::sync::{oneshot, Mutex};
+
+/// Default permissions of the generated App.
+///
+/// The floor a workflow needs to check out code and report status: GitHub
+/// always grants `metadata: read`, `contents: read` backs `actions/checkout`,
+/// `pull_requests: read` backs PR-triggered runs, and `checks: write` lets
+/// the engine publish check runs. Anything beyond that is a decision the
+/// operator should make in the App's settings, not one this flow makes for
+/// them — an installation token is capped by the App's grant, so a narrow
+/// default cannot silently widen a job's authority.
+const DEFAULT_PERMISSIONS: &[(&str, &str)] = &[
+    ("checks", "write"),
+    ("contents", "read"),
+    ("metadata", "read"),
+    ("pull_requests", "read"),
+];
+
+/// Events the App subscribes to when webhooks are configured.
+const DEFAULT_EVENTS: &[&str] = &["push", "pull_request"];
+
+/// How long to wait for the operator to finish in the browser.
+const BROWSER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
+
+/// How long to wait for the App installation after the App itself exists.
+///
+/// Shorter than [`BROWSER_TIMEOUT`]: by this point the credentials are
+/// already written, so a timeout costs the operator a printed URL, not the
+/// setup.
+const INSTALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+
+/// Credentials GitHub returns from a manifest conversion.
+#[derive(Deserialize)]
+pub(crate) struct AppCredentials {
+    /// Numeric App id (the JWT `iss`).
+    pub id: u64,
+    /// URL slug, for the installation link.
+    #[serde(default)]
+    pub slug: Option<String>,
+    /// PKCS#1 private key.
+    pub pem: String,
+    /// `X-Hub-Signature-256` secret; absent when the manifest disabled hooks.
+    #[serde(default)]
+    pub webhook_secret: Option<String>,
+    /// Human-facing App page.
+    #[serde(default)]
+    pub html_url: Option<String>,
+}
+
+/// Manual `Debug`: this carries the App's private key and webhook secret,
+/// either of which a single `debug!(?credentials)` would otherwise disclose.
+impl std::fmt::Debug for AppCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AppCredentials")
+            .field("id", &self.id)
+            .field("slug", &self.slug)
+            .field("pem", &"<redacted>")
+            .field(
+                "webhook_secret",
+                &self.webhook_secret.as_ref().map(|_| "<redacted>"),
+            )
+            .field("html_url", &self.html_url)
+            .finish()
+    }
+}
+
+impl AppCredentials {
+    /// Where the operator installs the App on their repositories.
+    ///
+    /// Prefers the slug-based path, which lands directly on the repository
+    /// picker; falls back to the App page when GitHub omitted the slug.
+    pub(crate) fn install_url(&self) -> Option<String> {
+        self.slug
+            .as_ref()
+            .map(|slug| format!("https://github.com/apps/{slug}/installations/new"))
+            .or_else(|| self.html_url.clone())
+    }
+}
+
+/// Everything the flow learned, in order of arrival.
+#[derive(Debug)]
+pub(crate) struct Registration {
+    pub credentials: AppCredentials,
+    /// Installation id, when the operator completed the install before
+    /// [`INSTALL_TIMEOUT`]. The engine discovers it per repository anyway,
+    /// so its absence is not a failure.
+    pub installation_id: Option<u64>,
+}
+
+/// Where the App is created: a personal account or an organization.
+pub(crate) fn creation_url(org: Option<&str>, state: &str) -> String {
+    match org {
+        Some(org) => format!(
+            "https://github.com/organizations/{org}/settings/apps/new?state={state}",
+            org = urlencode(org),
+            state = urlencode(state),
+        ),
+        None => format!(
+            "https://github.com/settings/apps/new?state={state}",
+            state = urlencode(state)
+        ),
+    }
+}
+
+/// The manifest GitHub renders as a pre-filled App-creation form.
+///
+/// `hook_attributes` is only meaningful when GitHub can reach the engine, so
+/// a loopback-only setup ships the App with webhooks inactive rather than
+/// pointing them at an address that will never resolve from GitHub's side.
+pub(crate) fn manifest(
+    name: &str,
+    redirect_url: &str,
+    public_url: Option<&str>,
+) -> serde_json::Value {
+    let permissions: serde_json::Map<String, serde_json::Value> = DEFAULT_PERMISSIONS
+        .iter()
+        .map(|(scope, access)| ((*scope).to_owned(), serde_json::Value::from(*access)))
+        .collect();
+    let mut manifest = serde_json::json!({
+        "name": name,
+        "url": public_url.unwrap_or("https://github.com/preloop-dev/preloop"),
+        "redirect_url": redirect_url,
+        "setup_url": format!("{}/installed", redirect_url.trim_end_matches("/callback")),
+        "setup_on_update": false,
+        "public": false,
+        "default_permissions": permissions,
+    });
+    match public_url {
+        Some(public) => {
+            manifest["hook_attributes"] = serde_json::json!({
+                "url": format!("{}/api/v1/github/webhooks", public.trim_end_matches('/')),
+                "active": true,
+            });
+            manifest["default_events"] = serde_json::json!(DEFAULT_EVENTS);
+        }
+        // An inactive hook still gets a secret from GitHub, so a later
+        // `--public-url` only has to flip the switch in App settings.
+        None => manifest["hook_attributes"] = serde_json::json!({ "active": false }),
+    }
+    manifest
+}
+
+/// Shared state of the one-shot listener.
+struct Flow {
+    /// CSRF nonce echoed by GitHub; a callback carrying anything else did not
+    /// originate from the form this process served.
+    state: String,
+    name: String,
+    public_url: Option<String>,
+    redirect_url: String,
+    api_base: String,
+    /// Install URL, published by the callback for the `/installed` page.
+    install_url: Mutex<Option<String>>,
+    /// Fires once, with the converted credentials.
+    credentials_tx: Mutex<Option<oneshot::Sender<Result<AppCredentials>>>>,
+    /// Fires once, with the installation id GitHub redirects back with.
+    installed_tx: Mutex<Option<oneshot::Sender<u64>>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CallbackQuery {
+    code: String,
+    #[serde(default)]
+    state: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct InstalledQuery {
+    #[serde(default)]
+    installation_id: Option<u64>,
+}
+
+/// Run the browser flow to completion.
+///
+/// Returns once GitHub has converted the manifest; the installation step is
+/// best-effort and bounded by [`INSTALL_TIMEOUT`].
+pub(crate) async fn register(
+    name: &str,
+    org: Option<&str>,
+    port: u16,
+    public_url: Option<&str>,
+    open_browser: bool,
+) -> Result<Registration> {
+    let listener = tokio::net::TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, port)))
+        .await
+        .with_context(|| format!("binding 127.0.0.1:{port} for the GitHub redirect"))?;
+    let local = listener
+        .local_addr()
+        .context("reading the local listener address")?;
+    let base = format!("http://127.0.0.1:{}", local.port());
+    println!("Open this URL to create the GitHub App:\n  {base}");
+    if open_browser && open_in_browser(&base).is_err() {
+        println!("(could not open a browser automatically — open the URL above)");
+    }
+    println!("Waiting for GitHub to redirect back…");
+    let api_base = std::env::var("PRELOOP_GITHUB_API_URL")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "https://api.github.com".to_owned());
+    register_on(listener, name, org, public_url, &api_base).await
+}
+
+/// [`register`] against an already-bound listener, so a test can learn the
+/// address before the flow starts.
+async fn register_on(
+    listener: tokio::net::TcpListener,
+    name: &str,
+    org: Option<&str>,
+    public_url: Option<&str>,
+    api_base: &str,
+) -> Result<Registration> {
+    let local = listener
+        .local_addr()
+        .context("reading the local listener address")?;
+    let base = format!("http://127.0.0.1:{}", local.port());
+    let (credentials_tx, credentials_rx) = oneshot::channel();
+    let (installed_tx, installed_rx) = oneshot::channel();
+    let flow = Arc::new(Flow {
+        state: nonce(),
+        name: name.to_owned(),
+        public_url: public_url.map(str::to_owned),
+        redirect_url: format!("{base}/callback"),
+        api_base: api_base.to_owned(),
+        install_url: Mutex::new(None),
+        credentials_tx: Mutex::new(Some(credentials_tx)),
+        installed_tx: Mutex::new(Some(installed_tx)),
+    });
+    let org = org.map(str::to_owned);
+    let router = Router::new()
+        .route("/", get(page_form))
+        .route("/callback", get(page_callback))
+        .route("/installed", get(page_installed))
+        .with_state((flow.clone(), org));
+
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let server = tokio::spawn({
+        let shutdown = shutdown.clone();
+        async move {
+            axum::serve(listener, router)
+                .with_graceful_shutdown(async move { shutdown.cancelled().await })
+                .await
+        }
+    });
+
+    let credentials = match tokio::time::timeout(BROWSER_TIMEOUT, credentials_rx).await {
+        Ok(Ok(result)) => result?,
+        Ok(Err(_)) => anyhow::bail!("the registration listener stopped before GitHub replied"),
+        Err(_) => anyhow::bail!(
+            "timed out after {}s waiting for GitHub — re-run `preloop setup github --via app`",
+            BROWSER_TIMEOUT.as_secs()
+        ),
+    };
+
+    let installation_id = match tokio::time::timeout(INSTALL_TIMEOUT, installed_rx).await {
+        Ok(Ok(id)) => Some(id),
+        _ => None,
+    };
+    shutdown.cancel();
+    let _ = server.await;
+    Ok(Registration {
+        credentials,
+        installation_id,
+    })
+}
+
+/// The form page: GitHub only accepts a manifest as a form POST, so this is
+/// a self-submitting form rather than a link.
+async fn page_form(State((flow, org)): State<(Arc<Flow>, Option<String>)>) -> impl IntoResponse {
+    let manifest = manifest(&flow.name, &flow.redirect_url, flow.public_url.as_deref());
+    let action = creation_url(org.as_deref(), &flow.state);
+    let scope = match &org {
+        Some(org) => format!("the <strong>{}</strong> organization", escape(org)),
+        None => "your personal account".to_owned(),
+    };
+    let webhooks = match &flow.public_url {
+        Some(public) => format!("Webhooks deliver to {}.", escape(public)),
+        None => "Webhooks are off — this engine is not reachable from GitHub.".to_owned(),
+    };
+    Html(format!(
+        r#"<!DOCTYPE html>
+<html>
+<head><title>Create the preloop GitHub App</title></head>
+<body style="font-family: system-ui, sans-serif; padding: 40px; max-width: 640px; margin: auto;">
+  <h1>Create the preloop GitHub App</h1>
+  <p>This creates a private App named <strong>{name}</strong> on {scope}, with
+     permissions {permissions}. {webhooks}</p>
+  <p>GitHub returns the credentials to this page, which writes them to your
+     local config — the private key never leaves this machine.</p>
+  <form id="manifest-form" action="{action}" method="post">
+    <input type="hidden" name="manifest" value='{manifest}'>
+    <button type="submit" style="font-size: 16px; padding: 10px 20px; cursor: pointer; background: #2da44e; color: white; border: none; border-radius: 6px; font-weight: bold;">Create on GitHub</button>
+  </form>
+</body>
+</html>"#,
+        name = escape(&flow.name),
+        scope = scope,
+        permissions = escape(
+            &DEFAULT_PERMISSIONS
+                .iter()
+                .map(|(scope, access)| format!("{scope}: {access}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        webhooks = webhooks,
+        action = escape(&action),
+        manifest = escape_attr(&manifest.to_string()),
+    ))
+}
+
+/// GitHub's redirect target: converts the one-time code, then sends the
+/// browser on to the installation page so the operator never copies a URL.
+async fn page_callback(
+    State((flow, _)): State<(Arc<Flow>, Option<String>)>,
+    Query(query): Query<CallbackQuery>,
+) -> axum::response::Response {
+    if query.state.as_deref() != Some(flow.state.as_str()) {
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            Html(error_page(
+                "State mismatch",
+                "This callback did not come from the form this command served.",
+            )),
+        )
+            .into_response();
+    }
+    let converted = convert(&flow.api_base, &query.code).await;
+    let install_url = converted
+        .as_ref()
+        .ok()
+        .and_then(AppCredentials::install_url);
+    let response = match &converted {
+        Ok(_) => match &install_url {
+            Some(url) => {
+                *flow.install_url.lock().await = Some(url.clone());
+                Redirect::to(url).into_response()
+            }
+            None => Html(success_page(
+                "App created",
+                "Install it on your repositories from the App's settings page.",
+            ))
+            .into_response(),
+        },
+        Err(error) => (
+            axum::http::StatusCode::BAD_GATEWAY,
+            Html(error_page("Conversion failed", &format!("{error:#}"))),
+        )
+            .into_response(),
+    };
+    if let Some(tx) = flow.credentials_tx.lock().await.take() {
+        let _ = tx.send(converted);
+    }
+    response
+}
+
+/// GitHub's post-install redirect (`setup_url`).
+async fn page_installed(
+    State((flow, _)): State<(Arc<Flow>, Option<String>)>,
+    Query(query): Query<InstalledQuery>,
+) -> impl IntoResponse {
+    if let Some(id) = query.installation_id {
+        if let Some(tx) = flow.installed_tx.lock().await.take() {
+            let _ = tx.send(id);
+        }
+    }
+    Html(success_page(
+        "preloop is connected",
+        "Credentials are written to your local config. You can close this tab and return to the terminal.",
+    ))
+}
+
+/// Exchange the one-time manifest code for the App's credentials.
+async fn convert(api_base: &str, code: &str) -> Result<AppCredentials> {
+    let url = format!("{}/app-manifests/{}/conversions", api_base, urlencode(code));
+    // Not `crate::build_client()`: that one is pinned to the engine's unix
+    // socket, and this call goes to api.github.com.
+    let response = reqwest::Client::new()
+        .post(&url)
+        .header("User-Agent", "preloop")
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+        .context("calling GitHub's manifest conversion endpoint")?;
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    anyhow::ensure!(
+        status.is_success(),
+        "GitHub rejected the manifest conversion ({status}): {}",
+        body.trim()
+    );
+    serde_json::from_str(&body).context("parsing GitHub's manifest conversion response")
+}
+
+/// Open `url` in the platform browser. Failure is not fatal — the URL is
+/// always printed first.
+pub(crate) fn open_in_browser(url: &str) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    let (program, args): (&str, Vec<&str>) = ("open", vec![url]);
+    #[cfg(target_os = "windows")]
+    let (program, args): (&str, Vec<&str>) = ("cmd", vec!["/C", "start", "", url]);
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    let (program, args): (&str, Vec<&str>) = ("xdg-open", vec![url]);
+
+    let status = std::process::Command::new(program)
+        .args(args)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .with_context(|| format!("spawning {program}"))?;
+    anyhow::ensure!(status.success(), "{program} exited with {status}");
+    Ok(())
+}
+
+/// 128 bits of CSRF nonce, hex-encoded.
+fn nonce() -> String {
+    let bytes: [u8; 16] = rand::random();
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+/// Percent-encode everything outside the unreserved set, so a slug or nonce
+/// cannot break out of the query string it is spliced into.
+fn urlencode(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char)
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+/// Escape HTML text content.
+fn escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// Escape a value destined for a single-quoted HTML attribute. The manifest
+/// is JSON, so it is full of double quotes: the attribute is single-quoted
+/// and only the single quote (and `&`/`<`) needs escaping.
+fn escape_attr(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('\'', "&#39;")
+}
+
+fn success_page(title: &str, detail: &str) -> String {
+    format!(
+        r#"<!DOCTYPE html>
+<html><head><title>{title}</title></head>
+<body style="font-family: system-ui, sans-serif; padding: 40px; max-width: 640px; margin: auto;">
+  <h1 style="color: #2da44e;">{title}</h1>
+  <p>{detail}</p>
+</body></html>"#,
+        title = escape(title),
+        detail = escape(detail)
+    )
+}
+
+fn error_page(title: &str, detail: &str) -> String {
+    format!(
+        r#"<!DOCTYPE html>
+<html><head><title>{title}</title></head>
+<body style="font-family: system-ui, sans-serif; padding: 40px; max-width: 640px; margin: auto;">
+  <h1 style="color: #cf222e;">{title}</h1>
+  <p>{detail}</p>
+  <p>Re-run <code>preloop setup github --via app</code> to try again.</p>
+</body></html>"#,
+        title = escape(title),
+        detail = escape(detail)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A stand-in for `api.github.com`'s manifest-conversion endpoint.
+    ///
+    /// Returns the address it listens on; the caller passes it to
+    /// [`register_on`] as the API base.
+    async fn mock_github() -> String {
+        let listener = tokio::net::TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+            .await
+            .unwrap();
+        let base = format!("http://127.0.0.1:{}", listener.local_addr().unwrap().port());
+        let router = Router::new().route(
+            "/app-manifests/:code/conversions",
+            axum::routing::post(|axum::extract::Path(code): axum::extract::Path<String>| async move {
+                assert_eq!(code, "conversion-code", "the code from GitHub is forwarded verbatim");
+                axum::Json(serde_json::json!({
+                    "id": 424242,
+                    "slug": "preloop-local",
+                    "pem": "-----BEGIN RSA PRIVATE KEY-----\nKEY\n-----END RSA PRIVATE KEY-----",
+                    "webhook_secret": "hook-secret",
+                    "html_url": "https://github.com/apps/preloop-local",
+                }))
+            }),
+        );
+        tokio::spawn(async move { axum::serve(listener, router).await });
+        base
+    }
+
+    /// The whole redirect dance: the form page hands GitHub a manifest and a
+    /// nonce, the callback converts the code and forwards the browser to the
+    /// install page, and `setup_url` reports the installation back.
+    #[tokio::test]
+    async fn browser_flow_converts_and_reports_the_installation() {
+        let api = mock_github().await;
+        let listener = tokio::net::TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+            .await
+            .unwrap();
+        let base = format!("http://127.0.0.1:{}", listener.local_addr().unwrap().port());
+        let flow =
+            tokio::spawn(
+                async move { register_on(listener, "preloop-local", None, None, &api).await },
+            );
+
+        let client = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .unwrap();
+        let form = client
+            .get(&base)
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+        assert!(
+            form.contains(r#"action="https://github.com/settings/apps/new?state="#),
+            "the form must post the manifest to GitHub: {form}"
+        );
+        let state = form
+            .split("apps/new?state=")
+            .nth(1)
+            .and_then(|rest| rest.split('"').next())
+            .expect("state nonce in the form action")
+            .to_owned();
+        assert!(
+            form.contains("127.0.0.1") && form.contains("/callback"),
+            "the manifest must redirect back to this listener"
+        );
+
+        // A callback that did not come from this form is refused, and the
+        // flow stays open for the real one.
+        let forged = client
+            .get(format!("{base}/callback?code=conversion-code&state=forged"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(forged.status(), reqwest::StatusCode::BAD_REQUEST);
+
+        let callback = client
+            .get(format!(
+                "{base}/callback?code=conversion-code&state={state}"
+            ))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(callback.status(), reqwest::StatusCode::SEE_OTHER);
+        assert_eq!(
+            callback
+                .headers()
+                .get("location")
+                .and_then(|value| value.to_str().ok()),
+            Some("https://github.com/apps/preloop-local/installations/new"),
+            "the browser is sent straight to the install page"
+        );
+
+        client
+            .get(format!(
+                "{base}/installed?installation_id=99&setup_action=install"
+            ))
+            .send()
+            .await
+            .unwrap();
+
+        let registration = flow.await.unwrap().unwrap();
+        assert_eq!(registration.credentials.id, 424242);
+        assert_eq!(
+            registration.credentials.webhook_secret.as_deref(),
+            Some("hook-secret")
+        );
+        assert!(registration
+            .credentials
+            .pem
+            .contains("BEGIN RSA PRIVATE KEY"));
+        assert_eq!(registration.installation_id, Some(99));
+    }
+
+    /// GitHub rejecting the conversion must surface as an error, not a
+    /// half-written config.
+    #[tokio::test]
+    async fn conversion_failure_is_reported() {
+        let listener = tokio::net::TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+            .await
+            .unwrap();
+        let base = format!("http://127.0.0.1:{}", listener.local_addr().unwrap().port());
+        let api_listener =
+            tokio::net::TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+                .await
+                .unwrap();
+        let api = format!(
+            "http://127.0.0.1:{}",
+            api_listener.local_addr().unwrap().port()
+        );
+        tokio::spawn(async move {
+            let router = Router::new().route(
+                "/app-manifests/:code/conversions",
+                axum::routing::post(|| async {
+                    (axum::http::StatusCode::UNPROCESSABLE_ENTITY, "code expired")
+                }),
+            );
+            axum::serve(api_listener, router).await
+        });
+        let flow =
+            tokio::spawn(
+                async move { register_on(listener, "preloop-local", None, None, &api).await },
+            );
+
+        let client = reqwest::Client::new();
+        let form = client
+            .get(&base)
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+        let state = form
+            .split("apps/new?state=")
+            .nth(1)
+            .and_then(|rest| rest.split('"').next())
+            .expect("state nonce in the form action")
+            .to_owned();
+        let response = client
+            .get(format!("{base}/callback?code=stale&state={state}"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::BAD_GATEWAY);
+
+        let error = flow.await.unwrap().unwrap_err();
+        assert!(
+            format!("{error:#}").contains("code expired"),
+            "GitHub's reason must reach the operator: {error:#}"
+        );
+    }
+
+    #[test]
+    fn manifest_disables_webhooks_without_a_public_url() {
+        let manifest = manifest("preloop", "http://127.0.0.1:4000/callback", None);
+        assert_eq!(manifest["hook_attributes"]["active"], false);
+        assert!(manifest.get("default_events").is_none());
+        assert_eq!(
+            manifest["setup_url"], "http://127.0.0.1:4000/installed",
+            "the post-install redirect must return to this listener"
+        );
+        assert_eq!(manifest["public"], false);
+        assert_eq!(manifest["default_permissions"]["contents"], "read");
+    }
+
+    #[test]
+    fn manifest_points_webhooks_at_a_public_url() {
+        let manifest = manifest(
+            "preloop",
+            "http://127.0.0.1:4000/callback",
+            Some("https://ci.example.com/"),
+        );
+        assert_eq!(
+            manifest["hook_attributes"]["url"],
+            "https://ci.example.com/api/v1/github/webhooks"
+        );
+        assert_eq!(manifest["hook_attributes"]["active"], true);
+        assert_eq!(manifest["default_events"][0], "push");
+    }
+
+    #[test]
+    fn creation_url_targets_the_org_when_given() {
+        assert_eq!(
+            creation_url(Some("acme"), "abc123"),
+            "https://github.com/organizations/acme/settings/apps/new?state=abc123"
+        );
+        assert_eq!(
+            creation_url(None, "abc123"),
+            "https://github.com/settings/apps/new?state=abc123"
+        );
+    }
+
+    #[test]
+    fn install_url_prefers_the_slug() {
+        let credentials = AppCredentials {
+            id: 7,
+            slug: Some("my-app".to_owned()),
+            pem: String::new(),
+            webhook_secret: None,
+            html_url: Some("https://github.com/apps/my-app".to_owned()),
+        };
+        assert_eq!(
+            credentials.install_url().as_deref(),
+            Some("https://github.com/apps/my-app/installations/new")
+        );
+        let without_slug = AppCredentials {
+            slug: None,
+            ..credentials
+        };
+        assert_eq!(
+            without_slug.install_url().as_deref(),
+            Some("https://github.com/apps/my-app")
+        );
+    }
+
+    #[test]
+    fn manifest_attribute_escaping_cannot_close_the_attribute() {
+        let escaped = escape_attr(r#"{"name":"it's <b>"}"#);
+        assert!(!escaped.contains('\''), "single quotes must be escaped");
+        assert!(!escaped.contains('<'), "tags must be escaped");
+        assert!(
+            escaped.contains(r#""name""#),
+            "double quotes stay literal inside a single-quoted attribute"
+        );
+    }
+}

--- a/crates/preloop-cli/src/github_auth.rs
+++ b/crates/preloop-cli/src/github_auth.rs
@@ -191,7 +191,7 @@ impl StoredAuth {
             (None, Some(source)) => {
                 format!("DISABLED — {source} set but no {APP_ID_ENV}; jobs get a local JWT")
             }
-            (None, None) => "disabled — no App configured".to_owned(),
+            (None, None) => "disabled — no App configured (local-only mode)".to_owned(),
         };
 
         let webhooks = if webhook {
@@ -201,6 +201,13 @@ impl StoredAuth {
         };
 
         format!("github: tokens: {tokens}; webhooks: {webhooks}")
+    }
+
+    /// Whether the effective configuration is empty — no App, no webhook
+    /// secret. Reads the environment like [`Self::report`], so values that
+    /// came from outside this file count.
+    pub fn is_unconfigured() -> bool {
+        env_value(APP_ID_ENV).is_none() && !env_present(WEBHOOK_SECRET_ENV)
     }
 }
 

--- a/crates/preloop-cli/src/github_setup.rs
+++ b/crates/preloop-cli/src/github_setup.rs
@@ -42,6 +42,36 @@ pub struct GithubSetupArgs {
     #[arg(long)]
     pub pem_file: Option<PathBuf>,
 
+    /// Create the App under this organization instead of your personal
+    /// account (with --via app, browser flow).
+    #[arg(long)]
+    pub org: Option<String>,
+
+    /// Port for the loopback listener GitHub redirects back to
+    /// (with --via app, browser flow). 0 picks a free port.
+    #[arg(long, default_value_t = 0)]
+    pub port: u16,
+
+    /// Public HTTPS URL of this engine. Enables webhook delivery on the
+    /// created App; without it the App is created with webhooks off.
+    #[arg(long)]
+    pub public_url: Option<String>,
+
+    /// Name of the created App (with --via app, browser flow). GitHub
+    /// requires it to be globally unique.
+    #[arg(long, default_value = "preloop-local")]
+    pub app_name: String,
+
+    /// Print the URL instead of opening a browser.
+    #[arg(long)]
+    pub no_browser: bool,
+
+    /// Webhook secret to store. The App flow receives one from GitHub
+    /// automatically; set this when you created the webhook yourself
+    /// (any `--via pat` deployment that wants push triggers).
+    #[arg(long)]
+    pub webhook_secret: Option<String>,
+
     /// PAT to store (with --via pat). Falls back to PRELOOP_GITHUB_PAT,
     /// then an interactive prompt.
     #[arg(long)]
@@ -64,6 +94,12 @@ impl std::fmt::Debug for GithubSetupArgs {
             .field("via", &self.via)
             .field("app_id", &self.app_id)
             .field("pem_file", &self.pem_file)
+            .field("org", &self.org)
+            .field("port", &self.port)
+            .field("public_url", &self.public_url)
+            .field("app_name", &self.app_name)
+            .field("no_browser", &self.no_browser)
+            .field("webhook_secret", &redacted(self.webhook_secret.is_some()))
             .field("token", &redacted(self.token.is_some()))
             .field("repos", &self.repos)
             .field("workspace", &self.workspace)
@@ -190,20 +226,28 @@ async fn cmd_setup_github(args: GithubSetupArgs) -> anyhow::Result<()> {
                  \x20     scoped to each workflow's `permissions:` block.\n\
                  pat  Fine-grained PAT — for orgs that gate app installations.\n\
                  \n\
-                 Run `preloop setup github --via app --app-id <ID> --pem-file <KEY>` after\n\
-                 creating the App:\n\
-                 \x20 1. github.com/settings/apps/new — name it (e.g. `dummy-preloop-app`),\n\
-                 \x20    disable webhook, permissions: Contents: Read-only and\n\
-                 \x20    Pull requests: Read-only (if your workflows read PRs).\n\
-                 \x20    Upload the repo-root logo.png as the App avatar.\n\
-                 \x20 2. Generate a private key — save the PEM.\n\
-                 \x20 3. Install the App on your repositories:\n\
-                 \x20    https://github.com/apps/<slug>/installations/new\n\
-                 \x20 4. Re-run this command with --app-id and --pem-file."
+                 `preloop setup github --via app` creates the App for you: it opens a\n\
+                 local page, GitHub asks you to confirm, and the App id, private key,\n\
+                 and webhook secret are written to your config automatically.\n\
+                 \x20 --org <NAME>       create it under an organization\n\
+                 \x20 --public-url <URL> also enable webhook delivery to this engine\n\
+                 \n\
+                 Already have an App? Skip the browser:\n\
+                 \x20 preloop setup github --via app --app-id <ID> --pem-file <KEY>"
             );
             return Ok(());
         }
     };
+    // Applied before the credential path runs, so `--via app --public-url`
+    // pushes this exact secret to GitHub rather than minting a fresh one.
+    // App *creation* still wins: GitHub generates the secret it will sign
+    // with, and nothing local can override that.
+    if let Some(secret) = args.webhook_secret.as_deref() {
+        let mut config = preloop_runner_server::config::load_config()?;
+        config.github.webhook_secret = Some(secret.to_owned());
+        let path = write_config(&config)?;
+        println!("Webhook secret stored in {}", path.display());
+    }
     match via {
         Via::App => setup_app(&args).await,
         Via::Pat => setup_pat(&args).await,
@@ -211,24 +255,48 @@ async fn cmd_setup_github(args: GithubSetupArgs) -> anyhow::Result<()> {
 }
 
 async fn setup_app(args: &GithubSetupArgs) -> anyhow::Result<()> {
-    let app_id = args
-        .app_id
-        .as_deref()
-        .context("--app-id is required with --via app")?;
-    let pem_path = args
-        .pem_file
-        .as_deref()
-        .context("--pem-file is required with --via app")?;
-    let pem = std::fs::read_to_string(pem_path)
-        .with_context(|| format!("reading App private key {}", pem_path.display()))?;
+    // Nothing supplied means "create the App for me"; either flag on its own
+    // is a half-finished manual setup, and silently starting a browser flow
+    // would create a second App the operator did not ask for.
+    let (app_id, pem, webhook_secret) = match (args.app_id.as_deref(), args.pem_file.as_deref()) {
+        (None, None) => {
+            // An App is already configured: creating a second one would leave
+            // the first installed and minting tokens, and the operator almost
+            // certainly meant "point the one I have at this URL".
+            let existing = preloop_runner_server::config::load_config()?.github;
+            if let (Some(app_id), Some(pem)) = (existing.app_id, existing.app_pem) {
+                return match args.public_url.as_deref() {
+                    Some(public_url) => {
+                        enable_webhooks(&app_id, &pem, public_url, existing.webhook_secret).await
+                    }
+                    None => {
+                        println!(
+                            "App {app_id} is already configured in {}.\n\
+                             \x20 --public-url <URL>  point its webhook at a reachable address\n\
+                             \x20 --app-id/--pem-file replace it with a different App\n\
+                             Delete the [github] keys from that file to start over.",
+                            preloop_runner_server::config::config_path().display()
+                        );
+                        Ok(())
+                    }
+                };
+            }
+            return setup_app_via_browser(args).await;
+        }
+        (Some(app_id), Some(pem_path)) => {
+            let pem = std::fs::read_to_string(pem_path)
+                .with_context(|| format!("reading App private key {}", pem_path.display()))?;
+            (app_id.to_owned(), pem, None)
+        }
+        (Some(_), None) => anyhow::bail!(
+            "--pem-file is required alongside --app-id (omit both to create the App in a browser)"
+        ),
+        (None, Some(_)) => anyhow::bail!(
+            "--app-id is required alongside --pem-file (omit both to create the App in a browser)"
+        ),
+    };
 
-    let mut config = preloop_runner_server::config::load_config()?;
-    config.github.app_id = Some(app_id.to_owned());
-    config.github.app_pem = Some(pem.clone());
-    if config.github.mint_failure.is_none() {
-        config.github.mint_failure = Some("local".into());
-    }
-    let path = write_config(&config)?;
+    let path = save_app_credentials(&app_id, &pem, webhook_secret)?;
     println!("Wrote {}", path.display());
     println!(
         "App {app_id} configured. If the App is not yet installed on your repositories:\n\
@@ -239,7 +307,104 @@ async fn setup_app(args: &GithubSetupArgs) -> anyhow::Result<()> {
         println!("Tip: verify with `preloop doctor --repo owner/name`.");
         return Ok(());
     }
-    doctor_app(app_id, &pem, &args.repos).await
+    doctor_app(&app_id, &pem, &args.repos).await
+}
+
+/// Persist App credentials to the engine's config file.
+///
+/// The webhook secret only exists on the manifest path — GitHub generates it
+/// during creation — so it is written when present and left untouched
+/// otherwise, which keeps a manual re-run from clearing a working secret.
+fn save_app_credentials(
+    app_id: &str,
+    pem: &str,
+    webhook_secret: Option<String>,
+) -> anyhow::Result<PathBuf> {
+    let mut config = preloop_runner_server::config::load_config()?;
+    config.github.app_id = Some(app_id.to_owned());
+    config.github.app_pem = Some(pem.to_owned());
+    if config.github.mint_failure.is_none() {
+        config.github.mint_failure = Some("local".into());
+    }
+    if webhook_secret.is_some() {
+        config.github.webhook_secret = webhook_secret;
+    }
+    write_config(&config)
+}
+
+/// Create the App through GitHub's manifest flow and store what comes back.
+async fn setup_app_via_browser(args: &GithubSetupArgs) -> anyhow::Result<()> {
+    let registration = crate::app_manifest::register(
+        &args.app_name,
+        args.org.as_deref(),
+        args.port,
+        args.public_url.as_deref(),
+        !args.no_browser,
+    )
+    .await?;
+    let credentials = &registration.credentials;
+    let app_id = credentials.id.to_string();
+    let path = save_app_credentials(
+        &app_id,
+        &credentials.pem,
+        credentials.webhook_secret.clone(),
+    )?;
+    println!("Created App {app_id} and wrote {}", path.display());
+    if credentials.webhook_secret.is_some() {
+        println!("Webhook secret stored — signed deliveries will verify.");
+    }
+    match registration.installation_id {
+        Some(id) => println!("Installed (installation {id})."),
+        None => {
+            if let Some(url) = credentials.install_url() {
+                println!("Install it on your repositories to finish:\n  {url}");
+            }
+        }
+    }
+    println!("Restart the engine (`preloop serve`) to pick up the config.");
+    if args.repos.is_empty() {
+        println!("Tip: verify with `preloop doctor --repo owner/name`.");
+        return Ok(());
+    }
+    doctor_app(&app_id, &credentials.pem, &args.repos).await
+}
+
+/// Point an already-configured App's webhook at a reachable URL.
+///
+/// Reuses the stored secret when there is one — rotating it would silently
+/// break any other consumer of the same App — and generates one otherwise,
+/// since GitHub only signs deliveries when a secret is set.
+async fn enable_webhooks(
+    app_id: &str,
+    pem: &str,
+    public_url: &str,
+    stored_secret: Option<String>,
+) -> anyhow::Result<()> {
+    let secret = match stored_secret.filter(|secret| !secret.is_empty()) {
+        Some(secret) => secret,
+        None => {
+            let bytes: [u8; 32] = rand::random();
+            bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+        }
+    };
+    let hook_url = format!(
+        "{}/api/v1/github/webhooks",
+        public_url.trim_end_matches('/')
+    );
+    preloop_runner_server::github_app::set_app_webhook_config(app_id, pem, &hook_url, &secret)
+        .await?;
+    let mut config = preloop_runner_server::config::load_config()?;
+    config.github.webhook_secret = Some(secret);
+    let path = write_config(&config)?;
+    println!("App {app_id} webhook now delivers to {hook_url}");
+    println!("Secret stored in {}", path.display());
+    println!(
+        "If deliveries do not arrive, tick **Active** under Webhook in the App's\n\
+         settings — GitHub's API cannot set that flag, and an App created\n\
+         without --public-url starts with it off."
+    );
+    println!("Restart the engine (`preloop serve`) to pick up the secret.");
+    Ok(())
 }
 
 async fn setup_pat(args: &GithubSetupArgs) -> anyhow::Result<()> {
@@ -262,6 +427,14 @@ async fn setup_pat(args: &GithubSetupArgs) -> anyhow::Result<()> {
         println!("  - {line}");
     }
     println!("Metadata: Read-only is always required (GitHub enforces it).");
+    // GitHub has no API for minting a fine-grained PAT — unlike Apps, which
+    // have the manifest flow — so the browser is unavoidable here. Opening
+    // the page is the most that can be automated.
+    println!(
+        "Note: check runs are App-only at GitHub's end, so a PAT-configured engine\n\
+         \x20 records them locally instead of publishing them to the commit. Use\n\
+         \x20 `--via app` if you want status checks on PRs."
+    );
     if oidc_declared {
         println!(
             "Note: your workflows also declare `id-token: write` — OIDC token issuance. For preloop\n             \x20 the ENGINE is the OIDC issuer (it mints the token with its own key); GitHub's\n             \x20 provider applies only to hosted runs. Either way it is not a PAT permission —\n             \x20 no action needed on the PAT. To consume the token, configure your cloud\n             \x20 provider's trust to accept the engine's OIDC issuer."
@@ -280,6 +453,13 @@ async fn setup_pat(args: &GithubSetupArgs) -> anyhow::Result<()> {
                 // when a human is typing, but keep plain stdin for pipes so
                 // automation still works. Same convention as `secret set`.
                 if std::io::stdin().is_terminal() {
+                    // Only for a human at a prompt: a piped token means
+                    // automation, which has no use for a browser window.
+                    if !args.no_browser {
+                        let _ = crate::app_manifest::open_in_browser(
+                            "https://github.com/settings/personal-access-tokens/new",
+                        );
+                    }
                     rpassword::prompt_password("Paste the PAT (hidden): ")?
                         .trim()
                         .to_owned()
@@ -480,7 +660,8 @@ pub(crate) async fn cmd_doctor(args: DoctorArgs) -> anyhow::Result<()> {
     let path = preloop_runner_server::config::config_path();
     if !path.exists() {
         anyhow::bail!(
-            "no config file at {} — run `preloop setup github` first",
+            "no config file at {} — run `preloop setup github --via app` first \
+             (creates the GitHub App in your browser)",
             path.display()
         );
     }

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -15,6 +15,7 @@ use std::io::Read;
 use std::path::PathBuf;
 use std::time::Duration;
 
+mod app_manifest;
 mod debug_session;
 mod github_auth;
 mod github_setup;
@@ -629,6 +630,9 @@ fn resolve_github_auth(args: &ServeArgs, state_dir: &std::path::Path) -> anyhow:
 
     auth.apply();
     eprintln!("[preloop] {}", github_auth::StoredAuth::report());
+    if github_auth::StoredAuth::is_unconfigured() {
+        eprintln!("[preloop] connect GitHub with `preloop setup` — until then, jobs get local tokens and webhooks are unverified");
+    }
     Ok(())
 }
 
@@ -644,7 +648,7 @@ async fn cmd_engine(args: ServeArgs) -> anyhow::Result<()> {
         .listen
         .clone()
         .or_else(|| std::env::var("PRELOOP_LISTEN").ok())
-        .unwrap_or_else(|| "0.0.0.0:9090".to_owned())
+        .unwrap_or_else(|| "127.0.0.1:9090".to_owned())
         .parse()
         .context("--listen / PRELOOP_LISTEN must be a socket address")?;
     let public_url = args
@@ -707,7 +711,7 @@ async fn cmd_engine(args: ServeArgs) -> anyhow::Result<()> {
     let pool_available = match &pool_config {
         Ok(_) => true,
         Err(error) => {
-            tracing::warn!(%error, "local runner provisioning unavailable; control plane remains available");
+            tracing::warn!(%error, "local runner provisioning unavailable; jobs queue until a runner is available");
             false
         }
     };
@@ -841,22 +845,39 @@ fn local_runner_pool_config(
         .or_else(|| {
             let exe_dir = std::env::current_exe().ok()?.parent()?.to_path_buf();
             let target_dir = exe_dir.parent()?;
-            // Prefer Linux guest binaries when the CLI itself is a macOS
-            // development build. The runner executes inside Linux VMs.
-            let candidates = [
+            let mut candidates = Vec::new();
+            // Released installs (`install.sh`, `preloop update`) place the
+            // Linux guest runner under <prefix>/lib/preloop/runner/<triple>/.
+            // Prefer the host's own Linux triple, then any installed triple.
+            if let Some(prefix) = exe_dir.parent() {
+                let runner_dir = prefix.join("lib/preloop/runner");
+                candidates.push(runner_dir.join(linux_guest_triple()));
+                if let Ok(entries) = std::fs::read_dir(&runner_dir) {
+                    let mut installed: Vec<_> = entries
+                        .flatten()
+                        .map(|entry| entry.path())
+                        .filter(|path| path.is_dir())
+                        .collect();
+                    installed.sort();
+                    candidates.extend(installed);
+                }
+            }
+            // Development builds keep the guest binary under target/<triple>/;
+            // the runner executes inside Linux VMs.
+            candidates.extend([
                 target_dir.join("aarch64-unknown-linux-gnu/debug"),
                 target_dir.join("aarch64-unknown-linux-musl/debug"),
                 target_dir.join("aarch64-unknown-linux-gnu/release"),
                 target_dir.join("aarch64-unknown-linux-musl/release"),
                 exe_dir.join("preloop-runner"),
                 exe_dir.to_path_buf(),
-            ];
+            ]);
             candidates
                 .into_iter()
                 .find(|directory| directory.join("preloop-runner").is_file())
         })
         .filter(|path| linux_runner_bundle(path))
-        .context("Linux runner bundle unavailable; run `just build-preloop` to build target/aarch64-unknown-linux-gnu/debug/preloop-runner")?;
+        .context("Linux runner bundle unavailable; set PRELOOP_RUNNER_BUNDLE to a directory containing a Linux preloop-runner, or build one with `just build-preloop` (docs/vm-images.md)")?;
     let use_packed_artifact = env_flag("PRELOOP_USE_PACKED_GOLDEN", false);
     // The workspace is scanned for toolchain version files (rust-toolchain.toml,
     // .nvmrc, etc.) so the golden can be built with the project's toolchains
@@ -1104,6 +1125,15 @@ fn linux_runner_bundle(path: &std::path::Path) -> bool {
     };
     let mut magic = [0_u8; 4];
     file.read_exact(&mut magic).is_ok() && magic == *b"\x7fELF"
+}
+
+/// The Linux guest triple the local microVM pool runs on this host.
+pub(crate) fn linux_guest_triple() -> &'static str {
+    if cfg!(target_arch = "x86_64") {
+        "x86_64-unknown-linux-gnu"
+    } else {
+        "aarch64-unknown-linux-gnu"
+    }
 }
 
 fn env_flag(name: &str, default: bool) -> bool {

--- a/crates/preloop-cli/src/server_install.rs
+++ b/crates/preloop-cli/src/server_install.rs
@@ -45,7 +45,7 @@ pub(crate) enum ServerCommand {
 
 #[derive(Debug, Args)]
 pub(crate) struct InstallArgs {
-    /// Address to bind. Defaults to the engine default (0.0.0.0:9090); on
+    /// Address to bind. Defaults to the engine default (127.0.0.1:9090); on
     /// Linux the port is published through socket activation.
     #[arg(long, value_name = "ADDR")]
     listen: Option<SocketAddr>,
@@ -487,7 +487,7 @@ fn readwrite_paths(exe: &Path, home: &Path, user: bool) -> String {
 fn render_systemd_socket(listen: Option<SocketAddr>) -> String {
     let addr = listen
         .map(|addr| addr.to_string())
-        .unwrap_or_else(|| "9090".to_owned());
+        .unwrap_or_else(|| "127.0.0.1:9090".to_owned());
     format!(
         r#"[Unit]
 Description=Preloop HTTP control-plane socket
@@ -1086,8 +1086,8 @@ mod tests {
     }
 
     #[test]
-    fn systemd_socket_defaults_to_9090_and_honors_listen() {
-        assert!(render_systemd_socket(None).contains("ListenStream=9090"));
+    fn systemd_socket_defaults_to_loopback_and_honors_listen() {
+        assert!(render_systemd_socket(None).contains("ListenStream=127.0.0.1:9090"));
         let custom: SocketAddr = "127.0.0.1:8080".parse().unwrap();
         let unit = render_systemd_socket(Some(custom));
         assert!(unit.contains("ListenStream=127.0.0.1:8080"));

--- a/crates/preloop-cli/src/update.rs
+++ b/crates/preloop-cli/src/update.rs
@@ -101,6 +101,17 @@ pub(crate) async fn run(args: UpdateArgs) -> anyhow::Result<()> {
     .await?;
     verify_checksum(&client, selected.archive, selected.checksum, &archive_path).await?;
 
+    // macOS installs run workflows inside Linux VMs: refresh the bundled
+    // Linux runner before replacing the CLI, so a successful update never
+    // leaves a runner from an older release behind. A release missing the
+    // asset is a warning, not a failure — the engine's startup message
+    // explains the consequence.
+    #[cfg(target_os = "macos")]
+    match update_linux_runner_bundle(&client, &release).await {
+        Ok(()) => println!("installed Linux runner bundle"),
+        Err(error) => println!("warning: Linux runner bundle not updated: {error:#}"),
+    }
+
     let staged_binary = temp_dir.path().join(binary_name());
     extract_binary(&archive_path, &staged_binary)?;
     let executable = std::env::current_exe().context("locate running preloop executable")?;
@@ -109,6 +120,43 @@ pub(crate) async fn run(args: UpdateArgs) -> anyhow::Result<()> {
 
     println!("installed preloop {}", remote_version);
     restart_systemd_service().await?;
+    Ok(())
+}
+
+/// Download the release's Linux runner bundle and install it at
+/// `<prefix>/lib/preloop/runner/<triple>/preloop-runner`, the layout
+/// `local_runner_pool_config` discovers.
+#[cfg(target_os = "macos")]
+async fn update_linux_runner_bundle(client: &Client, release: &Release) -> anyhow::Result<()> {
+    let triple = crate::linux_guest_triple();
+    let asset_name = format!("preloop-runner-{triple}");
+    let asset = release
+        .assets
+        .iter()
+        .find(|asset| asset.name == asset_name)
+        .with_context(|| format!("release {} has no {asset_name} asset", release.tag_name))?;
+    let checksum = release
+        .assets
+        .iter()
+        .find(|asset| asset.name == format!("{asset_name}.sha256"));
+    let staging = tempfile::tempdir().context("create runner bundle staging directory")?;
+    let bundle_path = staging.path().join(&asset.name);
+    download(client, &asset.browser_download_url, &bundle_path).await?;
+    verify_checksum(client, asset, checksum, &bundle_path).await?;
+
+    let executable = std::env::current_exe().context("locate running preloop executable")?;
+    let prefix = executable
+        .parent()
+        .and_then(|dir| dir.parent())
+        .context("expected install layout <prefix>/bin/preloop")?;
+    let destination_dir = prefix.join("lib/preloop/runner").join(triple);
+    std::fs::create_dir_all(&destination_dir)
+        .with_context(|| format!("create {}", destination_dir.display()))?;
+    let destination = destination_dir.join("preloop-runner");
+    tokio::fs::copy(&bundle_path, &destination)
+        .await
+        .with_context(|| format!("install {}", destination.display()))?;
+    set_executable_permissions(&destination)?;
     Ok(())
 }
 

--- a/crates/preloop-orchestrator/src/lib.rs
+++ b/crates/preloop-orchestrator/src/lib.rs
@@ -116,41 +116,45 @@ fn runner_volumes(
 ///
 /// Reuses the same shell routine the golden bake used — it is pure
 /// `curl | tar` plus an atomic temp-dir publish, so it runs identically on
-/// the host. Skips when the external is already present, so a concurrent
-/// engine start or an operator-provided directory is left untouched.
+/// the host. Skips the download when the external is already present, so a
+/// concurrent engine start or an operator-provided directory keeps its
+/// contents. Permissions are still normalized on every call: the download is
+/// what gets skipped, not the repair, or a host that published its externals
+/// before the guest runner went non-root would stay broken forever.
 fn ensure_host_externals(config: &RunnerPoolConfig) -> Result<(), OrchestratorError> {
     let externals = config.externals_dir.join("externals");
-    if externals.join("node24").join("bin").join("node").is_file() {
-        return Ok(());
-    }
-    std::fs::create_dir_all(&externals).map_err(|error| {
-        OrchestratorError::Config(format!(
-            "failed to create externals directory {}: {error}",
-            externals.display()
-        ))
-    })?;
-    for command in node_externals_at(config.externals_dir.to_string_lossy().as_ref()) {
-        let status = std::process::Command::new("sh")
-            .arg("-c")
-            .arg(&command[2])
-            .status()
-            .map_err(|error| {
-                OrchestratorError::Config(format!(
-                    "failed to spawn host externals install: {error}"
-                ))
-            })?;
-        if !status.success() {
-            return Err(OrchestratorError::Config(
-                "host node externals install failed; \
-                 check network egress to nodejs.org"
-                    .to_owned(),
-            ));
+    if !externals.join("node24").join("bin").join("node").is_file() {
+        std::fs::create_dir_all(&externals).map_err(|error| {
+            OrchestratorError::Config(format!(
+                "failed to create externals directory {}: {error}",
+                externals.display()
+            ))
+        })?;
+        for command in node_externals_at(config.externals_dir.to_string_lossy().as_ref()) {
+            let status = std::process::Command::new("sh")
+                .arg("-c")
+                .arg(&command[2])
+                .status()
+                .map_err(|error| {
+                    OrchestratorError::Config(format!(
+                        "failed to spawn host externals install: {error}"
+                    ))
+                })?;
+            if !status.success() {
+                return Err(OrchestratorError::Config(
+                    "host node externals install failed; \
+                     check network egress to nodejs.org"
+                        .to_owned(),
+                ));
+            }
         }
+        info!(
+            path = %externals.display(),
+            "Node externals installed on host; mounting into runners"
+        );
     }
-    info!(
-        path = %externals.display(),
-        "Node externals installed on host; mounting into runners"
-    );
+    // Repair directories published before the guest runner went non-root.
+    relax_externals_permissions(&externals);
     // Artifact-based machines reach node through the baked symlink
     // `<root>/externals -> /opt/preloop/bin/externals` (the packed launcher
     // has no IRQ headroom for a third virtiofs mount), so the runner bundle
@@ -189,8 +193,65 @@ fn ensure_host_externals(config: &RunnerPoolConfig) -> Result<(), OrchestratorEr
             ),
         }
     }
+    // `cp -a` preserves the source mode, so the bundle copy needs the same
+    // repair as the host directory.
+    relax_externals_permissions(&bundle_externals);
     Ok(())
 }
+
+/// Make published Node externals traversable by the unprivileged guest account.
+///
+/// `mktemp -d` publishes 0700 and `cp -a` preserves it. That was invisible
+/// while the guest runner ran as root; it now drops to uid 1001
+/// (`as_runner_user`), which cannot traverse a 0700 directory owned by
+/// another uid. The runner probes the interpreter with `is_file()`, and
+/// EACCES is indistinguishable from absent there — so every JS action dies
+/// with "bundled node24 is missing" while the binary sits right there,
+/// readable, one directory down.
+///
+/// Only the group/other read+execute bits are added: enough to run the
+/// interpreter, never enough to modify it. Best-effort — a bundle inside a
+/// root-owned release directory is the deploy step's responsibility, and a
+/// failure here must not stop the pool from starting.
+#[cfg(unix)]
+fn relax_externals_permissions(externals: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    const TRAVERSABLE: u32 = 0o055;
+
+    let Ok(entries) = std::fs::read_dir(externals) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(metadata) = std::fs::metadata(&path) else {
+            continue;
+        };
+        if !metadata.is_dir() {
+            continue;
+        }
+        let mode = metadata.permissions().mode();
+        if mode & TRAVERSABLE == TRAVERSABLE {
+            continue;
+        }
+        match std::fs::set_permissions(&path, std::fs::Permissions::from_mode(mode | TRAVERSABLE)) {
+            Ok(()) => info!(
+                path = %path.display(),
+                "Relaxed node externals permissions for the non-root guest runner"
+            ),
+            Err(error) => warn!(
+                path = %path.display(),
+                %error,
+                "Could not relax node externals permissions; \
+                 JS actions will fail as the non-root guest user"
+            ),
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn relax_externals_permissions(_externals: &Path) {}
+
 async fn download_prebaked_golden(payload: &Path) -> bool {
     let default_url = format!(
         "https://github.com/preloopdev/preloop/releases/download/v{}/preloop-ubuntu-24.04-{}",
@@ -457,10 +518,12 @@ fn node_externals_at(runner_root: &str) -> Vec<Vec<String>> {
                NAME=$1; VERSION=$2; \
                DEST=$RUNNER_EXTERNALS/$NAME; \
                if [ -f \"$DEST/bin/node\" ]; then \
+                 chmod 755 \"$DEST\"; \
                  echo \"$NAME already present, skipping\"; continue; \
                fi; \
                echo \"Installing $NAME $VERSION into golden...\"; \
                TEMP=$(mktemp -d \"$RUNNER_EXTERNALS/.$NAME.XXXXXX\") && \
+                chmod 755 \"$TEMP\" && \
                 ARCH=$(uname -m); \
                 if [ \"$ARCH\" = \"aarch64\" ] || [ \"$ARCH\" = \"arm64\" ]; then NODE_ARCH=linux-arm64; else NODE_ARCH=linux-x64; fi; \
                 curl -fsSL \"https://nodejs.org/dist/$VERSION/node-$VERSION-$NODE_ARCH.tar.gz\" | \
@@ -2947,6 +3010,101 @@ chmod +x "$destination/bin/node"
         assert!(status.success());
         assert!(root.join("externals/node20/bin/node").is_file());
         assert!(root.join("externals/node24/bin/node").is_file());
+    }
+
+    /// The guest runner drops to uid 1001, so a 0700 `node24/` hides a
+    /// perfectly good interpreter behind EACCES and every JS action fails
+    /// with "bundled node24 is missing". `mktemp -d` publishes exactly that
+    /// mode, so the publish step has to widen it.
+    #[test]
+    fn published_node_externals_are_traversable_by_other_users() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path();
+        let bin = root.join("stub-bin");
+        std::fs::create_dir_all(&bin).unwrap();
+
+        let curl = bin.join("curl");
+        std::fs::write(&curl, "#!/bin/sh\nprintf archive\n").unwrap();
+        std::fs::set_permissions(&curl, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let tar = bin.join("tar");
+        std::fs::write(
+            &tar,
+            r#"#!/bin/sh
+input=$(cat)
+[ "$input" = archive ] || exit 41
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = -C ]; then
+    shift
+    destination=$1
+  fi
+  shift
+done
+mkdir -p "$destination/bin"
+printf '#!/bin/sh\nexit 0\n' > "$destination/bin/node"
+chmod +x "$destination/bin/node"
+"#,
+        )
+        .unwrap();
+        std::fs::set_permissions(&tar, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let command = node_externals_at(root.to_str().unwrap()).pop().unwrap();
+        let status = Command::new(&command[0])
+            .args(&command[1..])
+            .env(
+                "PATH",
+                format!(
+                    "{}:{}",
+                    bin.display(),
+                    std::env::var("PATH").unwrap_or_default()
+                ),
+            )
+            .status()
+            .unwrap();
+        assert!(status.success());
+
+        for name in ["node20", "node24"] {
+            let mode = std::fs::metadata(root.join("externals").join(name))
+                .unwrap()
+                .permissions()
+                .mode();
+            assert_eq!(
+                mode & 0o055,
+                0o055,
+                "{name} must stay traversable for the non-root guest runner (mode {mode:o})"
+            );
+        }
+    }
+
+    /// Externals published before the non-root switch are already on disk at
+    /// 0700, and the installer skips directories that already carry a node
+    /// binary — so start-up has to repair them in place or the host never
+    /// recovers without manual intervention.
+    #[test]
+    fn existing_externals_are_repaired_in_place() {
+        let directory = tempfile::tempdir().unwrap();
+        let externals = directory.path().join("externals");
+        let node24 = externals.join("node24").join("bin");
+        std::fs::create_dir_all(&node24).unwrap();
+        std::fs::write(node24.join("node"), "#!/bin/sh\nexit 0\n").unwrap();
+        std::fs::set_permissions(
+            externals.join("node24"),
+            std::fs::Permissions::from_mode(0o700),
+        )
+        .unwrap();
+
+        relax_externals_permissions(&externals);
+
+        let mode = std::fs::metadata(externals.join("node24"))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o055, 0o055, "0700 externals must be repaired");
+        assert_eq!(
+            mode & 0o022,
+            0,
+            "repair must not grant write access to other users"
+        );
     }
 
     #[test]

--- a/crates/preloop-runner-server/src/bootstrap.rs
+++ b/crates/preloop-runner-server/src/bootstrap.rs
@@ -418,7 +418,19 @@ pub async fn serve(config: ServerConfig) -> anyhow::Result<()> {
                                         .serve_connection_with_upgrades(io, service)
                                         .await
                                     {
-                                        warn!(%error, "Unix socket HTTP connection failed");
+                                        // Clients routinely drop the socket after
+                                        // their request (the CLI's own readiness
+                                        // probe included); a failed final
+                                        // write-shutdown is teardown noise, not a
+                                        // protocol failure.
+                                        let is_shutdown = error
+                                            .downcast_ref::<hyper::Error>()
+                                            .is_some_and(|e| e.is_shutdown());
+                                        if is_shutdown {
+                                            debug!(%error, "Unix socket connection closed");
+                                        } else {
+                                            warn!(%error, "Unix socket HTTP connection failed");
+                                        }
                                     }
                                 });
                             }

--- a/crates/preloop-runner-server/src/config.rs
+++ b/crates/preloop-runner-server/src/config.rs
@@ -37,6 +37,11 @@ pub struct GitHubConfig {
     /// policy. Also the credential for the `--via pat` setup path.
     #[serde(default)]
     pub pat: Option<String>,
+    /// Shared secret for `X-Hub-Signature-256` webhook verification.
+    /// Written by the App-manifest setup flow, which receives it from
+    /// GitHub. Env: `PRELOOP_WEBHOOK_SECRET`.
+    #[serde(default)]
+    pub webhook_secret: Option<String>,
     /// GitHub server URL exposed to workflows as `github.server_url` /
     /// `GITHUB_SERVER_URL`. Defaults to `https://github.com`; point it at a
     /// GHES-style host when the engine fronts one. Env: `PRELOOP_GITHUB_SERVER_URL`.
@@ -75,6 +80,7 @@ impl std::fmt::Debug for GitHubConfig {
             .field("app_pem", &redacted(self.app_pem.is_some()))
             .field("mint_failure", &self.mint_failure)
             .field("pat", &redacted(self.pat.is_some()))
+            .field("webhook_secret", &redacted(self.webhook_secret.is_some()))
             .finish()
     }
 }
@@ -347,6 +353,7 @@ mod tests {
                 ),
                 mint_failure: Some("pat".into()),
                 pat: Some("ghp_secret".into()),
+                webhook_secret: None,
                 server_url: None,
                 api_url: None,
                 graphql_url: None,

--- a/crates/preloop-runner-server/src/github.rs
+++ b/crates/preloop-runner-server/src/github.rs
@@ -1243,6 +1243,8 @@ pub(crate) async fn github_callback(
     #[derive(Deserialize)]
     struct AppManifestConversion {
         id: u64,
+        #[serde(default)]
+        slug: Option<String>,
         pem: String,
         webhook_secret: Option<String>,
     }
@@ -1263,6 +1265,10 @@ pub(crate) async fn github_callback(
         "GitHub App credentials received"
     );
 
+    let install = credentials
+        .slug
+        .as_ref()
+        .map(|slug| format!("https://github.com/apps/{slug}/installations/new"));
     let credentials_html = format!(
         r#"<!DOCTYPE html>
 <html>
@@ -1275,18 +1281,29 @@ pub(crate) async fn github_callback(
     <p><strong>Webhook Secret:</strong> {}</p>
     <p><strong>Private Key PEM:</strong></p>
     <pre style="background: #f6f8fa; padding: 16px; border-radius: 6px; overflow-x: auto;">{}</pre>
-    <p>To use this App, configure your local environment and restart `preloop`:</p>
+    <p>Save the key to a file, then hand both to the engine and restart it:</p>
     <pre style="background: #f6f8fa; padding: 16px; border-radius: 6px;">
+preloop setup github --via app --app-id {} --pem-file ./app.pem
 export PRELOOP_WEBHOOK_SECRET="{}"
-export PRELOOP_GITHUB_APP_ID="{}"
     </pre>
+    <p>{}</p>
+    <p>On the machine running the engine, <code>preloop setup github --via app</code>
+       does all of this without copying anything out of a browser.</p>
 </body>
 </html>"#,
         credentials.id,
         credentials.webhook_secret.as_deref().unwrap_or("none"),
         credentials.pem,
+        credentials.id,
         credentials.webhook_secret.as_deref().unwrap_or("none"),
-        credentials.id
+        install
+            .as_ref()
+            .map(|url| format!(
+                r#"Then install it on your repositories: <a href="{url}">{url}</a>"#
+            ))
+            .unwrap_or_else(|| {
+                "Then install it on your repositories from the App's settings page.".to_owned()
+            }),
     );
 
     Ok(axum::response::Html(credentials_html))

--- a/crates/preloop-runner-server/src/github_app.rs
+++ b/crates/preloop-runner-server/src/github_app.rs
@@ -901,6 +901,61 @@ async fn verify_app_config_at(
     Ok(granted)
 }
 
+/// Point an existing App's webhook at `url` with `secret`.
+///
+/// Creating a second App just to change a URL is the alternative, and it
+/// leaves the first one installed and minting tokens — so a deployment that
+/// starts on loopback and later gains a public address updates the App it
+/// already has. Authenticates with the App JWT, the only credential
+/// `/app/hook/config` accepts.
+///
+/// GitHub exposes no `active` flag on this endpoint: an App created with
+/// `hook_attributes.active = false` keeps that checkbox until it is flipped
+/// in the App's settings. The caller is expected to say so.
+pub async fn set_app_webhook_config(
+    app_id: &str,
+    pem: &str,
+    url: &str,
+    secret: &str,
+) -> anyhow::Result<()> {
+    set_app_webhook_config_at(&api_base(), app_id, pem, url, secret).await
+}
+
+/// [`set_app_webhook_config`] against an explicit API base.
+async fn set_app_webhook_config_at(
+    api_base: &str,
+    app_id: &str,
+    pem: &str,
+    url: &str,
+    secret: &str,
+) -> anyhow::Result<()> {
+    let creds = credentials_for(app_id, pem)?;
+    let app_jwt = sign_app_jwt(&creds.app_id, &creds.private_key)?;
+    let response = crate::shared_http::CLIENT
+        .patch(format!("{api_base}/app/hook/config"))
+        .bearer_auth(&app_jwt)
+        .header("Accept", "application/vnd.github+json")
+        .header("User-Agent", "preloop")
+        .json(&serde_json::json!({
+            "url": url,
+            "content_type": "json",
+            "secret": secret,
+            "insecure_ssl": "0",
+        }))
+        .send()
+        .await
+        .context("calling GitHub to update the App webhook configuration")?;
+    let status = response.status();
+    if status.is_success() {
+        return Ok(());
+    }
+    let body = response.text().await.unwrap_or_default();
+    anyhow::bail!(
+        "GitHub refused the webhook update ({status}): {}",
+        body.trim()
+    )
+}
+
 /// Build credentials from raw config pieces (no environment involved).
 fn credentials_for(app_id: &str, pem: &str) -> anyhow::Result<GitHubAppCredentials> {
     let private_key = parse_private_key(pem).context("parsing the GitHub App private key")?;
@@ -1412,6 +1467,98 @@ mod tests {
             .to_pkcs1_pem(rsa::pkcs1::LineEnding::LF)
             .expect("encode PKCS#1")
             .to_string()
+    }
+
+    /// `/app/hook/config` is JWT-only and silently ignores anything else, so
+    /// the request must carry the App JWT — not an installation token — and
+    /// the exact url/secret pair the caller asked for.
+    #[tokio::test]
+    async fn webhook_config_update_sends_app_jwt_and_payload() {
+        use axum::{Json, Router};
+
+        let seen: Arc<std::sync::Mutex<Option<(String, serde_json::Value)>>> =
+            Arc::new(std::sync::Mutex::new(None));
+        let stub = Router::new().route(
+            "/app/hook/config",
+            axum::routing::patch({
+                let seen = Arc::clone(&seen);
+                move |headers: axum::http::HeaderMap, Json(body): Json<serde_json::Value>| {
+                    let seen = Arc::clone(&seen);
+                    async move {
+                        let auth = headers
+                            .get("authorization")
+                            .and_then(|value| value.to_str().ok())
+                            .unwrap_or_default()
+                            .to_owned();
+                        *seen.lock().expect("stub state") = Some((auth, body));
+                        Json(json!({"url": "https://ci.example.com/api/v1/github/webhooks"}))
+                    }
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind stub API");
+        let api_base = format!("http://{}", listener.local_addr().expect("stub address"));
+        tokio::spawn(async move { axum::serve(listener, stub).await.expect("serve stub API") });
+
+        set_app_webhook_config_at(
+            &api_base,
+            "424",
+            &test_pem(),
+            "https://ci.example.com/api/v1/github/webhooks",
+            "hook-secret",
+        )
+        .await
+        .expect("update the webhook configuration");
+
+        let seen = seen.lock().expect("stub state");
+        let (auth, body) = seen.as_ref().expect("the stub received the PATCH");
+        let token = auth
+            .strip_prefix("Bearer ")
+            .expect("bearer authorization header");
+        // An App JWT is RS256 with the App id as `iss`; an installation token
+        // would be an opaque `ghs_…` string and GitHub would reject it.
+        let claims = token.split('.').nth(1).expect("jwt payload segment");
+        let claims: serde_json::Value = serde_json::from_slice(
+            &base64::Engine::decode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, claims)
+                .expect("decode jwt claims"),
+        )
+        .expect("parse jwt claims");
+        assert_eq!(claims["iss"], "424", "the App id signs the request");
+        assert_eq!(body["url"], "https://ci.example.com/api/v1/github/webhooks");
+        assert_eq!(body["secret"], "hook-secret");
+        assert_eq!(body["content_type"], "json");
+        assert_eq!(body["insecure_ssl"], "0", "TLS verification stays on");
+    }
+
+    /// A refusal must surface GitHub's reason instead of reporting success.
+    #[tokio::test]
+    async fn webhook_config_update_reports_refusal() {
+        use axum::Router;
+
+        let stub = Router::new().route(
+            "/app/hook/config",
+            axum::routing::patch(|| async {
+                (
+                    axum::http::StatusCode::UNPROCESSABLE_ENTITY,
+                    "url is invalid",
+                )
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind stub API");
+        let api_base = format!("http://{}", listener.local_addr().expect("stub address"));
+        tokio::spawn(async move { axum::serve(listener, stub).await.expect("serve stub API") });
+
+        let error = set_app_webhook_config_at(&api_base, "424", &test_pem(), "nope", "s")
+            .await
+            .expect_err("an invalid url must fail");
+        assert!(
+            format!("{error:#}").contains("url is invalid"),
+            "GitHub's reason must reach the operator: {error:#}"
+        );
     }
 
     /// A contents-only probe token makes the pull-requests, actions and issues

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -5888,7 +5888,7 @@ async fn try_req(app: &Router, method: Method, uri: &str, body: Value) -> (Statu
             header::AUTHORIZATION,
             // Strict-by-default registration accepts only the system
             // credential; test servers run with the default token.
-            &format!("RemoteAuth {DEFAULT_PRELOOP_SYSTEM_TOKEN}"),
+            format!("RemoteAuth {DEFAULT_PRELOOP_SYSTEM_TOKEN}"),
         );
     }
     let request = if body.is_null() {
@@ -8477,6 +8477,109 @@ async fn pat_only_config_supplies_job_github_token() {
         .expect("job message carries a GitHub token variable");
     assert_eq!(token.value.as_deref(), Some("github_pat_testvalue"));
     assert_eq!(token.is_secret, Some(true));
+}
+
+/// The App-manifest setup flow receives the webhook secret from GitHub and
+/// stores it in the config file. Before that key existed the secret lived
+/// only in `PRELOOP_WEBHOOK_SECRET`, so a configured engine still rejected
+/// every signed delivery until the operator re-exported it by hand.
+#[tokio::test]
+async fn config_webhook_secret_verifies_signed_deliveries() {
+    let temp = tempfile::tempdir().unwrap();
+    let ws_dir = temp.path().join("workspace");
+    tokio::fs::create_dir_all(ws_dir.join(".github/workflows"))
+        .await
+        .unwrap();
+    tokio::fs::write(
+        ws_dir.join(".github/workflows/build.yml"),
+        "on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n",
+    )
+    .await
+    .unwrap();
+    let config_path = temp.path().join("config.toml");
+    std::fs::write(
+        &config_path,
+        "[github]\nwebhook_secret = \"from-config-file\"\n",
+    )
+    .unwrap();
+
+    // Explicit config path rather than `PRELOOP_CONFIG`, which would race
+    // every other test building an `AppState`.
+    let mut state = AppState::new_with_config(temp.path().to_path_buf(), config_path)
+        .await
+        .unwrap();
+    assert_eq!(
+        state.webhook_secret.as_deref(),
+        Some("from-config-file"),
+        "the config file is a valid source for the webhook secret"
+    );
+    state.local_workspace = Some(ws_dir);
+    let app = app(state.clone(), CancellationToken::new());
+
+    let payload = serde_json::json!({
+        "ref": "refs/heads/main",
+        "before": "0000000000000000000000000000000000000000",
+        "after": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+        "repository": {"full_name": "owner/repo", "default_branch": "main"},
+        "commits": [{
+            "id": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+            "added": ["src/main.rs"],
+            "modified": [],
+            "removed": []
+        }],
+    });
+    let body = serde_json::to_vec(&payload).unwrap();
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+    let mut mac = Hmac::<Sha256>::new_from_slice(b"from-config-file").unwrap();
+    mac.update(&body);
+    let signature = format!(
+        "sha256={}",
+        mac.finalize()
+            .into_bytes()
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>()
+    );
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/v1/github/webhooks")
+                .header("x-github-event", "push")
+                .header("x-github-delivery", "config-secret-delivery")
+                .header("x-hub-signature-256", &signature)
+                .header("content-type", "application/json")
+                .body(Body::from(body.clone()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "a correctly signed delivery is accepted with only the config file configured"
+    );
+
+    // The same body under a different secret must still be rejected —
+    // otherwise the check is decorative.
+    let forged = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/v1/github/webhooks")
+                .header("x-github-event", "push")
+                .header("x-github-delivery", "forged-delivery")
+                .header("x-hub-signature-256", "sha256=deadbeef")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(forged.status(), StatusCode::UNAUTHORIZED);
 }
 
 #[tokio::test]

--- a/crates/preloop-runner-server/src/state.rs
+++ b/crates/preloop-runner-server/src/state.rs
@@ -583,7 +583,6 @@ impl AppState {
         // Capture queue length before moving `inner` into the Mutex so the
         // `queue_depth` atomic is set to the recovered ready-queue size.
         let recovered_queue_len = inner.queue.len();
-        let webhook_secret = std::env::var("PRELOOP_WEBHOOK_SECRET").ok();
         let local_workspace = std::env::var("PRELOOP_LOCAL_WORKSPACE")
             .ok()
             .map(PathBuf::from);
@@ -605,6 +604,19 @@ impl AppState {
         let credential = crate::config::load_credential_secrets()?;
         crate::config::merge_secret_stores(&mut config, credential);
         let github_app = crate::github_app::load_from(&config)?;
+        // Env wins over the config file, matching every other credential
+        // here. An empty value in either source counts as unset: a blank
+        // export must not disable signature verification silently.
+        let webhook_secret = env::var("PRELOOP_WEBHOOK_SECRET")
+            .ok()
+            .filter(|secret| !secret.is_empty())
+            .or_else(|| {
+                config
+                    .github
+                    .webhook_secret
+                    .clone()
+                    .filter(|secret| !secret.is_empty())
+            });
         // Env wins over the config file, matching every other `PRELOOP_GITHUB_*`
         // override. An empty value in either source counts as unset.
         let github_pat = env::var("PRELOOP_GITHUB_TOKEN")

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -118,8 +118,15 @@ Configure GitHub credentials.
 | Flag | Description |
 |---|---|
 | `--via <app\|pat>` | Credential type. `app` (recommended) or `pat` (fine-grained PAT, for orgs that gate App installations) |
+| *(no App flags)* | With `--via app` and no `--app-id`/`--pem-file`, creates the App through GitHub's manifest flow in your browser and stores everything |
 | `--app-id <ID>` | GitHub App ID (with `--via app`) |
 | `--pem-file <PATH>` | Path to the GitHub App private key PEM (with `--via app`) |
+| `--org <NAME>` | Create the App under an organization instead of your account |
+| `--public-url <URL>` | Enable webhook delivery to this URL. On an already-configured App, updates its webhook instead of creating a second App |
+| `--app-name <NAME>` | Name of the created App (default `preloop-local`; GitHub requires global uniqueness) |
+| `--port <N>` | Pin the loopback port GitHub redirects back to (default: a free port) |
+| `--no-browser` | Print the URL instead of opening a browser |
+| `--webhook-secret <SECRET>` | Store a webhook secret you created yourself (the App flow gets one from GitHub automatically) |
 | `--token <TOKEN>` | PAT to store (with `--via pat`). Falls back to `PRELOOP_GITHUB_PAT`, then an interactive prompt |
 | `--repo <REPOS>` | Repository to verify the credential against (repeatable) |
 | `--workspace <WORKSPACE>` | Workspace whose workflows should drive the permission checklist |
@@ -140,7 +147,7 @@ Install/remove the control plane as a supervised service.
 
 | Flag | Description |
 |---|---|
-| `--listen <ADDR>` | Bind address. Defaults to the engine default (`0.0.0.0:9090`); on Linux the port publishes through socket activation |
+| `--listen <ADDR>` | Bind address. Defaults to the engine default (`127.0.0.1:9090`); on Linux the port publishes through socket activation |
 | `--public-url <URL>` | Externally reachable base URL (webhook + Checks links). GitHub must reach it — public DNS + reverse proxy, or a tunnel (cloudflared, ngrok, Tailscale Funnel) |
 | `--github-app-id <ID>` | GitHub App id |
 | `--github-app-key <PATH>` | GitHub App private key PEM path |
@@ -251,7 +258,7 @@ preloop plan -f ci.yml --json                    # inspect the expanded DAG
 preloop status                                   # run list
 preloop cancel <run_id>                          # stop a run
 preloop secret set GH_TOKEN --repo owner/repo    # repo-scoped secret
-preloop setup github --via app --app-id 123 --pem-file key.pem
+preloop setup github --via app                   # creates the App in a browser
 preloop doctor --repo owner/repo
 preloop server install --public-url https://ci.example.com --webhook-secret "$(openssl rand -hex 32)"
 preloop serve                                    # foreground engine + pool

--- a/docs/github-app-webhook.md
+++ b/docs/github-app-webhook.md
@@ -196,7 +196,7 @@ GitHub App token minting is strictly all-or-nothing:
 The microVM orchestrator requires the cross-compiled Linux ARM64 runner binary at `target/aarch64-unknown-linux-gnu/debug/preloop-runner`:
 - Running `cargo clean` removes this binary, causing `preloop serve` to log:
   ```text
-  WARN preloop: local runner pool unavailable... error=Linux runner bundle unavailable
+  WARN preloop: local runner provisioning unavailable; jobs queue until a runner is available error=Linux runner bundle unavailable...
   ```
 - **Recovery**: Rebuild the runner bundle with `cargo zigbuild` before starting the server:
   ```sh

--- a/docs/github-tokens.md
+++ b/docs/github-tokens.md
@@ -86,7 +86,26 @@ setup: Preloop always supplies *some* `GITHUB_TOKEN` value.
 A GitHub App gives each job a short-lived installation token scoped to the
 repository the run belongs to and to the permissions that job declares.
 
-1. Visit `http://<server>/api/v1/github/register` in a browser. Use the
+On the machine running the engine, one command does the whole thing:
+
+```sh
+preloop setup github --via app          # add --org NAME for an org App
+```
+
+It serves the manifest from a single-use loopback listener, GitHub redirects
+the one-time code back to it, and the App id, private key, and webhook secret
+land in `~/.preloop/config.toml` (mode 0600). Add `--public-url https://…` to
+create the App with webhook delivery enabled; without it webhooks are off,
+since GitHub cannot reach `localhost`. Restart the engine to pick the
+credentials up.
+
+### From a browser, against a remote engine
+
+When the engine already runs somewhere GitHub can reach, the same manifest is
+served by the engine itself. This path *displays* the credentials rather than
+storing them — you copy them to the engine yourself:
+
+1. Visit `https://<server>/api/v1/github/register` in a browser. Use the
    server's final public HTTPS URL if you also want webhook delivery — GitHub
    cannot reach `localhost`, and the manifest only includes webhook settings for
    non-local hosts.
@@ -101,8 +120,8 @@ repository the run belongs to and to the permissions that job declares.
 5. Configure the server and restart it:
 
    ```sh
-   export PRELOOP_GITHUB_APP_ID="123456"
-   export PRELOOP_GITHUB_APP_PEM_FILE="/secure/path/preloop-app.pem"
+   preloop setup github --via app --app-id 123456 --pem-file /secure/path/preloop-app.pem
+   export PRELOOP_WEBHOOK_SECRET="…"   # or set github.webhook_secret in config.toml
    ```
 
 ### Configuration reference

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -51,7 +51,7 @@ access at all** — see option A.
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/preloopdev/preloop/main/install.sh | sh
-preloop setup github          # store GitHub App credentials
+preloop setup github --via app --public-url https://ci.example.com
 ```
 
 Then install it as a supervised service — systemd on Linux, launchd on macOS:
@@ -95,7 +95,7 @@ All configuration is environment variables; CLI flags override them.
 
 | Variable | Default | Meaning |
 |---|---|---|
-| `PRELOOP_LISTEN` | `0.0.0.0:9090` | Bind address. **The default is all interfaces — see §6.** |
+| `PRELOOP_LISTEN` | `127.0.0.1:9090` | Bind address. Loopback by default — expose with `--listen 0.0.0.0:9090` behind a proxy or tunnel (see §6). |
 | `PRELOOP_PUBLIC_URL` | `http://127.0.0.1:<port>` | Externally reachable base URL. Used for `details_url` on check runs |
 | `PRELOOP_HOME` | `$HOME/.preloop` | State directory (database, blobs, cache, credentials) |
 | `PRELOOP_STORE_URL` | SQLite in the state dir | `sqlite://<path>`, a bare path, or `postgres://…?sslmode=require\|verify-full` |
@@ -251,9 +251,11 @@ path exposes job logs.
 
 ## 6. Security: what must not be public
 
-**`PRELOOP_LISTEN` defaults to `0.0.0.0:9090`.** On a host with a public IP that
-publishes the control plane to the internet. Bind loopback or a private address
-and put a proxy in front.
+**`PRELOOP_LISTEN` defaults to `127.0.0.1:9090`**, so a bare `preloop serve` is
+only reachable from the host. To expose the control plane (tunnels reach it via
+`127.0.0.1` anyway), bind a private address or `0.0.0.0` — and put a proxy in
+front. Publishing `0.0.0.0` on a host with a public IP exposes the API to the
+internet with no authentication on the queue path.
 
 **Never publish the whole API surface.** Restrict your proxy or tunnel to
 `/api/v1/github/webhooks`, as every example above does.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -14,7 +14,7 @@ run unmodified.
 
 ## Requirements
 
-- macOS (Apple Silicon) or Linux, 64-bit
+- macOS (Apple Silicon), Windows or Linux, 64-bit
 - [smolvm] for the default VM runner pool (`preloop runner` works without it)
 - A GitHub account for credentials (see below)
 
@@ -30,8 +30,7 @@ curl -fsSL https://raw.githubusercontent.com/preloopdev/preloop/main/install.sh 
 
 - For the full microVM runner pool, enable nested virtualization in
   `.wslconfig` (`[wsl2] nestedVirtualization=true`) so `/dev/kvm` is exposed.
-- Without it, `preloop runner` still works (jobs run as WSL processes); only
-  the VM pool needs KVM.
+- Without it, `preloop runner` still works (jobs run as WSL processes); only the VM pool needs KVM.
 
 ## Quick start
 
@@ -66,26 +65,72 @@ you what you are doing.
 
 ### Option A — GitHub App
 
-App creation is a browser-only step (GitHub has no API for creating user
-apps):
+GitHub has no API for creating an App, but it does accept a *manifest*: a
+form POST that pre-fills the creation page. `preloop setup github --via app`
+uses it, so the only manual step is clicking **Create on GitHub**.
 
-1. Create the app at <https://github.com/settings/apps/new>. You only need a
-   name; leave webhooks off. Note the **App ID** and download the **private
-   key** (PEM). Set the app avatar to `logo.png` from the repo root (GitHub has
-   no API for app avatars — it is a browser-only field on this form).
-2. Install the app on the account(s) whose repos you run:
-   <https://github.com/apps/YOUR-APP/installations/new>. Grant it the repos
-   you want to run — the engine cannot mint tokens for repos outside the
-   installation.
-3. Configure the engine:
+```sh
+preloop setup github --via app
+```
 
-   ```sh
-   preloop setup github --via app --app-id 123456 --pem-file app.pem
-   preloop doctor --repo owner/repo
-   ```
+The command binds a single-use listener on loopback, opens it in your
+browser, and uses it as the manifest's redirect target. You click **Create on
+GitHub**; GitHub redirects back with a one-time code, and the CLI converts it
+into the App id, private key, and webhook secret and writes them to
+`~/.preloop/config.toml` (mode 0600). The browser then lands on the
+installation page — pick the repositories you run, and the CLI reports the
+installation id and exits.
 
-   The engine mints a fresh installation token per job — no long-lived
-   secret sits in the config.
+The private key never leaves the machine: the redirect target is
+`127.0.0.1`, not a hosted page.
+
+| Flag | Effect |
+|---|---|
+| `--org NAME` | Create the App under an organization instead of your account. |
+| `--public-url URL` | Also enable webhook delivery to that URL. Omitted, the App is created with webhooks off — GitHub cannot reach `localhost`. |
+| `--app-name NAME` | App name (GitHub requires global uniqueness). Default `preloop-local`. |
+| `--port N` | Pin the loopback port instead of taking a free one. |
+| `--no-browser` | Print the URL instead of opening a browser (headless/SSH). |
+
+#### What "webhooks off" means
+
+Without `--public-url` the App is created with its webhook inactive, because
+GitHub cannot reach `127.0.0.1`. That only removes GitHub's ability to *call
+you*; everything outbound still works:
+
+| | webhooks off (default) | `--public-url` |
+|---|---|---|
+| What starts a run | you do: `preloop run`, `just submit-ci` | a `push`/`pull_request` on GitHub |
+| Private-repo checkout, `gh`, API steps | works — the App mints a token per job | same |
+| Check runs on the commit | published (outbound to GitHub) | same |
+
+So a laptop setup is a complete CI system you trigger yourself. When you later
+get a reachable address — a tunnel is enough — point the App you already have
+at it:
+
+```sh
+cloudflared tunnel --url http://127.0.0.1:9090      # → https://xxx.trycloudflare.com
+preloop setup github --via app --public-url https://xxx.trycloudflare.com
+```
+
+That updates the existing App's webhook URL and secret through GitHub's API
+(`PATCH /app/hook/config`) instead of creating a second App, and stores the
+secret so deliveries verify. GitHub exposes no API for the webhook **Active**
+checkbox, so an App created without `--public-url` needs that ticked once in
+its settings; the command says so.
+
+Already have an App — or your org blocks manifest creation? Create it by hand
+at <https://github.com/settings/apps/new> (name it, leave webhooks off,
+download the PEM), install it on the accounts whose repos you run at
+<https://github.com/apps/YOUR-APP/installations/new>, then:
+
+```sh
+preloop setup github --via app --app-id 123456 --pem-file app.pem
+preloop doctor --repo owner/repo
+```
+
+Either way the engine mints a fresh installation token per job — no
+long-lived secret sits in the config.
 
 ### Option B — fine-grained PAT
 
@@ -98,6 +143,25 @@ or without `--token` (prompted, hidden input):
 ```sh
 preloop setup github --via pat --repo owner/repo
 ```
+
+Unlike Apps, PATs have no manifest flow — GitHub exposes no API for creating
+one — so this path opens the creation page and waits at a hidden prompt.
+`--no-browser` skips the opening; piping the token in (or setting
+`PRELOOP_GITHUB_PAT`) skips the prompt entirely, so automation is unaffected.
+
+Two things a PAT does not get you:
+
+- **Check runs.** GitHub's checks API only accepts App installation tokens, so
+  a PAT-configured engine records check runs locally instead of publishing
+  them to the commit. Jobs still get the PAT as `GITHUB_TOKEN`, so checkout,
+  `gh`, and API steps work normally.
+- **A webhook secret.** The App flow receives one from GitHub; here you create
+  the webhook yourself (repository → Settings → Webhooks, pointed at
+  `<public-url>/api/v1/github/webhooks`) and store its secret:
+
+  ```sh
+  preloop setup github --via pat --webhook-secret "$(openssl rand -hex 32)"
+  ```
 
 Create the PAT at <https://github.com/settings/personal-access-tokens/new>
 with **Repository access → Only select repositories** and the permissions the
@@ -188,6 +252,7 @@ app_id = "123456"
 app_pem = "-----BEGIN RSA PRIVATE KEY-----…"
 mint_failure = "pat"        # "local" | "error" | "pat"
 pat = "github_pat_…"
+webhook_secret = "…"        # written by `setup github --via app`
 
 [secrets]
 DOCKERHUB_TOKEN = "…"
@@ -197,9 +262,10 @@ AWS_CREDS = "…"
 ```
 
 Environment variables override the file per field (`PRELOOP_GITHUB_APP_ID`,
-`PRELOOP_GITHUB_APP_PEM`, `PRELOOP_GITHUB_PAT`, …) — the file is the durable store,
-env vars are the escape hatch for containers. GitHub credential changes are
-picked up on engine restart; secrets changes apply live.
+`PRELOOP_GITHUB_APP_PEM`, `PRELOOP_GITHUB_PAT`, `PRELOOP_WEBHOOK_SECRET`, …) —
+the file is the durable store, env vars are the escape hatch for containers.
+GitHub credential changes are picked up on engine restart; secrets changes
+apply live.
 
 ## doctor
 

--- a/docs/vm-images.md
+++ b/docs/vm-images.md
@@ -60,6 +60,22 @@ preloop build-golden \
 - When the pool warms a golden, it also pre-pulls the `container:` /
   `services:` images declared by the current workspace's workflows.
 
+## Where the engine finds the runner bundle
+
+The pool needs a **Linux** `preloop-runner` (the runner executes inside a
+Linux microVM, so the host's own binary never qualifies). The engine searches,
+in order:
+
+1. `PRELOOP_RUNNER_BUNDLE` — a directory containing a Linux `preloop-runner`.
+2. `<prefix>/lib/preloop/runner/<triple>/` — where `install.sh` and
+   `preloop update` place the bundle on macOS releases (the host's Linux
+   triple first, then any installed triple).
+3. `target/<triple>/{debug,release}` under a development build.
+
+On Linux hosts the installed `preloop-runner` is already a Linux binary, so no
+bundle is needed. Missing on macOS, the engine logs a startup warning and
+submitted jobs queue until a runner exists.
+
 ## Version tracking (`versions.toml`)
 
 Every pinned version lives in one place — `versions.toml` — and is consumed

--- a/install.sh
+++ b/install.sh
@@ -140,6 +140,48 @@ install_from_release() {
             say "installed $BIN_DIR/$bin"
         fi
     done
+
+    # macOS installs run workflows inside Linux microVMs, so the release must
+    # also carry the Linux runner binary. Install it where the engine looks:
+    # <prefix>/lib/preloop/runner/<linux-triple>/preloop-runner. Best effort —
+    # a release without the asset still installs; the engine's startup warning
+    # explains the consequence.
+    if [ "$os" = "darwin" ]; then
+        case "$arch" in
+            x86_64) linux_triple="x86_64-unknown-linux-gnu" ;;
+            aarch64) linux_triple="aarch64-unknown-linux-gnu" ;;
+        esac
+        bundle="preloop-runner-$linux_triple"
+        # Trailing quote anchors the match so the `.sha256` asset's URL
+        # (same prefix, longer name) cannot be captured instead.
+        bundle_url="$(printf '%s' "$json" | sed -n "s/.*\"browser_download_url\":[[:space:]]*\"\([^\"]*\/$bundle\)\".*/\1/p" | head -1)"
+        if [ -n "$bundle_url" ]; then
+            say "downloading $bundle..."
+            local bundle_archive="$tmp/$bundle"
+            if command -v curl >/dev/null 2>&1; then
+                curl -fsSL "$bundle_url" -o "$bundle_archive" 2>/dev/null || bundle_archive=""
+            elif command -v wget >/dev/null 2>&1; then
+                wget -q "$bundle_url" -O "$bundle_archive" 2>/dev/null || bundle_archive=""
+            fi
+            if [ -n "${bundle_archive:-}" ] && [ -s "$bundle_archive" ]; then
+                expected="$(curl -fsSL "${bundle_url}.sha256" 2>/dev/null | awk '{print $1}')"
+                if [ -n "$expected" ]; then
+                    if command -v sha256sum >/dev/null 2>&1; then
+                        actual="$(sha256sum "$bundle_archive" | awk '{print $1}')"
+                    else
+                        actual="$(shasum -a 256 "$bundle_archive" | awk '{print $1}')"
+                    fi
+                    [ "$actual" = "$expected" ] || die "runner bundle checksum mismatch — refusing to install"
+                fi
+                runner_dir="$PREFIX/lib/preloop/runner/$linux_triple"
+                mkdir -p "$runner_dir"
+                install -m 0755 "$bundle_archive" "$runner_dir/preloop-runner"
+                say "installed $runner_dir/preloop-runner"
+            else
+                say "runner bundle download failed — workflows will not execute locally (see docs/vm-images.md)"
+            fi
+        fi
+    fi
     [ -x "$BIN_DIR/preloop" ] || return 1
     return 0
 }
@@ -179,6 +221,11 @@ else
     ZIGBUILD=0
 fi
 
+case "$arch" in
+    x86_64) RUNNER_TARGET="x86_64-unknown-linux-gnu" ;;
+    aarch64) RUNNER_TARGET="aarch64-unknown-linux-gnu" ;;
+esac
+
 PRELOOP_SRC="${PRELOOP_SRC:-$HOME/.preloop-src}"
 REPO_URL="${PRELOOP_REPO:-https://github.com/preloopdev/preloop.git}"
 mkdir -p "$PRELOOP_SRC"
@@ -196,10 +243,16 @@ say "building preloop (release)..."
 cargo build --release -p preloop-cli -p preloop-runner-server 2>/dev/null \
     || cargo build --release -p preloop-cli -p aksh-runner-server
 if [ "$ZIGBUILD" = 1 ] && command -v cargo-zigbuild >/dev/null 2>&1; then
-    say "cross-compiling the Linux microVM runner (aarch64)..."
-    cargo zigbuild --release -p preloop-runner --target aarch64-unknown-linux-gnu 2>/dev/null || \
-        cargo zigbuild --release -p aksh-runner --target aarch64-unknown-linux-gnu 2>/dev/null || \
+    say "cross-compiling the Linux microVM runner ($RUNNER_TARGET)..."
+    cargo zigbuild --release -p preloop-runner --target "$RUNNER_TARGET" 2>/dev/null || \
+        cargo zigbuild --release -p aksh-runner --target "$RUNNER_TARGET" 2>/dev/null || \
         say "runner build failed — host CLI works, but microVM jobs need it (see docs/setup.md)"
+    if [ -x "$PRELOOP_SRC/target/$RUNNER_TARGET/release/preloop-runner" ]; then
+        runner_dir="$PREFIX/lib/preloop/runner/$RUNNER_TARGET"
+        mkdir -p "$runner_dir"
+        install -m 0755 "$PRELOOP_SRC/target/$RUNNER_TARGET/release/preloop-runner" "$runner_dir/preloop-runner"
+        say "installed $runner_dir/preloop-runner (source build)"
+    fi
 else
     say "skipping microVM runner cross-build (no zig/cargo-zigbuild)"
 fi


### PR DESCRIPTION
## What

Every dogfood CI job had been failing ~1s after start with:

```
##[error]bundled node24 is missing at /var/lib/preloop-runner/externals/node24/bin/node;
         system Node is v22 but the action requires Node 24
```

## Root cause

`mktemp -d` publishes **0700** and `cp -a` preserves it. That was invisible while the guest runner ran as root; since `ecce6a44` it drops to uid **1001** (`as_runner_user` → `setpriv --reuid 1001`), which cannot traverse a 0700 directory owned by uid 1000.

| path | mode | owner |
|---|---|---|
| `externals/` | 755 | 1000 |
| `externals/node24/` | **700** | 1000 |
| `externals/node24/bin/node` | 755 | 1000 |

The runner probes the interpreter with `is_file()`, where EACCES is indistinguishable from absent, so it fell back to system Node v22 and failed the Node 24 requirement. `checkout`, `rust-toolchain`, `rust-cache` and `upload-artifact` are all JS actions, so every job died at action preparation while the interpreter sat there readable one directory down.

## Fix

- Publish the directory 0755 at the source (`node_externals_at`).
- Normalize permissions on every engine start so hosts that published externals before the non-root switch repair themselves. Only group/other read+execute are added, never write.
- The *download* is what gets skipped when externals already exist — not the repair, or a broken host stays broken forever.

## Verification

Remediated the live host and re-ran a real Node-24 action on the dogfood server:

| | before | after |
|---|---|---|
| `actions/checkout` | `bundled node24 is missing` — never ran | **executes**: runs git, `node action exited with code 1` |

Locally: `cargo fmt --check` clean, clippy clean, 37 lib + 10 integration tests pass, including two new ones (`published_node_externals_are_traversable_by_other_users`, `existing_externals_are_repaired_in_place`).

## Also in this branch

- `fix(conformance)` — replay server opts into permissive registration (goldens carry real GitHub-issued tokens this control plane can never mint; the escape `docs/roadmap.md` reserves). Unblocks all 39 `just conform` scenarios.
- `feat(webhook)` — read `github.webhook_secret` from the config file, env still wins.
- `feat(cli)` — GitHub App manifest registration flow.
- `feat(release)` — ship the Linux runner bundle with every release.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes runner pool failures by making Node 24 externals readable to the non-root guest runner. Also adds one-command GitHub App setup, verifies webhooks from config, and ships a Linux `preloop-runner` bundle with each release.

- **Bug Fixes**
  - Publish `externals/node24` as 0755 and repair permissions on every engine start; skips download but still fixes perms so the guest runner can traverse and find Node 24.
  - Conformance: replay server uses permissive registration to unblock all scenarios.
  - Demote Unix-socket write-shutdown noise to debug.

- **New Features**
  - `preloop setup github --via app` creates the GitHub App via the manifest flow and stores App ID, PEM, and webhook secret; supports `--org`, `--public-url`, `--app-name`, `--port`, `--no-browser`.
  - Server reads `github.webhook_secret` from config (env still wins) and verifies signed webhooks.
  - Releases include a Linux `preloop-runner` bundle; `install.sh` and `preloop update` place it under `<prefix>/lib/preloop/runner/<triple>/`.
  - Default listen is `127.0.0.1:9090` (was `0.0.0.0:9090`); expose intentionally with `--listen 0.0.0.0:9090`.

<sup>Written for commit 3cc6c3ea9e233c2f8f71714986db528754985010. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

