### PR TITLE
fix: make :sync work on macOS hosts and current smolvm guests

### DIFF
--- a/crates/preloop-cli/src/debug_session.rs
+++ b/crates/preloop-cli/src/debug_session.rs
@@ -870,32 +870,58 @@ fn sync_workspace(session: &DebugSession, force: bool) -> Result<String> {
     if !modified.is_empty() {
         let archive = std::env::temp_dir().join(format!("preloop-sync-{}.tar", std::process::id()));
         let list = std::env::temp_dir().join(format!("preloop-sync-{}.list", std::process::id()));
-        let mut list_contents = Vec::new();
-        for path in &modified {
-            list_contents.extend_from_slice(path.as_bytes());
-            list_contents.push(0);
-        }
-        std::fs::write(&list, list_contents).context("staging the sync file list")?;
-
         // tar carries mode bits, so a synced `check.sh` keeps its +x. Losing
         // that would fail the retry for a reason unrelated to the fix.
-        let tar = std::process::Command::new("tar")
-            .current_dir(&host)
-            .arg("-cf")
-            .arg(&archive)
-            .arg("--null")
-            .arg("--verbatim-files-from")
-            .arg("-T")
-            .arg(&list)
-            .output()
-            .context("building the sync archive")?;
-        let _ = std::fs::remove_file(&list);
-        if !tar.status.success() {
-            let _ = std::fs::remove_file(&archive);
-            anyhow::bail!(
-                "tar failed: {}",
-                String::from_utf8_lossy(&tar.stderr).trim()
-            );
+        //
+        // macOS BSD tar doesn't support --verbatim-files-from or --null with -T,
+        // so on macOS we write newline-separated paths and drop both flags.
+        #[cfg(target_os = "macos")]
+        {
+            let list_contents: String = modified.iter().map(|p| format!("{p}\n")).collect();
+            std::fs::write(&list, list_contents).context("staging the sync file list")?;
+            let tar = std::process::Command::new("tar")
+                .current_dir(&host)
+                .arg("-cf")
+                .arg(&archive)
+                .arg("-T")
+                .arg(&list)
+                .output()
+                .context("building the sync archive")?;
+            let _ = std::fs::remove_file(&list);
+            if !tar.status.success() {
+                let _ = std::fs::remove_file(&archive);
+                anyhow::bail!(
+                    "tar failed: {}",
+                    String::from_utf8_lossy(&tar.stderr).trim()
+                );
+            }
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            let mut list_contents = Vec::new();
+            for path in &modified {
+                list_contents.extend_from_slice(path.as_bytes());
+                list_contents.push(0);
+            }
+            std::fs::write(&list, list_contents).context("staging the sync file list")?;
+            let tar = std::process::Command::new("tar")
+                .current_dir(&host)
+                .arg("-cf")
+                .arg(&archive)
+                .arg("--null")
+                .arg("--verbatim-files-from")
+                .arg("-T")
+                .arg(&list)
+                .output()
+                .context("building the sync archive")?;
+            let _ = std::fs::remove_file(&list);
+            if !tar.status.success() {
+                let _ = std::fs::remove_file(&archive);
+                anyhow::bail!(
+                    "tar failed: {}",
+                    String::from_utf8_lossy(&tar.stderr).trim()
+                );
+            }
         }
 
         let bytes = std::fs::metadata(&archive).map(|m| m.len()).unwrap_or(0);


### PR DESCRIPTION
## Problem

`:sync` in `preloop debug` is broken in two independent ways on the primary macOS + smolvm setup:

1. **macOS BSD tar** rejects GNU `--verbatim-files-from` / `--null`:
   ```
   tar failed: tar: Option --verbatim-files-from is not supported
   ```

2. **smolvm `machine cp`** reports `100%` success while the guest process tree never sees the bytes — including on non-tmpfs paths like `/var/tmp`. Sync then fails the post-copy `wc -c` check:
   ```
   copy of /var/tmp/preloop-sync.tar reported success but the machine sees 0 of N bytes
   ```

## Fix

- `#[cfg(target_os = "macos")]` tar path: newline-separated file list, no GNU flags. Linux keeps null-separated + `--verbatim-files-from`.
- `push_to_guest`: stream via `smolvm machine exec -i` (`cat > remote`) instead of `machine cp`. Keep the `wc -c` verification so a regression stays loud.

## Verified

`fixtures/workflows/debug-demo.yml` on an isolated engine:

1. `marker.txt = BROKEN` → verify fails, job pauses with `[d/r/s/a]`
2. Host fix → `s` (sync + retry)
3. `✓ synced …` → `⟳ retrying step 3` → `✓ Run: Success`

## Files

- `crates/preloop-cli/src/debug_session.rs`