### PR TITLE
feat(orchestrator): bake crun-rosetta docker runtime into golden (32512)

### DIFF
--- a/crates/preloop-orchestrator/assets/crun-rosetta
+++ b/crates/preloop-orchestrator/assets/crun-rosetta
@@ -1,0 +1,105 @@
+#!/bin/sh
+# crun-rosetta -- OCI runtime shim wired as dockerd's default-runtime, and
+# also installed as /usr/local/bin/runc (PATH precedes /usr/bin): buildx's
+# embedded executor (`docker build` on Docker >= 23) finds its "runc" by PATH
+# lookup and never consults the daemon's runtime config.
+#
+# Containers created by an in-guest dockerd never pass through the smolvm
+# agent's spec assembly, so they miss the /mnt/rosetta bind mount that
+# crates/smolvm-agent/src/rosetta.rs injects into agent-created containers.
+# amd64 binaries then die with `rosetta-wrapper: unexpected initial stop:
+# 32512` because the binfmt wrapper's execve("/mnt/rosetta/rosetta") misses in
+# the container's mount namespace. dockerd resolves a named default-runtime to
+# a binary path and execs it with the full OCI runtime CLI, so this shim adds
+# the same read-only mount to the bundle's config.json before exec'ing the
+# real crun with the original argv.
+#
+# Two normalizations happen to every bundle (when writable):
+#
+# 1. dockerd's spec generator emits "blockIO": {} on every container; crun
+#    treats a present blockIO section as a directive to write io.max /
+#    io.weight, which this VM's kernel (libkrunfw, built without
+#    CONFIG_BLK_DEV_THROTTLING) has no files for: `open `io.max`:
+#    No such file or directory`. runc silently skips the empty section;
+#    drop it the same way so crun under dockerd works at all (arm64
+#    included). A blockIO section with real limits is left untouched.
+#
+# 2. The Rosetta mount injection described above, only when ALL of these
+#    hold:
+#    * Rosetta is enabled for the machine, as seen from THIS namespace --
+#      either SMOLVM_ROSETTA=1 (the sentinel the host sets on guest init;
+#      VALUE_ON in crates/smolvm-protocol/src/guest_env.rs, same check as
+#      rosetta.rs::is_enabled; bare-VM processes descend from the agent,
+#      PID 1, and inherit it) OR the translator is visible at
+#      /mnt/rosetta/rosetta (the mount the agent adds to every workload
+#      container's spec when Rosetta is on; exec'd containers don't inherit
+#      PID 1's env, so the mount is the signal there). Both signal the same
+#      boot-time crates/smolvm-agent/src/rosetta.rs::setup().
+#    * No existing mount already claims /mnt/rosetta -- a user's explicit
+#      `-v /mnt/rosetta:...` mount wins.
+#
+# Everything fails SOFT: any scan/jq problem still execs crun untouched, so a
+# shim bug can degrade x86_64 translation but never block container startup.
+set -u
+
+# Guest path of the Rosetta 2 runtime virtiofs share. Mirrors
+# smolvm_protocol::ROSETTA_GUEST_PATH (crates/smolvm-protocol/src/lib.rs).
+# Overridable for tests (they can't populate /mnt/rosetta on the host).
+ROSETTA_PATH=${CRUN_ROSETTA_PATH:-/mnt/rosetta}
+
+# The real runtime. Overridable for tests, which stub crun to record argv.
+REAL_CRUN=${CRUN_ROSETTA_CRUN:-/usr/bin/crun}
+
+# Find the bundle path: `--bundle PATH`, `--bundle=PATH`, `-b PATH`, `-b=PATH`.
+bundle=
+prev=
+for arg in "$@"; do
+    if [ "$prev" = "--bundle" ] || [ "$prev" = "-b" ]; then
+        bundle=$arg
+        break
+    fi
+    case "$arg" in
+        --bundle=*) bundle=${arg#--bundle=} ; break ;;
+        -b=*) bundle=${arg#-b=} ; break ;;
+    esac
+    prev=$arg
+done
+
+# Enabled for the machine = env sentinel in this process, or the translator
+# already visible from this namespace (see header for why both).
+inject=0
+if [ "${SMOLVM_ROSETTA:-}" = "1" ] || [ -e "$ROSETTA_PATH/rosetta" ]; then
+    inject=1
+fi
+
+if [ -n "$bundle" ]; then
+    config=$bundle/config.json
+    if [ -f "$config" ]; then
+        tmp=$config.crun-rosetta.$$
+        # One jq pass: drops dockerd's empty blockIO (kernel has no io.max;
+        # see header) and, when enabled, appends the ro runtime bind mount.
+        # Outputs the doc unchanged when neither case applies (the cmp below
+        # then skips the swap), so user mounts and real IO limits always win.
+        if jq --arg dst "$ROSETTA_PATH" --argjson inject "$inject" '
+                (if .linux.resources.blockIO == {} then
+                     del(.linux.resources.blockIO)
+                 else . end)
+                | if $inject == 1 and (((.mounts // []) | any(.destination == $dst)) == false) then
+                    .mounts = ((.mounts // []) + [{
+                        destination: $dst,
+                        type: "bind",
+                        source: $dst,
+                        options: ["bind", "ro"]
+                    }])
+                else . end
+            ' "$config" > "$tmp" 2>/dev/null; then
+            if ! cmp -s "$tmp" "$config"; then
+                mv "$tmp" "$config"
+                echo "crun-rosetta: patched $config (blockIO strip; rosetta mount inject=$inject)" >&2
+            fi
+        fi
+        rm -f "$tmp"
+    fi
+fi
+
+exec "$REAL_CRUN" "$@"

--- a/crates/preloop-orchestrator/src/lib.rs
+++ b/crates/preloop-orchestrator/src/lib.rs
@@ -591,6 +591,45 @@ pub fn docker_data_root() -> &'static str {
     DOCKER_DATA_ROOT
 }
 
+/// The OCI runtime shim wired as the golden's docker `default-runtime`.
+///
+/// Byte-identical to the shim proven live on the smolvm side
+/// (`scripts/rosetta/crun-rosetta` in the rosetta-mount-shim work; its sha256
+/// is pinned in `tests/golden_fidelity.rs` so an edit here fails loudly).
+/// dockerd resolves a named runtime to a binary path and execs it with the
+/// full OCI runtime CLI, so this POSIX sh wrapper rewrites the bundle's
+/// `config.json` before exec'ing the real crun:
+///
+/// 1. Drops dockerd's always-present empty `blockIO` section. The VM's
+///    libkrunfw kernel is built without `CONFIG_BLK_DEV_THROTTLING`, so crun
+///    treats the section as a directive to write `io.max` / `io.weight` and
+///    fails EVERY container create with the kernel-side error
+///    "open `io.max`: No such file or directory". runc silently skips the
+///    empty section; the strip mirrors it so crun can replace runc at all
+///    (arm64 included). Real IO limits are left untouched.
+///
+/// 2. Injects a read-only `/mnt/rosetta` bind mount, but only when Rosetta
+///    is enabled for the machine (`SMOLVM_ROSETTA=1` in the shim's
+///    environment, or the translator visible at `/mnt/rosetta/rosetta`) and
+///    no user mount already claims the path. Without it, amd64-only images
+///    die inside dockerd-created containers with `rosetta-wrapper:
+///    unexpected initial stop: 32512` — the binfmt wrapper's
+///    `execve("/mnt/rosetta/rosetta")` misses in the container's mount
+///    namespace, because the smolvm agent only injects the mount into specs
+///    it assembles itself, not ones dockerd builds.
+///
+/// Buildx's embedded executor (`docker build` on Docker >= 23) never consults
+/// the daemon's runtime config; it execs `runc` by PATH lookup. The bake
+/// therefore also symlinks `/usr/local/bin/runc` (PATH-prior to the real
+/// `/usr/bin/runc`, which stays untouched) at this shim.
+const CRUN_ROSETTA_SHIM: &str = include_str!("../assets/crun-rosetta");
+
+/// The docker `default-runtime` shim baked into the golden. Exposed for the
+/// fidelity tests.
+pub fn crun_rosetta_shim() -> &'static str {
+    CRUN_ROSETTA_SHIM
+}
+
 /// Loopback `/etc/hosts` contents. Exposed for the fidelity tests.
 pub fn loopback_hosts() -> &'static str {
     LOOPBACK_HOSTS
@@ -716,7 +755,14 @@ pub fn base_install_script() -> String {
           docker buildx version | grep -F 'v{DOCKER_BUILDX_VERSION}' && \
           docker compose version --short | grep -F '{DOCKER_COMPOSE_VERSION}' && \
           mkdir -p {DOCKER_DATA_ROOT} /etc/docker && \
-          printf '{{\"data-root\":\"{DOCKER_DATA_ROOT}\"}}\\n' > /etc/docker/daemon.json) && \
+         printf '{{\"data-root\":\"{DOCKER_DATA_ROOT}\",\"runtimes\":{{\"crun-rosetta\":{{\"path\":\"/usr/local/bin/crun-rosetta\"}}}},\"default-runtime\":\"crun-rosetta\"}}\\n' > /etc/docker/daemon.json && \
+         echo \"### install crun v{CRUN_VERSION} + rosetta runtime shim\" >&2 && \
+         curl -fsSL \"https://github.com/containers/crun/releases/download/{CRUN_VERSION}/crun-{CRUN_VERSION}-linux-$LFS_ARCH\" -o /usr/bin/crun && \
+         chmod 0755 /usr/bin/crun && \
+         /usr/bin/crun --version | grep -F '{CRUN_VERSION}' && \
+         printf '%s' {crun_rosetta_shim_quoted} > /usr/local/bin/crun-rosetta && \
+         chmod 0755 /usr/local/bin/crun-rosetta && \
+         ln -sf crun-rosetta /usr/local/bin/runc) && \
          (echo \"### fetch cargo-shear\" >&2 && \
           curl -sSL https://github.com/Boshen/cargo-shear/releases/download/v{CARGO_SHEAR_VERSION}/cargo-shear-$(uname -m)-unknown-linux-musl.tar.gz 2>/dev/null | tar -xz -C /usr/local/bin 2>/dev/null || true) && \
          (echo \"### bake git v{GIT_VERSION}\" >&2 && \
@@ -740,7 +786,10 @@ pub fn base_install_script() -> String {
          rm -rf /usr/share/doc/* /usr/share/man/* /usr/share/info/*",
         docker_packages = docker_apt_packages(),
         compiler_packages = compiler_apt_packages(),
-        base_packages_pinned = base_packages_pinned()
+        base_packages_pinned = base_packages_pinned(),
+        // One single-quoted shell word: the shim embeds verbatim, and only a
+        // NUL (which a shell script cannot contain) would break the quoting.
+        crun_rosetta_shim_quoted = shell_quote(CRUN_ROSETTA_SHIM)
     )
 }
 

--- a/crates/preloop-orchestrator/tests/golden_fidelity.rs
+++ b/crates/preloop-orchestrator/tests/golden_fidelity.rs
@@ -10,8 +10,8 @@
 //! come to roughly 90 GB and are the job of setup actions and containers.
 
 use preloop_orchestrator::{
-    base_install_script, base_packages, compiler_packages, docker_data_root, docker_packages,
-    loopback_hosts, BASE_NODE_VERSION,
+    base_install_script, base_packages, compiler_packages, crun_rosetta_shim, docker_data_root,
+    docker_packages, loopback_hosts, BASE_NODE_VERSION, CRUN_VERSION,
 };
 
 /// Commands a workflow may reasonably assume exist, because `ubuntu-latest`
@@ -352,4 +352,137 @@ fn loopback_resolves_by_name() {
             "missing standard entry `{entry}` present on a stock Ubuntu host"
         );
     }
+}
+
+/// Docker-in-VM containers on Apple Silicon need `/mnt/rosetta` in their mount
+/// namespace or every amd64 binary dies with `rosetta-wrapper: unexpected
+/// initial stop: 32512`. The VM agent only injects that mount into specs it
+/// assembles itself; containers an in-guest dockerd creates (every `container:`
+/// job, every `services:` sidecar, every `docker run` in a workflow) bypass it.
+/// The golden therefore runs dockerd with the `crun-rosetta` shim as its
+/// default runtime: the shim rewrites each bundle's config.json (drop the
+/// empty `blockIO` section the libkrunfw kernel has no cgroup files for, add
+/// the read-only `/mnt/rosetta` bind when Rosetta is enabled) and execs crun.
+/// This wiring is the image-side counterpart of the smolvm agent fix and is
+/// byte-identical to the version proven live against the failing workload.
+#[test]
+fn golden_wires_crun_rosetta_as_docker_default_runtime() {
+    let script = base_install_script();
+
+    // daemon.json: the runtime is merged into the config the bake already owns
+    // (data-root keeps container storage on the forkable ext4 volume).
+    let daemon_json = format!(
+        "{{\"data-root\":\"{}\",\"runtimes\":{{\"crun-rosetta\":{{\"path\":\"/usr/local/bin/crun-rosetta\"}}}},\"default-runtime\":\"crun-rosetta\"}}",
+        docker_data_root()
+    );
+    assert!(
+        script.contains(&daemon_json),
+        "daemon.json must name crun-rosetta the default runtime without \
+         clobbering the container data-root; missing: {daemon_json}"
+    );
+
+    // The shim and its pinned static backend both land in the image. crun must
+    // be >= 1.14: buildx's embedded executor invokes `runc run --keep`.
+    for fragment in [
+        format!("crun-{CRUN_VERSION}-linux-$LFS_ARCH"),
+        "https://github.com/containers/crun/releases/download/".to_owned(),
+        "chmod 0755 /usr/bin/crun".to_owned(),
+        format!("/usr/bin/crun --version | grep -F '{CRUN_VERSION}'"),
+        "chmod 0755 /usr/local/bin/crun-rosetta".to_owned(),
+        "ln -sf crun-rosetta /usr/local/bin/runc".to_owned(),
+    ] {
+        assert!(script.contains(&fragment), "bake lost {fragment:?}");
+    }
+
+    // The shim rides into the image as one shell word; without it dockerd has
+    // a default-runtime pointing at nothing and every container create fails.
+    assert!(
+        script.contains("> /usr/local/bin/crun-rosetta"),
+        "the crun-rosetta shim itself must be installed by the bake"
+    );
+    // buildx execs `runc` by PATH lookup and ignores daemon.json, which is why
+    // the symlink exists ahead of /usr/bin. Docker's own runc there must stay
+    // untouched, both for non-shim inspection and as the escape hatch.
+    assert!(
+        !script.contains("-o /usr/bin/runc"),
+        "the bake must not shadow docker's real /usr/bin/runc"
+    );
+    // The shim's config.json rewrite uses jq; it rides in the apt baseline.
+    assert!(
+        base_packages().split_whitespace().any(|p| p == "jq"),
+        "the crun-rosetta shim requires jq in the golden"
+    );
+}
+
+#[test]
+fn crun_rosetta_shim_is_byte_identical_to_the_live_proven_version() {
+    let shim = crun_rosetta_shim();
+
+    // sha256 of scripts/rosetta/crun-rosetta in the smolvm rosetta worktree at
+    // the live-proven commit (07b5449). The exact bytes that ran green against
+    // `docker build thekevjames/coveralls:4.0.0` on an amd64 image are the
+    // contract here; any edit must be re-proven, not merged silently.
+    use sha2::Digest as _;
+    let digest: String = sha2::Sha256::digest(shim.as_bytes())
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect();
+    assert_eq!(
+        digest, "dec932252ddf7d1766e9fbbb4700e6fb7b890ac0d259a4ffa0b365f7b9884935",
+        "crun-rosetta drifted from the live-proven bytes"
+    );
+
+    // Defense in depth against a wholesale replacement: pin the load-bearing
+    // behaviors a rewrite could quietly lose.
+    for fragment in [
+        // dockerd emits "blockIO": {} on every container; crun writes io.max
+        // for it and the libkrunfw kernel lacks CONFIG_BLK_DEV_THROTTLING, so
+        // without this strip EVERY docker container fails to create.
+        "del(.linux.resources.blockIO)",
+        // Enablement gates: the boot sentinel env var, or the translator
+        // already visible from the shim's namespace (exec'd containers don't
+        // inherit PID 1's env).
+        "${SMOLVM_ROSETTA:-}",
+        "$ROSETTA_PATH/rosetta",
+        "ROSETTA_PATH=${CRUN_ROSETTA_PATH:-/mnt/rosetta}",
+        // The injected mount itself: bind, read-only, and never over a
+        // destination a user already claimed.
+        ".destination == $dst",
+        "options: [\"bind\", \"ro\"]",
+        // The real runtime the golden installs and the shim must hand off to.
+        "REAL_CRUN=${CRUN_ROSETTA_CRUN:-/usr/bin/crun}",
+        "exec \"$REAL_CRUN\" \"$@\"",
+    ] {
+        assert!(
+            shim.contains(fragment),
+            "crun-rosetta lost its {fragment:?} behavior"
+        );
+    }
+}
+
+/// The bake embeds the shim as one single-quoted word in the install script.
+/// A quoting slip would corrupt the file dockerd execs for every container, so
+/// reconstruct the fragment independently (the POSIX `'\''` idiom) and demand
+/// a real shell hands the exact bytes back.
+#[cfg(unix)]
+#[test]
+fn baked_shim_reconstructs_verbatim_through_the_shell() {
+    let quoted = format!("'{}'", crun_rosetta_shim().replace('\'', "'\\''"));
+    let install_fragment = format!("printf '%s' {quoted} > /usr/local/bin/crun-rosetta");
+    assert!(
+        base_install_script().contains(&install_fragment),
+        "the bake must embed the shim with the POSIX single-quote idiom"
+    );
+
+    let output = std::process::Command::new("sh")
+        .arg("-c")
+        .arg(format!("printf '%s' {quoted}"))
+        .output()
+        .expect("a POSIX sh is present on every dev and CI platform");
+    assert!(output.status.success());
+    assert_eq!(
+        output.stdout,
+        crun_rosetta_shim().as_bytes(),
+        "shell-quoted shim must round-trip byte-exact"
+    );
 }

--- a/versions.toml
+++ b/versions.toml
@@ -28,6 +28,12 @@ git_lfs_version = "3.7.1"
 docker_version = "28.0.4"
 docker_buildx_version = "0.35.0"
 docker_compose_version = "2.38.2"
+# Static upstream crun backing the golden's docker default-runtime shim
+# (assets/crun-rosetta in preloop-orchestrator). Must be >= 1.14: buildx's
+# embedded executor invokes `runc run --keep`, which older crun predates. The
+# GitHub release asset is statically linked, so it carries no glibc coupling
+# to the Ubuntu base.
+crun_version = "1.23.1"
 clang_versions = "16 17 18"
 clang_default_version = "18"
 clang_16_version = "16.0.6"


### PR DESCRIPTION
## Summary

Amd64-only Docker images fail inside preloop's golden VMs on Apple Silicon with `rosetta-wrapper: unexpected initial stop: 32512`: Rosetta translation works in the VM, but dockerd-created containers never inherit the `/mnt/rosetta` virtiofs mount, so the binfmt_misc wrapper cannot reach the translator. The smolvm-side fix (preloopdev/smolvm#4) wires a `crun-rosetta` runtime shim into the agent rootfs; this PR bakes the same proven wiring into **preloop's golden image**, so image-based runners get the fix with no smolvm changes.

The bake now emits:

- `/etc/docker/daemon.json` merged with `runtimes."crun-rosetta"` + `default-runtime: crun-rosetta` (data-root preserved);
- the `crun-rosetta` shim installed at `/usr/local/bin/crun-rosetta` — byte-identical to the live-proven version in preloopdev/smolvm#4 (`crates/preloop-orchestrator/assets/crun-rosetta`, sha256-pinned in tests so drift fails loudly): strips dockerd's empty `blockIO` section (the libkrunfw kernel lacks `CONFIG_BLK_DEV_THROTTLING`) and injects the read-only `/mnt/rosetta` mount when Rosetta is enabled, never overriding user mounts, failing soft;
- a `/usr/local/bin/runc -> crun-rosetta` symlink so buildx's embedded executor (which bypasses daemon runtimes via PATH lookup) is intercepted too; `/usr/bin/runc` from the docker package stays untouched;
- static crun 1.23.1 pinned in `versions.toml` (buildx's `runc run --keep` contract requires crun >= 1.14), downloaded per-arch with version verification.

## Verification

- 3 new `golden_fidelity` tests: exact merged daemon.json, shim byte-identity (sha256 + 8 behavior fragments), and shell round-trip byte-exactness of the embedded shim through the real `sh`. Full `preloop-orchestrator` suite green (42 lib + 17 golden_fidelity + 10 lifecycle), clippy + fmt clean.
- Live repro on the exact runtime stack (Ubuntu 24.04 + docker 28.0.4 + crun 1.23.1, rosetta-enabled VM): arm64 container -> `aarch64`; amd64 container -> `x86_64` with `/mnt/rosetta/rosetta` visible; the black.md workload — `docker build` of `thekevjames/coveralls:4.0.0` with `RUN python3 -m pip install Cython` — exits 0 with Cython 3.2.9 installing and importing; user-specified `/mnt/rosetta` mounts win over injection (no double-inject).

## Notes / limitations

- Same limitations as the smolvm PR: docker I/O-limit flags remain unsupported (kernel gap), explicit `--runtime=runc` and third-party buildx container drivers still bypass the shim, jq becomes a docker runtime dependency, and crun (not runc) is docker's runtime in the image.
- References upstream bug: smol-machines/smolvm#894.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Golden images previously lacked the `crun-rosetta` Docker runtime, so amd64 containers on Apple Silicon could fail with `rosetta-wrapper: unexpected initial stop: 32512`. This change bakes the runtime into the golden image and makes runner conformance comparisons deterministic by comparing normalized structured reports.

**Golden image**

- Sets `crun-rosetta` as dockerd's default runtime while preserving `data-root`, and installs static `crun` 1.23.1 plus the buildx-compatible `/usr/local/bin/runc` symlink.
- The shim removes dockerd's empty `blockIO`, adds a read-only `/mnt/rosetta` mount only when needed, and falls back to unmodified `crun` if patching fails.
- Explicit `--runtime=runc` and third-party buildx drivers still bypass the shim; `jq` is now an image dependency, with fidelity tests covering configuration, behavior, and shell quoting.

**Conformance and CI**

- Compares endpoint coverage, statuses, schemas, and normalized response values, including transport prefixes, GUIDs, URLs, timestamps, numbers, high-entropy identifiers, and complete JWTs.
- Serializes empty job matrices as `{}`; release automation now runs only on version tags.
- Keeps caches in the runner home, skips unsupported clippy and doc-test cases, exposes installed Rust tools on `PATH`, and uses Rust `1.97`.

<sup>Written for commit c382a3e179ad7ea6ac6fe2423d4ad788943a6aba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Rosetta support for containers running through the bundled Docker runtime, improving compatibility for workloads requiring Rosetta translation.
  * Added structured conformance reports with normalized comparisons, schema checks, endpoint coverage, and machine-readable failure details.
* **Bug Fixes**
  * Containers without matrix configuration now receive a consistent empty matrix object.
* **Chores**
  * Release automation now runs only when version tags are pushed, not for pull requests.
  * Updated CI workflows with consistent Rust toolchain and build-cache environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->