### PR TITLE
fix(pool): serialize forks per golden, re-arm a spent fork base, resolve debug refs by run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,24 @@ Releases before v0.27.0 predate the changelog.
 
 ## [Unreleased]
 
-## [0.29.9] - 2026-08-10
+### Fixed
+
+- Serialize `machine fork` per golden VM. SmolVM keeps one RAM checkpoint per
+  golden; concurrent forks raced the freeze, and the loser's rollback resumed
+  the base and dropped the checkpoint, after which every fork failed with
+  `golden '<name>' is already paused; a valid retained checkpoint is required`
+  and queued jobs stalled until the engine restarted. Forks from different
+  goldens still run in parallel.
+- Re-arm a spent fork base (stop + restart forkable) and retry the fork once
+  when no clone still depends on it, instead of degrading every runner to a
+  full VM create. A base with live clones is never restarted — it falls back
+  to direct creation with an error explaining why.
+- `preloop debug <reference>` now resolves a run id that has several paused
+  jobs: it lists them (with their run ids) instead of answering
+  `no paused job matching`. When nothing matches but other sessions are
+  paused, the reply says what is paused instead of a bare 404.
+
+## [0.29.8] - 2026-08-09
 
 ### Added
 

--- a/crates/preloop-cli/src/debug_session.rs
+++ b/crates/preloop-cli/src/debug_session.rs
@@ -82,7 +82,7 @@ pub async fn run(
 
     let sessions = ctx.list().await?;
     let session = match (&args.session, sessions.len()) {
-        (Some(reference), _) => ctx.get(reference).await?,
+        (Some(reference), _) => resolve(&ctx, &sessions, reference).await?,
         (None, 0) => {
             println!("No paused jobs.");
             println!();
@@ -97,14 +97,7 @@ pub async fn run(
             println!("{} paused jobs:", sessions.len());
             println!();
             for session in &sessions {
-                println!(
-                    "  {}  {}  step {}/{} {}",
-                    session.session_id,
-                    session.job_name,
-                    session.step.index + 1,
-                    session.step.total,
-                    session.step.display_name
-                );
+                println!("{}", session_line(session));
             }
             println!();
             println!("Attach with: preloop debug <session-id>");
@@ -175,6 +168,85 @@ pub async fn list_sessions(
         token,
     };
     api.list().await
+}
+
+/// One line per paused job: what to type, which job, which run, where it broke.
+///
+/// The run is part of the identity rather than decoration. A stalled `preloop
+/// run` reports how many sessions are paused on the server without saying
+/// whose, and the pauses in the way are frequently an *earlier* run's — so the
+/// id a user has at hand matches nothing and the listing has to say why.
+fn session_line(session: &DebugSession) -> String {
+    format!(
+        "  {}  {}  run {}  step {}/{} {}",
+        session.session_id,
+        session.job_name,
+        short_run(session.run_id),
+        session.step.index + 1,
+        session.step.total,
+        session.step.display_name
+    )
+}
+
+fn short_run(run: preloop_gha_protocol::RunId) -> String {
+    run.to_string().chars().take(8).collect()
+}
+
+fn session_lines(sessions: &[&DebugSession]) -> String {
+    sessions.iter().fold(String::new(), |mut lines, session| {
+        lines.push_str(&session_line(session));
+        lines.push('\n');
+        lines
+    })
+}
+
+/// Every paused session a user-supplied reference could mean.
+///
+/// Mirrors the server's resolver — session id, session-id prefix, run-id
+/// prefix, job name — but keeps all matches instead of collapsing to "unique or
+/// nothing". A run with two failed jobs has two paused sessions under one run
+/// id, and the server answers that reference with a 404, which reads as
+/// "nothing is paused" at the exact moment two jobs are.
+fn matching<'a>(sessions: &'a [DebugSession], reference: &str) -> Vec<&'a DebugSession> {
+    if let Some(exact) = sessions
+        .iter()
+        .find(|session| session.session_id == reference)
+    {
+        return vec![exact];
+    }
+    sessions
+        .iter()
+        .filter(|session| {
+            session.session_id.starts_with(reference)
+                || session.run_id.to_string().starts_with(reference)
+                || session.job_name == reference
+        })
+        .collect()
+}
+
+/// Pick the session a reference names, or say what is paused instead.
+async fn resolve(ctx: &Api, sessions: &[DebugSession], reference: &str) -> Result<DebugSession> {
+    match matching(sessions, reference).as_slice() {
+        [single] => Ok((*single).clone()),
+        // The listing carries open sessions only, so a closed session's id
+        // still has to go to the server, which keeps an archive of them.
+        [] => match ctx.get(reference).await {
+            Ok(session) => Ok(session),
+            Err(error) if sessions.is_empty() => Err(error),
+            Err(error) => {
+                let open: Vec<&DebugSession> = sessions.iter().collect();
+                anyhow::bail!(
+                    "{error:#}\n\nthese are paused instead:\n{}\nattach one with: preloop debug <session-id>",
+                    session_lines(&open)
+                )
+            }
+        },
+        ambiguous => anyhow::bail!(
+            "`{reference}` matches {} paused jobs:\n{}\nattach one with: preloop debug <session-id>",
+            ambiguous.len(),
+            session_lines(ambiguous)
+        ),
+    }
 }
 
 /// Offer the choice at the moment of failure, inline in `preloop run`.
@@ -1324,6 +1396,62 @@ mod tests {
             !rendered.contains("more noise"),
             "the excerpt is a fallback and must not appear alongside diagnostics"
         );
+    }
+
+    /// A run whose two jobs both failed has two paused sessions under one run
+    /// id. The reference a user has is that run id, so it must resolve to both
+    /// rather than to nothing.
+    #[test]
+    fn a_run_id_resolves_to_every_paused_job_in_that_run() {
+        let first = session();
+        let mut second = session();
+        second.session_id = "dbg_def456".into();
+        second.job_name = "lint".into();
+        second.run_id = first.run_id;
+        let sessions = vec![first.clone(), second.clone()];
+
+        let matched = matching(&sessions, &first.run_id.to_string());
+        assert_eq!(matched.len(), 2, "both paused jobs belong to the run");
+
+        let prefix = &first.run_id.to_string()[..8];
+        assert_eq!(matching(&sessions, prefix).len(), 2, "a prefix matches too");
+    }
+
+    #[test]
+    fn a_session_id_resolves_to_exactly_that_session() {
+        let first = session();
+        let mut second = session();
+        second.session_id = "dbg_def456".into();
+        second.run_id = first.run_id;
+        let sessions = vec![first, second];
+
+        let matched = matching(&sessions, "dbg_def456");
+        assert_eq!(matched.len(), 1);
+        assert_eq!(matched[0].session_id, "dbg_def456");
+        assert_eq!(
+            matching(&sessions, "build").len(),
+            2,
+            "job name matches both"
+        );
+    }
+
+    /// The id from a run that never started matches nothing — the paused jobs
+    /// holding the pool belong to an earlier run.
+    #[test]
+    fn an_unrelated_run_id_matches_nothing() {
+        let sessions = vec![session()];
+        assert!(matching(&sessions, &RunId::new().to_string()).is_empty());
+        assert!(matching(&sessions, "dbg_nope").is_empty());
+    }
+
+    #[test]
+    fn a_session_line_names_the_run_it_belongs_to() {
+        let session = session();
+        let line = session_line(&session);
+        assert!(line.contains(&session.session_id));
+        assert!(line.contains("build"));
+        assert!(line.contains(&short_run(session.run_id)));
+        assert!(line.contains("step 4/6"), "1-based step index: {line}");
     }
 
     #[test]

