### PR TITLE
fix(github): handle check run reruns

### DIFF
--- a/crates/preloop-runner-server/src/github.rs
+++ b/crates/preloop-runner-server/src/github.rs
@@ -278,6 +278,93 @@ pub(crate) async fn report_check_run_queued(
     }
 }
 
+/// Move an existing GitHub check run back to the queue after a rerequest.
+pub(crate) async fn report_existing_check_run_queued(
+    shared: &Arc<SharedState>,
+    repo: &str,
+    job_id: &JobId,
+    run_id: RunId,
+    check_run_id: u64,
+) {
+    let token = resolve_check_run_token(shared, repo).await;
+    if let Some(token) = &token {
+        let mut body = serde_json::json!({
+            "status": "queued",
+        });
+        if let Some(url) = run_details_url(run_id) {
+            body["details_url"] = serde_json::json!(url);
+        }
+        let path = format!("check-runs/{check_run_id}");
+        if let Err(error) =
+            send_github_check_request(token, repo, reqwest::Method::PATCH, &path, body).await
+        {
+            warn!(
+                %run_id,
+                %job_id,
+                check_run_id,
+                %error,
+                "Failed to requeue GitHub check run"
+            );
+        }
+    } else {
+        info!(
+            %run_id,
+            %job_id,
+            check_run_id,
+            "Mock requeued GitHub check run"
+        );
+    }
+}
+
+/// Publish queued/completed checks for a native rerun.
+pub(crate) async fn report_check_runs_for_run(
+    shared: &Arc<SharedState>,
+    run_id: RunId,
+    reused_check_run: Option<(JobId, u64)>,
+) {
+    let (repository, sha, jobs) = {
+        let inner = shared.state.inner.lock().await;
+        let Some(run) = inner.runs.get(&run_id) else {
+            return;
+        };
+        (
+            run.submission.repository.clone(),
+            run.submission.sha.clone(),
+            run.jobs.keys().cloned().collect::<Vec<_>>(),
+        )
+    };
+
+    for job_id in jobs {
+        if let Some((reused_job_id, check_run_id)) = &reused_check_run {
+            if reused_job_id == &job_id {
+                report_existing_check_run_queued(
+                    shared,
+                    &repository,
+                    &job_id,
+                    run_id,
+                    *check_run_id,
+                )
+                .await;
+            } else {
+                report_check_run_queued(shared, &repository, &sha, &job_id, run_id).await;
+            }
+        } else {
+            report_check_run_queued(shared, &repository, &sha, &job_id, run_id).await;
+        }
+
+        let status = {
+            let inner = shared.state.inner.lock().await;
+            inner
+                .runs
+                .get(&run_id)
+                .and_then(|run| run.jobs.get(&job_id).copied())
+        };
+        if let Some(status) = status.filter(|status| status.is_terminal()) {
+            report_check_run_completed(shared, run_id, &job_id, status).await;
+        }
+    }
+}
+
 /// Report check run status to in_progress on GitHub or simulate it locally.
 pub(crate) async fn report_check_run_in_progress(
     shared: &Arc<SharedState>,
@@ -868,6 +955,110 @@ impl Drop for InFlightReservationGuard {
     }
 }
 
