### PR TITLE
fix(update): warn when PATH shadows the installed smolvm [skip ci]

### DIFF
--- a/crates/preloop-cli/src/update.rs
+++ b/crates/preloop-cli/src/update.rs
@@ -302,6 +302,18 @@ async fn ensure_smolvm(client: &Client) -> anyhow::Result<()> {
     verify_checksum(client, archive_asset, checksum_asset, &archive_path).await?;
     install_smolvm_from_archive(&archive_path, version, &install)?;
     println!("installed smolvm {version}");
+    // The install lands in `~/.local/bin`; if PATH still resolves another
+    // binary, the engine keeps failing and the user is left confused about
+    // why the update did not help. Say so explicitly.
+    if !smolvm_supports_mount_socket().await {
+        println!(
+            "warning: installed smolvm {version} to {}, but `smolvm` on PATH still \
+             resolves to a binary without --mount-socket; the engine resolves `smolvm` \
+             from PATH, so make sure {} comes first",
+            install.prefix.display(),
+            install.bin_dir.display()
+        );
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Post-install re-probe in `preloop update`: if PATH still resolves a smolvm without --mount-socket after installing to ~/.local/bin, warn explicitly instead of silently reporting the update as fixing the engine.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`preloop update` now re-checks PATH after installing `smolvm` to `~/.local/bin` and warns if PATH still resolves a different `smolvm` without `--mount-socket`. This avoids false “fixed” messages and guides users to put `~/.local/bin` first in PATH.

<sup>Written for commit 3ef39ccd5c86bdd0011c2a0e977b317160944633. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