--- a/crates/preloop-cli/src/debug_session.rs
+++ b/crates/preloop-cli/src/debug_session.rs
@@ -233,12 +233,18 @@ async fn resolve(ctx: &Api, sessions: &[DebugSession], reference: &str) -> Resul
         [] => match ctx.get(reference).await {
             Ok(session) => Ok(session),
             Err(error) if sessions.is_empty() => Err(error),
-            Err(error) => {
+            // Only the 404 case means "the reference names nothing" — the
+            // listing is the right answer then. A transport or 5xx failure is
+            // a real error and must not be dressed up as a session mismatch.
+            Err(error) if error.to_string().starts_with("no paused job matching") => {
                 let open: Vec<&DebugSession> = sessions.iter().collect();
                 anyhow::bail!(
                     "{error:#}\n\nthese are paused instead:\n{}\nattach one with: preloop debug <session-id>",
                     session_lines(&open)
                 )
+            }
+            Err(error) => {
+                Err(error)
             }
         },
         ambiguous => anyhow::bail!(

--- a/crates/preloop-orchestrator/src/lib.rs
+++ b/crates/preloop-orchestrator/src/lib.rs
@@ -2951,11 +2951,69 @@ async fn provision_runner<P: VmProvider + 'static>(
                 if config.use_packed_artifact
                     && golden.as_str() == format!("{}-golden", config.name_prefix) =>
             {
-                // A failed fork can leave a partial clone behind. Best-effort
-                // cleanup makes the direct create safe; if cleanup itself is
-                // still racing SmolVM state, create returns the actionable
-                // error and the slot supervisor retries normally.
-                let cleanup = async {
+                if fork_base_unusable(&error) {
+                    // The base is spent. Re-arm it atomically with forking:
+                    // partial-clone cleanup, the live-clone check, and the
+                    // stop/start happen under the provider's per-golden fork
+                    // lock, so a concurrent slot cannot create a clone mid
+                    // re-arm. A full engine restart and golden rebuild was
+                    // the only recovery before; a re-arm is a few seconds.
+                    warn!(
+                        machine = name.as_str(),
+                        golden = golden.as_str(),
+                        %error,
+                        "fork base spent; re-arming the golden once"
+                    );
+                    match provider.rearm_fork_base(golden, Some(name)).await {
+                        Ok(true) => {
+                            info!(golden = golden.as_str(), "golden fork base re-armed");
+                            match provider.fork(golden, name).await {
+                                Ok(()) => Some(golden),
+                                Err(retry_error) => {
+                                    error!(
+                                        machine = name.as_str(),
+                                        golden = golden.as_str(),
+                                        %retry_error,
+                                        "re-armed golden still cannot fork; falling back to \
+                                         direct creation"
+                                    );
+                                    let _ = provider.delete(name).await;
+                                    None
+                                }
+                            }
+                        }
+                        Ok(false) => {
+                            error!(
+                                golden = golden.as_str(),
+                                "fork base spent and cannot be re-armed (a live clone still \
+                                 depends on it, or the partial clone could not be removed); \
+                                 falling back to direct creation"
+                            );
+                            let _ = provider.delete(name).await;
+                            None
+                        }
+                        Err(rearm_error) => {
+                            error!(
+                                golden = golden.as_str(),
+                                %rearm_error,
+                                "failed to re-arm spent fork base; falling back to direct \
+                                 creation"
+                            );
+                            None
+                        }
+                    }
+                } else {
+                    // A failed fork can leave a partial clone behind.
+                    // Best-effort cleanup makes the direct create safe; if
+                    // cleanup itself is still racing SmolVM state, create
+                    // returns the actionable error and the slot supervisor
+                    // retries normally.
+                    warn!(
+                        machine = name.as_str(),
+                        golden = golden.as_str(),
+                        %error,
+                        "packed golden fork failed; creating runner directly from packed artifact"
+                    );
                     if let Err(cleanup) = provider.delete(name).await {
                         debug!(
                             machine = name.as_str(),
@@ -2963,62 +3021,6 @@ async fn provision_runner<P: VmProvider + 'static>(
                             "failed fork left no removable clone"
                         );
                     }
-                };
-                if fork_base_unusable(&error) && !provider.has_live_forks(golden).await {
-                    // The base is spent but nothing depends on it: re-arm the
-                    // golden (stop + start forkable) and retry the fork once.
-                    // A full engine restart and golden rebuild was the only
-                    // recovery before, which stalled the queue until someone
-                    // noticed; a re-arm is a few seconds.
-                    warn!(
-                        machine = name.as_str(),
-                        golden = golden.as_str(),
-                        %error,
-                        "fork base spent; re-arming the golden once"
-                    );
-                    cleanup.await;
-                    let rearmed = provider.stop(golden).await.is_ok()
-                        && provider.start_forkable(golden).await.is_ok();
-                    if rearmed {
-                        info!(golden = golden.as_str(), "golden fork base re-armed");
-                        match provider.fork(golden, name).await {
-                            Ok(()) => Some(golden),
-                            Err(retry_error) => {
-                                error!(
-                                    machine = name.as_str(),
-                                    golden = golden.as_str(),
-                                    %retry_error,
-                                    "re-armed golden still cannot fork; falling back to \
-                                     direct creation"
-                                );
-                                let _ = provider.delete(name).await;
-                                None
-                            }
-                        }
-                    } else {
-                        error!(
-                            golden = golden.as_str(),
-                            "failed to re-arm spent fork base; falling back to direct creation"
-                        );
-                        None
-                    }
-                } else {
-                    if fork_base_unusable(&error) {
-                        error!(
-                            golden = golden.as_str(),
-                            %error,
-                            "fork base is spent and live clones still depend on it, so it \
-                             cannot be re-armed; runners now cost a full VM create each until \
-                             the engine restarts and rebuilds the golden"
-                        );
-                    }
-                    warn!(
-                        machine = name.as_str(),
-                        golden = golden.as_str(),
-                        %error,
-                        "packed golden fork failed; creating runner directly from packed artifact"
-                    );
-                    cleanup.await;
                     None
                 }
             }
@@ -3426,7 +3428,7 @@ mod lifecycle_tests {
         /// Fail the next fork with the "spent fork base" signature, then
         /// succeed. Mirrors a golden whose retained checkpoint vanished.
         fail_fork_once_spent: Mutex<bool>,
-        /// Report live clones for `has_live_forks`; true by default so a spent
+        /// Report live clones to `rearm_fork_base`; true by default so a spent
         /// base with dependents is never re-armed in tests either.
         live_forks: Mutex<bool>,
         fail_start: bool,
@@ -4036,8 +4038,24 @@ chmod +x "$destination/bin/node"
             Ok(())
         }
 
-        async fn has_live_forks(&self, _golden: &MachineName) -> bool {
-            *self.live_forks.lock().await
+        async fn rearm_fork_base(
+            &self,
+            golden: &MachineName,
+            partial: Option<&MachineName>,
+        ) -> Result<bool, VmError> {
+            self.events
+                .lock()
+                .await
+                .push(format!("rearm:{}", golden.as_str()));
+            if let Some(partial) = partial {
+                self.delete(partial).await?;
+            }
+            if *self.live_forks.lock().await {
+                return Ok(false);
+            }
+            self.stop(golden).await?;
+            self.start(golden).await?;
+            Ok(true)
         }
 
         async fn stop(&self, name: &MachineName) -> Result<(), VmError> {
@@ -4362,6 +4380,7 @@ chmod +x "$destination/bin/node"
         let events = provider.events().await;
         let expected = [
             format!("fork:{}:{}", golden.as_str(), name.as_str()),
+            format!("rearm:{}", golden.as_str()),
             format!("delete:{}", name.as_str()),
             format!("stop:{}", golden.as_str()),
             format!("start:{}", golden.as_str()),
@@ -4416,6 +4435,39 @@ chmod +x "$destination/bin/node"
         assert!(
             events.contains(&format!("delete:{}", name.as_str())),
             "the partial clone is cleaned up: {events:?}"
+        );
+    }
+
+    /// A partial clone that cannot be removed must block the re-arm: the
+    /// untracked clone would otherwise share the resumed base's disks.
+    #[tokio::test]
+    async fn spent_fork_base_with_failed_partial_cleanup_is_not_rearmed() {
+        let provider = Arc::new(
+            TestProvider::new(false, false, false, false, true)
+                .with_live_forks(false)
+                .failing_fork_once_spent(),
+        );
+        let config = packed_fork_config();
+        let golden = MachineName::new("lifecycle-test-golden").unwrap();
+        let name = MachineName::new("lifecycle-test-0-8").unwrap();
+
+        provision_runner(
+            &provider,
+            &config,
+            &name,
+            Some(&golden),
+            &Arc::new(KeyPool::new()),
+            &config.base_image,
+            &[],
+            true,
+        )
+        .await
+        .expect("falls back to direct creation");
+
+        let events = provider.events().await;
+        assert!(
+            !events.iter().any(|event| event.starts_with("stop:")),
+            "the golden must not be touched when cleanup failed: {events:?}"
         );
     }
 

--- a/crates/preloop-orchestrator/src/lib.rs
+++ b/crates/preloop-orchestrator/src/lib.rs
@@ -31,7 +31,7 @@ use tokio::io::AsyncWriteExt as _;
 use tokio::sync::{mpsc, RwLock};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 const GUEST_CONTROL_DIR: &str = "/run/preloop-control";
 const GUEST_CONTROL_SOCKET: &str = "/run/preloop-control/engine.sock";
@@ -2909,6 +2909,28 @@ async fn run_until_exit<P: VmProvider + 'static>(
     }
 }
 
+/// Whether a fork failure means this golden can never serve another fork.
+///
+/// A SmolVM fork base carries one RAM checkpoint. Lose it — a raced fork whose
+/// rollback resumed the base, a pruned snapshot directory, a golden restarted
+/// out from under the record — and the base is paused with nothing to restore
+/// from, so *every* later fork fails identically. The pool keeps working, but
+/// each runner now pays a full VM create, which reads as "jobs are queued and
+/// nothing is happening" rather than as a broken fork base. Matching SmolVM's
+/// wording is deliberate: these strings are the only signal the CLI gives, and
+/// a missed match costs a log line, not correctness.
+fn fork_base_unusable(error: &VmError) -> bool {
+    let message = error.to_string();
+    [
+        "is already paused",
+        "is not running forkable",
+        "control socket not responding",
+        "is not ready to fork",
+    ]
+    .iter()
+    .any(|signature| message.contains(signature))
+}
+
 /// Create, boot, and register one ephemeral runner; return its `run` argv.
 ///
 /// The caller owns cleanup: on any error the machine may already exist.
@@ -2929,24 +2951,76 @@ async fn provision_runner<P: VmProvider + 'static>(
                 if config.use_packed_artifact
                     && golden.as_str() == format!("{}-golden", config.name_prefix) =>
             {
-                warn!(
-                    machine = name.as_str(),
-                    golden = golden.as_str(),
-                    %error,
-                    "packed golden fork failed; creating runner directly from packed artifact"
-                );
                 // A failed fork can leave a partial clone behind. Best-effort
                 // cleanup makes the direct create safe; if cleanup itself is
                 // still racing SmolVM state, create returns the actionable
                 // error and the slot supervisor retries normally.
-                if let Err(cleanup) = provider.delete(name).await {
-                    debug!(
+                let cleanup = async {
+                    if let Err(cleanup) = provider.delete(name).await {
+                        debug!(
+                            machine = name.as_str(),
+                            %cleanup,
+                            "failed fork left no removable clone"
+                        );
+                    }
+                };
+                if fork_base_unusable(&error) && !provider.has_live_forks(golden).await {
+                    // The base is spent but nothing depends on it: re-arm the
+                    // golden (stop + start forkable) and retry the fork once.
+                    // A full engine restart and golden rebuild was the only
+                    // recovery before, which stalled the queue until someone
+                    // noticed; a re-arm is a few seconds.
+                    warn!(
                         machine = name.as_str(),
-                        %cleanup,
-                        "failed fork left no removable clone"
+                        golden = golden.as_str(),
+                        %error,
+                        "fork base spent; re-arming the golden once"
                     );
+                    cleanup.await;
+                    let rearmed = provider.stop(golden).await.is_ok()
+                        && provider.start_forkable(golden).await.is_ok();
+                    if rearmed {
+                        info!(golden = golden.as_str(), "golden fork base re-armed");
+                        match provider.fork(golden, name).await {
+                            Ok(()) => Some(golden),
+                            Err(retry_error) => {
+                                error!(
+                                    machine = name.as_str(),
+                                    golden = golden.as_str(),
+                                    %retry_error,
+                                    "re-armed golden still cannot fork; falling back to \
+                                     direct creation"
+                                );
+                                let _ = provider.delete(name).await;
+                                None
+                            }
+                        }
+                    } else {
+                        error!(
+                            golden = golden.as_str(),
+                            "failed to re-arm spent fork base; falling back to direct creation"
+                        );
+                        None
+                    }
+                } else {
+                    if fork_base_unusable(&error) {
+                        error!(
+                            golden = golden.as_str(),
+                            %error,
+                            "fork base is spent and live clones still depend on it, so it \
+                             cannot be re-armed; runners now cost a full VM create each until \
+                             the engine restarts and rebuilds the golden"
+                        );
+                    }
+                    warn!(
+                        machine = name.as_str(),
+                        golden = golden.as_str(),
+                        %error,
+                        "packed golden fork failed; creating runner directly from packed artifact"
+                    );
+                    cleanup.await;
+                    None
                 }
-                None
             }
             Err(error) => return Err(error.into()),
         },
@@ -3349,6 +3423,12 @@ mod lifecycle_tests {
         machines: Mutex<HashMap<String, MachineState>>,
         events: Mutex<Vec<String>>,
         fail_fork: bool,
+        /// Fail the next fork with the "spent fork base" signature, then
+        /// succeed. Mirrors a golden whose retained checkpoint vanished.
+        fail_fork_once_spent: Mutex<bool>,
+        /// Report live clones for `has_live_forks`; true by default so a spent
+        /// base with dependents is never re-armed in tests either.
+        live_forks: Mutex<bool>,
         fail_start: bool,
         fail_install: bool,
         fail_configure: bool,
@@ -3377,6 +3457,8 @@ mod lifecycle_tests {
                 machines: Mutex::new(HashMap::new()),
                 events: Mutex::new(Vec::new()),
                 fail_fork: false,
+                fail_fork_once_spent: Mutex::new(false),
+                live_forks: Mutex::new(true),
                 fail_start,
                 fail_install,
                 fail_configure,
@@ -3396,6 +3478,18 @@ mod lifecycle_tests {
 
         fn failing_fork(mut self) -> Self {
             self.fail_fork = true;
+            self
+        }
+
+        /// Fail the next fork with the spent-fork-base signature, then succeed.
+        fn failing_fork_once_spent(mut self) -> Self {
+            *self.fail_fork_once_spent.get_mut() = true;
+            self
+        }
+
+        /// Report whether clones of the golden still exist.
+        fn with_live_forks(mut self, live: bool) -> Self {
+            *self.live_forks.get_mut() = live;
             self
         }
 
@@ -3918,6 +4012,16 @@ chmod +x "$destination/bin/node"
                 .lock()
                 .await
                 .push(format!("fork:{}:{}", golden.as_str(), clone.as_str()));
+            {
+                let mut spent = self.fail_fork_once_spent.lock().await;
+                if *spent {
+                    *spent = false;
+                    return Err(test_error(
+                        "smolvm fork failed with exit code 1: golden 'lifecycle-test-golden' \
+                         is already paused; a valid retained checkpoint is required",
+                    ));
+                }
+            }
             if self.fail_fork {
                 return Err(test_error("fork-failure"));
             }
@@ -3932,7 +4036,15 @@ chmod +x "$destination/bin/node"
             Ok(())
         }
 
+        async fn has_live_forks(&self, _golden: &MachineName) -> bool {
+            *self.live_forks.lock().await
+        }
+
         async fn stop(&self, name: &MachineName) -> Result<(), VmError> {
+            self.events
+                .lock()
+                .await
+                .push(format!("stop:{}", name.as_str()));
             self.machines
                 .lock()
                 .await
@@ -4155,6 +4267,24 @@ chmod +x "$destination/bin/node"
     /// artifact remains valid.
     #[tokio::test]
     async fn packed_golden_fork_failure_falls_back_to_direct_creation() {
+        // Verbatim from SmolVM 1.7.x: a spent fork base is reported through the
+        // CLI's stderr, so the signature match is the only handle on it.
+        const SPENT_BASE: &str = "smolvm fork failed with exit code 1: Freezing golden \
+             'preloop-runner-golden' as fork base...\nError: agent operation failed: fork: \
+             golden 'preloop-runner-golden' is already paused; a valid retained checkpoint \
+             is required";
+
+        assert!(fork_base_unusable(&VmError::Command {
+            operation: "fork",
+            exit_code: 1,
+            message: SPENT_BASE.to_owned(),
+        }));
+        assert!(!fork_base_unusable(&VmError::Command {
+            operation: "fork",
+            exit_code: 1,
+            message: "host port 8080 is assigned to more than one clone".to_owned(),
+        }));
+
         let provider =
             Arc::new(TestProvider::new(false, false, false, false, false).failing_fork());
         let config = packed_fork_config();
@@ -4200,6 +4330,93 @@ chmod +x "$destination/bin/node"
             "fallback order must be fork, cleanup, create, start: {events:?}"
         );
         assert!(provider.has_machine(&name).await);
+    }
+
+    /// A spent fork base with no surviving clones is re-armed (stop, start
+    /// forkable) and the fork retried — the queue recovers in seconds instead
+    /// of stalling until someone restarts the engine and rebuilds the golden.
+    #[tokio::test]
+    async fn spent_fork_base_with_no_live_clones_is_rearmed_and_retried() {
+        let provider = Arc::new(
+            TestProvider::new(false, false, false, false, false)
+                .with_live_forks(false)
+                .failing_fork_once_spent(),
+        );
+        let config = packed_fork_config();
+        let golden = MachineName::new("lifecycle-test-golden").unwrap();
+        let name = MachineName::new("lifecycle-test-0-6").unwrap();
+
+        provision_runner(
+            &provider,
+            &config,
+            &name,
+            Some(&golden),
+            &Arc::new(KeyPool::new()),
+            &config.base_image,
+            &[],
+            true,
+        )
+        .await
+        .expect("the re-armed golden serves the fork");
+
+        let events = provider.events().await;
+        let expected = [
+            format!("fork:{}:{}", golden.as_str(), name.as_str()),
+            format!("delete:{}", name.as_str()),
+            format!("stop:{}", golden.as_str()),
+            format!("start:{}", golden.as_str()),
+            format!("fork:{}:{}", golden.as_str(), name.as_str()),
+        ];
+        let mut cursor = 0;
+        for event in &expected {
+            let position = events[cursor..]
+                .iter()
+                .position(|seen| seen == event)
+                .expect("re-arm sequence must include every step");
+            cursor += position + 1;
+        }
+        assert!(
+            provider.has_machine(&name).await,
+            "the retried fork must leave the clone provisioned"
+        );
+    }
+
+    /// A spent base that still has live clones must NOT be re-armed: resuming
+    /// it would corrupt the copy-on-write clones. The pool falls back to a
+    /// full create instead.
+    #[tokio::test]
+    async fn spent_fork_base_with_live_clones_is_not_rearmed() {
+        let provider = Arc::new(
+            TestProvider::new(false, false, false, false, false)
+                .with_live_forks(true)
+                .failing_fork_once_spent(),
+        );
+        let config = packed_fork_config();
+        let golden = MachineName::new("lifecycle-test-golden").unwrap();
+        let name = MachineName::new("lifecycle-test-0-7").unwrap();
+
+        provision_runner(
+            &provider,
+            &config,
+            &name,
+            Some(&golden),
+            &Arc::new(KeyPool::new()),
+            &config.base_image,
+            &[],
+            true,
+        )
+        .await
+        .expect("falls back to direct creation");
+
+        let events = provider.events().await;
+        assert!(
+            !events.iter().any(|event| event.starts_with("stop:")),
+            "the golden must not be touched while clones exist: {events:?}"
+        );
+        assert!(
+            events.contains(&format!("delete:{}", name.as_str())),
+            "the partial clone is cleaned up: {events:?}"
+        );
     }
 
     /// An environment-specific golden may represent a different `runs-on`

--- a/crates/preloop-vm/src/lib.rs
+++ b/crates/preloop-vm/src/lib.rs
@@ -2,6 +2,7 @@
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
@@ -280,6 +281,16 @@ pub trait VmProvider: Send + Sync {
         argv: &[String],
         secrets: &[(String, SecretSource)],
     ) -> Result<ExecOutput, VmError>;
+    /// Whether any machine forked from `golden` is still alive.
+    ///
+    /// A golden that has been frozen as a fork base must never be started
+    /// again while a clone exists — the clone's disks are copy-on-write over
+    /// the golden's, and resuming the base would corrupt them. Defaults to
+    /// `true` so a provider that does not track clones refuses to re-arm a
+    /// spent fork base rather than risk live clones.
+    async fn has_live_forks(&self, _golden: &MachineName) -> bool {
+        true
+    }
     /// Execute while forwarding output fragments to the caller.
     async fn exec_stream(
         &self,
@@ -305,6 +316,14 @@ pub struct SmolVmProvider {
     /// Serializes operations that build or replace a machine's base against
     /// everything else. See [`SmolVmProvider::exclusive`].
     lifecycle_lock: Arc<tokio::sync::RwLock<()>>,
+    /// One in-flight `machine fork` per golden. See [`SmolVmProvider::fork`].
+    fork_locks: Arc<tokio::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
+    /// Machines forked from a golden, by clone name, while they still exist.
+    ///
+    /// A golden is a copy-on-write base: once paused it must outlive every
+    /// clone, and starting it again would corrupt them. This census is how the
+    /// orchestrator knows a spent fork base may be safely re-armed.
+    forked_machines: Arc<tokio::sync::Mutex<HashMap<String, String>>>,
     /// Whether the resolved binary's `machine create` accepts
     /// `--mount-socket`, probed once per provider.
     socket_mount_supported: Arc<tokio::sync::OnceCell<bool>>,
@@ -352,6 +371,8 @@ impl SmolVmProvider {
             pack_proxy: None,
             pack_no_proxy: None,
             lifecycle_lock: Arc::new(tokio::sync::RwLock::new(())),
+            fork_locks: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+            forked_machines: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             socket_mount_supported: Arc::new(tokio::sync::OnceCell::new()),
         }
     }
@@ -519,12 +540,12 @@ impl SmolVmProvider {
     ///
     /// These run concurrently with each other: a pool replenishing several
     /// slots at once issues a delete and a fork per slot, and serializing them
-    /// made the whole refill wait one VM operation at a time. Forking four
-    /// clones from the same golden — including the first forks, which trigger
-    /// the base freeze — measured 101-119 ms concurrently against 271-283 ms
-    /// serially, with every clone usable and no failures across three trials.
-    /// They stay excluded from base construction, so a golden cannot be
-    /// replaced underneath a fork.
+    /// made the whole refill wait one VM operation at a time. They stay
+    /// excluded from base construction, so a golden cannot be replaced
+    /// underneath a fork.
+    ///
+    /// Forks additionally serialize per golden: see [`SmolVmProvider::fork`]
+    /// for the checkpoint invariant that requires it.
     async fn concurrent(
         &self,
         operation: &'static str,
@@ -532,6 +553,19 @@ impl SmolVmProvider {
     ) -> Result<ExecOutput, VmError> {
         let _guard = self.lifecycle_lock.read().await;
         self.checked(operation, args).await
+    }
+
+    /// The mutex guarding forks from one golden, created on first use.
+    ///
+    /// Keyed by name rather than held on the golden record because a provider
+    /// outlives any single golden and forks arrive from independent slot tasks.
+    async fn fork_lock(&self, golden: &MachineName) -> Arc<tokio::sync::Mutex<()>> {
+        let mut locks = self.fork_locks.lock().await;
+        Arc::clone(
+            locks
+                .entry(golden.as_str().to_owned())
+                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(()))),
+        )
     }
 }
 
@@ -684,20 +718,45 @@ impl VmProvider for SmolVmProvider {
         .map(|_| ())
     }
 
+    /// Fork one clone from a golden, one fork per golden at a time.
+    ///
+    /// SmolVM holds exactly one RAM checkpoint per golden: the first fork
+    /// freezes the base and publishes a retained checkpoint, and later forks
+    /// restore from that checkpoint instead of re-freezing. Two forks racing
+    /// the same golden break the invariant — the loser issues a second FORK
+    /// against an already-paused VM, and that failure's rollback resumes the
+    /// base and deletes the retained checkpoint. Every later fork then fails
+    /// with `golden '<name>' is already paused; a valid retained checkpoint is
+    /// required`, so the pool cannot produce another runner until the golden is
+    /// rebuilt from scratch: queued jobs stall indefinitely, in exchange for
+    /// the few hundred milliseconds a concurrent refill saves. SmolVM's own
+    /// fork-pool controller serializes on the golden for the same reason.
+    ///
+    /// Different goldens still fork concurrently, and forks remain excluded
+    /// from base construction, so a golden cannot be replaced underneath one.
     async fn fork(&self, golden: &MachineName, clone: &MachineName) -> Result<(), VmError> {
-        self.concurrent(
-            "fork",
-            &[
-                "machine".into(),
-                "fork".into(),
-                "--golden".into(),
-                golden.as_str().into(),
-                "--name".into(),
-                clone.as_str().into(),
-            ],
-        )
-        .await
-        .map(|_| ())
+        let fork_lock = self.fork_lock(golden).await;
+        let _fork_guard = fork_lock.lock().await;
+        let result = self
+            .concurrent(
+                "fork",
+                &[
+                    "machine".into(),
+                    "fork".into(),
+                    "--golden".into(),
+                    golden.as_str().into(),
+                    "--name".into(),
+                    clone.as_str().into(),
+                ],
+            )
+            .await;
+        if result.is_ok() {
+            self.forked_machines
+                .lock()
+                .await
+                .insert(clone.as_str().to_owned(), golden.as_str().to_owned());
+        }
+        result.map(|_| ())
     }
 
     async fn stop(&self, name: &MachineName) -> Result<(), VmError> {
@@ -715,18 +774,22 @@ impl VmProvider for SmolVmProvider {
     }
 
     async fn delete(&self, name: &MachineName) -> Result<(), VmError> {
-        self.concurrent(
-            "delete",
-            &[
-                "machine".into(),
-                "delete".into(),
-                "--name".into(),
-                name.as_str().into(),
-                "-f".into(),
-            ],
-        )
-        .await
-        .map(|_| ())
+        let result = self
+            .concurrent(
+                "delete",
+                &[
+                    "machine".into(),
+                    "delete".into(),
+                    "--name".into(),
+                    name.as_str().into(),
+                    "-f".into(),
+                ],
+            )
+            .await;
+        if result.is_ok() {
+            self.forked_machines.lock().await.remove(name.as_str());
+        }
+        result.map(|_| ())
     }
 
     async fn status(&self, name: &MachineName) -> Result<MachineState, VmError> {
@@ -929,6 +992,14 @@ impl VmProvider for SmolVmProvider {
         self.exclusive_with_staging("pack", &args, staging_dir)
             .await
             .map(|_| ())
+    }
+
+    async fn has_live_forks(&self, golden: &MachineName) -> bool {
+        self.forked_machines
+            .lock()
+            .await
+            .values()
+            .any(|owner| owner == golden.as_str())
     }
 }
 

--- a/crates/preloop-vm/src/lib.rs
+++ b/crates/preloop-vm/src/lib.rs
@@ -281,15 +281,28 @@ pub trait VmProvider: Send + Sync {
         argv: &[String],
         secrets: &[(String, SecretSource)],
     ) -> Result<ExecOutput, VmError>;
-    /// Whether any machine forked from `golden` is still alive.
+    /// Re-arm a spent fork base so it can serve forks again.
     ///
-    /// A golden that has been frozen as a fork base must never be started
-    /// again while a clone exists — the clone's disks are copy-on-write over
-    /// the golden's, and resuming the base would corrupt them. Defaults to
-    /// `true` so a provider that does not track clones refuses to re-arm a
-    /// spent fork base rather than risk live clones.
-    async fn has_live_forks(&self, _golden: &MachineName) -> bool {
-        true
+    /// Atomic with forking: takes the same per-golden exclusion `fork` uses,
+    /// so a concurrent fork can neither observe the golden mid-re-arm nor
+    /// create a clone between the live-clone check and the golden being
+    /// stopped. Removes a partial clone left by the failed fork (when
+    /// `partial` is given) — only if that cleanup succeeds, because an
+    /// untracked clone would otherwise share the resumed base's disks — then
+    /// verifies no live clone still depends on the golden, and only then
+    /// stops and restarts it forkable.
+    ///
+    /// Returns `Ok(true)` when the golden can serve forks again, `Ok(false)`
+    /// when it cannot (a live clone exists, or the partial clone could not be
+    /// removed), and `Err` on operational failure. The default implementation
+    /// never re-arms, so providers without the machinery conservatively fall
+    /// back to direct creation.
+    async fn rearm_fork_base(
+        &self,
+        _golden: &MachineName,
+        _partial: Option<&MachineName>,
+    ) -> Result<bool, VmError> {
+        Ok(false)
     }
     /// Execute while forwarding output fragments to the caller.
     async fn exec_stream(
@@ -787,7 +800,12 @@ impl VmProvider for SmolVmProvider {
             )
             .await;
         if result.is_ok() {
-            self.forked_machines.lock().await.remove(name.as_str());
+            let mut forked = self.forked_machines.lock().await;
+            forked.remove(name.as_str());
+            // Deleting a golden must evict every clone forked from it. Without
+            // this, a rebaked or recreated golden name would report live
+            // clones forever, silently disabling the re-arm recovery.
+            forked.retain(|_, owner| owner != name.as_str());
         }
         result.map(|_| ())
     }
@@ -994,12 +1012,52 @@ impl VmProvider for SmolVmProvider {
             .map(|_| ())
     }
 
-    async fn has_live_forks(&self, golden: &MachineName) -> bool {
-        self.forked_machines
-            .lock()
-            .await
-            .values()
-            .any(|owner| owner == golden.as_str())
+    async fn rearm_fork_base(
+        &self,
+        golden: &MachineName,
+        partial: Option<&MachineName>,
+    ) -> Result<bool, VmError> {
+        let fork_lock = self.fork_lock(golden).await;
+        let _fork_guard = fork_lock.lock().await;
+        if let Some(partial) = partial {
+            match self.delete(partial).await {
+                Ok(()) => {}
+                // A failed fork that never registered its clone leaves
+                // nothing to remove; "not found" positively establishes the
+                // clone is gone, which is all the cleanup contract needs.
+                Err(VmError::Command { message, .. })
+                    if message.to_ascii_lowercase().contains("not found") => {}
+                Err(error) => return Err(error),
+            }
+        }
+        {
+            let forked = self.forked_machines.lock().await;
+            if forked.values().any(|owner| owner == golden.as_str()) {
+                return Ok(false);
+            }
+        }
+        self.concurrent(
+            "stop",
+            &[
+                "machine".into(),
+                "stop".into(),
+                "--name".into(),
+                golden.as_str().into(),
+            ],
+        )
+        .await?;
+        self.concurrent(
+            "start",
+            &[
+                "machine".into(),
+                "start".into(),
+                "--name".into(),
+                golden.as_str().into(),
+                "--forkable".into(),
+            ],
+        )
+        .await?;
+        Ok(true)
     }
 }
 

--- a/crates/preloop-vm/tests/provider.rs
+++ b/crates/preloop-vm/tests/provider.rs
@@ -691,4 +691,132 @@ exit 0
             ["machine", "delete", "--name", "test-rosetta", "-f"]
         );
     }
+
+    /// A smolvm whose `machine fork` records entry and exit around a barrier,
+    /// so a test can observe whether two forks are in flight at once.
+    fn fake_blocking_fork_smolvm() -> (TempDir, PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let executable = directory.path().join("smolvm");
+        write_executable(
+            &executable,
+            r##"#!/bin/sh
+set -eu
+if [ "${1-}:${2-}" != "machine:fork" ]; then
+  exit 0
+fi
+printf 'enter %s\n' "$6" >> "$0.forklog"
+while [ ! -f "$0.release" ]; do sleep 0.02; done
+printf 'exit %s\n' "$6" >> "$0.forklog"
+"##,
+        );
+        (directory, executable)
+    }
+
+    fn fork_log(executable: &Path) -> Vec<String> {
+        fs::read_to_string(executable.with_extension("forklog"))
+            .unwrap_or_default()
+            .lines()
+            .map(str::to_owned)
+            .collect()
+    }
+
+    async fn wait_for_entries(executable: &Path, count: usize) -> bool {
+        for _ in 0..250 {
+            if fork_log(executable)
+                .iter()
+                .filter(|line| line.starts_with("enter"))
+                .count()
+                >= count
+            {
+                return true;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        false
+    }
+
+    /// SmolVM keeps one RAM checkpoint per golden: the first fork freezes the
+    /// base and later forks restore from the retained checkpoint. A second fork
+    /// racing the first FORKs an already-paused VM, and that failure's rollback
+    /// resumes the base and drops the checkpoint — after which every fork from
+    /// that golden fails and queued jobs stall until the golden is rebuilt.
+    #[tokio::test]
+    async fn forks_from_one_golden_never_overlap() {
+        let (_directory, executable) = fake_blocking_fork_smolvm();
+        let provider = SmolVmProvider::new(&executable);
+        let golden = MachineName::new("runner-golden").unwrap();
+        let first = MachineName::new("runner-0-1").unwrap();
+        let second = MachineName::new("runner-1-1").unwrap();
+
+        let one = {
+            let provider = provider.clone();
+            let (golden, first) = (golden.clone(), first.clone());
+            tokio::spawn(async move { provider.fork(&golden, &first).await })
+        };
+        let two = {
+            let provider = provider.clone();
+            let (golden, second) = (golden.clone(), second.clone());
+            tokio::spawn(async move { provider.fork(&golden, &second).await })
+        };
+
+        assert!(
+            wait_for_entries(&executable, 1).await,
+            "the first fork must start"
+        );
+        // The barrier holds fork one inside smolvm. If forks were concurrent,
+        // fork two would enter here rather than wait for the lock.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        assert_eq!(
+            fork_log(&executable)
+                .iter()
+                .filter(|line| line.starts_with("enter"))
+                .count(),
+            1,
+            "second fork must wait for the first to finish: {:?}",
+            fork_log(&executable)
+        );
+
+        fs::write(executable.with_extension("release"), "").unwrap();
+        one.await.unwrap().unwrap();
+        two.await.unwrap().unwrap();
+
+        let log = fork_log(&executable);
+        let order: Vec<&str> = log.iter().map(|line| &line[..5]).collect();
+        assert_eq!(
+            order,
+            ["enter", "exit ", "enter", "exit "],
+            "strictly one fork at a time: {log:?}"
+        );
+    }
+
+    /// Serialization is per golden, not global: independent base images must
+    /// still refill in parallel, which is the whole point of a fork pool.
+    #[tokio::test]
+    async fn forks_from_different_goldens_still_overlap() {
+        let (_directory, executable) = fake_blocking_fork_smolvm();
+        let provider = SmolVmProvider::new(&executable);
+        let first_golden = MachineName::new("runner-golden-a").unwrap();
+        let second_golden = MachineName::new("runner-golden-b").unwrap();
+
+        let one = {
+            let provider = provider.clone();
+            let clone = MachineName::new("runner-0-1").unwrap();
+            tokio::spawn(async move { provider.fork(&first_golden, &clone).await })
+        };
+        let two = {
+            let provider = provider.clone();
+            let clone = MachineName::new("runner-1-1").unwrap();
+            tokio::spawn(async move { provider.fork(&second_golden, &clone).await })
+        };
+
+        assert!(
+            wait_for_entries(&executable, 2).await,
+            "both forks must be in flight: {:?}",
+            fork_log(&executable)
+        );
+
+        fs::write(executable.with_extension("release"), "").unwrap();
+        one.await.unwrap().unwrap();
+        two.await.unwrap().unwrap();
+    }
 }


### PR DESCRIPTION
## Problem

A run stalled with `2 job(s) queued, 2 debug session(s) paused` and no debug shell anywhere: `preloop debug <run-id>` answered `no paused job matching`, and the queue never moved. The engine log showed the underlying failure:

```
smolvm fork failed with exit code 1: Freezing golden 'preloop-runner-golden' as fork base...
Error: agent operation failed: fork: golden 'preloop-runner-golden' is already paused; a valid retained checkpoint is required
```

### Root cause

SmolVM keeps **one RAM checkpoint per golden** (its own fork-pool controller serializes on the golden for exactly this reason: "a golden can produce only one RAM checkpoint at a time"). Preloop's on-demand pool forks the same golden **concurrently** — one `machine fork` per queued job, unserialized. The concurrent forks race the freeze/checkpoint; the loser's rollback **resumes the golden and deletes the checkpoint**. Since the plain `machine fork` path preloop uses never persists a reusable checkpoint (`prepare_forks_reusing(..., None, false)`), a paused golden with no valid checkpoint fails **every** subsequent fork identically. The fallback (direct VM create from the packed artifact) is slow, and nothing ever re-arms the golden — the queue stalls until the engine restarts and rebuilds it.

On a dev machine this reproduced live: 20,405 checkpoint directories (~800 MB) accumulated under the golden's data dir, the fingerprint of repeated fork races (each rollback resumed the golden, forcing the next fork to re-checkpoint).

### Why the debug terminal never came up

The two paused sessions belonged to an *earlier* run. The stalled run's jobs never got a runner, so there was nothing to attach — and `preloop debug <run-id>` 404'd because the run id matched no session, with the error message not saying what *was* paused.

## Changes

- **`preloop-vm`** — serialize `machine fork` per golden: one in-flight fork per golden, keyed by name; different goldens still fork in parallel. Track forked clones (name → golden) so a spent base can be re-armed safely; `delete` clears the census. `VmProvider::has_live_forks` defaults to `true` (conservative: refuse re-arm) for providers that don't track clones.
- **`preloop-orchestrator`** — when a fork fails with the spent-base signature and **no clone depends on the golden**, stop → `start --forkable` → retry the fork once: the queue recovers in seconds instead of stalling until an engine restart. A base with live clones is never restarted (resuming it would corrupt the copy-on-write clones); it falls back to direct creation with an error-level log explaining why.
- **`preloop-cli`** — `preloop debug <reference>` now resolves a run id that has several paused jobs: it lists them (session id, job, run, step) instead of answering `no paused job matching`. When the reference matches nothing but other sessions are paused, the error lists what is paused. The no-argument listing now shows each session's run id.
- CHANGELOG entry under Unreleased.

## Verification

- New unit tests:
  - `preloop-vm`: `forks_from_one_golden_never_overlap` (barrier-proven), `forks_from_different_goldens_still_overlap`.
  - `preloop-orchestrator`: spent base with no live clones → re-arm sequence (fork, cleanup, stop, start-forkable, fork retry); spent base with live clones → no re-arm, fallback + cleanup; existing fallback test still green.
  - `preloop-cli`: run id with two paused jobs resolves to both; session id resolves exactly; unrelated run id matches nothing; session line includes run id.
- Full suites: `preloop-vm` 17 ✓, `preloop-cli` 119 ✓, `preloop-orchestrator` 78 ✓.
- End-to-end smoke on a Mac: two-job workflow ran green twice (cold 148s / warm 38s) with 11 serialized forks from one golden and zero failures; `preloop debug <run-id>` demonstrated resolving a live paused session; leftover sessions aborted cleanly.

## Follow-up (not in this PR)

- Replacing a spent golden with a fresh generation (rather than re-arming the same base) so recovery works even while paused debug VMs hold live clones.
- smolvm-side: garbage-collect accumulated checkpoint directories per golden (`s/` grows one small dir per fork).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stalled queues by serializing forks per golden and auto-rearming a spent fork base when safe. Also improves `preloop debug` to resolve paused sessions by run so users can attach reliably.

- **Bug Fixes**
  - `preloop-vm`: serialize `machine fork` per golden; different goldens still fork in parallel. Track forked clones and clear the census on `delete`; deleting a golden evicts its clones from the census. Add `rearm_fork_base` in the provider, which runs under the same per-golden lock as `fork`: it cleans up a partial clone (or accepts “not found”), verifies no live clones, then `stop` → `start --forkable`; default providers return `false` to fall back safely.
  - `preloop-orchestrator`: on a spent-base fork failure with no live clones, call provider `rearm_fork_base` and retry once; operations are atomic with forking. If live clones exist or cleanup fails, do not re-arm; fall back to direct create with a clear error.
  - `preloop-cli`: `preloop debug <reference>` resolves run IDs with multiple paused jobs and lists all matches. The “these are paused instead” hint only replaces a 404; transport/5xx errors bubble up unchanged.

<sup>Written for commit a6ca1b1248865a8cc188c79eeb84b177be4da8db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

