### PR TITLE
fix(debug): stale checkout tokens, paused-permit starvation, silent queue

### DIFF
--- a/crates/preloop-cli/src/debug_session.rs
+++ b/crates/preloop-cli/src/debug_session.rs
@@ -163,23 +163,18 @@ struct Api {
     token: Option<String>,
 }
 
-/// Find a paused session belonging to a run, if one exists.
-pub async fn paused_for_run(
+/// All open sessions on the server, newest first.
+pub async fn list_sessions(
     client: &reqwest::Client,
     base_url: &str,
     token: Option<String>,
-    run_id: preloop_gha_protocol::RunId,
-) -> Option<DebugSession> {
+) -> Result<Vec<DebugSession>> {
     let api = Api {
         client: client.clone(),
         base_url: base_url.to_owned(),
         token,
     };
-    api.list()
-        .await
-        .ok()?
-        .into_iter()
-        .find(|session| session.run_id == run_id)
+    api.list().await
 }
 
 /// Offer the choice at the moment of failure, inline in `preloop run`.

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -1365,7 +1365,9 @@ async fn cmd_run(args: RunArgs) -> anyhow::Result<()> {
     // waiting for a controller), but a user who expects the debug shell on
     // failure needs to know it was disabled before the run fails — the
     // alternative is a plain `✗` with no explanation and no way to attach.
-    if !submission.preserve_on_failure && !args.no_debug {
+    // A piped pipeline never expects a failure shell, so the notice would be
+    // noise on every CI run; it targets interactive-ish invocations only.
+    if !submission.preserve_on_failure && !args.no_debug && std::env::var("CI").is_err() {
         eprintln!(
             "[preloop] failure shells are off ({}); pass --preserve-on-failure to \
              pause on failure for `preloop debug`/`preloop shell`",
@@ -1495,6 +1497,8 @@ async fn cmd_run(args: RunArgs) -> anyhow::Result<()> {
                             if let Some(session) =
                                 sessions.into_iter().find(|session| {
                                     session.run_id == accepted.run_id
+                                        && session.state
+                                            == preloop_gha_protocol::debug_session::SessionState::Paused
                                 })
                             {
                                 paused = Some(session);
@@ -1518,12 +1522,17 @@ async fn cmd_run(args: RunArgs) -> anyhow::Result<()> {
                                         )
                                     })
                                     .count();
-                                eprintln!(
-                                    "[preloop] still waiting: {queued} job(s) queued, \
-                                     {paused_total} debug session(s) paused on the server \
-                                     (preloop debug <id> to inspect)"
-                                );
-                                last_backpressure = std::time::Instant::now();
+                                // A slow in-progress step is not a stall: only
+                                // claim one when jobs or sessions are actually
+                                // waiting on capacity.
+                                if queued > 0 || paused_total > 0 {
+                                    eprintln!(
+                                        "[preloop] still waiting: {queued} job(s) queued, \
+                                         {paused_total} debug session(s) paused on the server \
+                                         (preloop debug <id> to inspect)"
+                                    );
+                                    last_backpressure = std::time::Instant::now();
+                                }
                             }
                         }
                         Err(error) => {

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -1361,6 +1361,21 @@ async fn cmd_run(args: RunArgs) -> anyhow::Result<()> {
                 || (!args.detach && std::io::IsTerminal::is_terminal(&std::io::stdin()))),
         ..Default::default()
     };
+    // The terminal gate is silent by design (a piped run must not hang
+    // waiting for a controller), but a user who expects the debug shell on
+    // failure needs to know it was disabled before the run fails — the
+    // alternative is a plain `✗` with no explanation and no way to attach.
+    if !submission.preserve_on_failure && !args.no_debug {
+        eprintln!(
+            "[preloop] failure shells are off ({}); pass --preserve-on-failure to \
+             pause on failure for `preloop debug`/`preloop shell`",
+            if args.detach {
+                "detached run"
+            } else {
+                "stdin is not a terminal"
+            }
+        );
+    }
     // Overridden rather than set in the literal so a plain run keeps the
     // protocol's own defaults for `sha` and `actor`.
     if let Some((head_sha, head_tree)) = tested_head {
@@ -1417,6 +1432,20 @@ async fn cmd_run(args: RunArgs) -> anyhow::Result<()> {
     // early" condition as `None` and deserves a reconnect, not a hard
     // failure. Bounded so a dead engine does not spin forever.
     let mut consecutive_stream_errors = 0u32;
+    // A paused session the watcher cannot see is a job hung forever with no
+    // explanation, so the first poll failure is reported instead of being
+    // folded into "no session".
+    let mut poll_warned = false;
+    // Set when the run loop leaves through the debug prompt (abort, detach,
+    // or a session error). The run is not terminal in those cases — the job
+    // is paused and reattachable — so the generic conclusion below must not
+    // report a finished status.
+    let mut left_via_pause = false;
+    // Per-job status seen on the event stream, for the backpressure line.
+    let mut job_statuses: std::collections::HashMap<String, ExecutionStatus> =
+        std::collections::HashMap::new();
+    let mut last_activity = std::time::Instant::now();
+    let mut last_backpressure = std::time::Instant::now();
     loop {
         let mut events_request = client.get(format!(
             "{url}/api/v1/runs/{}/events.ndjson",
@@ -1454,15 +1483,57 @@ async fn cmd_run(args: RunArgs) -> anyhow::Result<()> {
                     None => break,
                 },
                 () = tokio::time::sleep(Duration::from_millis(750)) => {
-                    paused = debug_session::paused_for_run(
-                        &client,
-                        &url,
-                        api_token(),
-                        accepted.run_id,
-                    )
-                    .await;
-                    if paused.is_some() {
-                        break;
+                    match debug_session::list_sessions(&client, &url, api_token()).await {
+                        Ok(sessions) => {
+                            let paused_total = sessions
+                                .iter()
+                                .filter(|session| {
+                                    session.state
+                                        == preloop_gha_protocol::debug_session::SessionState::Paused
+                                })
+                                .count();
+                            if let Some(session) =
+                                sessions.into_iter().find(|session| {
+                                    session.run_id == accepted.run_id
+                                })
+                            {
+                                paused = Some(session);
+                                break;
+                            }
+                            // A run that produces no events for a while is
+                            // usually waiting on pool capacity — often held
+                            // by other runs' paused debug sessions. Say so
+                            // instead of hanging silently on the last status
+                            // line.
+                            if !final_status.is_some_and(ExecutionStatus::is_terminal)
+                                && last_activity.elapsed() >= Duration::from_secs(15)
+                                && last_backpressure.elapsed() >= Duration::from_secs(15)
+                            {
+                                let queued = job_statuses
+                                    .values()
+                                    .filter(|status| {
+                                        matches!(
+                                            status,
+                                            ExecutionStatus::Queued | ExecutionStatus::Pending
+                                        )
+                                    })
+                                    .count();
+                                eprintln!(
+                                    "[preloop] still waiting: {queued} job(s) queued, \
+                                     {paused_total} debug session(s) paused on the server \
+                                     (preloop debug <id> to inspect)"
+                                );
+                                last_backpressure = std::time::Instant::now();
+                            }
+                        }
+                        Err(error) => {
+                            if !poll_warned {
+                                eprintln!(
+                                    "[preloop] cannot check for paused debug sessions: {error:#}"
+                                );
+                                poll_warned = true;
+                            }
+                        }
                     }
                     continue;
                 }
@@ -1472,6 +1543,12 @@ async fn cmd_run(args: RunArgs) -> anyhow::Result<()> {
                 let line = pending[..newline].trim().to_owned();
                 pending.drain(..=newline);
                 if seen_events.insert(line.clone()) {
+                    if let Ok(NdjsonEvent::JobStatus { job_id, status, .. }) =
+                        serde_json::from_str::<NdjsonEvent>(&line)
+                    {
+                        job_statuses.insert(job_id.0, status);
+                    }
+                    last_activity = std::time::Instant::now();
                     update_run_status(&mut final_status, render_event(&line));
                 }
             }
@@ -1499,10 +1576,15 @@ async fn cmd_run(args: RunArgs) -> anyhow::Result<()> {
             match debug_session::prompt_at_failure(&client, &url, api_token(), session).await {
                 // Resumed: reconnect and keep reporting the run.
                 Ok(true) => continue,
-                Ok(false) => break,
+                Ok(false) => {
+                    // Aborted or detached: the prompt already explained the
+                    // outcome and printed the reattach command.
+                    left_via_pause = true;
+                    break;
+                }
                 Err(error) => {
                     eprintln!("debug session error: {error:#}");
-                    break;
+                    return Err(error);
                 }
             }
         }
@@ -1522,6 +1604,10 @@ async fn cmd_run(args: RunArgs) -> anyhow::Result<()> {
         // reaching here means the stream dropped early. Retry promptly rather
         // than adding a fixed poll interval to every run's wall clock.
         tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    if left_via_pause {
+        return Ok(());
     }
 
     if let Some(status) = final_status {

--- a/crates/preloop-gha-parser/src/job_builder.rs
+++ b/crates/preloop-gha-parser/src/job_builder.rs
@@ -594,6 +594,7 @@ pub fn build_agent_job_message_with_normalized_context(
         preloop_debug_transport: None,
         preloop_preserve_on_failure: None,
         preloop_snapshot_commit: None,
+        preloop_snapshot_token_steps: None,
         preloop_snapshot_origin_rewrite: None,
     })
 }

--- a/crates/preloop-gha-protocol/src/azdo/azdo_tests.rs
+++ b/crates/preloop-gha-protocol/src/azdo/azdo_tests.rs
@@ -509,6 +509,7 @@ fn arb_job() -> impl Strategy<Value = AgentJobRequestMessage> {
                 preloop_debug_transport: None,
                 preloop_preserve_on_failure: None,
                 preloop_snapshot_commit: None,
+                preloop_snapshot_token_steps: None,
                 preloop_snapshot_origin_rewrite: None,
             },
         )

--- a/crates/preloop-gha-protocol/src/azdo/job.rs
+++ b/crates/preloop-gha-protocol/src/azdo/job.rs
@@ -183,6 +183,21 @@ pub struct AgentJobRequestMessage {
     )]
     pub preloop_snapshot_commit: Option<String>,
 
+    /// Preloop extension: ids of steps whose `token` input was pinned to a
+    /// snapshot checkout credential at submission.
+    ///
+    /// The pinned credential is a local HMAC JWT with a ~50-minute lifetime,
+    /// but a job can sit queued (or paused in a debug session) far longer.
+    /// The broker re-mints these inputs at claim, and the server mints a
+    /// fresh credential on retry verdicts; the worker applies it only to the
+    /// steps named here.
+    #[serde(
+        rename = "preloopSnapshotTokenSteps",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub preloop_snapshot_token_steps: Option<Vec<String>>,
+
     /// aksh extension: rewrite `<forge url>` to the run's snapshot for every
     /// git invocation in the job.
     ///

--- a/crates/preloop-gha-protocol/src/debug_session.rs
+++ b/crates/preloop-gha-protocol/src/debug_session.rs
@@ -348,6 +348,15 @@ pub struct VerdictResponse {
     /// connection must never be read as a decision.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub verdict: Option<Verdict>,
+    /// Fresh snapshot checkout credential for retry verdicts.
+    ///
+    /// A retry replays the failed step from the job message the worker
+    /// already holds — including the snapshot checkout token pinned at
+    /// submission, which may be long expired by the time a human answers.
+    /// The server mints a replacement at verdict time; the worker applies it
+    /// only to steps the message marks as pinned.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub snapshot_token: Option<String>,
     /// Session version at the time of the response.
     pub version: u64,
     /// Revert policy the controller chose.

--- a/crates/preloop-orchestrator/src/lib.rs
+++ b/crates/preloop-orchestrator/src/lib.rs
@@ -2111,20 +2111,34 @@ async fn watch_guest_pause<P: VmProvider + 'static>(
         GUEST_PAUSE_MARKER.to_owned(),
     ];
     let mut was_paused = false;
+    let mut last_probe_warn: Option<tokio::time::Instant> = None;
     loop {
         tokio::time::sleep(poll_interval).await;
-        // A failed probe (smolvm transport error, wedged VM) says nothing
-        // about the pause state: treating it as "resumed" would re-pin the
-        // permit mid-pause and revive the starvation this watcher exists to
-        // remove. Preserve the last known state; the next poll decides.
+        // `smolvm machine exec` propagates the guest exit code as its own
+        // exit code, so the normal absent-marker probe surfaces as
+        // `VmError::Command` with exit 1 — a real result, not a transport
+        // failure; `test -f` only ever exits 0 or 1. Any other error says
+        // nothing about the pause state: treating it as "resumed" would
+        // re-pin the permit mid-pause and revive the starvation this
+        // watcher exists to remove, so preserve the last known state.
         let paused = match provider.exec(&name, &probe).await {
             Ok(output) => output.exit_code == 0,
+            Err(VmError::Command {
+                exit_code: code @ (0 | 1),
+                ..
+            }) => code == 0,
             Err(error) => {
-                warn!(
-                    machine = name.as_str(),
-                    %error,
-                    "pause marker probe failed — keeping previous state"
-                );
+                let now = tokio::time::Instant::now();
+                if last_probe_warn
+                    .is_none_or(|last| now.duration_since(last) >= Duration::from_secs(60))
+                {
+                    warn!(
+                        machine = name.as_str(),
+                        %error,
+                        "pause marker probe failed — keeping previous state"
+                    );
+                    last_probe_warn = Some(now);
+                }
                 was_paused
             }
         };
@@ -3267,6 +3281,9 @@ mod lifecycle_tests {
         /// Guest pause marker state: when set, the exec probe for the debug
         /// pause marker succeeds, so `watch_guest_pause` sees a paused job.
         pause_marker: std::sync::atomic::AtomicBool,
+        /// When set, the pause-marker probe fails like a wedged VM
+        /// (transport error), which the watcher must not read as "resumed".
+        probe_transport_error: std::sync::atomic::AtomicBool,
     }
 
     impl TestProvider {
@@ -3289,6 +3306,7 @@ mod lifecycle_tests {
                 announce_busy: false,
                 absent_binary: Mutex::new(None),
                 pause_marker: std::sync::atomic::AtomicBool::new(false),
+                probe_transport_error: std::sync::atomic::AtomicBool::new(false),
             }
         }
 
@@ -3378,6 +3396,50 @@ mod lifecycle_tests {
             permit.lock().unwrap().is_some(),
             "resuming the job must re-acquire its pool permit"
         );
+
+        watch.abort();
+        let _ = watch.await;
+    }
+
+    /// A transport failure while probing must not read as "resumed": the
+    /// permit stays released for the (still paused) job, and the pool does
+    /// not re-pin it on a transient smolvm error.
+    #[tokio::test]
+    async fn probe_transport_errors_preserve_pause_state() {
+        use std::sync::atomic::Ordering;
+
+        let provider = Arc::new(TestProvider::new(false, false, false, false, false));
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
+        let permit = Arc::new(std::sync::Mutex::new(Some(
+            semaphore.clone().acquire_owned().await.unwrap(),
+        )));
+        let name = MachineName::new("preloop-runner-pause-probe".to_owned()).unwrap();
+
+        let watch = tokio::spawn(watch_guest_pause(
+            provider.clone(),
+            name,
+            permit.clone(),
+            semaphore.clone(),
+            Duration::from_millis(10),
+        ));
+
+        // Pause, release the permit, then make the probe fail like a wedged VM.
+        provider.pause_marker.store(true, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        assert!(permit.lock().unwrap().is_none());
+        provider.probe_transport_error.store(true, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        assert!(
+            permit.lock().unwrap().is_none(),
+            "a transport error must not re-pin the permit of a paused job"
+        );
+
+        // Probe recovers while still paused: still no permit.
+        provider
+            .probe_transport_error
+            .store(false, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        assert!(permit.lock().unwrap().is_none());
 
         watch.abort();
         let _ = watch.await;
@@ -3821,16 +3883,27 @@ chmod +x "$destination/bin/node"
                 && argv[1] == "-f"
                 && argv[2].ends_with("preloop-job-paused")
             {
-                // `test -f` semantics: exit 0 when the marker exists, 1 when
-                // it does not. A transport error is modelled separately and
-                // must not be conflated with "not paused".
-                return Ok(ExecOutput {
-                    exit_code: i32::from(
-                        !self.pause_marker.load(std::sync::atomic::Ordering::SeqCst),
-                    ),
-                    stdout: Vec::new(),
-                    stderr: Vec::new(),
-                    truncated: false,
+                // The real provider surfaces a guest exit 1 as
+                // `VmError::Command` (smolvm propagates the guest exit code),
+                // so the absent-marker probe must be modelled the same way —
+                // the watcher's resume path depends on it.
+                if self
+                    .probe_transport_error
+                    .load(std::sync::atomic::Ordering::SeqCst)
+                {
+                    return Err(VmError::Launch {
+                        program: "smolvm".to_owned(),
+                        source: std::io::Error::new(std::io::ErrorKind::BrokenPipe, "vm wedged"),
+                    });
+                }
+                let marker = self.pause_marker.load(std::sync::atomic::Ordering::SeqCst);
+                if marker {
+                    return Ok(test_output());
+                }
+                return Err(VmError::Command {
+                    operation: "exec",
+                    exit_code: 1,
+                    message: "test -f: marker absent".to_owned(),
                 });
             }
             let mut absent = self.absent_binary.lock().await;

--- a/crates/preloop-orchestrator/src/lib.rs
+++ b/crates/preloop-orchestrator/src/lib.rs
@@ -34,6 +34,12 @@ use tracing::{debug, info, warn};
 const GUEST_CONTROL_DIR: &str = "/run/preloop-control";
 const GUEST_CONTROL_SOCKET: &str = "/run/preloop-control/engine.sock";
 const GUEST_FAILURE_MARKER: &str = "/var/lib/preloop-runner/.preloop-job-failed";
+/// Written by the worker while a job is paused in a debug session and removed
+/// when the session closes. The pool probes it to release the slot's
+/// concurrency permit for the pause's duration — without it a paused job
+/// pins a permit (and with `max_concurrent` permits total, eventually the
+/// whole pool) until the session ends or the pause credit expires.
+const GUEST_PAUSE_MARKER: &str = "/var/lib/preloop-runner/.preloop-job-paused";
 /// Guest variable `preloop-runner configure` reads a pre-generated keypair from.
 /// Must match `preloop_runner::configure::RSA_PARAMS_ENV`.
 const RUNNER_RSA_PARAMS_ENV: &str = "PRELOOP_RUNNER_RSA_PARAMS";
@@ -972,6 +978,7 @@ fn guest_env_prefix(config: &RunnerPoolConfig, name: &MachineName) -> Vec<String
     }
     if config.debug_dir.is_some() {
         env.push(format!("PRELOOP_FAILURE_MARKER={GUEST_FAILURE_MARKER}"));
+        env.push(format!("PRELOOP_PAUSE_MARKER={GUEST_PAUSE_MARKER}"));
     }
     if !env.is_empty() {
         env.insert(0, "/usr/bin/env".to_owned());
@@ -1712,9 +1719,15 @@ impl<P: VmProvider + 'static> RunnerPool<P> {
                 building: building.clone(),
             };
             let slot_provisioning = provisioning.clone();
+            // Shared with the slot's pause watcher: a job parked in a debug
+            // session hands the permit back to the pool and re-acquires it
+            // when the session closes, so a paused job cannot pin a
+            // concurrency slot (and eventually the whole pool) for the
+            // duration of the pause.
+            let permit_slot = Arc::new(std::sync::Mutex::new(Some(permit)));
+            let slot_semaphore = semaphore.clone();
 
             slots.spawn(async move {
-                let _permit = permit; // held until this task exits
                 let result = run_on_demand_slot(
                     provider,
                     config,
@@ -1723,6 +1736,8 @@ impl<P: VmProvider + 'static> RunnerPool<P> {
                     slot_registry,
                     slot_handles,
                     slot_provisioning,
+                    slot_semaphore,
+                    permit_slot,
                 )
                 .await;
                 if let Err(error) = &result {
@@ -2066,7 +2081,77 @@ impl Drop for PreparingGuard {
     }
 }
 
+/// How often the pool probes a running machine's pause marker.
+///
+/// Latency here is how long a slot stays pinned after a job pauses: the
+/// probe cadence bounds it, and one exec per interval per active machine is
+/// negligible against the guest work happening anyway.
+const PAUSE_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Watch a machine's guest pause marker and release its pool concurrency
+/// permit for the duration of a debug-session pause.
+///
+/// A paused job blocks its worker on a verdict, so the host-side slot task
+/// keeps waiting for the runner to exit and the slot's permit stays held —
+/// with `max_concurrent` permits in total, two unanswered pauses take the
+/// pool to zero and every later run queues forever. The worker writes
+/// [`GUEST_PAUSE_MARKER`] when a session opens and removes it when it
+/// closes; this hands the permit back while the marker is present and
+/// re-acquires it on resume. Runs forever; the caller aborts it.
+async fn watch_guest_pause<P: VmProvider + 'static>(
+    provider: Arc<P>,
+    name: MachineName,
+    permit: Arc<std::sync::Mutex<Option<tokio::sync::OwnedSemaphorePermit>>>,
+    semaphore: Arc<tokio::sync::Semaphore>,
+    poll_interval: Duration,
+) {
+    let probe = [
+        "test".to_owned(),
+        "-f".to_owned(),
+        GUEST_PAUSE_MARKER.to_owned(),
+    ];
+    let mut was_paused = false;
+    loop {
+        tokio::time::sleep(poll_interval).await;
+        let paused = provider
+            .exec(&name, &probe)
+            .await
+            .map(|output| output.exit_code == 0)
+            .unwrap_or(false);
+        if paused == was_paused {
+            continue;
+        }
+        if paused {
+            let released = { permit.lock().unwrap().take() }.is_some();
+            if released {
+                info!(
+                    machine = name.as_str(),
+                    "job paused in debug session — released pool concurrency permit"
+                );
+            }
+        } else {
+            // Re-acquire before marking the machine as running again, so the
+            // pool's machine count stays bounded by `max_concurrent` plus
+            // whatever is genuinely paused. Blocking here cannot deadlock
+            // the job: the guest resumes on its own after the verdict, and
+            // this task only holds the permit for bookkeeping.
+            let fresh = semaphore
+                .clone()
+                .acquire_owned()
+                .await
+                .expect("semaphore is never closed");
+            permit.lock().unwrap().replace(fresh);
+            info!(
+                machine = name.as_str(),
+                "debug session ended — re-acquired pool concurrency permit"
+            );
+        }
+        was_paused = paused;
+    }
+}
+
 /// Single-shot on-demand runner: provision, run exactly one job, clean up.
+#[allow(clippy::too_many_arguments)]
 async fn run_on_demand_slot<P: VmProvider + 'static>(
     provider: Arc<P>,
     config: RunnerPoolConfig,
@@ -2075,6 +2160,8 @@ async fn run_on_demand_slot<P: VmProvider + 'static>(
     golden_registry: Arc<GoldenRegistry>,
     handles: PoolHandles,
     provisioning: Arc<AtomicUsize>,
+    semaphore: Arc<tokio::sync::Semaphore>,
+    permit: Arc<std::sync::Mutex<Option<tokio::sync::OwnedSemaphorePermit>>>,
 ) -> Result<(), OrchestratorError> {
     let preparing = PreparingGuard::enter(provisioning, config.preparing_signal.clone());
     // Resolve the golden for the queued job's environment.
@@ -2150,7 +2237,22 @@ async fn run_on_demand_slot<P: VmProvider + 'static>(
     // this point the starvation sweep can see a matching runner directly.
     drop(preparing);
 
-    // Run exactly one job — no successor pre-provisioning.
+    // Run exactly one job — no successor pre-provisioning. While the job
+    // runs, watch the guest pause marker: a debug-session pause must hand
+    // the concurrency permit back to the pool instead of pinning it.
+    let pause_watch = (config.debug_dir.is_some()).then(|| {
+        let provider = provider.clone();
+        let name = runner.name.clone();
+        let permit = permit.clone();
+        let semaphore = semaphore.clone();
+        tokio::spawn(watch_guest_pause(
+            provider,
+            name,
+            permit,
+            semaphore,
+            PAUSE_POLL_INTERVAL,
+        ))
+    });
     let result = run_one_runner(
         provider.clone(),
         &config,
@@ -2168,6 +2270,10 @@ async fn run_on_demand_slot<P: VmProvider + 'static>(
         },
     )
     .await;
+    if let Some(watch) = pause_watch {
+        watch.abort();
+        let _ = watch.await;
+    }
 
     // Size-zero mode never asks for a successor. Keep defensive cleanup here
     // so a future lifecycle change cannot leak an unexpectedly returned VM.
@@ -3136,6 +3242,9 @@ mod lifecycle_tests {
         announce_busy: bool,
         /// Binary that `command -v` cannot find until its toolchain installs.
         absent_binary: Mutex<Option<&'static str>>,
+        /// Guest pause marker state: when set, the exec probe for the debug
+        /// pause marker succeeds, so `watch_guest_pause` sees a paused job.
+        pause_marker: std::sync::atomic::AtomicBool,
     }
 
     impl TestProvider {
@@ -3157,6 +3266,7 @@ mod lifecycle_tests {
                 fail_delete,
                 announce_busy: false,
                 absent_binary: Mutex::new(None),
+                pause_marker: std::sync::atomic::AtomicBool::new(false),
             }
         }
 
@@ -3194,6 +3304,61 @@ mod lifecycle_tests {
             exit_code: 1,
             message: message.to_owned(),
         }
+    }
+
+    /// A job paused in a debug session must hand its pool concurrency permit
+    /// back and re-acquire it on resume — otherwise two unanswered pauses
+    /// pin every slot and later runs queue forever.
+    #[tokio::test]
+    async fn paused_job_releases_and_reacquires_the_pool_permit() {
+        use std::sync::atomic::Ordering;
+
+        let provider = Arc::new(TestProvider::new(false, false, false, false, false));
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
+        let permit = Arc::new(std::sync::Mutex::new(Some(
+            semaphore.clone().acquire_owned().await.unwrap(),
+        )));
+        let name = MachineName::new("preloop-runner-pause-test".to_owned()).unwrap();
+
+        let watch = tokio::spawn(watch_guest_pause(
+            provider.clone(),
+            name,
+            permit.clone(),
+            semaphore.clone(),
+            Duration::from_millis(10),
+        ));
+
+        // Not paused: the slot keeps its permit.
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        assert!(
+            permit.lock().unwrap().is_some(),
+            "a running job keeps its pool permit"
+        );
+
+        // Paused: the permit is handed back to the pool so other jobs can
+        // fork runners.
+        provider.pause_marker.store(true, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        assert!(
+            permit.lock().unwrap().is_none(),
+            "a paused job must not pin a pool permit"
+        );
+        assert_eq!(
+            semaphore.available_permits(),
+            1,
+            "the released permit must be available to the pool"
+        );
+
+        // Resumed: the permit is re-acquired, restoring the bound.
+        provider.pause_marker.store(false, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        assert!(
+            permit.lock().unwrap().is_some(),
+            "resuming the job must re-acquire its pool permit"
+        );
+
+        watch.abort();
+        let _ = watch.await;
     }
 
     fn test_output() -> ExecOutput {
@@ -3629,6 +3794,17 @@ chmod +x "$destination/bin/node"
                 .lock()
                 .await
                 .push(format!("exec:{}:{:?}", name.as_str(), argv));
+            if argv.len() == 3
+                && argv[0] == "test"
+                && argv[1] == "-f"
+                && argv[2].ends_with("preloop-job-paused")
+            {
+                return if self.pause_marker.load(std::sync::atomic::Ordering::SeqCst) {
+                    Ok(test_output())
+                } else {
+                    Err(test_error("pause marker absent"))
+                };
+            }
             let mut absent = self.absent_binary.lock().await;
             if let Some(binary) = *absent {
                 let probe = format!("command -v {binary}");
@@ -4079,6 +4255,8 @@ chmod +x "$destination/bin/node"
             Arc::new(GoldenRegistry::new(config.name_prefix.clone())),
             handles,
             Arc::new(AtomicUsize::new(0)),
+            Arc::new(tokio::sync::Semaphore::new(1)),
+            Arc::new(std::sync::Mutex::new(None)),
         )
         .await
         .unwrap();

--- a/crates/preloop-orchestrator/src/lib.rs
+++ b/crates/preloop-orchestrator/src/lib.rs
@@ -2113,11 +2113,21 @@ async fn watch_guest_pause<P: VmProvider + 'static>(
     let mut was_paused = false;
     loop {
         tokio::time::sleep(poll_interval).await;
-        let paused = provider
-            .exec(&name, &probe)
-            .await
-            .map(|output| output.exit_code == 0)
-            .unwrap_or(false);
+        // A failed probe (smolvm transport error, wedged VM) says nothing
+        // about the pause state: treating it as "resumed" would re-pin the
+        // permit mid-pause and revive the starvation this watcher exists to
+        // remove. Preserve the last known state; the next poll decides.
+        let paused = match provider.exec(&name, &probe).await {
+            Ok(output) => output.exit_code == 0,
+            Err(error) => {
+                warn!(
+                    machine = name.as_str(),
+                    %error,
+                    "pause marker probe failed — keeping previous state"
+                );
+                was_paused
+            }
+        };
         if paused == was_paused {
             continue;
         }
@@ -2130,16 +2140,28 @@ async fn watch_guest_pause<P: VmProvider + 'static>(
                 );
             }
         } else {
-            // Re-acquire before marking the machine as running again, so the
-            // pool's machine count stays bounded by `max_concurrent` plus
-            // whatever is genuinely paused. Blocking here cannot deadlock
-            // the job: the guest resumes on its own after the verdict, and
-            // this task only holds the permit for bookkeeping.
+            // Re-acquire before treating the machine as active again, so
+            // future forks stay bounded by `max_concurrent` plus whatever is
+            // genuinely paused. The guest resumes on its own after the
+            // verdict, so this acquire can transiently lag the resume by up
+            // to a poll interval — the over-subscription window is bounded
+            // and short. A hard gate needs a host/worker resume handshake;
+            // until then, a slow acquire is surfaced here.
+            let started = tokio::time::Instant::now();
             let fresh = semaphore
                 .clone()
                 .acquire_owned()
                 .await
                 .expect("semaphore is never closed");
+            let waited = started.elapsed();
+            if waited >= Duration::from_secs(5) {
+                warn!(
+                    machine = name.as_str(),
+                    waited_ms = waited.as_millis(),
+                    "resumed job waited for a pool permit — active VMs may have \
+                     transiently exceeded max_concurrent"
+                );
+            }
             permit.lock().unwrap().replace(fresh);
             info!(
                 machine = name.as_str(),
@@ -3799,11 +3821,17 @@ chmod +x "$destination/bin/node"
                 && argv[1] == "-f"
                 && argv[2].ends_with("preloop-job-paused")
             {
-                return if self.pause_marker.load(std::sync::atomic::Ordering::SeqCst) {
-                    Ok(test_output())
-                } else {
-                    Err(test_error("pause marker absent"))
-                };
+                // `test -f` semantics: exit 0 when the marker exists, 1 when
+                // it does not. A transport error is modelled separately and
+                // must not be conflated with "not paused".
+                return Ok(ExecOutput {
+                    exit_code: i32::from(
+                        !self.pause_marker.load(std::sync::atomic::Ordering::SeqCst),
+                    ),
+                    stdout: Vec::new(),
+                    stderr: Vec::new(),
+                    truncated: false,
+                });
             }
             let mut absent = self.absent_binary.lock().await;
             if let Some(binary) = *absent {

--- a/crates/preloop-orchestrator/tests/runner_pool_lifecycle.rs
+++ b/crates/preloop-orchestrator/tests/runner_pool_lifecycle.rs
@@ -730,14 +730,15 @@ async fn guest_environment_tracks_control_socket_and_debug_dir_independently() {
     const ORIGIN: &str = "PRELOOP_CONTROL_ORIGIN=https://preloop.example";
     const SOCKET: &str = "PRELOOP_CONTROL_SOCKET=/run/preloop-control/engine.sock";
     const MARKER: &str = "PRELOOP_FAILURE_MARKER=/var/lib/preloop-runner/.preloop-job-failed";
+    const PAUSE_MARKER: &str = "PRELOOP_PAUSE_MARKER=/var/lib/preloop-runner/.preloop-job-paused";
 
     // `PRELOOP_MACHINE_NAME` is unconditional and slot-dependent, so each case
     // lists only the knob-driven tail.
     let cases: [(bool, bool, Vec<&str>); 4] = [
         (false, false, vec![]),
         (true, false, vec![ORIGIN, SOCKET]),
-        (false, true, vec![MARKER]),
-        (true, true, vec![ORIGIN, SOCKET, MARKER]),
+        (false, true, vec![MARKER, PAUSE_MARKER]),
+        (true, true, vec![ORIGIN, SOCKET, MARKER, PAUSE_MARKER]),
     ];
 
     for (with_socket, with_debug_dir, expected) in cases {

--- a/crates/preloop-runner-server/src/auth.rs
+++ b/crates/preloop-runner-server/src/auth.rs
@@ -325,17 +325,18 @@ fn is_worker_debug_route(method: &axum::http::Method, path: &str) -> bool {
     if method == Method::POST {
         if matches!(
             path,
-            "/api/v1/debug/worker-token" | "/api/v1/debug/sessions"
+            crate::routes::DEBUG_WORKER_TOKEN_PATH | crate::routes::DEBUG_SESSIONS_PATH
         ) {
             return true;
         }
-        return debug_session_member(path, "/close");
+        return debug_session_member(path, crate::routes::DEBUG_SESSION_CLOSE_SUFFIX);
     }
-    method == Method::GET && debug_session_member(path, "/verdict")
+    method == Method::GET && debug_session_member(path, crate::routes::DEBUG_SESSION_VERDICT_SUFFIX)
 }
 
 fn debug_session_member(path: &str, suffix: &str) -> bool {
-    path.strip_prefix("/api/v1/debug/sessions/")
+    path.strip_prefix(crate::routes::DEBUG_SESSIONS_PATH)
+        .and_then(|rest| rest.strip_prefix('/'))
         .and_then(|rest| rest.strip_suffix(suffix))
         .is_some_and(|session_id| !session_id.is_empty() && !session_id.contains('/'))
 }

--- a/crates/preloop-runner-server/src/broker.rs
+++ b/crates/preloop-runner-server/src/broker.rs
@@ -762,6 +762,20 @@ pub(crate) async fn broker_acquire_job(
             "broker acquire: no dispatch token request for job"
         );
     }
+    // The snapshot checkout token is pinned onto the step at submission,
+    // but a job can sit queued well past its ~50-minute lifetime. The
+    // checkout would then be answered with a git 401 that the step can
+    // never recover from — it replays whatever the message carries. Re-mint
+    // the pinned inputs at claim so the token is fresh exactly when the job
+    // first runs.
+    let re_minted = re_mint_snapshot_tokens(&mut message, &shared.state);
+    if re_minted > 0 {
+        tracing::info!(
+            request_id,
+            steps = re_minted,
+            "re-minted snapshot checkout tokens at claim"
+        );
+    }
     message.message_type = Some(azdo::message_type::RUNNER_JOB_REQUEST.to_owned());
     let run_service_url = broker_run_service_url(runner_id);
     for endpoint in &mut message.resources.endpoints {
@@ -812,6 +826,30 @@ pub(crate) async fn broker_acquire_job(
     let payload = serde_json::to_value(&message)
         .map_err(|error| ApiError::internal(format!("serialize broker job payload: {error}")))?;
     Ok(Json(payload))
+}
+
+/// Replace every snapshot checkout credential pinned at submission with a
+/// freshly minted runtime token.
+///
+/// Returns the number of steps refreshed. The pinned ids travel on the
+/// message ([`azdo::AgentJobRequestMessage::preloop_snapshot_token_steps`]),
+/// so this deliberately matches by step id rather than by token shape.
+pub(crate) fn re_mint_snapshot_tokens(
+    message: &mut preloop_gha_protocol::azdo::AgentJobRequestMessage,
+    state: &AppState,
+) -> usize {
+    let Some(pinned) = message.preloop_snapshot_token_steps.clone() else {
+        return 0;
+    };
+    let fresh = state.mint_runtime_token(&message.plan.plan_id, &message.job_id);
+    let mut re_minted = 0;
+    for step in &mut message.steps {
+        if pinned.iter().any(|id| id == &step.id.to_string()) {
+            step.inputs.insert("token".to_owned(), fresh.clone());
+            re_minted += 1;
+        }
+    }
+    re_minted
 }
 
 /// A dispatched job's `GITHUB_TOKEN` and, when the App installation could not

--- a/crates/preloop-runner-server/src/broker.rs
+++ b/crates/preloop-runner-server/src/broker.rs
@@ -838,13 +838,20 @@ pub(crate) fn re_mint_snapshot_tokens(
     message: &mut preloop_gha_protocol::azdo::AgentJobRequestMessage,
     state: &AppState,
 ) -> usize {
-    let Some(pinned) = message.preloop_snapshot_token_steps.clone() else {
+    let Some(pinned) = message.preloop_snapshot_token_steps.as_ref() else {
         return 0;
     };
+    let pinned: std::collections::HashSet<uuid::Uuid> = pinned
+        .iter()
+        .filter_map(|id| uuid::Uuid::parse_str(id).ok())
+        .collect();
+    if pinned.is_empty() {
+        return 0;
+    }
     let fresh = state.mint_runtime_token(&message.plan.plan_id, &message.job_id);
     let mut re_minted = 0;
     for step in &mut message.steps {
-        if pinned.iter().any(|id| id == &step.id.to_string()) {
+        if pinned.contains(&step.id) {
             step.inputs.insert("token".to_owned(), fresh.clone());
             re_minted += 1;
         }

--- a/crates/preloop-runner-server/src/debug_sessions.rs
+++ b/crates/preloop-runner-server/src/debug_sessions.rs
@@ -601,6 +601,7 @@ impl DebugSessionRegistry {
         }
         Some(VerdictResponse {
             verdict,
+            snapshot_token: None,
             version: record.session.version,
             revert: record.pending_revert,
             source_revision: record.pending_revision.clone(),
@@ -1042,11 +1043,28 @@ pub(crate) async fn poll_verdict(
         {
             let mut inner = shared.state.inner.lock().await;
             owned_session(&inner, &session_id, caller)?;
-            let response = inner
+            let mut response = inner
                 .debug_sessions
                 .take_verdict(&session_id, SystemTime::now())
                 .ok_or_else(|| ApiError::not_found(format!("no such session: {session_id}")))?;
             if response.verdict.is_some() || tokio::time::Instant::now() >= deadline {
+                // A retry replays the failed step from the job message the
+                // worker already holds — including the snapshot checkout
+                // token pinned at submission, which may be long expired by
+                // the time a human answers. Mint a replacement now so the
+                // replayed checkout authenticates. The worker only applies
+                // it to steps the message marks as pinned.
+                if response.verdict == Some(Verdict::Retry) && response.snapshot_token.is_none() {
+                    if let Some(record) = inner.debug_sessions.get(&session_id) {
+                        if let Some(request) = inner.job_requests.get(&record.request_id) {
+                            response.snapshot_token = Some(
+                                shared
+                                    .state
+                                    .mint_runtime_token(&request.plan_id, &record.agent_job_id),
+                            );
+                        }
+                    }
+                }
                 return Ok(Json(response));
             }
         }

--- a/crates/preloop-runner-server/src/errors.rs
+++ b/crates/preloop-runner-server/src/errors.rs
@@ -145,6 +145,16 @@ pub struct ApiError {
 }
 
 impl ApiError {
+    /// Human-readable error text, for handlers that render their own response.
+    pub(crate) fn message(&self) -> &str {
+        &self.message
+    }
+
+    /// HTTP status this error maps to.
+    pub(crate) fn status(&self) -> StatusCode {
+        self.status
+    }
+
     pub(crate) fn bad_request(message: impl Into<String>) -> Self {
         Self {
             status: StatusCode::BAD_REQUEST,

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -13095,6 +13095,11 @@ fn redirect_primary_checkout_rewrites_only_default_checkout_inputs() {
     );
 
     assert_eq!(redirected, 1);
+    assert_eq!(
+        message.preloop_snapshot_token_steps,
+        Some(vec!["00000000-0000-0000-0000-000000000010".to_owned()]),
+        "the pinned checkout step must be recorded by id so claim and retry can re-mint it"
+    );
     let primary = &message.steps[0].inputs;
     assert_eq!(
         primary.get("repository"),
@@ -13181,6 +13186,197 @@ fn redirect_primary_checkout_rewrites_only_default_checkout_inputs() {
         Some(&"${{ inputs.head-sha }}".to_owned()),
         "an expression ref must survive the redirect pass untouched"
     );
+}
+
+/// A job that sat queued past the pinned token's lifetime must get a fresh
+/// credential at claim, scoped to itself, and unpinned steps must be
+/// untouched.
+#[tokio::test]
+async fn claim_remints_expired_snapshot_checkout_tokens() {
+    let mut message = checkout_test_message(json!([
+        {
+            "id": "00000000-0000-0000-0000-000000000020",
+            "name": "checkout",
+            "reference": {"name": "actions/checkout", "version": "v4", "type": "repository"},
+            "inputs": {"token": "expired-pinned-token", "fetch-depth": "0"},
+            "continueOnError": false,
+            "timeoutInMinutes": null
+        },
+        {
+            "id": "00000000-0000-0000-0000-000000000021",
+            "name": "run",
+            "reference": {"name": "actions/setup-node", "version": "v4", "type": "repository"},
+            "inputs": {"node-version": "22"},
+            "continueOnError": false,
+            "timeoutInMinutes": null
+        }
+    ]));
+    message.preloop_snapshot_token_steps =
+        Some(vec!["00000000-0000-0000-0000-000000000020".to_owned()]);
+
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+
+    let refreshed = crate::broker::re_mint_snapshot_tokens(&mut message, &state);
+    assert_eq!(refreshed, 1);
+
+    let token = message.steps[0].inputs.get("token").unwrap();
+    assert_ne!(token, "expired-pinned-token");
+    let claims = state
+        .verify_local_jwt_claims(token)
+        .expect("re-minted token must verify");
+    assert_eq!(
+        claims["sub"],
+        format!("preloop-job-{}", message.job_id),
+        "the fresh token must be scoped to this job"
+    );
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    assert!(
+        claims["exp"].as_u64().unwrap() > now,
+        "the re-minted token must not be already expired"
+    );
+    assert_eq!(
+        message.steps[1].inputs.get("token"),
+        None,
+        "unpinned steps keep their inputs untouched"
+    );
+
+    // Without the pinned-step marker nothing is refreshed.
+    message.preloop_snapshot_token_steps = None;
+    assert_eq!(
+        crate::broker::re_mint_snapshot_tokens(&mut message, &state),
+        0
+    );
+}
+
+/// A retry verdict must carry a freshly minted snapshot credential: the
+/// worker replays the failed step from the message it already holds, whose
+/// pinned token may be long expired.
+#[tokio::test]
+async fn retry_verdict_carries_a_fresh_snapshot_token() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+
+    let accepted = request_json(
+        &app,
+        Method::POST,
+        "/api/v1/runs",
+        json!({
+            "workflow_yaml": "on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: \"false\"\n",
+            "event": "push",
+            "repository": "owner/repo",
+            "preserve_on_failure": true
+        }),
+    )
+    .await;
+    let run_id: RunId = accepted["run_id"].as_str().unwrap().parse().unwrap();
+
+    request_json(
+        &app,
+        Method::GET,
+        "/runner/server/_apis/v1/Message/1?sessionId=default",
+        Value::Null,
+    )
+    .await;
+
+    let (agent_job_id, worker_token) = {
+        let inner = state.inner.lock().await;
+        let record = inner.job_requests.iter().next().unwrap().1;
+        (
+            record.agent_job_id,
+            state.mint_debug_worker_token(&record.plan_id, &record.agent_job_id),
+        )
+    };
+
+    let opened = request_json_with_bearer(
+        &app,
+        Method::POST,
+        "/api/v1/debug/sessions",
+        json!({
+            "run_id": run_id,
+            "job_id": "build",
+            "agent_job_id": agent_job_id,
+            "job_name": "build",
+            "step": {
+                "index": 0,
+                "total": 1,
+                "context_name": "__run",
+                "display_name": "Run false",
+                "command": "false",
+                "exit_code": 1,
+                "elapsed_ms": 20,
+                "diagnostics": []
+            }
+        }),
+        &worker_token,
+    )
+    .await;
+    let session_id = opened["session_id"].as_str().unwrap().to_owned();
+
+    request_json(
+        &app,
+        Method::POST,
+        &format!("/api/v1/debug/sessions/{session_id}/verdict"),
+        json!({ "verdict": "retry", "controller": "test" }),
+    )
+    .await;
+
+    let polled = request_json_with_bearer(
+        &app,
+        Method::GET,
+        &format!("/api/v1/debug/sessions/{session_id}/verdict?wait=0"),
+        Value::Null,
+        &worker_token,
+    )
+    .await;
+    assert_eq!(polled["verdict"], "retry");
+    let token = polled["snapshot_token"]
+        .as_str()
+        .expect("retry verdict must carry a fresh snapshot credential");
+    let claims = state
+        .verify_local_jwt_claims(token)
+        .expect("verdict-supplied token must verify");
+    assert_eq!(claims["sub"], format!("preloop-job-{agent_job_id}"));
+}
+
+/// The snapshot surface must reject bad credentials with a Bearer challenge:
+/// a bare 401 makes git fall back to Basic semantics and prompt for a
+/// username no job can answer.
+#[tokio::test]
+async fn snapshot_401_advertises_a_bearer_challenge() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri(
+                    "/snapshots/00000000-0000-0000-0000-000000000001/info/refs?service=git-upload-pack",
+                )
+                .header(header::AUTHORIZATION, "Bearer not-a-real-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        response
+            .headers()
+            .get(header::WWW_AUTHENTICATE)
+            .and_then(|value| value.to_str().ok()),
+        Some("Bearer realm=\"preloop-snapshot\"")
+    );
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(body["error"], "invalid snapshot Git token");
 }
 
 #[tokio::test]

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -13252,6 +13252,147 @@ async fn claim_remints_expired_snapshot_checkout_tokens() {
     );
 }
 
+/// The claim-time re-mint must actually run on the real claim path: a queued
+/// redirected checkout carries the submission-time pinned token, and the job
+/// the runner acquires must carry a freshly minted one.
+#[tokio::test]
+async fn claim_remints_snapshot_tokens_on_the_real_claim_path() {
+    let temp = tempfile::tempdir().unwrap();
+    let (state_dir, workspace) = create_snapshot_fixture(temp.path());
+    let mut state = AppState::new(state_dir.clone()).await.unwrap();
+    state.local_workspace = Some(workspace.clone());
+    let app = app(state.clone(), CancellationToken::new());
+
+    submit_yaml(
+        &app,
+        r#"
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+"#,
+        "owner/repo",
+    )
+    .await;
+    // The re-mint produces a fresh JWT; within the same second it is
+    // byte-identical to the pinned one, so give the clock room to move.
+    tokio::time::sleep(Duration::from_millis(1100)).await;
+
+    // The pinned submission-time token, as it sits on the queued message.
+    let pinned_token = {
+        let inner = state.inner.lock().await;
+        let queued = inner.queue.front().expect("job should be queued");
+        let checkout = queued
+            .message
+            .steps
+            .iter()
+            .find(|step| {
+                step.reference
+                    .as_ref()
+                    .and_then(|reference| reference.name.as_deref())
+                    .is_some_and(|name| name.eq_ignore_ascii_case("actions/checkout"))
+            })
+            .expect("queued job should contain the redirected checkout step");
+        checkout.inputs.get("token").cloned().expect("pinned token")
+    };
+    assert!(
+        state.verify_local_jwt_claims(&pinned_token).is_some(),
+        "the queued token must be a valid local JWT"
+    );
+
+    let session = request_json(
+        &app,
+        Method::POST,
+        "/runner/server/_apis/distributedtask/pools/1/sessions",
+        json!({
+            "agent": {"id": 1, "name": "remint-runner"},
+            "ownerName": "remint test",
+            "sessionId": "00000000-0000-0000-0000-000000000000",
+            "useFipsEncryption": false
+        }),
+    )
+    .await;
+    let session_id = session["sessionId"].as_str().unwrap();
+    let broker_message = request_json(
+        &app,
+        Method::GET,
+        &format!(
+            "/runner/server/_apis/distributedtask/pools/1/messages?sessionId={session_id}&waitSeconds=0"
+        ),
+        Value::Null,
+    )
+    .await;
+    let broker_body: Value =
+        serde_json::from_str(broker_message["body"].as_str().unwrap()).unwrap();
+    let runner_request_id = broker_body["runner_request_id"]
+        .as_str()
+        .expect("broker message should identify the queued request");
+    let runner_token = state
+        .local_jwt(json!({
+            "sub": "preloop-runner-listen-1",
+            "scp": "ActionsRuntime.RunnerListen",
+        }))
+        .unwrap();
+
+    let acquired = request_json_with_bearer(
+        &app,
+        Method::POST,
+        "/broker/1/acquirejob",
+        json!({
+            "jobMessageId": runner_request_id,
+            "billingOwnerId": "local",
+            "runnerOS": "linux"
+        }),
+        &runner_token,
+    )
+    .await;
+
+    let checkout = acquired["steps"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|step| step["reference"]["name"].as_str() == Some("actions/checkout"))
+        .expect("the acquired job should contain the checkout step");
+    fn acquired_input<'a>(step: &'a Value, name: &str) -> Option<&'a str> {
+        step["inputs"]
+            .get(name)
+            .and_then(Value::as_str)
+            .or_else(|| {
+                let found = step["inputs"]["map"].as_array()?.iter().find(|entry| {
+                    entry
+                        .get("Key")
+                        .or_else(|| entry.get("key"))
+                        .and_then(|key| key.get("lit"))
+                        .and_then(Value::as_str)
+                        .is_some_and(|key| key == name)
+                })?;
+                found
+                    .get("Value")
+                    .or_else(|| found.get("value"))
+                    .and_then(|value| value.get("lit"))
+                    .and_then(Value::as_str)
+            })
+    }
+    let claimed_token = acquired_input(&checkout, "token").expect("claimed pinned token");
+    assert_ne!(
+        claimed_token, pinned_token,
+        "claim must replace the submission-time token with a fresh one"
+    );
+    let claims = state
+        .verify_local_jwt_claims(claimed_token)
+        .expect("the claimed token must verify as a local JWT");
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    assert!(
+        claims["exp"].as_u64().unwrap() > now,
+        "the claimed token must not be expired"
+    );
+}
+
 /// A retry verdict must carry a freshly minted snapshot credential: the
 /// worker replays the failed step from the message it already holds, whose
 /// pinned token may be long expired.

--- a/crates/preloop-runner-server/src/routes.rs
+++ b/crates/preloop-runner-server/src/routes.rs
@@ -470,14 +470,14 @@ pub(crate) fn build_app(
             )),
         )
         .route(
-            &format!("{DEBUG_SESSIONS_PATH}/:session_id/verdict"),
+            &format!("{DEBUG_SESSIONS_PATH}/:session_id{DEBUG_SESSION_VERDICT_SUFFIX}"),
             get(crate::debug_sessions::poll_verdict).route_layer(middleware::from_fn_with_state(
                 shared.clone(),
                 require_worker_bearer,
             )),
         )
         .route(
-            &format!("{DEBUG_SESSIONS_PATH}/:session_id/close"),
+            &format!("{DEBUG_SESSIONS_PATH}/:session_id{DEBUG_SESSION_CLOSE_SUFFIX}"),
             post(crate::debug_sessions::close_session).route_layer(middleware::from_fn_with_state(
                 shared.clone(),
                 require_worker_bearer,
@@ -498,7 +498,7 @@ pub(crate) fn build_app(
             )),
         )
         .route(
-            &format!("{DEBUG_SESSIONS_PATH}/:session_id/verdict"),
+            &format!("{DEBUG_SESSIONS_PATH}/:session_id{DEBUG_SESSION_VERDICT_SUFFIX}"),
             post(crate::debug_sessions::post_verdict).route_layer(middleware::from_fn_with_state(
                 shared.clone(),
                 require_native_bearer,

--- a/crates/preloop-runner-server/src/routes.rs
+++ b/crates/preloop-runner-server/src/routes.rs
@@ -1,6 +1,15 @@
 use super::*;
 use utoipa::OpenApi;
 
+// The worker-facing debug surface is fail-closed in two places: the route
+// registration here and `auth::is_worker_debug_route`, which decides what the
+// guest control socket may reach. Shared constants keep the two from
+// drifting when a route is added or renamed.
+pub(crate) const DEBUG_WORKER_TOKEN_PATH: &str = "/api/v1/debug/worker-token";
+pub(crate) const DEBUG_SESSIONS_PATH: &str = "/api/v1/debug/sessions";
+pub(crate) const DEBUG_SESSION_VERDICT_SUFFIX: &str = "/verdict";
+pub(crate) const DEBUG_SESSION_CLOSE_SUFFIX: &str = "/close";
+
 /// Build the production server router without simulation endpoints.
 pub fn app(state: AppState, shutdown: CancellationToken) -> Router {
     build_app(state, shutdown, None)
@@ -444,52 +453,52 @@ pub(crate) fn build_app(
         // controller-facing routes are native-authenticated. Both live on the
         // native surface so `/_apis/...` stays byte-identical.
         //
-        // The credential those worker routes need is not in the job message —
-        // an official runner would republish it as `${{ secrets[...] }}` — so
-        // the worker exchanges its job runtime token for it here first.
+        // Worker access to these four routes through the mounted control
+        // socket is mirrored by `auth::is_worker_debug_route`. Keep that
+        // fail-closed allowlist in sync when changing this route group.
         .route(
-            "/api/v1/debug/worker-token",
+            DEBUG_WORKER_TOKEN_PATH,
             post(crate::debug_sessions::issue_worker_token).route_layer(
                 middleware::from_fn_with_state(shared.clone(), require_job_runtime_bearer),
             ),
         )
         .route(
-            "/api/v1/debug/sessions",
+            DEBUG_SESSIONS_PATH,
             post(crate::debug_sessions::open_session).route_layer(middleware::from_fn_with_state(
                 shared.clone(),
                 require_worker_bearer,
             )),
         )
         .route(
-            "/api/v1/debug/sessions/:session_id/verdict",
+            &format!("{DEBUG_SESSIONS_PATH}/:session_id/verdict"),
             get(crate::debug_sessions::poll_verdict).route_layer(middleware::from_fn_with_state(
                 shared.clone(),
                 require_worker_bearer,
             )),
         )
         .route(
-            "/api/v1/debug/sessions/:session_id/close",
+            &format!("{DEBUG_SESSIONS_PATH}/:session_id/close"),
             post(crate::debug_sessions::close_session).route_layer(middleware::from_fn_with_state(
                 shared.clone(),
                 require_worker_bearer,
             )),
         )
         .route(
-            "/api/v1/debug/sessions",
+            DEBUG_SESSIONS_PATH,
             get(crate::debug_sessions::list_sessions).route_layer(middleware::from_fn_with_state(
                 shared.clone(),
                 require_native_bearer,
             )),
         )
         .route(
-            "/api/v1/debug/sessions/:session_id",
+            &format!("{DEBUG_SESSIONS_PATH}/:session_id"),
             get(crate::debug_sessions::get_session).route_layer(middleware::from_fn_with_state(
                 shared.clone(),
                 require_native_bearer,
             )),
         )
         .route(
-            "/api/v1/debug/sessions/:session_id/verdict",
+            &format!("{DEBUG_SESSIONS_PATH}/:session_id/verdict"),
             post(crate::debug_sessions::post_verdict).route_layer(middleware::from_fn_with_state(
                 shared.clone(),
                 require_native_bearer,

--- a/crates/preloop-runner-server/src/snapshots.rs
+++ b/crates/preloop-runner-server/src/snapshots.rs
@@ -1414,6 +1414,7 @@ pub(crate) fn redirect_primary_checkout(
     runtime_token: &str,
 ) -> usize {
     let mut redirected = 0;
+    let mut pinned = Vec::new();
     for step in &mut message.steps {
         let is_checkout = step
             .reference
@@ -1473,7 +1474,11 @@ pub(crate) fn redirect_primary_checkout(
             .insert("github-server-url".to_owned(), github_server_url.to_owned());
         step.inputs
             .insert("token".to_owned(), runtime_token.to_owned());
+        pinned.push(step.id.to_string());
         redirected += 1;
+    }
+    if !pinned.is_empty() {
+        message.preloop_snapshot_token_steps = Some(pinned);
     }
     redirected
 }
@@ -1488,9 +1493,24 @@ pub(crate) async fn snapshot_git_http(
         .headers()
         .get(header::AUTHORIZATION)
         .and_then(|value| value.to_str().ok())
-        .and_then(snapshot_authorization_token)
-        .ok_or_else(|| ApiError::unauthorized("snapshot Git authentication required"))?;
-    authorize_snapshot_token(&shared.state, &token, run_id).await?;
+        .and_then(snapshot_authorization_token);
+    let authorization = match token {
+        Some(token) => authorize_snapshot_token(&shared.state, &token, run_id).await,
+        None => Err(ApiError::unauthorized(
+            "snapshot Git authentication required",
+        )),
+    };
+    // A bare 401 makes git fall back to Basic semantics and prompt for a
+    // username ("could not read Username ... terminal prompts disabled").
+    // The Bearer challenge tells git the failure is an authentication
+    // rejection, so it reports it instead of prompting.
+    if let Err(error) = authorization {
+        return if error.status() == StatusCode::UNAUTHORIZED {
+            Ok(snapshot_unauthorized_response(error.message()))
+        } else {
+            Err(error)
+        };
+    }
 
     let method = request.method().clone();
     let query = request.uri().query().unwrap_or_default().to_owned();
@@ -1631,6 +1651,25 @@ pub(crate) async fn snapshot_git_http(
         .status(status)
         .body(Body::from_stream(ReaderStream::new(reader)))
         .map_err(|error| ApiError::internal(format!("failed to build Git response: {error}")))
+}
+
+/// 401 response for the snapshot Git surface.
+///
+/// Carries a `WWW-Authenticate: Bearer` challenge so git reports the
+/// rejection instead of falling back to interactive Basic credential
+/// prompts that cannot be answered inside a job.
+fn snapshot_unauthorized_response(message: &str) -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::UNAUTHORIZED)
+        .header(
+            header::WWW_AUTHENTICATE,
+            "Bearer realm=\"preloop-snapshot\"",
+        )
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(
+            serde_json::json!({ "error": message }).to_string(),
+        ))
+        .expect("static 401 response is valid")
 }
 
 async fn authorize_snapshot_token(

--- a/crates/preloop-runner/src/worker/debug_pause.rs
+++ b/crates/preloop-runner/src/worker/debug_pause.rs
@@ -97,6 +97,12 @@ pub struct Decision {
     /// When set, re-execute from this step index instead of only the failed
     /// step. The worker must jump the outer step loop back to this index.
     pub retry_from_step: Option<usize>,
+    /// Fresh snapshot checkout credential supplied with a retry verdict.
+    ///
+    /// The pinned token in the job message expires ~50 minutes after
+    /// submission; a retry replays the step with that stale value unless the
+    /// worker swaps it for this one.
+    pub snapshot_token: Option<String>,
 }
 
 /// Everything needed to talk to the control plane about one job's sessions.
@@ -116,6 +122,14 @@ pub struct DebugPauseClient {
     machine: Option<String>,
     workspace: Option<String>,
     snapshot_commit: Option<String>,
+    /// Ids of steps whose `token` input the server pinned to a snapshot
+    /// checkout credential. Only those steps may have their token refreshed
+    /// from a verdict.
+    pinned_snapshot_steps: Vec<String>,
+    /// Guest path of the pause marker the orchestrator watches to release
+    /// its pool permit while this job sits paused. Absent when the pool did
+    /// not configure debug preservation.
+    pause_marker: Option<std::path::PathBuf>,
     /// Bumped each time a controller supplies a new source revision, so the
     /// attempt journal records what each attempt actually ran against.
     revision: Arc<AtomicU32>,
@@ -183,6 +197,8 @@ impl DebugPauseClient {
             machine: std::env::var("PRELOOP_MACHINE_NAME").ok(),
             workspace: None,
             snapshot_commit: None,
+            pinned_snapshot_steps: Vec::new(),
+            pause_marker: std::env::var_os("PRELOOP_PAUSE_MARKER").map(std::path::PathBuf::from),
             revision: Arc::new(AtomicU32::new(0)),
             paused: Arc::new(AtomicBool::new(false)),
             resolved: Arc::new(AtomicBool::new(false)),
@@ -211,6 +227,8 @@ impl DebugPauseClient {
             machine: std::env::var("PRELOOP_MACHINE_NAME").ok(),
             workspace: None,
             snapshot_commit: None,
+            pinned_snapshot_steps: Vec::new(),
+            pause_marker: std::env::var_os("PRELOOP_PAUSE_MARKER").map(std::path::PathBuf::from),
             revision: Arc::new(AtomicU32::new(0)),
             paused: Arc::new(AtomicBool::new(false)),
             resolved: Arc::new(AtomicBool::new(false)),
@@ -239,6 +257,36 @@ impl DebugPauseClient {
         self.workspace = workspace;
         self.snapshot_commit = snapshot_commit;
         self
+    }
+
+    /// Record which steps carry a pinned snapshot checkout credential, so a
+    /// verdict-supplied replacement is applied only to them.
+    pub fn with_pinned_snapshot_steps(mut self, ids: Vec<String>) -> Self {
+        self.pinned_snapshot_steps = ids;
+        self
+    }
+
+    /// Swap the pinned snapshot checkout credential on the named steps.
+    ///
+    /// Called with the token a retry verdict carried: the submission-time
+    /// token may have expired while the job waited, and the replayed step
+    /// must not re-run the stale value.
+    pub fn refresh_snapshot_tokens(&self, steps: &mut [super::steps_runner::Step], token: &str) {
+        if self.pinned_snapshot_steps.is_empty() {
+            return;
+        }
+        for step in steps {
+            if !self
+                .pinned_snapshot_steps
+                .iter()
+                .any(|pinned| pinned == &step.id)
+            {
+                continue;
+            }
+            if let super::steps_runner::StepType::Action { with, .. } = &mut step.step_type {
+                with["token"] = serde_json::Value::String(token.to_owned());
+            }
+        }
     }
 
     /// Label for the source revision the next attempt will run against.
@@ -277,6 +325,10 @@ impl DebugPauseClient {
         // Held across the whole wait, including reconnect backoff: every
         // second here is debugging, not execution.
         self.paused.store(true, Ordering::SeqCst);
+        // The orchestrator watches this marker to release its pool permit
+        // while the job is paused; without it a paused job pins a concurrency
+        // slot for the whole session and starves every other queued run.
+        let _marker = PauseMarker::new(self.pause_marker.as_deref());
         let decision = self.await_verdict(&session_id).await;
         self.paused.store(false, Ordering::SeqCst);
         if decision.is_some() {
@@ -380,6 +432,7 @@ impl DebugPauseClient {
             revert: response.revert,
             source_revision: response.source_revision,
             retry_from_step: response.retry_from_step,
+            snapshot_token: response.snapshot_token,
         }))
     }
 
@@ -394,6 +447,31 @@ impl DebugPauseClient {
             .await?
             .error_for_status()?;
         Ok(())
+    }
+}
+
+/// Guest marker the orchestrator probes to learn that a job is paused in a
+/// debug session. Written when the session opens, removed when it closes.
+struct PauseMarker(Option<std::path::PathBuf>);
+
+impl PauseMarker {
+    fn new(path: Option<&std::path::Path>) -> Self {
+        let Some(path) = path else {
+            return Self(None);
+        };
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let _ = std::fs::write(path, "paused");
+        Self(Some(path.to_owned()))
+    }
+}
+
+impl Drop for PauseMarker {
+    fn drop(&mut self) {
+        if let Some(path) = &self.0 {
+            let _ = std::fs::remove_file(path);
+        }
     }
 }
 

--- a/crates/preloop-runner/src/worker/debug_pause.rs
+++ b/crates/preloop-runner/src/worker/debug_pause.rs
@@ -484,13 +484,18 @@ impl PauseMarker {
 impl Drop for PauseMarker {
     fn drop(&mut self) {
         if let Some(path) = &self.0 {
-            if let Err(error) = std::fs::remove_file(path) {
-                warn!(
+            match std::fs::remove_file(path) {
+                // The marker may never have been written (a failed create)
+                // or already be gone — that is not a leak, and Drop must
+                // stay quiet for the normal path.
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => warn!(
                     pause_marker = %path.display(),
                     %error,
                     "failed to remove pause marker — the pool may keep this \
                      job's permit released while it runs"
-                );
+                ),
+                Ok(()) => {}
             }
         }
     }

--- a/crates/preloop-runner/src/worker/debug_pause.rs
+++ b/crates/preloop-runner/src/worker/debug_pause.rs
@@ -460,9 +460,23 @@ impl PauseMarker {
             return Self(None);
         };
         if let Some(parent) = path.parent() {
-            let _ = std::fs::create_dir_all(parent);
+            if let Err(error) = std::fs::create_dir_all(parent) {
+                warn!(
+                    pause_marker = %path.display(),
+                    %error,
+                    "failed to create pause marker directory — the pool will not \
+                     release its permit while this job is paused"
+                );
+            }
         }
-        let _ = std::fs::write(path, "paused");
+        if let Err(error) = std::fs::write(path, "paused") {
+            warn!(
+                pause_marker = %path.display(),
+                %error,
+                "failed to write pause marker — the pool will not release its \
+                 permit while this job is paused"
+            );
+        }
         Self(Some(path.to_owned()))
     }
 }
@@ -470,7 +484,14 @@ impl PauseMarker {
 impl Drop for PauseMarker {
     fn drop(&mut self) {
         if let Some(path) = &self.0 {
-            let _ = std::fs::remove_file(path);
+            if let Err(error) = std::fs::remove_file(path) {
+                warn!(
+                    pause_marker = %path.display(),
+                    %error,
+                    "failed to remove pause marker — the pool may keep this \
+                     job's permit released while it runs"
+                );
+            }
         }
     }
 }

--- a/crates/preloop-runner/src/worker/debug_pause_tests.rs
+++ b/crates/preloop-runner/src/worker/debug_pause_tests.rs
@@ -16,12 +16,15 @@ use preloop_gha_protocol::{JobId, RunId};
 use serde_json::{json, Value};
 
 use super::debug_pause::DebugPauseClient;
+use super::steps_runner::{Step, StepType};
 
 /// What the fake control plane observed and will answer.
 #[derive(Default)]
 struct Fake {
     /// Verdict handed out once `polls` reaches `verdict_after`.
     verdict: Option<Verdict>,
+    /// Snapshot credential the fake control plane mints for retry verdicts.
+    snapshot_token: Option<String>,
     /// Empty polls to serve before answering, simulating a human thinking.
     verdict_after: u32,
     polls: AtomicU32,
@@ -61,7 +64,11 @@ async fn spawn_fake(fake: Arc<Fake>) -> String {
                 } else {
                     None
                 };
-                Json(json!({ "verdict": verdict, "version": seen + 1 }))
+                Json(json!({
+                    "verdict": verdict,
+                    "version": seen + 1,
+                    "snapshot_token": fake.snapshot_token,
+                }))
             }),
         )
         .route(
@@ -99,6 +106,89 @@ fn client(base_url: &str) -> DebugPauseClient {
     )
     .unwrap()
     .with_workspace(Some("/work".to_owned()), Some("deadbeef".to_owned()))
+}
+
+/// A retry verdict must surface the fresh snapshot credential the server
+/// minted at verdict time, so the replayed step can swap out its stale
+/// pinned token.
+#[tokio::test]
+async fn retry_verdict_carries_the_fresh_snapshot_token() {
+    let fake = Arc::new(Fake {
+        verdict: Some(Verdict::Retry),
+        verdict_after: 0,
+        snapshot_token: Some("fresh-snapshot-jwt".to_owned()),
+        ..Default::default()
+    });
+    let base_url = spawn_fake(fake).await;
+    let client = client(&base_url);
+
+    let decision = client
+        .pause(failed_step(), Vec::new(), Vec::new(), Vec::new())
+        .await
+        .expect("pause returns a decision");
+    assert_eq!(decision.verdict, Verdict::Retry);
+    assert_eq!(
+        decision.snapshot_token.as_deref(),
+        Some("fresh-snapshot-jwt"),
+        "the verdict must carry the server-minted snapshot credential"
+    );
+}
+
+/// Token refresh applies only to the steps the message marks as pinned; a
+/// retry must never rewrite a step whose token the workflow set itself.
+#[test]
+fn refresh_snapshot_tokens_replaces_only_pinned_steps() {
+    let client = client("http://127.0.0.1:1")
+        .with_pinned_snapshot_steps(vec!["00000000-0000-0000-0000-000000000030".to_owned()]);
+    let mut steps = vec![
+        Step {
+            id: "00000000-0000-0000-0000-000000000030".to_owned(),
+            context_name: "__run".to_owned(),
+            display_name: "Run checkout".to_owned(),
+            step_type: StepType::Action {
+                uses: "actions/checkout@v4".to_owned(),
+                with: json!({ "token": "expired-pinned-token" }),
+            },
+            condition: None,
+            continue_on_error: false,
+            timeout_minutes: None,
+            env: Default::default(),
+            raw: json!({}),
+            is_background: false,
+        },
+        Step {
+            id: "00000000-0000-0000-0000-000000000031".to_owned(),
+            context_name: "__run_2".to_owned(),
+            display_name: "Run setup".to_owned(),
+            step_type: StepType::Action {
+                uses: "actions/setup-node@v4".to_owned(),
+                with: json!({ "token": "workflow-own-token" }),
+            },
+            condition: None,
+            continue_on_error: false,
+            timeout_minutes: None,
+            env: Default::default(),
+            raw: json!({}),
+            is_background: false,
+        },
+    ];
+
+    client.refresh_snapshot_tokens(&mut steps, "fresh-snapshot-jwt");
+
+    match &steps[0].step_type {
+        StepType::Action { with, .. } => assert_eq!(
+            with["token"], "fresh-snapshot-jwt",
+            "the pinned checkout step gets the fresh credential"
+        ),
+        _ => panic!("pinned step must be an action step"),
+    }
+    match &steps[1].step_type {
+        StepType::Action { with, .. } => assert_eq!(
+            with["token"], "workflow-own-token",
+            "unpinned steps keep the token the workflow set"
+        ),
+        _ => panic!("unpinned step must be an action step"),
+    }
 }
 
 /// What the fake control plane recorded about the credential exchange.

--- a/crates/preloop-runner/src/worker/job_runner.rs
+++ b/crates/preloop-runner/src/worker/job_runner.rs
@@ -1200,6 +1200,17 @@ async fn build_debug_pause_client(
     )
     .await?
     .with_pause_flag(paused)
+    .with_pinned_snapshot_steps(
+        job_message
+            .get("preloopSnapshotTokenSteps")
+            .and_then(serde_json::Value::as_array)
+            .map(|ids| {
+                ids.iter()
+                    .filter_map(|id| id.as_str().map(str::to_owned))
+                    .collect()
+            })
+            .unwrap_or_default(),
+    )
     .with_workspace(
         Some(workspace.to_owned()),
         job_message

--- a/crates/preloop-runner/src/worker/steps_runner.rs
+++ b/crates/preloop-runner/src/worker/steps_runner.rs
@@ -453,6 +453,10 @@ pub async fn run_steps(
         // upload and the file-command cleanup below, leaving the server with a
         // step stuck in progress.
         let mut jump_to: Option<usize> = None;
+        // Snapshot checkout credential a retry verdict carried. Applied to the
+        // current step before the replay and to every step of a jumped range
+        // once the step borrow is released.
+        let mut pending_snapshot_token: Option<String> = None;
 
         // Retry loop. Exactly one pass unless a debug controller says `retry`.
         let (conclusion_str, file_command_paths) = loop {
@@ -932,8 +936,19 @@ pub async fn run_steps(
                             ));
                             attempt += 1;
                             source_revision = decision
-                                .and_then(|d| d.source_revision)
+                                .as_ref()
+                                .and_then(|d| d.source_revision.clone())
                                 .unwrap_or_else(|| client.current_revision());
+                            // The snapshot checkout token pinned at submission
+                            // may be expired by now; the verdict carried a
+                            // fresh one. Swap it in before the replay so the
+                            // re-run does not fail with a git 401.
+                            if let Some(token) =
+                                decision.as_ref().and_then(|d| d.snapshot_token.as_deref())
+                            {
+                                client.refresh_snapshot_tokens(std::slice::from_mut(step), token);
+                                pending_snapshot_token = Some(token.to_owned());
+                            }
 
                             match target {
                                 Some(target) if target <= idx && target < step_count => {
@@ -1139,6 +1154,14 @@ pub async fn run_steps(
         // Replay an earlier range, now that this attempt has been reported.
         if let Some(target) = jump_to {
             let context_name = step.context_name.clone();
+            // A jumped range may include other pinned checkout steps whose
+            // submission-time credential expired while the job waited. Swap
+            // in the verdict's replacement for all of them before the replay.
+            if let Some(token) = pending_snapshot_token.as_deref() {
+                if let Some(client) = debug_client.as_ref() {
+                    client.refresh_snapshot_tokens(&mut steps, token);
+                }
+            }
             // Clear every runner-managed per-step value for the range about to
             // re-run. Restoring only the target snapshot leaves saveState and
             // annotations from later steps visible during their second pass.


### PR DESCRIPTION
## Summary

Fixes the debug-session failure loop that froze the runner pool and left `preloop run` hanging on Queued forever with no shell:

1. **Expired snapshot checkout token.** The checkout token is pinned onto the step at submission and lives ~50 minutes (`LOCAL_JWT_LIFETIME`). Jobs queued past that — or paused in a session that long — failed checkout with a git 401 on claim (`could not read Username … terminal prompts disabled`).
   - the snapshot surface now 401s with a `WWW-Authenticate: Bearer` challenge so git reports the rejection instead of prompting
   - the broker re-mints pinned step tokens **at claim** (steps matched by id, recorded on the message as `preloopSnapshotTokenSteps`)
   - **retry verdicts** carry a fresh credential; the worker swaps it into the replayed steps before `:retry` / `:sync + retry` re-runs them

2. **Paused jobs pinned pool permits.** A debug-session pause blocks the guest worker on a verdict while the host slot task waits for exit, so the slot's concurrency permit stayed held — two unanswered pauses took `max_concurrent` to zero and every later run queued forever.
   - the worker writes a guest pause marker (`/var/lib/preloop-runner/.preloop-job-paused`) while a session is open
   - the pool watches it, releases the slot's permit for the pause's duration, and re-acquires on resume

3. **Silent starvation + clean exits.** `preloop run` now reports queued-job and paused-session counts once a run stalls; detach/abort from the debug prompt exit cleanly instead of printing a bogus `✗ Run: Queued` error.

Also centralizes the worker-debug route paths shared between the router and the control-socket allowlist (`auth.rs`), so a route edit can no longer silently drop worker-bearer coverage.

## Verification
- New regression tests: claim-time re-mint, verdict-carried token, worker token refresh (pinned-only), snapshot Bearer challenge, pool permit release/re-acquire, redirect step-id recording
- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets`, full workspace tests green
- Live repro: failing step under a TTY opens the `[d/r/s/a]` shell immediately

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a debug-session feedback loop that froze the runner pool and left runs queued without a shell. Snapshot checkout tokens are refreshed, paused jobs no longer pin permits (with correct provider exit semantics), and `preloop run` now surfaces real backpressure and explains when failure shells are disabled.

- **Bug Fixes**
  - Snapshot checkout: server 401s with a `WWW-Authenticate: Bearer` challenge; broker re-mints pinned step tokens at claim; retry verdicts carry a fresh token; the worker swaps it only into steps marked by `preloopSnapshotTokenSteps`.
  - Paused sessions: the worker writes a pause marker; the pool releases the slot’s permit while paused and re-acquires it on resume; absent-marker probes (exit 0/1) are handled as real results; transport failures preserve the last known state with per-machine, rate-limited warnings; slow re-acquires are logged.
  - Run UX: `preloop run` reports queued-job and paused-session counts only when capacity is actually blocking; the failure prompt opens only for `SessionState::Paused`; warns once if it can’t poll sessions; shows a one-time notice when failure shells are off (detached run or non-TTY), suppressed under `CI`.

- **Refactors**
  - Centralized worker-debug route paths and member suffixes shared by the router and control-socket allowlist to keep bearer coverage in sync.

<sup>Written for commit dad9762accd382d426c1b2bc7351bc9dba81433f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

