### PR TITLE
release: v0.29.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "preloop-cli"
-version = "0.29.1"
+version = "0.29.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/preloop-cli/Cargo.toml
+++ b/crates/preloop-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "preloop-cli"
-version = "0.29.1"
+version = "0.29.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Version bump for the v0.29.2 release (tag already pushed).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `preloop-cli` to v0.29.2 to publish the release and keep `Cargo.toml` and `Cargo.lock` in sync.

<sup>Written for commit 23a02cae684d03c90ca28a0c6d5c570c4a8f9197. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/97?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

