### PR TITLE
Fix packed golden recovery and live debug socket routing

### DIFF
--- a/.runner-watch/state.json
+++ b/.runner-watch/state.json
@@ -3,5 +3,5 @@
   "phase": "conformed",
   "from": "v2.322.0",
   "to": "v2.335.1",
-  "updated_at_unix": 1786147669
+  "updated_at_unix": 1786304468
 }

--- a/crates/preloop-gha-protocol/src/azdo/job.rs
+++ b/crates/preloop-gha-protocol/src/azdo/job.rs
@@ -693,7 +693,11 @@ pub struct TaskReference {
     pub name: Option<String>,
     #[serde(rename = "path", skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
-    #[serde(rename = "version", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "version",
+        alias = "ref",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub version: Option<String>,
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub reference_type: Option<String>,
@@ -713,6 +717,51 @@ pub struct ActionsDownloadInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn remote_action_reference_survives_wire_roundtrip() {
+        let step = TaskStep {
+            id: uuid::Uuid::nil(),
+            name: Some("Upload artifact".to_owned()),
+            context_name: None,
+            display_name: None,
+            display_name_token: None,
+            condition: None,
+            script: None,
+            reference: Some(TaskReference {
+                id: None,
+                name: Some("actions/upload-artifact".to_owned()),
+                path: None,
+                version: Some("v4".to_owned()),
+                reference_type: None,
+            }),
+            inputs: BTreeMap::new(),
+            env: BTreeMap::new(),
+            continue_on_error: None,
+            working_directory: None,
+            timeout_in_minutes: None,
+        };
+
+        let wire = serde_json::to_value(&step).unwrap();
+        assert_eq!(wire["reference"]["ref"], "v4");
+        assert!(
+            wire["reference"].get("version").is_none(),
+            "wire format must use the canonical `ref` field"
+        );
+
+        let decoded: TaskStep = serde_json::from_value(wire).unwrap();
+        assert_eq!(
+            decoded
+                .reference
+                .as_ref()
+                .and_then(|r| r.version.as_deref()),
+            Some("v4")
+        );
+
+        let reserialized = serde_json::to_value(&decoded).unwrap();
+        assert_eq!(reserialized["reference"]["ref"], "v4");
+        assert!(reserialized["reference"].get("version").is_none());
+    }
 
     /// The snapshot credential must never appear in Debug output of the job
     /// message DTO — `AgentJobRequestMessage` derives Debug and embeds

--- a/crates/preloop-orchestrator/src/lib.rs
+++ b/crates/preloop-orchestrator/src/lib.rs
@@ -645,8 +645,13 @@ fn node_externals_at(runner_root: &str) -> Vec<Vec<String>> {
 pub fn base_install_script() -> String {
     format!(
         "apt-get update -qq && \
-         DEBIAN_FRONTEND=noninteractive \
-         apt-get install -y -qq --no-install-recommends {base_packages_pinned} \
+         (echo \"### install hosted apt baseline\" >&2 && \
+          if ! DEBIAN_FRONTEND=noninteractive \
+             apt-get install -y -qq --no-install-recommends {base_packages_pinned}; then \
+            echo \"WARNING: exact hosted apt pins are unavailable; falling back to archive versions\" >&2; \
+            DEBIAN_FRONTEND=noninteractive \
+            apt-get install -y -qq --no-install-recommends {BASE_PACKAGES}; \
+          fi) \
          && printf '{LOOPBACK_HOSTS}' > /etc/hosts && \
          printf '127.0.0.1 %s\\n' \"$(hostname)\" >> /etc/hosts && \
          printf 'APT::Get::Assume-Yes \"true\";\\n' > /etc/apt/apt.conf.d/90assumeyes && \
@@ -657,19 +662,33 @@ pub fn base_install_script() -> String {
            *) LFS_ARCH=arm64; DOCKER_STATIC_ARCH=aarch64; DOCKER_PLUGIN_ARCH=arm64; COMPOSE_ARCH=aarch64 ;; \
          esac; \
          (echo \"### install hosted compiler matrix\" >&2 && \
-          DEBIAN_FRONTEND=noninteractive \
-          apt-get install -y -qq --no-install-recommends {compiler_packages} && \
-          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-{CLANG_DEFAULT_VERSION} 100 && \
-          update-alternatives --install /usr/bin/clang clang /usr/bin/clang-{CLANG_DEFAULT_VERSION} 100 && \
-          update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-{CLANG_DEFAULT_VERSION} 100 && \
-          update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-{CLANG_DEFAULT_VERSION} 100 && \
-          update-alternatives --install /usr/bin/run-clang-tidy run-clang-tidy /usr/bin/run-clang-tidy-{CLANG_DEFAULT_VERSION} 100 && \
-          clang-16 --version | head -1 | grep -F '{CLANG_16_VERSION}' && \
-          clang-17 --version | head -1 | grep -F '{CLANG_17_VERSION}' && \
-          clang-18 --version | head -1 | grep -F '{CLANG_18_VERSION}' && \
-          test \"$(gcc-12 -dumpfullversion)\" = '{GCC_12_VERSION}' && \
-          test \"$(gcc-13 -dumpfullversion)\" = '{GCC_13_VERSION}' && \
-          test \"$(gcc-14 -dumpfullversion)\" = '{GCC_14_VERSION}') && \
+          if DEBIAN_FRONTEND=noninteractive \
+             apt-get install -y -qq --no-install-recommends {compiler_packages}; then \
+            for version in {CLANG_VERSIONS}; do \
+              if [ -x /usr/bin/clang++-$version ]; then \
+                update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-$version 100 || true; \
+              fi; \
+              if [ -x /usr/bin/clang-$version ]; then \
+                update-alternatives --install /usr/bin/clang clang /usr/bin/clang-$version 100 || true; \
+              fi; \
+              if [ -x /usr/bin/clang-format-$version ]; then \
+                update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-$version 100 || true; \
+              fi; \
+              if [ -x /usr/bin/clang-tidy-$version ]; then \
+                update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-$version 100 || true; \
+              fi; \
+              if [ -x /usr/bin/run-clang-tidy-$version ]; then \
+                update-alternatives --install /usr/bin/run-clang-tidy run-clang-tidy /usr/bin/run-clang-tidy-$version 100 || true; \
+              fi; \
+            done; \
+          else \
+            echo \"WARNING: hosted compiler matrix is not available in this Ubuntu archive; continuing with the base compiler toolchain\" >&2; \
+            for package in clang clang-format clang-tidy gcc g++ gfortran; do \
+              DEBIAN_FRONTEND=noninteractive \
+              apt-get install -y -qq --no-install-recommends \"$package\" || \
+                echo \"compiler package unavailable: $package\" >&2; \
+            done; \
+          fi) && \
          (echo \"### fetch system node v{BASE_NODE_VERSION}\" >&2 && \
           curl -fsSL \"https://nodejs.org/dist/v{BASE_NODE_VERSION}/node-v{BASE_NODE_VERSION}-linux-$NODE_ARCH.tar.gz\" \
             | tar -xz --strip-components=1 -C /usr/local) && \

--- a/crates/preloop-orchestrator/src/lib.rs
+++ b/crates/preloop-orchestrator/src/lib.rs
@@ -2695,9 +2695,39 @@ async fn provision_runner<P: VmProvider + 'static>(
     environment_base: &str,
     toolchains: &[ToolchainLayer],
 ) -> Result<Vec<String>, OrchestratorError> {
-    if let Some(golden) = golden {
+    let forked_golden = match golden {
+        Some(golden) => match provider.fork(golden, name).await {
+            Ok(()) => Some(golden),
+            Err(error)
+                if config.use_packed_artifact
+                    && golden.as_str() == format!("{}-golden", config.name_prefix) =>
+            {
+                warn!(
+                    machine = name.as_str(),
+                    golden = golden.as_str(),
+                    %error,
+                    "packed golden fork failed; creating runner directly from packed artifact"
+                );
+                // A failed fork can leave a partial clone behind. Best-effort
+                // cleanup makes the direct create safe; if cleanup itself is
+                // still racing SmolVM state, create returns the actionable
+                // error and the slot supervisor retries normally.
+                if let Err(cleanup) = provider.delete(name).await {
+                    debug!(
+                        machine = name.as_str(),
+                        %cleanup,
+                        "failed fork left no removable clone"
+                    );
+                }
+                None
+            }
+            Err(error) => return Err(error.into()),
+        },
+        None => None,
+    };
+
+    if let Some(golden) = forked_golden {
         // Fork from the already-booted golden VM instant CoW clone.
-        provider.fork(golden, name).await?;
         // The PACKED golden carries its bake inside the artifact's flattened
         // rootfs, which forks inherit through the storage chain — so the apt
         // baseline is already there. Environment goldens are different:
@@ -3078,6 +3108,7 @@ mod lifecycle_tests {
     struct TestProvider {
         machines: Mutex<HashMap<String, MachineState>>,
         events: Mutex<Vec<String>>,
+        fail_fork: bool,
         fail_start: bool,
         fail_install: bool,
         fail_configure: bool,
@@ -3099,6 +3130,7 @@ mod lifecycle_tests {
             Self {
                 machines: Mutex::new(HashMap::new()),
                 events: Mutex::new(Vec::new()),
+                fail_fork: false,
                 fail_start,
                 fail_install,
                 fail_configure,
@@ -3111,6 +3143,11 @@ mod lifecycle_tests {
 
         fn announcing_busy(mut self) -> Self {
             self.announce_busy = true;
+            self
+        }
+
+        fn failing_fork(mut self) -> Self {
+            self.fail_fork = true;
             self
         }
 
@@ -3515,7 +3552,14 @@ chmod +x "$destination/bin/node"
             self.start(name).await
         }
 
-        async fn fork(&self, _golden: &MachineName, clone: &MachineName) -> Result<(), VmError> {
+        async fn fork(&self, golden: &MachineName, clone: &MachineName) -> Result<(), VmError> {
+            self.events
+                .lock()
+                .await
+                .push(format!("fork:{}:{}", golden.as_str(), clone.as_str()));
+            if self.fail_fork {
+                return Err(test_error("fork-failure"));
+            }
             self.events
                 .lock()
                 .await
@@ -3713,6 +3757,92 @@ chmod +x "$destination/bin/node"
         config.use_fork = true;
         config.use_packed_artifact = true;
         config
+    }
+
+    /// A retained SmolVM checkpoint can become unusable after the packed
+    /// golden has been prepared. Retrying the same fork forever starves every
+    /// queued job, while creating a runner directly from the same packed
+    /// artifact remains valid.
+    #[tokio::test]
+    async fn packed_golden_fork_failure_falls_back_to_direct_creation() {
+        let provider =
+            Arc::new(TestProvider::new(false, false, false, false, false).failing_fork());
+        let config = packed_fork_config();
+        let golden = MachineName::new("lifecycle-test-golden").unwrap();
+        let name = MachineName::new("lifecycle-test-0-4").unwrap();
+
+        provision_runner(
+            &provider,
+            &config,
+            &name,
+            Some(&golden),
+            &Arc::new(KeyPool::new()),
+            &config.base_image,
+            &[],
+        )
+        .await
+        .expect("a broken packed-golden fork falls back to direct creation");
+
+        let events = provider.events().await;
+        let fork = format!("fork:{}:{}", golden.as_str(), name.as_str());
+        let delete = format!("delete:{}", name.as_str());
+        let create = format!("create:{}", name.as_str());
+        let start = format!("start:{}", name.as_str());
+        let fork_index = events
+            .iter()
+            .position(|event| event == &fork)
+            .expect("fork was attempted first");
+        let delete_index = events
+            .iter()
+            .position(|event| event == &delete)
+            .expect("a partial clone was cleaned up");
+        let create_index = events
+            .iter()
+            .position(|event| event == &create)
+            .expect("runner was created from the packed artifact");
+        let start_index = events
+            .iter()
+            .position(|event| event == &start)
+            .expect("directly created runner was started");
+        assert!(
+            fork_index < delete_index && delete_index < create_index && create_index < start_index,
+            "fallback order must be fork, cleanup, create, start: {events:?}"
+        );
+        assert!(provider.has_machine(&name).await);
+    }
+
+    /// An environment-specific golden may represent a different `runs-on`
+    /// image from the packed artifact. Falling back there would run the job
+    /// on the wrong operating system, so only the default packed golden may
+    /// take the direct-create recovery path.
+    #[tokio::test]
+    async fn environment_golden_fork_failure_does_not_change_the_job_image() {
+        let provider =
+            Arc::new(TestProvider::new(false, false, false, false, false).failing_fork());
+        let config = packed_fork_config();
+        let golden = MachineName::new("lifecycle-test-golden-environment").unwrap();
+        let name = MachineName::new("lifecycle-test-0-5").unwrap();
+
+        let error = provision_runner(
+            &provider,
+            &config,
+            &name,
+            Some(&golden),
+            &Arc::new(KeyPool::new()),
+            "mirror.gcr.io/library/ubuntu:22.04",
+            &[],
+        )
+        .await
+        .expect_err("an environment-golden fork failure must propagate");
+
+        assert!(error.to_string().contains("fork-failure"));
+        let events = provider.events().await;
+        assert!(
+            !events
+                .iter()
+                .any(|event| event == &format!("create:{}", name.as_str())),
+            "must not replace an environment-specific image with the default pack: {events:?}"
+        );
     }
 
     /// A published pack can be older than the workspace's toolchain pin, so a

--- a/crates/preloop-orchestrator/tests/golden_fidelity.rs
+++ b/crates/preloop-orchestrator/tests/golden_fidelity.rs
@@ -201,6 +201,21 @@ fn install_script_pins_docker_repo_and_cargo_shear() {
     }
 }
 
+#[test]
+fn install_script_survives_archive_pin_drift() {
+    let script = base_install_script();
+    assert!(
+        script.contains("exact hosted apt pins are unavailable")
+            && script.contains("apt-get install -y -qq --no-install-recommends git curl wget"),
+        "the baseline must fall back to packages currently available in the archive"
+    );
+    assert!(
+        script.contains("hosted compiler matrix is not available")
+            && script.contains("for package in clang clang-format clang-tidy gcc g++ gfortran"),
+        "missing historical compiler packages must not strand the runner pool"
+    );
+}
+
 /// Hosted images keep their apt package lists, so real workflows install
 /// system packages with a bare `sudo apt-get install <pkg>` and no preceding
 /// `apt-get update` — uv's musl cell (`apt-get install musl-tools`) is one.

--- a/crates/preloop-runner-server/src/auth.rs
+++ b/crates/preloop-runner-server/src/auth.rs
@@ -317,6 +317,29 @@ pub(crate) fn effective_claim_runner(
     }
 }
 
+/// Worker-authenticated debug operations that the trusted runner performs
+/// through the guest's mounted control socket.
+fn is_worker_debug_route(method: &axum::http::Method, path: &str) -> bool {
+    use axum::http::Method;
+
+    if method == Method::POST {
+        if matches!(
+            path,
+            "/api/v1/debug/worker-token" | "/api/v1/debug/sessions"
+        ) {
+            return true;
+        }
+        return debug_session_member(path, "/close");
+    }
+    method == Method::GET && debug_session_member(path, "/verdict")
+}
+
+fn debug_session_member(path: &str, suffix: &str) -> bool {
+    path.strip_prefix("/api/v1/debug/sessions/")
+        .and_then(|rest| rest.strip_suffix(suffix))
+        .is_some_and(|session_id| !session_id.is_empty() && !session_id.contains('/'))
+}
+
 /// Socket-surface guard: the mounted control socket is reachable from inside
 /// every runner VM, so anything not part of the runner/broker protocol is
 /// refused there. Native management and GUI API prefixes have no legitimate
@@ -327,6 +350,7 @@ pub(crate) async fn runner_surface_only(
 ) -> Result<Response, ApiError> {
     const DENIED_PREFIXES: &[&str] = &["/internal/", "/runs/"];
     let path = request.uri().path();
+    let worker_debug_route = is_worker_debug_route(request.method(), path);
     let denied = DENIED_PREFIXES
         .iter()
         .any(|prefix| path.starts_with(prefix))
@@ -336,7 +360,10 @@ pub(crate) async fn runner_surface_only(
         // control socket. `/replay/*` is the other half of the same class:
         // the in-VM runner uploads its step logs and summaries to the signed
         // blob URLs its own Twirp handlers minted. Every other native prefix
-        // stays off the guest surface: workflow code is untrusted.
+        // stays off the guest surface except the worker half of live debugging:
+        // token exchange, session open, verdict poll, and close. Those routes
+        // authenticate a single active job and deliberately exclude the
+        // controller's list/read/verdict APIs.
         // `/api/v3/*` mints runner-management JWTs (`RunnerManage` scope) for
         // the GitHub-compatible registration flow — an engine-facing service
         // that untrusted workflow code must never reach through the mounted
@@ -346,7 +373,9 @@ pub(crate) async fn runner_surface_only(
         // system credential, which workflow code never holds — so the carve
         // out cannot be used to mint anything.
         || (path.starts_with("/api/v3/") && path != "/api/v3/actions/runner-registration")
-        || (path.starts_with("/api/v1/") && !path.starts_with("/api/v1/actions/"));
+        || (path.starts_with("/api/v1/")
+            && !path.starts_with("/api/v1/actions/")
+            && !worker_debug_route);
     if denied {
         return Err(ApiError::not_found(format!(
             "{path} not available on this endpoint"

--- a/crates/preloop-runner-server/src/github.rs
+++ b/crates/preloop-runner-server/src/github.rs
@@ -21,6 +21,33 @@ use crate::{
 };
 use preloop_gha_protocol::{AnnotationLevel, JobId, NdjsonEvent, RunId, WorkflowSubmission};
 
+/// Comma-separated workflow filenames or `.github/workflows/...` paths that
+/// GitHub, rather than Preloop, owns. This keeps release and artifact-publish
+/// workflows out of the local webhook dispatcher while leaving the default
+/// generic forges-only behavior unchanged.
+const GITHUB_OWNED_WORKFLOWS_ENV: &str = "PRELOOP_GITHUB_SKIP_WORKFLOWS";
+
+fn configured_github_owned_workflows() -> BTreeSet<String> {
+    std::env::var(GITHUB_OWNED_WORKFLOWS_ENV)
+        .ok()
+        .map(|value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .filter(|entry| !entry.is_empty())
+                .map(|entry| entry.trim_start_matches("./").to_owned())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn is_github_owned_workflow(filename: &str, configured: &BTreeSet<String>) -> bool {
+    let path = format!(".github/workflows/{filename}");
+    configured
+        .iter()
+        .any(|entry| entry == filename || entry == &path)
+}
+
 /// Webhook push event payload.
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub(crate) struct PushEvent {
@@ -920,6 +947,7 @@ async fn process_github_webhook(
     };
 
     let mut triggered_runs = Vec::new();
+    let github_owned_workflows = configured_github_owned_workflows();
 
     // 5. For each effective event, fetch workflows and submit runs
     for effective in &effective_events {
@@ -990,6 +1018,14 @@ async fn process_github_webhook(
         }
 
         for (filename, content) in workflows {
+            if is_github_owned_workflow(&filename, &github_owned_workflows) {
+                info!(
+                    workflow = %filename,
+                    event = %effective.event,
+                    "Skipping workflow owned by GitHub"
+                );
+                continue;
+            }
             // Scheduler reconciliation runs once for the complete workflow
             // inventory above so deletions are observable too.
             // Validate filter keys / conflicting filters (warning only — submit_run_inner
@@ -1368,6 +1404,24 @@ mod tests {
         format!("sha256={hex}")
     }
 
+    #[test]
+    fn github_owned_workflow_filter_matches_filename_or_path() {
+        let configured =
+            "release.yml, .github/workflows/release-golden.yml, ./release-linux-runner.yml"
+                .split(',')
+                .map(str::trim)
+                .map(|entry| entry.trim_start_matches("./").to_owned())
+                .collect();
+
+        assert!(is_github_owned_workflow("release.yml", &configured));
+        assert!(is_github_owned_workflow("release-golden.yml", &configured));
+        assert!(is_github_owned_workflow(
+            "release-linux-runner.yml",
+            &configured
+        ));
+        assert!(!is_github_owned_workflow("ci.yml", &configured));
+    }
+
     /// The signed push payload GitHub would deliver for `owner/repo`.
     fn signed_push_payload() -> (Vec<u8>, String) {
         let payload = serde_json::json!({
@@ -1592,6 +1646,36 @@ mod tests {
             "a delivery that triggered no workflow is still processed"
         );
         assert!(inner.runs.is_empty());
+    }
+
+    /// A deployment can leave release and artifact workflows to GitHub while
+    /// Preloop owns the ordinary CI workflows in the same repository.
+    #[tokio::test]
+    async fn webhook_skips_github_owned_workflows() {
+        let _env = crate::state::GITHUB_ENV_LOCK.lock().await;
+        std::env::set_var(GITHUB_OWNED_WORKFLOWS_ENV, "release.yml");
+
+        let temp = tempfile::tempdir().unwrap();
+        let ws_dir = temp.path().join("ws");
+        std::fs::create_dir_all(ws_dir.join(".github/workflows")).unwrap();
+        std::fs::write(
+            ws_dir.join(".github/workflows/release.yml"),
+            "on: push\njobs:\n  release:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo release\n",
+        )
+        .unwrap();
+        let fixture = WebhookFixture::with_workspace(&temp, ws_dir).await;
+
+        assert_eq!(
+            fixture.post("delivery-github-owned", Some("push")).await,
+            StatusCode::OK
+        );
+        let inner = fixture.state.inner.lock().await;
+        assert!(inner.runs.is_empty());
+        assert!(inner.webhook_deliveries.iter().any(|(id, state)| {
+            id == "delivery-github-owned" && matches!(state, WebhookDeliveryState::Completed(_))
+        }));
+
+        std::env::remove_var(GITHUB_OWNED_WORKFLOWS_ENV);
     }
 
     /// Issue 2: a delivery whose processing future is cancelled (client

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -6686,10 +6686,17 @@ fn open_session_body(run_id: RunId, agent_job_id: uuid::Uuid) -> Value {
 async fn the_debug_worker_token_exchange_is_narrowly_authorized() {
     let temp = tempfile::tempdir().unwrap();
     let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
-    let app = app(state.clone(), CancellationToken::new());
+    let native_app = app(state.clone(), CancellationToken::new());
+    // This is the path used by a runner inside a microVM. The worker reaches
+    // the server through the mounted control socket, so the socket guard must
+    // admit the narrowly authenticated worker routes without exposing the
+    // controller's native debug surface.
+    let app = native_app
+        .clone()
+        .layer(middleware::from_fn(crate::auth::runner_surface_only));
 
     let accepted = request_json(
-        &app,
+        &native_app,
         Method::POST,
         "/api/v1/runs",
         json!({
@@ -6774,7 +6781,7 @@ async fn the_debug_worker_token_exchange_is_narrowly_authorized() {
         &worker_token,
     )
     .await;
-    assert!(opened["session_id"].as_str().is_some());
+    let session_id = opened["session_id"].as_str().expect("opened session");
     assert_eq!(
         request_status_with_bearer(
             &app,
@@ -6787,6 +6794,25 @@ async fn the_debug_worker_token_exchange_is_narrowly_authorized() {
         StatusCode::UNAUTHORIZED,
         "the exchange must not have widened what a runtime token can reach"
     );
+
+    let polled = request_json_with_bearer(
+        &app,
+        Method::GET,
+        &format!("/api/v1/debug/sessions/{session_id}/verdict?wait=0"),
+        Value::Null,
+        &worker_token,
+    )
+    .await;
+    assert!(polled["verdict"].is_null());
+    let closed = request_json_with_bearer(
+        &app,
+        Method::POST,
+        &format!("/api/v1/debug/sessions/{session_id}/close"),
+        json!({ "state": "aborted" }),
+        &worker_token,
+    )
+    .await;
+    assert_eq!(closed["ok"], true);
 
     // One shot. A step that later finds `ACTIONS_RUNTIME_TOKEN` in its
     // environment has nothing left to spend.
@@ -13968,6 +13994,9 @@ async fn control_socket_surface_denies_native_and_test_apis() {
     for denied in [
         "/api/v1/secrets/owner/repo",
         "/api/v1/runs",
+        "/api/v1/debug/sessions",
+        "/api/v1/debug/sessions/dbg-controller-only",
+        "/api/v1/agent/debug/sessions/dbg-controller-only/events",
         "/internal/test/jobs/complete",
     ] {
         let response = socket_app
@@ -13988,6 +14017,24 @@ async fn control_socket_surface_denies_native_and_test_apis() {
             "socket must not expose {denied}"
         );
     }
+    let controller_verdict = socket_app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/v1/debug/sessions/dbg-controller-only/verdict")
+                .header(header::AUTHORIZATION, "Bearer preloop-system-token")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"verdict":"abort"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        controller_verdict.status(),
+        StatusCode::NOT_FOUND,
+        "the controller verdict API must stay off the guest socket"
+    );
 
     // The v3 registration-token endpoints mint runner-management JWTs
     // (`RunnerManage` scope) for the GitHub-compatible registration flow.

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -5041,6 +5041,131 @@ jobs:
 }
 
 #[tokio::test]
+async fn cancel_run_completes_github_checks_and_terminal_metadata() {
+    let check_completions = Arc::new(std::sync::Mutex::new(Vec::<serde_json::Value>::new()));
+    let mock_app = Router::new().route(
+        "/repos/owner/repo/check-runs/:id",
+        axum::routing::patch({
+            let check_completions = check_completions.clone();
+            move |Path(id): Path<u64>, body: axum::extract::Json<Value>| {
+                let check_completions = check_completions.clone();
+                async move {
+                    check_completions.lock().unwrap().push(body.0);
+                    Json(json!({"id": id}))
+                }
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        axum::serve(listener, mock_app).await.unwrap();
+    });
+
+    let _env = crate::state::GITHUB_ENV_LOCK.lock().await;
+    std::env::set_var("PRELOOP_GITHUB_API_URL", format!("http://127.0.0.1:{port}"));
+    std::env::set_var("PRELOOP_GITHUB_TOKEN", "cancel-test-token");
+
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let accepted = request_json(
+        &app,
+        Method::POST,
+        "/api/v1/runs",
+        json!({
+            "workflow_yaml": "on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n",
+            "event": "push",
+            "repository": "owner/repo"
+        }),
+    )
+    .await;
+    let run_id: RunId = accepted["run_id"].as_str().unwrap().parse().unwrap();
+    {
+        let mut inner = state.inner.lock().await;
+        let run = inner.runs.get_mut(&run_id).unwrap();
+        run.job_check_run_ids.insert(JobId("build".into()), 7);
+    }
+
+    let cancelled = request_json(
+        &app,
+        Method::POST,
+        &format!("/api/v1/runs/{run_id}/cancel"),
+        Value::Null,
+    )
+    .await;
+
+    std::env::remove_var("PRELOOP_GITHUB_API_URL");
+    std::env::remove_var("PRELOOP_GITHUB_TOKEN");
+
+    assert_eq!(cancelled["status"], "cancelled");
+    assert_eq!(cancelled["conclusion"], "cancelled");
+    assert!(
+        cancelled["completed_at"].is_string(),
+        "cancelled run must carry terminal completion metadata"
+    );
+    let completions = check_completions.lock().unwrap();
+    assert_eq!(completions.len(), 1);
+    assert_eq!(completions[0]["status"], "completed");
+    assert_eq!(completions[0]["conclusion"], "cancelled");
+}
+
+#[tokio::test]
+async fn cancel_run_refreshes_runner_pool_queue_metadata() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let first = request_json(
+        &app,
+        Method::POST,
+        "/api/v1/runs",
+        json!({
+            "workflow_yaml": "on: push\njobs:\n  build:\n    runs-on: ubuntu-22.04\n    steps:\n      - run: echo first\n",
+            "event": "push",
+            "repository": "owner/repo"
+        }),
+    )
+    .await;
+    request_json(
+        &app,
+        Method::POST,
+        "/api/v1/runs",
+        json!({
+            "workflow_yaml": "on: push\njobs:\n  build:\n    runs-on: ubuntu-24.04\n    steps:\n      - run: echo second\n",
+            "event": "push",
+            "repository": "owner/repo"
+        }),
+    )
+    .await;
+    assert_eq!(
+        *state.next_job_runs_on.read().unwrap(),
+        vec!["ubuntu-22.04"]
+    );
+    assert_eq!(
+        state.queue_depth.load(std::sync::atomic::Ordering::Acquire),
+        2
+    );
+
+    let cancelled = request_json(
+        &app,
+        Method::POST,
+        &format!("/api/v1/runs/{}/cancel", first["run_id"].as_str().unwrap()),
+        Value::Null,
+    )
+    .await;
+
+    assert_eq!(cancelled["conclusion"], "cancelled");
+    assert_eq!(
+        state.queue_depth.load(std::sync::atomic::Ordering::Acquire),
+        1
+    );
+    assert_eq!(
+        *state.next_job_runs_on.read().unwrap(),
+        vec!["ubuntu-24.04"]
+    );
+}
+
+#[tokio::test]
 async fn message_poll_waits_until_work_is_enqueued() {
     let temp = tempfile::tempdir().unwrap();
     let app = app(

--- a/crates/preloop-runner-server/src/runs.rs
+++ b/crates/preloop-runner-server/src/runs.rs
@@ -1348,6 +1348,7 @@ pub(crate) async fn submit_run_inner(
             .state
             .queue_depth
             .store(inner.queue.len(), std::sync::atomic::Ordering::Release);
+        runtime_scheduling::sync_next_job_labels(&inner, &shared.state.next_job_runs_on);
         let cancel_count = inner.cancellation_queue.len();
         drop(inner);
         // The sweep above only recorded the intent to expand; the subtree build
@@ -2087,14 +2088,40 @@ pub(crate) async fn cancel_run(
     }
     let cancellation_count =
         cancel_run_inner(&mut inner, run_id, None /* no concurrency reason */);
+    let cancelled_jobs = {
+        let run = inner
+            .runs
+            .get_mut(&run_id)
+            .ok_or_else(|| ApiError::not_found("run not found"))?;
+        runtime_scheduling::finalize_run_if_complete(run);
+        run.jobs
+            .iter()
+            .filter(|(_, status)| **status == ExecutionStatus::Cancelled)
+            .map(|(job_id, _)| job_id.clone())
+            .collect::<Vec<_>>()
+    };
     let record = inner
         .runs
         .get(&run_id)
         .cloned()
         .ok_or_else(|| ApiError::not_found("run not found"))?;
+    shared
+        .state
+        .queue_depth
+        .store(inner.queue.len(), std::sync::atomic::Ordering::Release);
+    runtime_scheduling::sync_next_job_labels(&inner, &shared.state.next_job_runs_on);
     drop(inner);
     if cancellation_count > 0 {
         shared.state.message_notify.notify_waiters();
+    }
+    for job_id in cancelled_jobs {
+        crate::github::report_check_run_completed(
+            &shared,
+            run_id,
+            &job_id,
+            ExecutionStatus::Cancelled,
+        )
+        .await;
     }
     shared
         .state

--- a/crates/preloop-runner-server/src/runtime_scheduling.rs
+++ b/crates/preloop-runner-server/src/runtime_scheduling.rs
@@ -2455,6 +2455,7 @@ pub(crate) async fn drain_expansions(shared: &SharedState) -> SchedulingOutcome 
             .state
             .queue_depth
             .store(inner.queue.len(), std::sync::atomic::Ordering::Release);
+        sync_next_job_labels(&inner, &shared.state.next_job_runs_on);
     }
 }
 

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -140,7 +140,7 @@ the [Specula](https://github.com/SpeculaIO/Specula) pipeline (code analysis
 → TLA+ spec generation → validation → bug confirmation) built a TLA+
 specification of the server's scheduling/gate logic from the Rust source,
 repaired it against TLC's strict typing during validation, and hunted bugs
-with real SANY + TLC runs (`experiments/specula-20260804/`).
+with real SANY + TLC runs (`experiments/specula-20260804/`). 
 
 **Six findings, all fixed and reconciled into the current tree** (2026-08-06):
 

--- a/scripts/preloop-e2e-bench.sh
+++ b/scripts/preloop-e2e-bench.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 
 unset all_proxy ALL_PROXY http_proxy https_proxy HTTP_PROXY HTTPS_PROXY \
-      no_proxy NO_PROXY 2>/dev/null || true
+      no_proxy NO_PROXY PRELOOP_RUNNER_URL PRELOOP_CONTROL_UPSTREAM 2>/dev/null || true
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -24,6 +24,7 @@ PRELOOP_BIN="$REPO_ROOT/target/release/preloop-server"
 RUNNER_DIR="${RUNNER_DIR:-$HOME/.cache/actions-runner/current}"
 PRELOOP_PORT="${PRELOOP_PORT:-9090}"
 CLIENT_URL="${CLIENT_URL:-http://127.0.0.1:$PRELOOP_PORT}"
+REGISTRATION_TOKEN="${PRELOOP_SYSTEM_TOKEN:-preloop-system-token}"
 STATE_DIR="$(mktemp -d /tmp/preloop-bench-XXXXXX)"
 LOG="$STATE_DIR/preloop.log"
 PRELOOP_PID=""
@@ -98,7 +99,10 @@ import urllib.request, json
 req = urllib.request.Request(
     '${CLIENT_URL}/api/v3/repos/owner/repo/actions/runners/registration-token',
     data=b'{}',
-    headers={'Content-Type':'application/json','Authorization':'RemoteAuth test'},
+    headers={
+        'Content-Type':'application/json',
+        'Authorization':'RemoteAuth ${REGISTRATION_TOKEN}',
+    },
     method='POST'
 )
 with urllib.request.urlopen(req, timeout=5) as r:


### PR DESCRIPTION
## Summary
- fall back to direct packed-artifact runner creation when the default packed golden cannot fork
- expose only worker-authenticated live-debug routes through the VM control socket
- retain controller and agent API isolation, plus environment-specific image fidelity

## Verification
- `just test-ci`
- forced all-forks-fail concurrent smoke: both jobs succeeded via direct packed creation
- PTY failing workflow: debug-worker token issued, session opened, and the interactive debug prompt displayed



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recovers packed-golden runner forks by falling back to direct creation, hardens base installs against apt drift, restricts the control socket to worker-only live debug, completes cancellation bookkeeping, and preserves action refs across restarts. Adds an opt-out for GitHub-owned workflows in webhook processing.

- **Bug Fixes**
  - `preloop-orchestrator`: On default packed-golden fork failure, clean up any clone and create from the pack; environment-specific goldens still error. Base install falls back when exact apt pins or compiler packages are missing.
  - `preloop-runner-server`: Control socket admits only worker debug routes (token exchange, open, verdict poll, close); controller/agent debug and other APIs stay denied.
  - `preloop-runner-server`: Run cancellation sets terminal status and completed_at, completes GitHub Checks as “cancelled,” and refreshes scheduler (queue depth + next-job labels).
  - `preloop-runner-server`: Webhook dispatcher can skip GitHub-owned workflows via `PRELOOP_GITHUB_SKIP_WORKFLOWS` (by filename or `.github/workflows/...` path).
  - `preloop-gha-protocol`: Preserve action `ref` across wire roundtrips; encode with canonical `ref` and accept it when decoding.

<sup>Written for commit 30fb871672bd1527957772c0afacc7d38d7efc82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



