### PR TITLE
release: v0.29.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "preloop-cli"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/preloop-cli/Cargo.toml
+++ b/crates/preloop-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "preloop-cli"
-version = "0.29.2"
+version = "0.29.3"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Version bump for v0.29.3 (tag already pushed): includes the smolvm auto-install (re-probe + symlink fixes).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `preloop-cli` v0.29.3. Includes `smolvm` auto-install reliability fixes.

- **Bug Fixes**
  - Re-probe after auto-install to verify `smolvm` is available.
  - Fix symlink creation and resolution to avoid broken links.

<sup>Written for commit daccf3cd6b0e69bc52d4dfdeb2a8b2f2a337a05c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