+/// Handle GitHub's Checks API rerequest action by resubmitting the native run
+/// that owns the requested check. GitHub sends this as a `check_run` webhook,
+/// not as a workflow trigger event.
+async fn process_check_run_rerequest(
+    shared: &Arc<SharedState>,
+    payload: &Value,
+) -> Result<(StatusCode, Json<Value>), StatusCode> {
+    if payload.get("action").and_then(Value::as_str) != Some("rerequested") {
+        return Ok((StatusCode::OK, Json(serde_json::json!([]))));
+    }
+
+    let Some(check_run) = payload.get("check_run") else {
+        warn!("check_run rerequest is missing check_run payload");
+        return Ok((StatusCode::OK, Json(serde_json::json!([]))));
+    };
+    let Some(check_run_id) = check_run.get("id").and_then(Value::as_u64) else {
+        warn!("check_run rerequest is missing check_run.id");
+        return Ok((StatusCode::OK, Json(serde_json::json!([]))));
+    };
+    let repository = payload
+        .get("repository")
+        .and_then(|repository| repository.get("full_name"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let head_sha = check_run
+        .get("head_sha")
+        .and_then(Value::as_str)
+        .filter(|sha| !sha.is_empty());
+    let job_name = check_run.get("name").and_then(Value::as_str);
+    let details_run_id = check_run
+        .get("details_url")
+        .and_then(Value::as_str)
+        .and_then(|url| {
+            url.trim_end_matches('/')
+                .rsplit('/')
+                .next()
+                .and_then(|value| value.parse::<RunId>().ok())
+        });
+
+    let target = {
+        let inner = shared.state.inner.lock().await;
+        let mut candidates = Vec::new();
+        if let Some(run_id) = details_run_id {
+            candidates.push(run_id);
+        }
+        candidates.extend(
+            inner
+                .runs
+                .keys()
+                .filter(|run_id| Some(**run_id) != details_run_id),
+        );
+
+        candidates.into_iter().find_map(|run_id| {
+            let run = inner.runs.get(&run_id)?;
+            if run.submission.repository != repository
+                || head_sha.is_some_and(|sha| run.head_sha != sha)
+                || !run.status.is_terminal()
+            {
+                return None;
+            }
+
+            let job_id = run
+                .job_check_run_ids
+                .iter()
+                .find_map(|(job_id, id)| (*id == check_run_id).then(|| job_id.clone()))
+                .or_else(|| {
+                    job_name
+                        .map(|name| JobId(name.to_owned()))
+                        .filter(|job_id| run.jobs.contains_key(job_id))
+                })?;
+            Some((run_id, job_id))
+        })
+    };
+
+    let Some((run_id, job_id)) = target else {
+        warn!(
+            repository,
+            check_run_id, "check_run rerequest does not match a known terminal run"
+        );
+        return Ok((StatusCode::OK, Json(serde_json::json!([]))));
+    };
+
+    let accepted = crate::rerun_run_inner(shared, run_id, Some((job_id.clone(), check_run_id)))
+        .await
+        .map_err(|error| {
+            error!(
+                %run_id,
+                %job_id,
+                check_run_id,
+                ?error,
+                "failed to resubmit check_run rerequest"
+            );
+            error.into_response().status()
+        })?;
+    info!(
+        %run_id,
+        rerun_run_id = %accepted.run_id,
+        %job_id,
+        check_run_id,
+        "resubmitted check_run rerequest"
+    );
+    Ok((StatusCode::OK, Json(serde_json::json!([accepted]))))
+}
+
 /// Processing half of [`handle_github_webhook`], after signature verification
 /// and delivery reservation.
 async fn process_github_webhook(
@@ -883,6 +1074,10 @@ async fn process_github_webhook(
 
     // 3. Parse the event payload
     let payload_val: Value = serde_json::from_slice(body).map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    if event_name == "check_run" {
+        return process_check_run_rerequest(shared, &payload_val).await;
+    }
 
     // 4. Look up the event adapter
     let adapter = match crate::events::adapter_for(event_name) {

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -7613,6 +7613,92 @@ jobs:
     assert!(*check_run_id > 0);
 }
 
+#[tokio::test]
+async fn github_check_run_rerequest_resubmits_the_owning_run() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    state.webhook_secret = Some("super-secret".to_owned());
+    let app = app(state.clone(), CancellationToken::new());
+
+    let accepted = request_json(
+        &app,
+        Method::POST,
+        "/api/v1/runs",
+        json!({
+            "workflow_yaml": "on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hello\n",
+            "event": "push",
+            "repository": "owner/repo",
+            "sha": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+        }),
+    )
+    .await;
+    let original_run_id: RunId = accepted["run_id"].as_str().unwrap().parse().unwrap();
+    let original_check_run_id = 1234;
+    {
+        let mut inner = state.inner.lock().await;
+        let run = inner.runs.get_mut(&original_run_id).unwrap();
+        run.jobs
+            .insert(JobId("build".to_owned()), ExecutionStatus::Failure);
+        run.status = ExecutionStatus::Failure;
+        run.conclusion = Some("failure".to_owned());
+        run.job_check_run_ids
+            .insert(JobId("build".to_owned()), original_check_run_id);
+    }
+
+    let payload = serde_json::json!({
+        "action": "rerequested",
+        "repository": {"full_name": "owner/repo"},
+        "check_run": {
+            "id": original_check_run_id,
+            "name": "build"
+        }
+    });
+    let payload_bytes = serde_json::to_vec(&payload).unwrap();
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+    type HmacSha256 = Hmac<Sha256>;
+    let mut mac = HmacSha256::new_from_slice(b"super-secret").unwrap();
+    mac.update(&payload_bytes);
+    let signature = format!(
+        "sha256={}",
+        mac.finalize()
+            .into_bytes()
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>()
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/v1/github/webhooks")
+                .header("x-github-event", "check_run")
+                .header("x-github-delivery", "rerun-delivery")
+                .header("x-hub-signature-256", signature)
+                .header("content-type", "application/json")
+                .body(Body::from(payload_bytes))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let inner = state.inner.lock().await;
+    assert_eq!(inner.runs.len(), 2);
+    let rerun = inner
+        .runs
+        .values()
+        .find(|run| run.run_id != original_run_id)
+        .expect("rerequest should create a new run");
+    assert_eq!(rerun.status, ExecutionStatus::Queued);
+    assert_eq!(
+        rerun.job_check_run_ids.get(&JobId("build".to_owned())),
+        Some(&original_check_run_id),
+        "the rerequest must continue reporting through the requested check run"
+    );
+}
+
 /// Scaffolding shared by the webhook delivery dedup tests: a workspace holding
 /// one push-triggered workflow, a server with a webhook secret, and the signed
 /// push payload GitHub would deliver.

--- a/crates/preloop-runner-server/src/runs.rs
+++ b/crates/preloop-runner-server/src/runs.rs
@@ -2133,10 +2133,11 @@ pub(crate) async fn cancel_run(
         .await;
     Ok(Json(record))
 }
-pub(crate) async fn rerun_run(
-    State(shared): State<Arc<SharedState>>,
-    Path(run_id): Path<RunId>,
-) -> Result<Json<RunAccepted>, ApiError> {
+pub(crate) async fn rerun_run_inner(
+    shared: &Arc<SharedState>,
+    run_id: RunId,
+    reused_check_run: Option<(JobId, u64)>,
+) -> Result<RunAccepted, ApiError> {
     let submission = {
         let inner = shared.state.inner.lock().await;
         inner
@@ -2145,7 +2146,25 @@ pub(crate) async fn rerun_run(
             .map(|run| (*run.submission).clone())
             .ok_or_else(|| ApiError::not_found("run not found"))?
     };
-    submit_run_inner(&shared, submission).await.map(Json)
+    let accepted = submit_run_inner(shared, submission).await?;
+
+    if let Some((job_id, check_run_id)) = reused_check_run.as_ref() {
+        let mut inner = shared.state.inner.lock().await;
+        if let Some(run) = inner.runs.get_mut(&accepted.run_id) {
+            if run.jobs.contains_key(job_id) {
+                run.job_check_run_ids.insert(job_id.clone(), *check_run_id);
+            }
+        }
+    }
+    crate::github::report_check_runs_for_run(shared, accepted.run_id, reused_check_run).await;
+    Ok(accepted)
+}
+
+pub(crate) async fn rerun_run(
+    State(shared): State<Arc<SharedState>>,
+    Path(run_id): Path<RunId>,
+) -> Result<Json<RunAccepted>, ApiError> {
+    rerun_run_inner(&shared, run_id, None).await.map(Json)
 }
 
 /// Upper bound on how long an event stream waits for the next event.


### PR DESCRIPTION
## Problem
GitHub sends a `check_run` webhook with action `rerequested` when a user clicks Re-run checks. Preloop acknowledged that webhook but had no adapter, so no native run was queued.

## Changes
- Match rerequested checks to their owning terminal run by repository, check ID, details URL, and job name.
- Resubmit the workflow through the existing rerun path.
- Reuse the requested GitHub check run ID so the existing check transitions back to queued/in-progress instead of leaving a duplicate failed check.
- Make native reruns publish check runs consistently.
- Add regression coverage for the signed `check_run` webhook.

## Verification
- `just test-ci` passed locally.
- Focused webhook and rerequest tests passed.
- `just conform` passed as part of the CI gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle GitHub `check_run` rerequested webhooks so clicking “Re-run checks” triggers a native rerun and updates the existing check instead of creating a duplicate. We match the rerequest to its terminal run, resubmit it, reuse the original check run ID, and re-publish check states.

- **Bug Fixes**
  - Handle `check_run` webhooks with action `rerequested` directly in the webhook path and map them to the owning terminal run using repository, head SHA, details URL, check ID, or job name.
  - Resubmit via the rerun path and reuse the requested check run ID; patch the reused check to queued and continue reporting via normal updates.
  - Publish queued/completed check runs for native reruns, including the reused check for its job.
  - Add a signed webhook test verifying the rerequest resubmits the owning run.

- **Refactors**
  - Extract `rerun_run_inner` to support reruns that reuse a GitHub check run and emit check-run updates for all jobs.

<sup>Written for commit 8a1c3ebc4f33f48434f8503c5a06dd76ba2178c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

