### PR TITLE
Harden SmolVM execution: seccomp/Landlock enforcement and a non-root service identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,8 @@ Releases before v0.27.0 predate the changelog.
   clone cleanup, the live-clone check, and the stop/restart run under the
   provider's per-golden fork lock, and cleanup must succeed before the base
   is touched. A base with live clones is never restarted — it falls back to
-  direct creation with an error explaining why.- `preloop debug <reference>` now resolves a run id that has several paused
+  direct creation with an error explaining why.
+- `preloop debug <reference>` now resolves a run id that has several paused
   jobs: it lists them (with their run ids) instead of answering
   `no paused job matching`; non-404 failures propagate their real cause.
   When nothing matches but other sessions are paused, the reply says what is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,116 @@ Releases before v0.27.0 predate the changelog.
 
 ## [Unreleased]
 
+### Added
+
+- `docs/internal/threatmodel.md`: threat model overview — attacker
+  assumptions, deployment topologies, defenses enforced for each attack
+  class (VM escape, hostile egress, secret theft, control-plane
+  impersonation, resource sabotage, supply chain), and candid current
+  limitations (internal doc).
+
+### Security
+
+- Harden standalone SmolVM execution for hostile workflow code: every Linux
+  operation that can boot or restart a machine (create, start, start_forkable,
+  fork, exec, pack) and every direct `smolvm machine exec`/`cp`/`shell` call
+  in the CLI (which connect to a machine, starting it when stopped) now run
+  `smolvm` with `SMOLVM_SECCOMP=enforce` and `SMOLVM_LANDLOCK=enforce` — the
+  hardening `smolvm serve` applies — so each `_boot-vm` is confined by
+  the syscall allowlist and filesystem Landlock rules instead of only
+  `harden_self`. A pre-set operator value wins (upstream precedence) but is
+  validated: modes SmolVM does not recognize fail the operation rather than
+  silently booting unconfined. macOS is unchanged (both controls are no-ops
+  upstream there). The policy is one exported function shared by the
+  provider and the CLI, with per-path command-environment tests.
+  Note that Landlock matches upstream exactly, while seccomp does not:
+  upstream `serve` defaults it on Linux/x86_64 only, though the boot
+  subprocess honours it on aarch64 too, so on Linux/aarch64 Preloop enables a
+  filter upstream leaves off. `docs/setup.md` documents the `Seccomp: 2`
+  check to confirm it on a new aarch64 host.
+- Per-VM host resource containment on Linux: the systemd service delegates
+  its cgroup subtree (`Delegate=cpu memory pids`) so every `_boot-vm` places
+  itself in a `vm-<pid>` leaf capped on CPU, PIDs, and memory. `Delegate=`
+  alone is insufficient — systemd chowns the subtree to the service user but
+  leaves `cgroup.subtree_control` empty, so child leaves get no limit files —
+  so the **server** performs the same one-time setup `smolvm serve` does
+  (vacate into a `preloop-supervisor` leaf, then enable the controllers on the
+  now-empty unit cgroup) via an explicit `init_vm_cgroup_delegation()` at
+  startup. The CLI never calls it: `preloop shell` and the debug session use a
+  read-only check and never mutate the cgroup hierarchy. No usable delegation,
+  no variable; the standalone path never claims per-VM UID isolation, which
+  requires a privileged supervisor.
+- The generated systemd service now runs under a dedicated `preloop` system
+  account (created at install, `kvm` group when `/dev/kvm` exists) instead of
+  root: a guest→VMM escape inherits the service identity, so root would hand
+  it the host. The unit adds an empty capability bounding set,
+  `ProtectKernelModules`/`ProtectKernelLogs`/`ProtectClock`,
+  `LockPersonality`, `RestrictRealtime`, and — critically — no longer grants
+  the serving unit write access to its own executable (only the root update
+  oneshot can replace the binary). State paths, socket activation, networking,
+  and `/dev/kvm` access are preserved; SmolVM data is pinned under
+  `PRELOOP_HOME/smolvm` and the installer bootstraps a service-visible
+  smolvm when only a root-home install exists — copied to
+  `/usr/local/lib/preloop/smolvm-prefix` and refreshed on re-install when the
+  source is newer, never shadowing an independently installed system binary.
+  The refresh is atomic: the new prefix is fully assembled in a sibling
+  staging directory and swapped into place with a rename, so a running service
+  never observes a mixed prefix; staging and backup are cleaned up on success
+  and failure alike.
+- **Keep privileged install artifacts out of the service-writable state dir.**
+  `PRELOOP_HOME` must be writable by the service, and on Unix the *directory*
+  write bit governs unlink and rename, so anything inside it can be replaced
+  by the service whatever the file's own owner and mode are. Three artifacts
+  therefore moved out, each closing a reproduced escalation:
+  - the bootstrapped smolvm prefix now lives at
+    `/usr/local/lib/preloop/smolvm-prefix`, root-owned and `a+rX` (never
+    chowned to the service). `/usr/local/bin/smolvm` points into it and root
+    executes that path when `preloop update` probes smolvm, so the previous
+    service-owned copy was a direct service-user → root escalation. Re-install
+    also repairs an already-chowned prefix.
+  - the systemd environment file now lives at `/etc/preloop/environment`,
+    `root:root` 0600. It previously ended up service-owned after any
+    re-install (the state-dir chown preceded the rewrite, and the rewrite
+    truncates in place rather than replacing the inode), and because
+    `EnvironmentFile=` overrides the unit's `Environment=`, a compromised VMM
+    could persist `SMOLVM_SECCOMP=off` and return unconfined via
+    `Restart=on-failure`.
+  - the staged GitHub App key now lives at
+    `/etc/preloop/github-app-key.pem`, `root:preloop` 0640 in a
+    `root:preloop` 0750 directory — readable by the service, writable only by
+    root, and no longer replaceable by it.
+  `preloop server uninstall` removes all three, so secrets no longer outlive
+  an uninstall that only purges the state dir.
+
+### Changed
+
+- `preloop server install` (Linux, system scope) creates the `preloop` service
+  account, chowns the state dir to it, stages a `root:preloop` 0640 copy of
+  `--github-app-key` into `/etc/preloop` (the caller's original is never
+  modified — chowning a key under `/root` would be useless because the service
+  user cannot traverse the parent), preparing the directories first so the very
+  install with a key works against a not-yet-existing (default or nested)
+  `--home`, and prints the `sudo -u preloop env PRELOOP_HOME=… preloop setup
+  github --save` flow for writing `config.toml`; see `docs/setup.md` "VM
+  sandbox (Linux)" for the verification procedure and the macOS limitation.
+- `preloop server install` now rejects a system-scope `--home` under `/home`,
+  `/root`, or `/run/user`: the `preloop` account cannot traverse those
+  whatever the state dir's own mode is, so the previous `ReadWritePaths`
+  carve-out produced a unit that looked correct and failed at first start.
+
+### Fixed
+
+- `preloop-cli` and `preloop-vm` did not compile for Linux at all (a
+  use-after-move in `add_to_kvm_group`, a `format!` arity bug that also
+  silently dropped the webhook hint from the install summary, and two test
+  errors). Every one of these lives behind `#[cfg(target_os = "linux")]`, so a
+  macOS development host never parsed them, and the work had not yet been
+  pushed for CI — which does build on Linux — to see.
+  Also fixed the pre-existing `clippy::needless_return` in
+  `preloop-socket-activation`, and the swapped `dir`/timer arguments that made
+  the install summary print
+  `units:  + preloop-update.{service,timer}/preloop.{service,socket}/etc/...`.
+
 ## [0.29.9-rc] - 2026-08-11
 
 ### Fixed
@@ -23,8 +133,7 @@ Releases before v0.27.0 predate the changelog.
   clone cleanup, the live-clone check, and the stop/restart run under the
   provider's per-golden fork lock, and cleanup must succeed before the base
   is touched. A base with live clones is never restarted — it falls back to
-  direct creation with an error explaining why.
-- `preloop debug <reference>` now resolves a run id that has several paused
+  direct creation with an error explaining why.- `preloop debug <reference>` now resolves a run id that has several paused
   jobs: it lists them (with their run ids) instead of answering
   `no paused job matching`; non-404 failures propagate their real cause.
   When nothing matches but other sessions are paused, the reply says what is
@@ -66,7 +175,6 @@ Releases before v0.27.0 predate the changelog.
 - `macos`/`windows` jobs wait for a registered external host instead of being
   failed by the Linux-only starvation sweep.
 - macOS BSD `tar` missing `--verbatim-files-from` is handled in sync.
-
 ## [0.29.8] - 2026-08-09
 
 ### Fixed

--- a/contrib/systemd/preloop-update.service
+++ b/contrib/systemd/preloop-update.service
@@ -9,7 +9,7 @@ Wants=network-online.target
 Type=oneshot
 ExecStart=/usr/local/bin/preloop update
 Environment=PRELOOP_HOME=/var/lib/preloop
-StateDirectory=preloop
+EnvironmentFile=-/etc/preloop/environment
 NoNewPrivileges=true
 ProtectSystem=full
 ProtectHome=read-only

--- a/contrib/systemd/preloop.service
+++ b/contrib/systemd/preloop.service
@@ -8,15 +8,39 @@ After=preloop.socket network-online.target
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/preloop serve
+Environment=PRELOOP_HOME=/var/lib/preloop
+Environment=HOME=/var/lib/preloop
+Environment=SMOLVM_DATA_DIR=/var/lib/preloop/smolvm
+# Root-owned (0600 root:root in a 0750 root:preloop directory), deliberately
+# NOT under /var/lib/preloop: the service owns the state dir, and the
+# directory write bit governs unlink/rename, so an env file there could be
+# replaced by a compromised service. EnvironmentFile= overrides Environment=,
+# so that would let it persist SMOLVM_SECCOMP=off across Restart=on-failure.
+EnvironmentFile=-/etc/preloop/environment
+# Dedicated service identity: a guest->VMM escape lands in the VMM process,
+# which inherits this identity. The installer creates the account and adds it
+# to the kvm group (for /dev/kvm). State files must be written as this user
+# (e.g. `sudo -u preloop env PRELOOP_HOME=/var/lib/preloop preloop setup
+# github --save`).
+User=preloop
+Group=preloop
 Restart=on-failure
 RestartSec=5s
-Environment=PRELOOP_HOME=/var/lib/preloop
-StateDirectory=preloop
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=full
 ProtectHome=read-only
-ReadWritePaths=/usr/local/bin
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectClock=true
+LockPersonality=true
+RestrictRealtime=true
+CapabilityBoundingSet=
+# Delegate the cgroup subtree so each SmolVM `_boot-vm` can place itself in a
+# per-VM capped leaf (cpu/pids/memory) via SMOLVM_CGROUP_ROOT.
+Delegate=cpu memory pids
+StateDirectory=preloop
+StateDirectoryMode=0700
 
 [Install]
 WantedBy=multi-user.target

--- a/crates/preloop-cli/src/debug_session.rs
+++ b/crates/preloop-cli/src/debug_session.rs
@@ -1061,7 +1061,7 @@ fn export_from_guest(session: &DebugSession, apply: bool) -> Result<()> {
 
     // Use a temporary index so `git add -N` can expose untracked files in the
     // patch without changing the guest workspace's real index.
-    let output = std::process::Command::new("smolvm")
+    let output = crate::smolvm_command()?
         .args(["machine", "exec", "--name", machine, "--", "sh", "-lc"])
         .arg(format!(
             "cd {} && \
@@ -1128,7 +1128,7 @@ fn guest_modified(
     candidates: &[String],
 ) -> Result<Vec<String>> {
     let quoted: Vec<String> = candidates.iter().map(|p| shell_quote(p)).collect();
-    let output = std::process::Command::new("smolvm")
+    let output = crate::smolvm_command()?
         .args(["machine", "exec", "--name", machine, "--", "sh", "-lc"])
         .arg(format!(
             "cd {} && git --literal-pathspecs status --porcelain -- {} 2>/dev/null || true",
@@ -1259,7 +1259,7 @@ fn push_to_guest(machine: &str, local: &std::path::Path, remote: &str) -> Result
         .len();
 
     guest_check(machine, &format!("rm -f {}", shell_quote(remote)))?;
-    let output = std::process::Command::new("smolvm")
+    let output = crate::smolvm_command()?
         .args([
             "machine",
             "cp",
@@ -1275,7 +1275,7 @@ fn push_to_guest(machine: &str, local: &std::path::Path, remote: &str) -> Result
         );
     }
 
-    let seen = std::process::Command::new("smolvm")
+    let seen = crate::smolvm_command()?
         .args(["machine", "exec", "--name", machine, "--", "sh", "-lc"])
         .arg(format!("wc -c < {} 2>/dev/null", shell_quote(remote)))
         .output()
@@ -1295,7 +1295,7 @@ fn push_to_guest(machine: &str, local: &std::path::Path, remote: &str) -> Result
 
 /// Run a command in the guest, failing loudly on a non-zero exit.
 fn guest_check(machine: &str, command: &str) -> Result<()> {
-    let output = std::process::Command::new("smolvm")
+    let output = crate::smolvm_command()?
         .args([
             "machine", "exec", "--name", machine, "--", "sh", "-lc", command,
         ])
@@ -1327,7 +1327,14 @@ fn run_in_guest(session: &DebugSession, command: &str) {
     };
     let workspace = session.workspace.as_deref().unwrap_or("/");
     let script = guest_command_script(workspace, command);
-    let status = std::process::Command::new("smolvm")
+    let mut command = match crate::smolvm_command() {
+        Ok(command) => command,
+        Err(error) => {
+            println!("  Could not build the smolvm command: {error}");
+            return;
+        }
+    };
+    let status = command
         .args([
             "machine", "exec", "--name", machine, "--", "sh", "-lc", &script,
         ])
@@ -1689,5 +1696,75 @@ mod tests {
         assert_eq!(next_revision("original"), "repair-1");
         assert_eq!(next_revision("repair-1"), "repair-2");
         assert_eq!(next_revision("repair-9"), "repair-10");
+    }
+
+    /// Every direct `smolvm machine exec/cp` spawn in the debug-session flow
+    /// can implicitly boot or restart a stopped machine (upstream connects,
+    /// starting the VM when needed), so each must carry the sandbox
+    /// environment the provider applies to its own boots. The observable
+    /// contract is the environment of the spawned process, captured by a
+    /// fake `smolvm` on PATH.
+    fn assert_sandbox_carried(executable: &std::path::Path) {
+        let read = |suffix: &str| {
+            std::fs::read_to_string(executable.with_extension(suffix))
+                .unwrap()
+                .trim()
+                .to_owned()
+        };
+        #[cfg(target_os = "linux")]
+        {
+            assert_eq!(read("seccomp"), "SMOLVM_SECCOMP=enforce");
+            assert_eq!(read("landlock"), "SMOLVM_LANDLOCK=enforce");
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            assert_eq!(read("seccomp"), "SMOLVM_SECCOMP=");
+            assert_eq!(read("landlock"), "SMOLVM_LANDLOCK=");
+        }
+    }
+
+    #[test]
+    fn guest_check_carries_the_sandbox_environment() {
+        crate::with_fake_smolvm_path(|executable| {
+            guest_check("vm-1", "echo ok").unwrap();
+            assert_sandbox_carried(executable);
+        });
+    }
+
+    #[test]
+    fn guest_modified_carries_the_sandbox_environment() {
+        crate::with_fake_smolvm_path(|executable| {
+            let modified = guest_modified("vm-1", "/work", &["src/a.rs".into()]).unwrap();
+            assert!(modified.is_empty());
+            assert_sandbox_carried(executable);
+        });
+    }
+
+    #[test]
+    fn push_to_guest_carries_the_sandbox_environment() {
+        crate::with_fake_smolvm_path(|executable| {
+            let staging = tempfile::tempdir().unwrap();
+            let local = staging.path().join("artifact.bin");
+            // The fake answers the post-copy byte-count probe with 12345.
+            std::fs::write(&local, vec![b'x'; 12_345]).unwrap();
+            push_to_guest("vm-1", &local, "/work/artifact.bin").unwrap();
+            assert_sandbox_carried(executable);
+        });
+    }
+
+    #[test]
+    fn export_from_guest_carries_the_sandbox_environment() {
+        crate::with_fake_smolvm_path(|executable| {
+            export_from_guest(&session(), true).unwrap();
+            assert_sandbox_carried(executable);
+        });
+    }
+
+    #[test]
+    fn run_in_guest_carries_the_sandbox_environment() {
+        crate::with_fake_smolvm_path(|executable| {
+            run_in_guest(&session(), "echo hi");
+            assert_sandbox_carried(executable);
+        });
     }
 }

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -87,6 +87,72 @@ pub(crate) fn preloop_home() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from(".preloop"))
 }
 
+/// A `smolvm` command carrying Preloop's Linux VM-sandbox environment.
+///
+/// Direct `machine exec`/`cp`/`shell` calls can implicitly boot or restart a
+/// stopped machine — upstream's exec path connects to the machine, starting
+/// it when needed, and `machine shell` does the same — so these spawns must
+/// carry the exact seccomp/Landlock/cgroup environment the VM provider
+/// applies to its own boots. This is the single chokepoint for them; the
+/// policy lives in [`preloop_vm::smolvm_sandbox_env`] and is a no-op on
+/// macOS, matching the provider.
+pub(crate) fn smolvm_command() -> anyhow::Result<std::process::Command> {
+    let mut command = std::process::Command::new("smolvm");
+    preloop_vm::apply_smolvm_sandbox_env(&mut command)?;
+    Ok(command)
+}
+
+#[cfg(test)]
+pub(crate) static SMOLVM_PATH_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// A fake `smolvm` on PATH that records the sandbox environment it was given
+/// and answers the debug-session byte-count probe. Serialized with
+/// [`SMOLVM_PATH_LOCK`]: `PATH` is process-global and the debug-session and
+/// shell tests run in the same binary.
+#[cfg(test)]
+pub(crate) fn fake_smolvm_on_path() -> (tempfile::TempDir, PathBuf) {
+    let directory = tempfile::tempdir().unwrap();
+    let executable = directory.path().join("smolvm");
+    std::fs::write(
+        &executable,
+        r##"#!/bin/sh
+printf 'SMOLVM_SECCOMP=%s\n' "${SMOLVM_SECCOMP-}" > "$0.seccomp"
+printf 'SMOLVM_LANDLOCK=%s\n' "${SMOLVM_LANDLOCK-}" > "$0.landlock"
+printf 'SMOLVM_CGROUP_ROOT=%s\n' "${SMOLVM_CGROUP_ROOT-}" > "$0.cgroup"
+case "$*" in
+  *"wc -c"*) printf '12345\n' ;;
+esac
+exit 0
+"##,
+    )
+    .unwrap();
+    let mut permissions = std::fs::metadata(&executable).unwrap().permissions();
+    use std::os::unix::fs::PermissionsExt;
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&executable, permissions).unwrap();
+    (directory, executable)
+}
+
+/// Run `test` with a fake `smolvm` first on PATH, restoring PATH afterwards.
+#[cfg(test)]
+pub(crate) fn with_fake_smolvm_path<T>(test: impl FnOnce(&PathBuf) -> T) -> T {
+    let _guard = SMOLVM_PATH_LOCK.blocking_lock();
+    let (directory, executable) = fake_smolvm_on_path();
+    let previous = std::env::var_os("PATH");
+    let mut path = directory.path().as_os_str().to_owned();
+    path.push(":");
+    if let Some(previous) = &previous {
+        path.push(previous);
+    }
+    std::env::set_var("PATH", path);
+    let result = test(&executable);
+    match previous {
+        Some(previous) => std::env::set_var("PATH", previous),
+        None => std::env::remove_var("PATH"),
+    }
+    result
+}
+
 #[derive(Debug, Parser)]
 #[command(name = "preloop", about = "Local CI with hardware isolation")]
 struct Cli {
@@ -844,6 +910,15 @@ async fn cmd_engine(args: ServeArgs) -> anyhow::Result<()> {
                 }
             }
             let pool_shutdown = shutdown.clone();
+            // Supervisor-side, once, before any VM boots: systemd's
+            // `Delegate=cpu memory pids` chowns this unit's cgroup subtree but
+            // leaves `cgroup.subtree_control` empty, so a `vm-<pid>` leaf would
+            // get no cpu/memory/pids limit files. This performs the same
+            // vacate-then-enable dance `smolvm serve` does. It is the only
+            // place Preloop writes to the cgroup hierarchy — the CLI paths
+            // (`preloop shell`, debug-session `machine exec`/`cp`) resolve the
+            // root read-only and never mutate it.
+            preloop_vm::init_vm_cgroup_delegation();
             Some(tokio::spawn(async move {
                 RunnerPool::new(std::sync::Arc::new(SmolVmProvider::default()), config)?
                     .run(pool_shutdown)
@@ -2061,8 +2136,10 @@ async fn cmd_shell(args: ShellArgs) -> anyhow::Result<()> {
         }
     });
 
-    // Run smolvm machine shell interactively.
-    let status = std::process::Command::new("smolvm")
+    // Run smolvm machine shell interactively. The shell boots a stopped
+    // machine, so the sandbox environment applies exactly as for a provider
+    // spawn.
+    let status = crate::smolvm_command()?
         .args(["machine", "shell", "--name", &machine_name])
         .stdin(std::process::Stdio::inherit())
         .stdout(std::process::Stdio::inherit())
@@ -2695,11 +2772,63 @@ mod tests {
 
     #[test]
     fn shell_explicit_ref() {
-        let cli = parse(&["shell", "run-42"]).unwrap();
+        let cli = parse(&["shell", "0"]).unwrap();
         let Command::Shell(args) = cli.command else {
             panic!("expected Shell");
         };
-        assert_eq!(args.run_ref.unwrap(), "run-42");
+        assert_eq!(args.run_ref.as_deref(), Some("0"));
+    }
+
+    /// `preloop shell` spawns `smolvm machine shell`, which boots a stopped
+    /// machine — the sandbox environment must reach it exactly like a
+    /// provider spawn. The observable contract is the environment of the
+    /// spawned process.
+    #[tokio::test]
+    async fn shell_spawn_carries_the_sandbox_environment() {
+        let _guard = crate::SMOLVM_PATH_LOCK.lock().await;
+        let (directory, executable) = crate::fake_smolvm_on_path();
+        let previous_path = std::env::var_os("PATH");
+        let mut path = directory.path().as_os_str().to_owned();
+        path.push(":");
+        if let Some(previous) = &previous_path {
+            path.push(previous);
+        }
+        std::env::set_var("PATH", path);
+
+        let home = tempfile::tempdir().unwrap();
+        let debug_dir = home.path().join("state/debug");
+        std::fs::create_dir_all(&debug_dir).unwrap();
+        std::fs::write(debug_dir.join("preloop-runner-0-1"), "claimed").unwrap();
+        std::env::set_var("PRELOOP_HOME", home.path());
+
+        let result = cmd_shell(ShellArgs {
+            run_ref: Some("preloop-runner-0-1".to_owned()),
+        })
+        .await;
+
+        std::env::remove_var("PRELOOP_HOME");
+        match previous_path {
+            Some(previous) => std::env::set_var("PATH", previous),
+            None => std::env::remove_var("PATH"),
+        }
+        result.unwrap();
+
+        let read = |suffix: &str| {
+            std::fs::read_to_string(executable.with_extension(suffix))
+                .unwrap()
+                .trim()
+                .to_owned()
+        };
+        #[cfg(target_os = "linux")]
+        {
+            assert_eq!(read("seccomp"), "SMOLVM_SECCOMP=enforce");
+            assert_eq!(read("landlock"), "SMOLVM_LANDLOCK=enforce");
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            assert_eq!(read("seccomp"), "SMOLVM_SECCOMP=");
+            assert_eq!(read("landlock"), "SMOLVM_LANDLOCK=");
+        }
     }
 
     // -- top-level --

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -98,6 +98,17 @@ pub(crate) fn preloop_home() -> PathBuf {
 /// macOS, matching the provider.
 pub(crate) fn smolvm_command() -> anyhow::Result<std::process::Command> {
     let mut command = std::process::Command::new("smolvm");
+    // The service unit pins `SMOLVM_DATA_DIR=<PRELOOP_HOME>/smolvm`
+    // (see crates/preloop-cli/src/server_install.rs), so the engine records
+    // its machines in that registry. A separately invoked `preloop shell` /
+    // `preloop debug` must consult the SAME registry or it cannot find the
+    // paused, service-owned machine — the caller's default data dir would
+    // resolve a different one. An operator value wins, so this only fills
+    // the gap, never overrides.
+    if std::env::var_os("SMOLVM_DATA_DIR").is_none() {
+        let data_dir = preloop_home().join("smolvm");
+        command.env("SMOLVM_DATA_DIR", data_dir);
+    }
     preloop_vm::apply_smolvm_sandbox_env(&mut command)?;
     Ok(command)
 }
@@ -119,6 +130,7 @@ pub(crate) fn fake_smolvm_on_path() -> (tempfile::TempDir, PathBuf) {
 printf 'SMOLVM_SECCOMP=%s\n' "${SMOLVM_SECCOMP-}" > "$0.seccomp"
 printf 'SMOLVM_LANDLOCK=%s\n' "${SMOLVM_LANDLOCK-}" > "$0.landlock"
 printf 'SMOLVM_CGROUP_ROOT=%s\n' "${SMOLVM_CGROUP_ROOT-}" > "$0.cgroup"
+printf 'SMOLVM_DATA_DIR=%s\n' "${SMOLVM_DATA_DIR-}" > "$0.datadir"
 case "$*" in
   *"wc -c"*) printf '12345\n' ;;
 esac
@@ -2120,6 +2132,13 @@ async fn cmd_shell(args: ShellArgs) -> anyhow::Result<()> {
     eprintln!("[preloop] Connecting to preserved VM: {machine_name}");
     eprintln!("[preloop] Exit the shell to release the VM.");
 
+    // Build the smolvm command BEFORE claiming the marker: an invalid
+    // sandbox override makes this fail, and the marker claim + heartbeat
+    // below must not exist yet when it does — otherwise the preserved VM
+    // would stay marked ACTIVE (and the heartbeat would keep touching the
+    // marker) until the orchestrator's idle timeout, with nobody attached.
+    let mut command = crate::smolvm_command()?;
+
     // Claim the session before starting so the orchestrator stops counting down.
     let _ = std::fs::write(&marker, preloop_orchestrator::DEBUG_MARKER_ACTIVE);
 
@@ -2139,7 +2158,7 @@ async fn cmd_shell(args: ShellArgs) -> anyhow::Result<()> {
     // Run smolvm machine shell interactively. The shell boots a stopped
     // machine, so the sandbox environment applies exactly as for a provider
     // spawn.
-    let status = crate::smolvm_command()?
+    let status = command
         .args(["machine", "shell", "--name", &machine_name])
         .stdin(std::process::Stdio::inherit())
         .stdout(std::process::Stdio::inherit())
@@ -2788,6 +2807,7 @@ mod tests {
         let _guard = crate::SMOLVM_PATH_LOCK.lock().await;
         let (directory, executable) = crate::fake_smolvm_on_path();
         let previous_path = std::env::var_os("PATH");
+        let previous_home = std::env::var_os("PRELOOP_HOME");
         let mut path = directory.path().as_os_str().to_owned();
         path.push(":");
         if let Some(previous) = &previous_path {
@@ -2806,7 +2826,10 @@ mod tests {
         })
         .await;
 
-        std::env::remove_var("PRELOOP_HOME");
+        match previous_home {
+            Some(previous) => std::env::set_var("PRELOOP_HOME", previous),
+            None => std::env::remove_var("PRELOOP_HOME"),
+        }
         match previous_path {
             Some(previous) => std::env::set_var("PATH", previous),
             None => std::env::remove_var("PATH"),
@@ -2829,6 +2852,14 @@ mod tests {
             assert_eq!(read("seccomp"), "SMOLVM_SECCOMP=");
             assert_eq!(read("landlock"), "SMOLVM_LANDLOCK=");
         }
+        // The direct CLI spawn must consult the engine's registry, not the
+        // caller's: pinned to <PRELOOP_HOME>/smolvm, which the unit sets for
+        // the service and this test sets to a temp dir.
+        let data_dir = home.path().join("smolvm");
+        assert_eq!(
+            read("datadir"),
+            format!("SMOLVM_DATA_DIR={}", data_dir.display())
+        );
     }
 
     // -- top-level --

--- a/crates/preloop-cli/src/server_install.rs
+++ b/crates/preloop-cli/src/server_install.rs
@@ -18,11 +18,46 @@ use std::process::Command;
 use anyhow::{bail, Context, Result};
 use clap::{Args, Parser, Subcommand};
 
+#[cfg(any(target_os = "linux", test))]
+use crate::set_private_file_permissions;
 use crate::{set_private_directory_permissions, write_private_file};
 
 /// Default state directory for the service.
 pub(crate) const DEFAULT_HOME: &str = "/var/lib/preloop";
 
+/// Root-owned configuration directory for system-scope installs.
+///
+/// `PRELOOP_HOME` must be writable by the service (the engine creates its DB,
+/// `config.toml`, and key material there), and on Unix the *directory* write
+/// bit governs unlink and rename — so any file inside it can be replaced by
+/// the service no matter what that file's own owner and mode are. Install
+/// artifacts the service must not be able to rewrite therefore live here
+/// instead of under `PRELOOP_HOME`: the systemd `EnvironmentFile` (which
+/// overrides the unit's own `Environment=`, so a writable copy would let a
+/// compromised service turn its sandbox off across a restart) and the staged
+/// GitHub App key.
+const SYSTEM_CONFIG_DIR: &str = "/etc/preloop";
+
+/// Root-owned parent for the bootstrapped smolvm copy.
+///
+/// Never under `PRELOOP_HOME`: `/usr/local/bin/smolvm` points into this prefix
+/// and **root** executes that path (`preloop update` probes `smolvm` before
+/// deciding to reinstall), so a service-writable prefix is a direct
+/// service-user → root escalation.
+#[cfg(any(target_os = "linux", test))]
+const SMOLVM_PREFIX_PARENT: &str = "/usr/local/lib/preloop";
+
+/// Dedicated system account the hardened system-scope service runs under.
+///
+/// A guest→VMM escape lands in the SmolVM boot subprocess, which inherits the
+/// service identity: running the whole control plane as root would hand an
+/// escape the host. The installer creates the account (and kvm group
+/// membership for /dev/kvm) at install time; user-scope units keep the
+/// installing user's identity.
+#[cfg(any(target_os = "linux", test))]
+const SERVICE_USER: &str = "preloop";
+
+#[cfg(any(target_os = "macos", test))]
 const LAUNCHD_LABEL: &str = "dev.preloop.server";
 #[cfg(any(target_os = "macos", test))]
 const LAUNCHD_PLIST: &str = "/Library/LaunchDaemons/dev.preloop.server.plist";
@@ -43,7 +78,7 @@ pub(crate) enum ServerCommand {
     Uninstall(UninstallArgs),
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub(crate) struct InstallArgs {
     /// Address to bind. Defaults to the engine default (127.0.0.1:9090); on
     /// Linux the port is published through socket activation.
@@ -142,7 +177,54 @@ fn install(args: InstallArgs) -> Result<()> {
             exe.display()
         );
     }
-    let env_lines = config_env_lines(&args)?;
+    if let Some(key) = &args.github_app_key {
+        anyhow::ensure!(
+            key.exists(),
+            "--github-app-key {} does not exist",
+            key.display()
+        );
+    }
+    // A system install runs as the dedicated `preloop` account, which cannot
+    // traverse a 0700 /home/<user> or /root. Such a --home would produce an
+    // install that looks fine and then fails at first start, so reject it
+    // here rather than shipping a broken unit.
+    #[cfg(any(target_os = "linux", test))]
+    if !args.user && home_blocked_by_protect_home(&home) {
+        bail!(
+            "--home {} is unusable for a system install: the `{SERVICE_USER}` service \
+             account cannot traverse /home, /root, or /run/user. Use {DEFAULT_HOME} \
+             (the default) or another root-reachable path, or install with --user.",
+            home.display()
+        );
+    }
+    // The state dir must exist before anything is staged into it: the very
+    // first system install with --github-app-key targets a not-yet-created
+    // (default or nested) directory, and staging the key copy would fail
+    // without it. prepare_home is idempotent and dry-run prints only.
+    prepare_home(&home, args.dry_run)?;
+    // The service account and the root-owned config dir must both exist
+    // before the key is staged into the latter and chowned to the former.
+    #[cfg(target_os = "linux")]
+    if !args.user {
+        ensure_service_user(&home, args.dry_run)?;
+        prepare_system_config_dir(args.dry_run)?;
+    }
+    let config_dir = if args.user {
+        home.clone()
+    } else {
+        PathBuf::from(SYSTEM_CONFIG_DIR)
+    };
+    let staged_key = staged_app_key(&args, &config_dir)?;
+    // The staged copy is root-owned 0600 until here; the service still has to
+    // read it, so widen it to root:preloop 0640 now that the account exists.
+    #[cfg(target_os = "linux")]
+    if !args.user && !args.dry_run {
+        if let Some(key) = &staged_key {
+            grant_service_read(key)
+                .with_context(|| format!("grant the service read access to {}", key.display()))?;
+        }
+    }
+    let env_lines = config_env_lines(&args, staged_key.as_deref())?;
     if let Some(path) = &args.systemd_credential {
         #[cfg(not(target_os = "linux"))]
         {
@@ -227,8 +309,14 @@ fn install_systemd(
     let update_service = render_systemd_update_service(exe, home, args.user)?;
     let timer = render_systemd_update_timer();
 
-    prepare_home(home, dry)?;
-    write_env_file(home, env_lines, dry)?;
+    if !args.user {
+        bootstrap_system_smolvm(dry)?;
+        chown_state_dir(home, dry)?;
+    }
+    // Written after chown_state_dir, and deliberately outside it for a system
+    // install: the env file lives in the root-owned config dir, so the
+    // recursive chown of the state dir never reaches it.
+    write_env_file(&env_file_path(home, args.user), env_lines, dry)?;
 
     // A rootless install cannot assume `~/.config/systemd/user` exists on a
     // fresh machine — create the unit directory before the first write.
@@ -268,33 +356,54 @@ fn install_systemd(
         );
     }
 
+    let identity = if args.user {
+        String::new()
+    } else {
+        // Self-terminating block: the template supplies the leading indent,
+        // this supplies the trailing one for whatever follows.
+        format!(
+            "identity: dedicated `{SERVICE_USER}` system account (kvm group for /dev/kvm);\n\
+             \x20          state dir chowned to it — config.toml must be written as that user:\n\
+             \x20          sudo -u {SERVICE_USER} env PRELOOP_HOME={} preloop setup github --save\n\
+             \x20 ",
+            home.display()
+        )
+    };
     let secrets = format!(
-        "secrets:   --webhook-secret/--github-app-* flags land in {}/environment (0600);\n\
+        "secrets:   --webhook-secret/--github-app-* flags land in {} (0600);\n\
          \x20          `setup github --save` writes config.toml (0600). Define a webhook\n\
          \x20          secret or GitHub webhook delivery is rejected.",
-        home.display()
+        env_file_path(home, args.user).display()
     );
     eprintln!(
         "[preloop] installed Preloop control plane as a {} systemd service:\n\
          \x20 units:   {}/preloop.{{service,socket}}{}\n\
-         \x20 state:   {} (0700), service config {}/environment (0600)\n\
+         \x20 state:   {} (0700), service config {} (0600)\n\
          \x20 status:  systemctl {} status preloop\n\
          \x20 logs:    journalctl {} -u preloop -f\n\
          \x20 GitHub:  re-run with --github-app-* flags, or run\n\
-         \x20          PRELOOP_HOME={} preloop setup github --save\n\
-         \x20 {}{}{}",
+         \x20          {}preloop setup github --save\n\
+         \x20 {}{}{}{}",
         if args.user { "user-scope" } else { "system" },
+        dir.display(),
         if args.no_update_timer {
             ""
         } else {
             " + preloop-update.{service,timer}"
         },
-        dir.display(),
         home.display(),
-        home.display(),
+        env_file_path(home, args.user).display(),
         if args.user { "--user" } else { "" },
         if args.user { "--user" } else { "" },
-        home.display(),
+        if args.user {
+            format!("PRELOOP_HOME={} ", home.display())
+        } else {
+            format!(
+                "sudo -u {SERVICE_USER} env PRELOOP_HOME={} ",
+                home.display()
+            )
+        },
+        identity,
         secrets,
         if args.user {
             "\n\
@@ -306,6 +415,451 @@ fn install_systemd(
         webhook_hint(args.public_url.as_deref()),
     );
     Ok(())
+}
+
+/// Whether a system account exists.
+#[cfg(target_os = "linux")]
+fn account_exists(name: &str) -> bool {
+    Command::new("getent")
+        .args(["passwd", name])
+        // `.output()` not `.status()`: getent prints the matched passwd line,
+        // which would land in the middle of the install plan.
+        .output()
+        .is_ok_and(|output| output.status.success())
+}
+
+/// Create the dedicated service account (idempotent) and add it to the `kvm`
+/// group when the host exposes `/dev/kvm` — the VMM opens it as the service
+/// identity. An existing account is never modified beyond group membership.
+#[cfg(target_os = "linux")]
+fn ensure_service_user(home: &Path, dry_run: bool) -> Result<()> {
+    if !account_exists(SERVICE_USER) {
+        let home_str = home.to_string_lossy();
+        let args = [
+            "--system",
+            "--home-dir",
+            &home_str,
+            "--shell",
+            "/usr/sbin/nologin",
+            "--comment",
+            "Preloop service account",
+            SERVICE_USER,
+        ];
+        if dry_run {
+            eprintln!(
+                "[preloop] would create system user {SERVICE_USER} (useradd {})",
+                args.join(" ")
+            );
+        } else {
+            match Command::new("useradd").args(args).status() {
+                Ok(status) if status.success() => {}
+                Ok(status) => bail!("useradd {SERVICE_USER} failed ({status})"),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => bail!(
+                    "`useradd` not found; create the service account manually and re-run: \
+                     useradd --system --home-dir {} --shell /usr/sbin/nologin {SERVICE_USER}",
+                    home.display()
+                ),
+                Err(error) => {
+                    return Err(error).with_context(|| format!("run useradd {SERVICE_USER}"))
+                }
+            }
+        }
+    }
+    add_to_kvm_group(dry_run)?;
+    Ok(())
+}
+
+/// The VMM opens `/dev/kvm` (root:kvm, 0660) under the service identity.
+/// Only meaningful when the host actually exposes KVM.
+#[cfg(target_os = "linux")]
+fn add_to_kvm_group(dry_run: bool) -> Result<()> {
+    if !Path::new("/dev/kvm").exists() {
+        return Ok(());
+    }
+    let group_exists = Command::new("getent")
+        .args(["group", "kvm"])
+        .output()
+        .is_ok_and(|output| output.status.success());
+    if !group_exists {
+        eprintln!(
+            "[preloop] warning: /dev/kvm exists but there is no `kvm` group; \
+             the service user cannot open /dev/kvm"
+        );
+        return Ok(());
+    }
+    if dry_run {
+        eprintln!(
+            "[preloop] would add {SERVICE_USER} to the kvm group \
+             (usermod -aG kvm {SERVICE_USER})"
+        );
+        return Ok(());
+    }
+    let status = Command::new("usermod")
+        .args(["-aG", "kvm", SERVICE_USER])
+        .status();
+    if !status.as_ref().is_ok_and(|status| status.success()) {
+        eprintln!(
+            "[preloop] warning: adding {SERVICE_USER} to the kvm group failed ({status:?}); \
+             the VM pool cannot open /dev/kvm"
+        );
+    }
+    Ok(())
+}
+
+/// Ensure the service can resolve `smolvm` on its PATH.
+///
+/// The unit runs with the stock systemd service PATH and a HOME under the
+/// state dir, so an install under `/root/.local/bin` (where `preloop update`
+/// and the official installer put it) is invisible and untraversable to the
+/// service account. When no system-wide smolvm exists, copy root's prefix
+/// into [`SMOLVM_PREFIX_PARENT`] and link it onto the PATH: the wrapper script
+/// resolves its own location, so the copy is self-contained (binary, libs,
+/// bundled agent rootfs).
+///
+/// The copy stays **root-owned and read-only to the service** (`a+rX`, never
+/// chowned), and lives outside `PRELOOP_HOME`. `/usr/local/bin/smolvm` points
+/// into it and root executes that path — `preloop update` probes `smolvm` for
+/// its version and `--mount-socket` support before deciding to reinstall — so
+/// a prefix the service could write, or a prefix inside a directory the
+/// service could unlink entries from, would hand a guest→VMM escape a root
+/// shell on the next `sudo preloop update`. The service needs read and execute
+/// on this tree, nothing more; its mutable data lives in `SMOLVM_DATA_DIR`
+/// under the state dir.
+///
+/// Lifecycle: the copy is refreshed on every re-install when the source
+/// install is newer (after `sudo preloop update`, re-running
+/// `sudo preloop server install` picks the new version up), and the managed
+/// `/usr/local/bin/smolvm` symlink is always re-pointed. An independently
+/// installed system smolvm (not our symlink) is left alone — the installer
+/// never shadows an operator-managed binary. Refreshes are atomic: the new
+/// prefix is fully assembled (copied, pruned, made world-readable) in a
+/// sibling staging directory and swapped into place with a rename, so a
+/// running service never observes a half-copied prefix; running VMMs hold
+/// open inodes and are unaffected. Root's machine database is never imported
+/// (it describes VMs the service cannot see).
+#[cfg(target_os = "linux")]
+fn bootstrap_system_smolvm(dry_run: bool) -> Result<()> {
+    let managed_link = Path::new("/usr/local/bin/smolvm");
+    let parent = Path::new(SMOLVM_PREFIX_PARENT);
+    let destination = parent.join("smolvm-prefix");
+    // `smolvm` is the wrapper script; `smolvm-bin` is the real binary the
+    // freshness check must compare (the copied prefix mirrors the source
+    // layout exactly).
+    let destination_bin = destination.join("smolvm");
+    let destination_binary = destination.join("smolvm-bin");
+    if independent_system_smolvm(managed_link, &destination_bin) {
+        return Ok(());
+    }
+    let source_link = Path::new("/root/.local/bin/smolvm");
+    let source_prefix = Path::new("/root/.smolvm");
+    if !source_link.exists() || !source_prefix.is_dir() {
+        eprintln!(
+            "[preloop] note: no smolvm on the service PATH and none installed for root; \
+             the VM pool needs `sudo preloop update` (or smolvm in /usr/local/bin) \
+             before it can launch machines"
+        );
+        return Ok(());
+    }
+    let stale = smolvm_copy_stale(&source_prefix.join("smolvm-bin"), &destination_binary);
+    if dry_run {
+        if stale {
+            eprintln!(
+                "[preloop] would copy {} into {} (root-owned, read-only to the service)",
+                source_prefix.display(),
+                destination.display()
+            );
+        }
+        eprintln!(
+            "[preloop] would symlink /usr/local/bin/smolvm -> {}",
+            destination_bin.display()
+        );
+        return Ok(());
+    }
+    std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    set_world_readable_directory(parent)?;
+    if stale {
+        let staging = parent.join(format!("smolvm-prefix.staging-{}", std::process::id()));
+        let backup = parent.join(format!("smolvm-prefix.backup-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&staging);
+        let _ = std::fs::remove_dir_all(&backup);
+        let assembled = (|| -> Result<()> {
+            std::fs::create_dir_all(&staging)
+                .with_context(|| format!("create {}", staging.display()))?;
+            let status = Command::new("cp")
+                .arg("-a")
+                .arg(format!("{}/.", source_prefix.display()))
+                .arg(format!("{}/", staging.display()))
+                .status()
+                .with_context(|| {
+                    format!(
+                        "copy {} into {}",
+                        source_prefix.display(),
+                        staging.display()
+                    )
+                })?;
+            if !status.success() {
+                bail!(
+                    "copying {} into {} failed ({status})",
+                    source_prefix.display(),
+                    staging.display()
+                );
+            }
+            // The copied database describes the root user's VMs — the service
+            // starts from a clean record instead of importing invisible
+            // machines.
+            for stale_db in ["smolvm.db", "smolvm.db-wal", "smolvm.db-shm"] {
+                let _ = std::fs::remove_file(staging.join(stale_db));
+            }
+            // Root's ~/.smolvm is typically 0700; the service must be able to
+            // read and execute the copy without being able to write it. Files
+            // stay root-owned — `a+rX` adds read (and execute where already
+            // executable), never write.
+            let status = Command::new("chmod")
+                .args(["-R", "a+rX"])
+                .arg(&staging)
+                .status()
+                .with_context(|| format!("chmod {}", staging.display()))?;
+            if !status.success() {
+                bail!("chmod {} failed ({status})", staging.display());
+            }
+            Ok(())
+        })();
+        if let Err(error) = assembled {
+            let _ = std::fs::remove_dir_all(&staging);
+            return Err(error);
+        }
+        atomic_directory_swap(&destination, &staging, &backup)?;
+    }
+    // Idempotent repair: an earlier release chowned this prefix to the service
+    // account, which is exactly the escalation path above. Take it back.
+    let status = Command::new("chown")
+        .args(["-R", "root:root"])
+        .arg(&destination)
+        .status()
+        .with_context(|| format!("chown {}", destination.display()))?;
+    if !status.success() {
+        bail!("chown {} failed ({status})", destination.display());
+    }
+    let status = Command::new("chmod")
+        .args(["-R", "a+rX"])
+        .arg(&destination)
+        .status()
+        .with_context(|| format!("chmod {}", destination.display()))?;
+    if !status.success() {
+        bail!("chmod {} failed ({status})", destination.display());
+    }
+    // The symlink lands in the standard system bin dir; make sure it exists
+    // (some minimal systems ship without it).
+    std::fs::create_dir_all("/usr/local/bin").context("create /usr/local/bin")?;
+    let status = Command::new("ln")
+        .args(["-sfn"])
+        .arg(&destination_bin)
+        .arg("/usr/local/bin/smolvm")
+        .status()
+        .with_context(|| "symlink /usr/local/bin/smolvm".to_string())?;
+    if !status.success() {
+        bail!("symlinking /usr/local/bin/smolvm failed ({status})");
+    }
+    Ok(())
+}
+
+/// Atomically replace `destination` with a fully-assembled `staging`
+/// directory: rename the current prefix aside, rename staging into place,
+/// then drop the backup. If the swap fails the previous prefix is restored.
+/// Staging and backup are always cleaned up, on success and failure alike.
+#[cfg(any(target_os = "linux", test))]
+fn atomic_directory_swap(destination: &Path, staging: &Path, backup: &Path) -> Result<()> {
+    let had_previous = destination.exists();
+    if had_previous {
+        std::fs::rename(destination, backup).with_context(|| {
+            format!(
+                "set aside old {} to {}",
+                destination.display(),
+                backup.display()
+            )
+        })?;
+    }
+    if let Err(error) = std::fs::rename(staging, destination) {
+        if had_previous {
+            let _ = std::fs::rename(backup, destination);
+        }
+        let _ = std::fs::remove_dir_all(staging);
+        return Err(error)
+            .with_context(|| format!("swap {} into {}", staging.display(), destination.display()));
+    }
+    if had_previous {
+        let _ = std::fs::remove_dir_all(backup);
+    }
+    Ok(())
+}
+
+/// Whether an independently managed smolvm already exists on the service
+/// PATH. The installer's own `/usr/local/bin/smolvm` symlink into the service
+/// prefix is NOT independent: it may be stale relative to a newer source
+/// install and must be refreshed, never mistaken for a current binary.
+#[cfg(any(target_os = "linux", test))]
+fn independent_system_smolvm(managed_link: &Path, destination_bin: &Path) -> bool {
+    let is_managed = std::fs::read_link(managed_link).is_ok_and(|target| target == destination_bin);
+    !is_managed
+        && [
+            managed_link,
+            Path::new("/usr/bin/smolvm"),
+            Path::new("/bin/smolvm"),
+        ]
+        .iter()
+        .any(|candidate| candidate.exists())
+}
+
+/// Whether the service copy of smolvm is stale relative to the source
+/// install: missing entirely (first install), or older than the source
+/// binary (refresh after an update).
+#[cfg(any(target_os = "linux", test))]
+fn smolvm_copy_stale(source_bin: &Path, destination_bin: &Path) -> bool {
+    !destination_bin.exists() || newer_than(source_bin, destination_bin)
+}
+
+/// Whether `source`'s mtime is newer than `destination`'s; unknown metadata
+/// counts as stale so the copy is made.
+#[cfg(any(target_os = "linux", test))]
+fn newer_than(source: &Path, destination: &Path) -> bool {
+    match (
+        std::fs::metadata(source).and_then(|meta| meta.modified()),
+        std::fs::metadata(destination).and_then(|meta| meta.modified()),
+    ) {
+        (Ok(source), Ok(destination)) => source > destination,
+        _ => true,
+    }
+}
+
+/// Hand the state directory to the service account so the non-root service
+/// can initialize and own its state (config.toml, DB, smolvm data, copied
+/// smolvm prefix). Runs as root at install; a no-op for user-scope installs.
+#[cfg(target_os = "linux")]
+fn chown_state_dir(home: &Path, dry_run: bool) -> Result<()> {
+    if dry_run {
+        eprintln!(
+            "[preloop] would chown -R {} to {SERVICE_USER}:{SERVICE_USER}",
+            home.display()
+        );
+        return Ok(());
+    }
+    let status = Command::new("chown")
+        .arg("-R")
+        .arg(format!("{SERVICE_USER}:{SERVICE_USER}"))
+        .arg(home)
+        .status()
+        .with_context(|| format!("chown {}", home.display()))?;
+    if !status.success() {
+        bail!("chown {} failed ({status})", home.display());
+    }
+    Ok(())
+}
+
+/// Resolve the GitHub App key path the environment file will reference.
+///
+/// Linux system scope: the service reads the key under its dedicated
+/// non-root account, and a key left in the caller's tree — e.g. under
+/// `/root` — is unreachable no matter how it is chowned, because the service
+/// user cannot traverse the parent directory. The installer therefore stages
+/// a copy in the root-owned [`SYSTEM_CONFIG_DIR`], which [`grant_service_read`]
+/// then hands to the service as `root:preloop` mode `0640`: readable by the
+/// service and nothing more. It deliberately does not
+/// live under `PRELOOP_HOME`, because the service can unlink and recreate any
+/// entry in a directory it owns, which would let it swap its own App key.
+/// The caller's original is never modified. Every other scope keeps the
+/// original path.
+#[cfg(any(target_os = "linux", test))]
+fn staged_app_key(args: &InstallArgs, config_dir: &Path) -> Result<Option<PathBuf>> {
+    let Some(source) = args.github_app_key.clone() else {
+        return Ok(None);
+    };
+    if args.user {
+        return Ok(Some(source));
+    }
+    let destination = config_dir.join("github-app-key.pem");
+    if std::fs::canonicalize(&source).is_ok_and(|resolved| resolved == destination) {
+        // Already the staged file (re-install with the staged path).
+        return Ok(Some(destination));
+    }
+    if args.dry_run {
+        eprintln!(
+            "[preloop] would copy {} to {} (0640 root:{SERVICE_USER}, read-only to the service)",
+            source.display(),
+            destination.display()
+        );
+        return Ok(Some(destination));
+    }
+    std::fs::copy(&source, &destination)
+        .with_context(|| format!("copy {} to {}", source.display(), destination.display()))?;
+    // Staged private by default; `grant_service_read` widens it to the service
+    // group once the account is known to exist. Ownership is an install-time
+    // concern, kept out of the staging logic so this stays testable without
+    // root or a `preloop` account.
+    set_private_file_permissions(&destination)
+        .with_context(|| format!("chmod 0600 {}", destination.display()))?;
+    Ok(Some(destination))
+}
+
+/// Create the root-owned system config directory: `0750 root:{SERVICE_USER}`
+/// so the service can traverse in to read its key, but cannot create, rename,
+/// or unlink anything inside it.
+#[cfg(target_os = "linux")]
+fn prepare_system_config_dir(dry_run: bool) -> Result<()> {
+    let dir = Path::new(SYSTEM_CONFIG_DIR);
+    if dry_run {
+        eprintln!(
+            "[preloop] would create {} (0750 root:{SERVICE_USER})",
+            dir.display()
+        );
+        return Ok(());
+    }
+    std::fs::create_dir_all(dir).with_context(|| format!("create {}", dir.display()))?;
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o750))
+        .with_context(|| format!("chmod 0750 {}", dir.display()))?;
+    let status = Command::new("chown")
+        .arg(format!("root:{SERVICE_USER}"))
+        .arg(dir)
+        .status()
+        .with_context(|| format!("chown {}", dir.display()))?;
+    if !status.success() {
+        bail!("chown {} failed ({status})", dir.display());
+    }
+    Ok(())
+}
+
+/// Hand a root-owned file to the service for reading only: `root:{SERVICE_USER}`
+/// mode `0640`. Requires the service account to exist, so it runs after
+/// [`ensure_service_user`].
+#[cfg(target_os = "linux")]
+fn grant_service_read(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o640))
+        .with_context(|| format!("chmod 0640 {}", path.display()))?;
+    let status = Command::new("chown")
+        .arg(format!("root:{SERVICE_USER}"))
+        .arg(path)
+        .status()
+        .with_context(|| format!("chown {}", path.display()))?;
+    if !status.success() {
+        bail!("chown {} failed ({status})", path.display());
+    }
+    Ok(())
+}
+
+/// `0755` — traversable and readable by every account, writable only by root.
+#[cfg(target_os = "linux")]
+fn set_world_readable_directory(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755))
+        .with_context(|| format!("chmod 0755 {}", path.display()))
+}
+
+/// Non-Linux installs keep the caller's key path (launchd runs as root, so
+/// traversal is not an issue).
+#[cfg(all(not(target_os = "linux"), not(test)))]
+fn staged_app_key(args: &InstallArgs, _config_dir: &Path) -> Result<Option<PathBuf>> {
+    Ok(args.github_app_key.clone())
 }
 
 #[cfg(target_os = "linux")]
@@ -359,6 +913,31 @@ fn uninstall_systemd(args: &UninstallArgs, home: &Path) -> Result<()> {
         dry,
         "reload systemd",
     );
+    // Secrets outlive --purge-data otherwise: for a system install the
+    // environment file and the staged App key live in the root-owned config
+    // dir, not under the state dir that --purge-data removes.
+    if !args.user {
+        for artifact in ["environment", "github-app-key.pem"] {
+            let path = Path::new(SYSTEM_CONFIG_DIR).join(artifact);
+            if path.exists() || dry {
+                remove_path(&path, dry)?;
+            }
+        }
+        // Only our own managed symlink, never an operator-installed binary.
+        let managed_link = Path::new("/usr/local/bin/smolvm");
+        let prefix = Path::new(SMOLVM_PREFIX_PARENT).join("smolvm-prefix");
+        if std::fs::read_link(managed_link).is_ok_and(|target| target.starts_with(&prefix)) {
+            remove_path(managed_link, dry)?;
+        }
+        if prefix.is_dir() {
+            if dry {
+                eprintln!("[preloop] would remove {}", prefix.display());
+            } else {
+                std::fs::remove_dir_all(&prefix)
+                    .with_context(|| format!("remove {}", prefix.display()))?;
+            }
+        }
+    }
     eprintln!(
         "[preloop] removed Preloop {} systemd units",
         if args.user { "user" } else { "system" }
@@ -374,6 +953,34 @@ fn render_systemd_service(
     credential: Option<&Path>,
 ) -> Result<String> {
     let exe_display = systemd_path(exe);
+    let identity = if user {
+        String::new()
+    } else {
+        // Dedicated service identity: an escape from the guest cannot reach
+        // root. The account (plus kvm group membership) is created by the
+        // installer; the state dir is chowned to it.
+        format!("User={SERVICE_USER}\nGroup={SERVICE_USER}\n")
+    };
+    let data_root = if user {
+        String::new()
+    } else {
+        // Pin SmolVM's data (machine records, VM disks, agent rootfs) under
+        // the state dir so it follows --home and stays owned by the service
+        // user — never the operator's or root's XDG tree.
+        format!(
+            "Environment=HOME={}\nEnvironment=SMOLVM_DATA_DIR={}/smolvm\n",
+            systemd_path(home),
+            systemd_path(home)
+        )
+    };
+    let delegation = if user {
+        String::new()
+    } else {
+        // Delegate this unit's cgroup subtree so `_boot-vm` can place each VM
+        // in its own capped `vm-<pid>` leaf (cpu/pids/memory). The provider
+        // only passes SMOLVM_CGROUP_ROOT when it observes this delegation.
+        "Delegate=cpu memory pids\n".to_owned()
+    };
     Ok(format!(
         r#"[Unit]
 Description=Preloop self-hosted GitHub Actions control plane
@@ -384,17 +991,25 @@ After=preloop.socket network-online.target
 Type=simple
 ExecStart={exe_display} serve
 Environment=PRELOOP_HOME={home}
-EnvironmentFile=-{home}/environment
-{credential}Restart=on-failure
+EnvironmentFile=-{env_file}
+{credential}{identity}{data_root}Restart=on-failure
 RestartSec=5s
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=full
 ProtectHome=read-only
-{readwrite}[Install]
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectClock=true
+LockPersonality=true
+RestrictRealtime=true
+CapabilityBoundingSet=
+{delegation}{state_directory}{readwrite}[Install]
 WantedBy={wanted_by}
 "#,
         home = home.display(),
+        env_file = systemd_path(&env_file_path(home, user)),
+        state_directory = state_directory_line(home, user),
         wanted_by = if user {
             "default.target"
         } else {
@@ -408,7 +1023,7 @@ WantedBy={wanted_by}
                 )
             })
             .unwrap_or_default(),
-        readwrite = readwrite_paths(exe, home, user),
+        readwrite = readwrite_paths(exe, home, user, false),
     ))
 }
 
@@ -450,28 +1065,38 @@ Wants=network-online.target
 Type=oneshot
 ExecStart={exe_display} update
 Environment=PRELOOP_HOME={home}
-EnvironmentFile=-{home}/environment
+EnvironmentFile=-{env_file}
 NoNewPrivileges=true
 ProtectSystem=full
 ProtectHome=read-only
 {readwrite}"#,
         home = home.display(),
-        readwrite = readwrite_paths(exe, home, user),
+        env_file = systemd_path(&env_file_path(home, user)),
+        readwrite = readwrite_paths(exe, home, user, true),
     ))
 }
 
-/// `ReadWritePaths=` line: the executable's directory (so the self-update
-/// timer can replace the binary under `ProtectSystem=full`) and, for
-/// user-scoped units, `PRELOOP_HOME` (which `ProtectHome=read-only` would
-/// otherwise make unwritable — the service cannot initialize its state).
-/// Paths are quoted per systemd's path-list syntax when they contain
-/// whitespace; an unquoted path with a space would split the list and the
-/// whitelist would silently miss the real directory.
+/// `ReadWritePaths=` line for a unit.
+///
+/// Only the update unit may rewrite the executable's directory
+/// (`replaceable_exe`): the self-update timer replaces the binary under
+/// `ProtectSystem=full`. The serving unit must NOT be able to write its own
+/// binary — a VMM escape under the service identity planting a new
+/// `ExecStart` target for the next root start to execute is an escalation
+/// path. The state dir is carved out only for user scope, where
+/// `ProtectHome=read-only` would otherwise block `~`; a system install under
+/// one of those roots is rejected outright by [`install`], and the default
+/// /var/lib/preloop needs no carve-out. Paths are quoted per
+/// systemd's path-list syntax when they contain whitespace; an unquoted path
+/// with a space would split the list and the whitelist would silently miss
+/// the real directory.
 #[cfg(any(target_os = "linux", test))]
-fn readwrite_paths(exe: &Path, home: &Path, user: bool) -> String {
+fn readwrite_paths(exe: &Path, home: &Path, user: bool, replaceable_exe: bool) -> String {
     let mut paths = Vec::new();
-    if let Some(dir) = readwrite_dir(exe) {
-        paths.push(systemd_path(&dir));
+    if replaceable_exe {
+        if let Some(dir) = readwrite_dir(exe) {
+            paths.push(systemd_path(&dir));
+        }
     }
     if user {
         paths.push(systemd_path(home));
@@ -481,6 +1106,46 @@ fn readwrite_paths(exe: &Path, home: &Path, user: bool) -> String {
     } else {
         format!("ReadWritePaths={}\n", paths.join(" "))
     }
+}
+
+/// `StateDirectory=` line for the default state directory: systemd then
+/// creates and chowns `/var/lib/preloop` for the service identity at every
+/// start. Custom `--home` paths cannot be expressed as a StateDirectory name,
+/// so those rely on the installer's chown instead.
+#[cfg(any(target_os = "linux", test))]
+fn state_directory_line(home: &Path, user: bool) -> String {
+    if !user && home == Path::new(DEFAULT_HOME) {
+        "StateDirectory=preloop\nStateDirectoryMode=0700\n".to_owned()
+    } else {
+        String::new()
+    }
+}
+
+/// Where the unit's `EnvironmentFile=` lives.
+///
+/// System scope puts it in the root-owned [`SYSTEM_CONFIG_DIR`] so the service
+/// identity cannot rewrite (or unlink and recreate) the file systemd feeds it;
+/// `EnvironmentFile=` overrides the unit's `Environment=`, so a service-owned
+/// copy would let a compromised VMM persist `SMOLVM_SECCOMP=off` across the
+/// next `Restart=on-failure`. User scope has no privilege boundary to defend,
+/// so it keeps the file beside the rest of the state.
+#[cfg(any(target_os = "linux", test))]
+fn env_file_path(home: &Path, user: bool) -> PathBuf {
+    if user {
+        home.join("environment")
+    } else {
+        Path::new(SYSTEM_CONFIG_DIR).join("environment")
+    }
+}
+
+/// `ProtectHome=read-only` makes these roots unwritable; a state dir under
+/// one of them needs an explicit `ReadWritePaths` carve-out (user scope), and
+/// is unusable altogether for a system install: the dedicated service account
+/// cannot traverse a `0700` `/home/<someone>` or `/root` no matter how the
+/// state dir itself is owned. [`install`] rejects those up front.
+#[cfg(any(target_os = "linux", test))]
+fn home_blocked_by_protect_home(home: &Path) -> bool {
+    home.starts_with("/home/") || home.starts_with("/root") || home.starts_with("/run/user")
 }
 
 #[cfg(any(target_os = "linux", test))]
@@ -524,7 +1189,7 @@ WantedBy=timers.target
 // launchd (macOS)
 // ---------------------------------------------------------------------------
 
-#[cfg(any(target_os = "macos", test))]
+#[cfg(target_os = "macos")]
 fn install_launchd(
     args: &InstallArgs,
     home: &Path,
@@ -534,8 +1199,6 @@ fn install_launchd(
     let dry = args.dry_run;
     let (plist_path, domain) = launchd_target(args.user);
     let plist = render_launchd_plist(exe, home, env_lines)?;
-
-    prepare_home(home, dry)?;
 
     if dry {
         eprintln!(
@@ -626,7 +1289,7 @@ fn webhook_hint(public_url: Option<&str>) -> String {
     }
 }
 
-#[cfg(any(target_os = "macos", test))]
+#[cfg(target_os = "macos")]
 fn uninstall_launchd(args: &UninstallArgs, home: &Path) -> Result<()> {
     let _ = home;
     let dry = args.dry_run;
@@ -723,7 +1386,10 @@ fn render_launchd_plist(exe: &Path, home: &Path, env_lines: &[String]) -> Result
 /// Environment-file lines for the config the operator supplied. Keys are the
 /// names `preloop serve` / the server already read (`PRELOOP_LISTEN`,
 /// `PRELOOP_PUBLIC_URL`, `PRELOOP_GITHUB_APP_*`, `PRELOOP_WEBHOOK_SECRET`).
-fn config_env_lines(args: &InstallArgs) -> Result<Vec<String>> {
+/// `app_key` is the path the environment file should reference — the staged
+/// service-owned copy on Linux system installs, the caller's original
+/// elsewhere; `None` falls back to `args.github_app_key`.
+fn config_env_lines(args: &InstallArgs, app_key: Option<&Path>) -> Result<Vec<String>> {
     let mut lines = Vec::new();
     if let Some(listen) = args.listen {
         lines.push(env_line("PRELOOP_LISTEN", &listen.to_string())?);
@@ -734,9 +1400,22 @@ fn config_env_lines(args: &InstallArgs) -> Result<Vec<String>> {
     if let Some(id) = &args.github_app_id {
         lines.push(env_line("PRELOOP_GITHUB_APP_ID", id)?);
     }
-    if let Some(key) = &args.github_app_key {
-        let key = std::fs::canonicalize(key)
-            .with_context(|| format!("resolve --github-app-key {}", key.display()))?;
+    if let Some(key) = app_key.or(args.github_app_key.as_deref()) {
+        let key = match std::fs::canonicalize(key) {
+            Ok(resolved) => resolved,
+            // A --dry-run stages the key copy without creating it; the
+            // absolute staged path still renders the correct environment
+            // file. Real installs resolve, because `install` validated that
+            // the original exists and the staged copy was just made.
+            Err(_) => {
+                anyhow::ensure!(
+                    key.is_absolute(),
+                    "--github-app-key must be an absolute path (got {})",
+                    key.display()
+                );
+                key.to_path_buf()
+            }
+        };
         lines.push(env_line(
             "PRELOOP_GITHUB_APP_PEM_FILE",
             &key.display().to_string(),
@@ -808,16 +1487,25 @@ fn prepare_home(home: &Path, dry_run: bool) -> Result<()> {
 }
 
 #[cfg(target_os = "linux")]
-fn write_env_file(home: &Path, env_lines: &[String], dry_run: bool) -> Result<()> {
+fn write_env_file(path: &Path, env_lines: &[String], dry_run: bool) -> Result<()> {
     if env_lines.is_empty() {
         return Ok(());
     }
-    let path = home.join("environment");
     if dry_run {
         eprintln!("[preloop] would write {} (0600)", path.display());
         return Ok(());
     }
-    write_private_file(&path, env_lines.join("\n").as_bytes())
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    // write_private_file uses O_CREAT|O_TRUNC without unlinking, so a rewrite
+    // preserves the existing inode — and with it the existing owner. For a
+    // system install the file sits in the root-owned config dir and is never
+    // reached by the state-dir chown, so it stays root-owned across
+    // re-installs. (Before this was true, a second `server install` handed the
+    // service write access to its own EnvironmentFile, which overrides the
+    // unit's Environment= and could disable the VM sandbox on restart.)
+    write_private_file(path, env_lines.join("\n").as_bytes())
         .with_context(|| format!("write {}", path.display()))?;
     Ok(())
 }
@@ -906,6 +1594,7 @@ fn xml_escape(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::fs::PermissionsExt;
 
     fn env_lines() -> Vec<String> {
         vec![
@@ -925,12 +1614,219 @@ mod tests {
         .unwrap();
         assert!(unit.contains("ExecStart=/usr/local/bin/preloop serve"));
         assert!(unit.contains("Environment=PRELOOP_HOME=/var/lib/preloop"));
-        assert!(unit.contains("EnvironmentFile=-/var/lib/preloop/environment"));
-        assert!(unit.contains("ReadWritePaths=/usr/local/bin"));
+        // Root-owned config dir, not the service-writable state dir.
+        assert!(unit.contains("EnvironmentFile=-/etc/preloop/environment"));
         assert!(unit.contains("Requires=preloop.socket"));
         assert!(unit.contains("NoNewPrivileges=true"));
         assert!(unit.contains("ProtectSystem=full"));
+        assert!(unit.contains("ProtectHome=read-only"));
         assert!(unit.contains("WantedBy=multi-user.target"));
+    }
+
+    /// The full default system-scope unit, byte for byte — the renderer is
+    /// the observable output, and contrib/systemd/preloop.service mirrors it.
+    #[test]
+    fn systemd_service_default_system_scope_renders_exactly() {
+        let unit = render_systemd_service(
+            Path::new("/usr/local/bin/preloop"),
+            Path::new(DEFAULT_HOME),
+            false,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            unit,
+            r#"[Unit]
+Description=Preloop self-hosted GitHub Actions control plane
+Requires=preloop.socket
+After=preloop.socket network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/preloop serve
+Environment=PRELOOP_HOME=/var/lib/preloop
+EnvironmentFile=-/etc/preloop/environment
+User=preloop
+Group=preloop
+Environment=HOME=/var/lib/preloop
+Environment=SMOLVM_DATA_DIR=/var/lib/preloop/smolvm
+Restart=on-failure
+RestartSec=5s
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=read-only
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectClock=true
+LockPersonality=true
+RestrictRealtime=true
+CapabilityBoundingSet=
+Delegate=cpu memory pids
+StateDirectory=preloop
+StateDirectoryMode=0700
+[Install]
+WantedBy=multi-user.target
+"#
+        );
+    }
+
+    /// The system-scope service must run under a dedicated non-root account:
+    /// a guest→VMM escape lands in the VMM process, which inherits the
+    /// service identity — root would hand the escape the host. The identity
+    /// is not applied to user-scope units (those already run as the
+    /// installing user, and systemd rejects User= there).
+    #[test]
+    fn systemd_service_runs_as_dedicated_non_root_identity() {
+        let unit = render_systemd_service(
+            Path::new("/usr/local/bin/preloop"),
+            Path::new(DEFAULT_HOME),
+            false,
+            None,
+        )
+        .unwrap();
+        assert!(unit.contains("User=preloop\nGroup=preloop\n"));
+        assert!(unit.contains("CapabilityBoundingSet=\n"));
+        assert!(unit.contains("StateDirectory=preloop"));
+        assert!(unit.contains("StateDirectoryMode=0700"));
+        assert!(unit.contains("Delegate=cpu memory pids"));
+        assert!(unit.contains("ProtectKernelModules=true"));
+        assert!(unit.contains("ProtectKernelLogs=true"));
+        assert!(unit.contains("ProtectClock=true"));
+        assert!(unit.contains("LockPersonality=true"));
+        assert!(unit.contains("RestrictRealtime=true"));
+        // The serving unit must not be able to rewrite its own binary, and
+        // the default state dir is owned via StateDirectory, so no
+        // ReadWritePaths at all.
+        assert!(!unit.contains("ReadWritePaths="));
+        // SmolVM data is pinned under the state dir, not the operator's or
+        // root's XDG tree, and HOME follows so the service identity never
+        // resolves a foreign home.
+        assert!(unit.contains("Environment=HOME=/var/lib/preloop"));
+        assert!(unit.contains("Environment=SMOLVM_DATA_DIR=/var/lib/preloop/smolvm"));
+
+        let user_unit = render_systemd_service(
+            Path::new("/usr/local/bin/preloop"),
+            Path::new("/Users/me/.preloop"),
+            true,
+            None,
+        )
+        .unwrap();
+        assert!(!user_unit.contains("User=preloop"));
+        assert!(!user_unit.contains("StateDirectory="));
+        assert!(!user_unit.contains("Delegate="));
+        assert!(!user_unit.contains("SMOLVM_DATA_DIR="));
+    }
+
+    /// Only the update unit may write the executable's directory: a VMM
+    /// escape (or any service-user code) planting a new binary for the next
+    /// root start to execute would be an escalation path.
+    #[test]
+    fn serving_unit_cannot_rewrite_its_own_binary() {
+        let service = render_systemd_service(
+            Path::new("/usr/local/bin/preloop"),
+            Path::new(DEFAULT_HOME),
+            false,
+            None,
+        )
+        .unwrap();
+        assert!(!service.contains("ReadWritePaths=/usr/local/bin"));
+        let update = render_systemd_update_service(
+            Path::new("/usr/local/bin/preloop"),
+            Path::new(DEFAULT_HOME),
+            false,
+        )
+        .unwrap();
+        assert!(update.contains("ReadWritePaths=/usr/local/bin"));
+    }
+
+    /// A system install under a `ProtectHome=read-only` root is rejected, not
+    /// papered over with a `ReadWritePaths` carve-out: the `preloop` account
+    /// cannot traverse a 0700 `/home/<user>` or `/root` however the state dir
+    /// itself is owned, so the carve-out produced a unit that looked correct
+    /// and failed at first start. A root-reachable custom home is fine and
+    /// needs no carve-out at all.
+    #[test]
+    fn system_install_rejects_a_home_the_service_account_cannot_traverse() {
+        for blocked in [
+            "/home/me/preloop-data",
+            "/root/preloop",
+            "/run/user/1000/preloop",
+        ] {
+            assert!(
+                home_blocked_by_protect_home(Path::new(blocked)),
+                "{blocked} must be rejected for a system install"
+            );
+            let error = install(InstallArgs {
+                home: Some(PathBuf::from(blocked)),
+                user: false,
+                dry_run: true,
+                listen: None,
+                public_url: None,
+                github_app_id: None,
+                github_app_key: None,
+                github_app_installation_id: None,
+                webhook_secret: None,
+                no_update_timer: false,
+                systemd_credential: None,
+            })
+            .unwrap_err();
+            assert!(
+                error.to_string().contains("unusable for a system install"),
+                "{blocked}: {error}"
+            );
+        }
+        // Root-reachable custom home: allowed, no carve-out, no StateDirectory.
+        assert!(!home_blocked_by_protect_home(Path::new("/srv/preloop")));
+        let open = render_systemd_service(
+            Path::new("/usr/local/bin/preloop"),
+            Path::new("/srv/preloop"),
+            false,
+            None,
+        )
+        .unwrap();
+        assert!(!open.contains("ReadWritePaths="));
+        assert!(!open.contains("StateDirectory="));
+        // User scope still carves out its home, which ProtectHome would block.
+        let user_unit = render_systemd_service(
+            Path::new("/usr/local/bin/preloop"),
+            Path::new("/home/me/.preloop"),
+            true,
+            None,
+        )
+        .unwrap();
+        assert!(user_unit.contains("ReadWritePaths=/home/me/.preloop"));
+    }
+
+    /// The whole point of the ownership split: nothing the service must not be
+    /// able to rewrite may live inside `PRELOOP_HOME`. The service owns that
+    /// directory, and on Unix the directory write bit governs unlink/rename,
+    /// so any entry in it can be replaced regardless of the entry's own mode.
+    #[test]
+    fn install_artifacts_live_outside_the_service_writable_state_dir() {
+        let home = Path::new(DEFAULT_HOME);
+        assert!(
+            !Path::new(SYSTEM_CONFIG_DIR).starts_with(home),
+            "the EnvironmentFile/App-key dir must not be under {}",
+            home.display()
+        );
+        assert!(
+            !Path::new(SMOLVM_PREFIX_PARENT).starts_with(home),
+            "the smolvm prefix (which /usr/local/bin/smolvm points into, and \
+             root executes) must not be under {}",
+            home.display()
+        );
+        // System scope: env file in the root-owned config dir. User scope: no
+        // privilege boundary, so it stays with the rest of the state.
+        assert_eq!(
+            env_file_path(home, false),
+            PathBuf::from("/etc/preloop/environment")
+        );
+        let user_home = Path::new("/home/me/.preloop");
+        assert_eq!(
+            env_file_path(user_home, true),
+            user_home.join("environment")
+        );
     }
 
     #[test]
@@ -968,7 +1864,16 @@ mod tests {
         )
         .unwrap();
         assert!(unit.contains("ExecStart=\"/opt/pre loop/preloop\" serve"));
-        assert!(unit.contains("ReadWritePaths=\"/opt/pre loop\""));
+        // The serving unit never gets the executable's directory, so no
+        // quoting is needed here; the update unit does carry it.
+        assert!(!unit.contains("ReadWritePaths="));
+        let update = render_systemd_update_service(
+            Path::new("/opt/pre loop/preloop"),
+            Path::new("/var/lib/preloop"),
+            false,
+        )
+        .unwrap();
+        assert!(update.contains("ReadWritePaths=\"/opt/pre loop\""));
     }
 
     #[test]
@@ -983,7 +1888,7 @@ mod tests {
         // ProtectHome=read-only would block ~/.preloop state; the unit must
         // carve out a writable exception.
         assert!(unit.contains("ProtectHome=read-only"));
-        assert!(unit.contains("ReadWritePaths=/usr/local/bin /Users/me/.preloop"));
+        assert!(unit.contains("ReadWritePaths=/Users/me/.preloop"));
         let system = render_systemd_service(
             Path::new("/usr/local/bin/preloop"),
             Path::new(DEFAULT_HOME),
@@ -991,15 +1896,37 @@ mod tests {
             None,
         )
         .unwrap();
-        // System scope grants only the executable's directory, never home.
-        assert!(system.contains("ReadWritePaths=/usr/local/bin\n"));
-        assert!(!system.contains("/var/lib/preloop\""));
+        // System scope relies on StateDirectory for the default home and
+        // grants no extra paths at all.
+        assert!(!system.contains("ReadWritePaths="));
     }
 
     #[test]
     fn readwrite_paths_quote_whitespace_dirs() {
-        let line = readwrite_paths(Path::new("/opt/pre loop/preloop"), Path::new("/h/p"), true);
-        assert_eq!(line, "ReadWritePaths=\"/opt/pre loop\" /h/p\n",);
+        // Update unit: executable dir + (user-scope) home, quoted.
+        let line = readwrite_paths(
+            Path::new("/opt/pre loop/preloop"),
+            Path::new("/h/p"),
+            true,
+            true,
+        );
+        assert_eq!(line, "ReadWritePaths=\"/opt/pre loop\" /h/p\n");
+        // Serving unit: only the state dir, never the executable's.
+        let serving = readwrite_paths(
+            Path::new("/opt/pre loop/preloop"),
+            Path::new("/h/p"),
+            true,
+            false,
+        );
+        assert_eq!(serving, "ReadWritePaths=/h/p\n");
+        // System scope with the default home: nothing at all.
+        let system = readwrite_paths(
+            Path::new("/usr/local/bin/preloop"),
+            Path::new(DEFAULT_HOME),
+            false,
+            false,
+        );
+        assert_eq!(system, "");
     }
 
     #[test]
@@ -1139,7 +2066,7 @@ mod tests {
             user: false,
             dry_run: false,
         };
-        let lines = config_env_lines(&args).unwrap();
+        let lines = config_env_lines(&args, None).unwrap();
         assert_eq!(
             lines,
             vec![
@@ -1178,6 +2105,401 @@ mod tests {
             readwrite_dir(Path::new("/usr/local/bin/preloop")).unwrap(),
             PathBuf::from("/usr/local/bin")
         );
+    }
+
+    /// The GitHub App key must be copied into service-owned state, never
+    /// chowned in place: the service user cannot traverse a `/root`-like
+    /// parent no matter how the file itself is owned. The caller's original
+    /// stays byte-for-byte and mode-for-mode untouched.
+    #[test]
+    fn staged_app_key_copies_into_state_without_touching_the_source() {
+        let source_dir = tempfile::tempdir().unwrap();
+        let source = source_dir.path().join("app.pem");
+        std::fs::write(&source, b"-----BEGIN PRIVATE KEY-----\nsecret\n").unwrap();
+        std::fs::set_permissions(&source, std::fs::Permissions::from_mode(0o600)).unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let args = InstallArgs {
+            listen: None,
+            public_url: None,
+            github_app_id: None,
+            github_app_key: Some(source.clone()),
+            github_app_installation_id: None,
+            webhook_secret: None,
+            home: None,
+            no_update_timer: false,
+            systemd_credential: None,
+            user: false,
+            dry_run: false,
+        };
+
+        let staged = staged_app_key(&args, home.path()).unwrap().unwrap();
+
+        let expected = home.path().join("github-app-key.pem");
+        assert_eq!(staged, expected);
+        assert_eq!(
+            std::fs::read(&expected).unwrap(),
+            b"-----BEGIN PRIVATE KEY-----\nsecret\n"
+        );
+        assert_eq!(
+            std::fs::metadata(&expected).unwrap().permissions().mode() & 0o777,
+            0o600,
+            "staged copy starts private; grant_service_read widens it to 0640 \
+             root:preloop once the service account exists"
+        );
+        // The caller's original is untouched.
+        assert_eq!(
+            std::fs::read(&source).unwrap(),
+            b"-----BEGIN PRIVATE KEY-----\nsecret\n"
+        );
+        assert_eq!(
+            std::fs::metadata(&source).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        // The environment file references the staged path, and dry-run
+        // renders the same line without creating the copy.
+        let env_args = InstallArgs {
+            github_app_key: Some(staged.clone()),
+            dry_run: false,
+            ..args.clone()
+        };
+        let lines = config_env_lines(&env_args, None).unwrap();
+        let canonical_staged = std::fs::canonicalize(&staged).unwrap();
+        assert!(
+            lines.iter().any(|line| line
+                == &format!("PRELOOP_GITHUB_APP_PEM_FILE={}", canonical_staged.display())),
+            "{lines:?}"
+        );
+        let dry_args = InstallArgs {
+            dry_run: true,
+            ..args
+        };
+        // A fresh home: dry-run must not create the staged copy anywhere.
+        let dry_home = tempfile::tempdir().unwrap();
+        let dry_staged = staged_app_key(&dry_args, dry_home.path()).unwrap().unwrap();
+        let dry_expected = dry_home.path().join("github-app-key.pem");
+        assert_eq!(dry_staged, dry_expected);
+        assert!(
+            !dry_expected.exists(),
+            "dry-run must not create the staged copy"
+        );
+        // Dry-run renders the staged path without a canonicalize round-trip.
+        let dry_lines = config_env_lines(&dry_args, Some(&dry_staged)).unwrap();
+        assert!(
+            dry_lines
+                .iter()
+                .any(|line| line
+                    == &format!("PRELOOP_GITHUB_APP_PEM_FILE={}", dry_expected.display()))
+        );
+    }
+
+    /// User-scope installs keep the caller's key path — the service runs as
+    /// the installing user, who can already reach it.
+    #[test]
+    fn staged_app_key_keeps_the_original_path_for_user_scope() {
+        let source_dir = tempfile::tempdir().unwrap();
+        let source = source_dir.path().join("app.pem");
+        std::fs::write(&source, b"key").unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let args = InstallArgs {
+            github_app_key: Some(source.clone()),
+            user: true,
+            dry_run: false,
+            listen: None,
+            public_url: None,
+            github_app_id: None,
+            github_app_installation_id: None,
+            webhook_secret: None,
+            home: None,
+            no_update_timer: false,
+            systemd_credential: None,
+        };
+        assert_eq!(
+            staged_app_key(&args, home.path()).unwrap(),
+            Some(source.clone())
+        );
+        assert!(!home.path().join("github-app-key.pem").exists());
+    }
+
+    /// The very first system install with `--github-app-key` targets a state
+    /// dir that does not exist yet (default or nested). `install()` must
+    /// prepare the directory before staging the key — this test pins that
+    /// ordering by reproducing the exact sequence against a nonexistent
+    /// nested path.
+    #[test]
+    fn first_install_stages_key_into_a_prepared_nested_state_dir() {
+        let base = tempfile::tempdir().unwrap();
+        let home = base.path().join("nested/preloop");
+        let source_dir = tempfile::tempdir().unwrap();
+        let source = source_dir.path().join("app.pem");
+        std::fs::write(&source, b"-----BEGIN PRIVATE KEY-----\nsecret\n").unwrap();
+        let args = InstallArgs {
+            github_app_key: Some(source.clone()),
+            dry_run: false,
+            user: false,
+            listen: None,
+            public_url: None,
+            github_app_id: None,
+            github_app_installation_id: None,
+            webhook_secret: None,
+            home: None,
+            no_update_timer: false,
+            systemd_credential: None,
+        };
+
+        // install()'s order: state dir first, then the staged key copy.
+        prepare_home(&home, false).unwrap();
+        let staged = staged_app_key(&args, &home).unwrap().unwrap();
+
+        assert_eq!(staged, home.join("github-app-key.pem"));
+        assert_eq!(
+            std::fs::read(&staged).unwrap(),
+            b"-----BEGIN PRIVATE KEY-----\nsecret\n"
+        );
+        assert_eq!(
+            std::fs::metadata(&staged).unwrap().permissions().mode() & 0o777,
+            0o600,
+            "staged copy starts private; grant_service_read widens it to 0640 \
+             root:preloop once the service account exists"
+        );
+        assert_eq!(
+            std::fs::metadata(&home).unwrap().permissions().mode() & 0o777,
+            0o700,
+            "state dir must stay 0700"
+        );
+        // The source is never modified.
+        assert_eq!(
+            std::fs::read(&source).unwrap(),
+            b"-----BEGIN PRIVATE KEY-----\nsecret\n"
+        );
+        // Without the prepared state dir the staging copy fails — the
+        // ordering is the contract.
+        let unprepared = base.path().join("other-nested/preloop");
+        assert!(
+            staged_app_key(&args, &unprepared).is_err(),
+            "staging into a nonexistent state dir must fail loudly"
+        );
+        assert!(!unprepared.exists());
+    }
+
+    /// The full `install()` pre-flight, dry-run, against a nonexistent
+    /// nested state dir with `--github-app-key`: it must succeed and leave
+    /// nothing behind.
+    #[test]
+    fn dry_run_install_handles_nonexistent_nested_home_with_key() {
+        let base = tempfile::tempdir().unwrap();
+        let home = base.path().join("nested/preloop");
+        let source_dir = tempfile::tempdir().unwrap();
+        let source = source_dir.path().join("app.pem");
+        std::fs::write(&source, b"key").unwrap();
+        let args = InstallArgs {
+            home: Some(home.clone()),
+            github_app_key: Some(source),
+            dry_run: true,
+            user: false,
+            listen: Some("127.0.0.1:9090".parse().unwrap()),
+            public_url: None,
+            github_app_id: None,
+            github_app_installation_id: None,
+            webhook_secret: None,
+            no_update_timer: false,
+            systemd_credential: None,
+        };
+
+        install(args).unwrap();
+
+        assert!(!home.exists(), "dry-run must not create the state dir");
+    }
+
+    /// First install: no service copy yet, so the copy is stale and must be
+    /// made; the managed symlink is not an independent binary.
+    #[test]
+    fn smolvm_bootstrap_first_install_needs_a_copy() {
+        let home = tempfile::tempdir().unwrap();
+        let destination_bin = home.path().join("smolvm-prefix/smolvm");
+        let bin_dir = tempfile::tempdir().unwrap();
+        let managed_link = bin_dir.path().join("smolvm");
+        let source_dir = tempfile::tempdir().unwrap();
+        let source = source_dir.path().join("smolvm-bin");
+        std::fs::write(&source, b"binary").unwrap();
+        assert!(smolvm_copy_stale(&source, &destination_bin));
+        assert!(!independent_system_smolvm(&managed_link, &destination_bin));
+    }
+
+    /// Pin a file's mtime relative to now. `smolvm_copy_stale` compares
+    /// modification times, and two consecutive `fs::write`s can land in the
+    /// same filesystem timestamp tick (they do on the ext4/overlayfs used by
+    /// Linux CI, though not on APFS), which made ordering-by-write-order
+    /// flaky. Set the times explicitly instead.
+    #[cfg(any(target_os = "linux", test))]
+    fn set_mtime_secs_ago(path: &Path, secs_ago: u64) {
+        let when = std::time::SystemTime::now() - std::time::Duration::from_secs(secs_ago);
+        std::fs::File::options()
+            .write(true)
+            .open(path)
+            .unwrap()
+            .set_modified(when)
+            .unwrap();
+    }
+
+    /// Refresh: after `preloop update` the source is newer and the copy must
+    /// be re-made; an up-to-date copy stays put.
+    #[test]
+    fn smolvm_bootstrap_refreshes_a_stale_copy_and_keeps_a_current_one() {
+        let source_dir = tempfile::tempdir().unwrap();
+        let source_bin = source_dir.path().join("smolvm-bin");
+        let destination_dir = tempfile::tempdir().unwrap();
+        let destination_bin = destination_dir.path().join("smolvm-bin");
+        std::fs::write(&destination_bin, b"old").unwrap();
+        std::fs::write(&source_bin, b"new").unwrap();
+        set_mtime_secs_ago(&destination_bin, 120);
+        set_mtime_secs_ago(&source_bin, 60);
+        assert!(smolvm_copy_stale(&source_bin, &destination_bin));
+
+        set_mtime_secs_ago(&source_bin, 120);
+        set_mtime_secs_ago(&destination_bin, 60);
+        assert!(!smolvm_copy_stale(&source_bin, &destination_bin));
+
+        // Identical mtimes (a same-tick copy) must NOT count as stale, or
+        // every re-install would rebuild the prefix.
+        let when = std::time::SystemTime::now();
+        for path in [&source_bin, &destination_bin] {
+            std::fs::File::options()
+                .write(true)
+                .open(path)
+                .unwrap()
+                .set_modified(when)
+                .unwrap();
+        }
+        assert!(!smolvm_copy_stale(&source_bin, &destination_bin));
+    }
+
+    /// The freshness check compares source `smolvm-bin` against destination
+    /// `smolvm-bin` — the wrapper file `smolvm` sits beside the real binary
+    /// and must not be used as a directory to look under.
+    #[test]
+    fn smolvm_bootstrap_compares_the_real_copied_binary_path() {
+        let home = tempfile::tempdir().unwrap();
+        let destination = home.path().join("smolvm-prefix");
+        let source_dir = tempfile::tempdir().unwrap();
+        let source_prefix = source_dir.path();
+        std::fs::create_dir_all(&destination).unwrap();
+
+        // Up to date: the destination binary is newer than the source.
+        std::fs::write(source_prefix.join("smolvm-bin"), b"old").unwrap();
+        std::fs::write(destination.join("smolvm-bin"), b"new").unwrap();
+        set_mtime_secs_ago(&source_prefix.join("smolvm-bin"), 120);
+        set_mtime_secs_ago(&destination.join("smolvm-bin"), 60);
+        assert!(!smolvm_copy_stale(
+            &source_prefix.join("smolvm-bin"),
+            &destination.join("smolvm-bin")
+        ));
+
+        // Stale: the source binary is newer — refresh needed.
+        std::fs::write(source_prefix.join("smolvm-bin"), b"newest").unwrap();
+        set_mtime_secs_ago(&source_prefix.join("smolvm-bin"), 10);
+        assert!(smolvm_copy_stale(
+            &source_prefix.join("smolvm-bin"),
+            &destination.join("smolvm-bin")
+        ));
+    }
+
+    #[test]
+    fn atomic_swap_first_install_moves_the_staging_dir_into_place() {
+        let directory = tempfile::tempdir().unwrap();
+        let destination = directory.path().join("smolvm-prefix");
+        let staging = directory.path().join("smolvm-prefix.staging-1");
+        let backup = directory.path().join("smolvm-prefix.backup-1");
+        std::fs::create_dir(&staging).unwrap();
+        std::fs::write(staging.join("smolvm-bin"), b"binary").unwrap();
+
+        atomic_directory_swap(&destination, &staging, &backup).unwrap();
+
+        assert_eq!(
+            std::fs::read(destination.join("smolvm-bin")).unwrap(),
+            b"binary"
+        );
+        assert!(!staging.exists());
+        assert!(!backup.exists());
+    }
+
+    /// A refresh must atomically replace the previous prefix: no reader can
+    /// observe a mix of old and new files, and no staging/backup debris
+    /// remains.
+    #[test]
+    fn atomic_swap_refresh_replaces_the_previous_prefix_without_leftovers() {
+        let directory = tempfile::tempdir().unwrap();
+        let destination = directory.path().join("smolvm-prefix");
+        let staging = directory.path().join("smolvm-prefix.staging-2");
+        let backup = directory.path().join("smolvm-prefix.backup-2");
+        std::fs::create_dir(&destination).unwrap();
+        std::fs::write(destination.join("smolvm-bin"), b"old-binary").unwrap();
+        std::fs::write(destination.join("lib"), b"old-lib").unwrap();
+        std::fs::create_dir(&staging).unwrap();
+        std::fs::write(staging.join("smolvm-bin"), b"new-binary").unwrap();
+        std::fs::write(staging.join("lib"), b"new-lib").unwrap();
+
+        atomic_directory_swap(&destination, &staging, &backup).unwrap();
+
+        assert_eq!(
+            std::fs::read(destination.join("smolvm-bin")).unwrap(),
+            b"new-binary"
+        );
+        assert_eq!(std::fs::read(destination.join("lib")).unwrap(), b"new-lib");
+        assert!(!staging.exists());
+        assert!(!backup.exists());
+    }
+
+    /// A failed swap must restore the previous prefix and leave no staging
+    /// or backup debris.
+    #[test]
+    fn atomic_swap_failure_restores_the_previous_prefix_and_cleans_up() {
+        let directory = tempfile::tempdir().unwrap();
+        let destination = directory.path().join("smolvm-prefix");
+        let staging = directory.path().join("smolvm-prefix.staging-3");
+        let backup = directory.path().join("smolvm-prefix.backup-3");
+        std::fs::create_dir(&destination).unwrap();
+        std::fs::write(destination.join("smolvm-bin"), b"old-binary").unwrap();
+        // staging is missing: the swap rename fails.
+
+        let error = atomic_directory_swap(&destination, &staging, &backup).unwrap_err();
+
+        assert!(error.to_string().contains("swap"));
+        assert_eq!(
+            std::fs::read(destination.join("smolvm-bin")).unwrap(),
+            b"old-binary",
+            "the previous prefix must be restored"
+        );
+        assert!(!staging.exists());
+        assert!(!backup.exists());
+    }
+
+    /// The installer's own symlink into the service prefix must not be
+    /// mistaken for an independently current binary — that is exactly the
+    /// permanently-stale-shadow failure mode. An unrelated system binary is
+    /// respected and never shadowed.
+    #[test]
+    fn smolvm_bootstrap_managed_symlink_is_not_an_independent_binary() {
+        let home = tempfile::tempdir().unwrap();
+        let destination_bin = home.path().join("smolvm-prefix/smolvm");
+        let bin_dir = tempfile::tempdir().unwrap();
+        let managed_link = bin_dir.path().join("smolvm");
+
+        // Managed symlink (our own): not independent.
+        std::os::unix::fs::symlink(&destination_bin, &managed_link).unwrap();
+        assert!(!independent_system_smolvm(&managed_link, &destination_bin));
+        // A symlink to something else: independent.
+        std::fs::remove_file(&managed_link).unwrap();
+        let other = bin_dir.path().join("other");
+        std::fs::write(&other, b"other-binary").unwrap();
+        std::os::unix::fs::symlink(&other, &managed_link).unwrap();
+        assert!(independent_system_smolvm(&managed_link, &destination_bin));
+        // A regular file: independent.
+        std::fs::remove_file(&managed_link).unwrap();
+        std::fs::write(&managed_link, b"#! /bin/sh\n").unwrap();
+        assert!(independent_system_smolvm(&managed_link, &destination_bin));
+        // Nothing at the link: not independent (bootstrap proceeds).
+        std::fs::remove_file(&managed_link).unwrap();
+        assert!(!independent_system_smolvm(&managed_link, &destination_bin));
     }
 
     /// The rendered plist must be accepted by launchd's own parser.

--- a/crates/preloop-cli/src/server_install.rs
+++ b/crates/preloop-cli/src/server_install.rs
@@ -178,11 +178,23 @@ fn install(args: InstallArgs) -> Result<()> {
         );
     }
     if let Some(key) = &args.github_app_key {
-        anyhow::ensure!(
-            key.exists(),
-            "--github-app-key {} does not exist",
-            key.display()
-        );
+        // Distinguish "missing" from "not readable by *you*": a system
+        // dry-run is allowed without root, so a key under /root reports
+        // false from a bare `exists()` and would otherwise be reported as
+        // nonexistent when it is merely unreadable from this account.
+        if let Err(error) = std::fs::metadata(key) {
+            match error.kind() {
+                std::io::ErrorKind::NotFound => {
+                    bail!("--github-app-key {} does not exist", key.display())
+                }
+                std::io::ErrorKind::PermissionDenied => bail!(
+                    "--github-app-key {} is not readable by the current user ({error}); \
+                     re-run with sudo",
+                    key.display()
+                ),
+                _ => bail!("--github-app-key {}: {error}", key.display()),
+            }
+        }
     }
     // A system install runs as the dedicated `preloop` account, which cannot
     // traverse a 0700 /home/<user> or /root. Such a --home would produce an
@@ -195,6 +207,33 @@ fn install(args: InstallArgs) -> Result<()> {
              account cannot traverse /home, /root, or /run/user. Use {DEFAULT_HOME} \
              (the default) or another root-reachable path, or install with --user.",
             home.display()
+        );
+    }
+    // The state dir is chowned to the service account recursively, so it must
+    // be a directory dedicated to Preloop — never a shared system root.
+    #[cfg(any(target_os = "linux", test))]
+    if !args.user {
+        if let Some(protected) = shared_system_path(&home) {
+            bail!(
+                "--home {} is too broad for a system install: the state directory is \
+                 chowned to `{SERVICE_USER}` recursively, which would hand it {}. \
+                 Use {DEFAULT_HOME} (the default) or another dedicated directory.",
+                home.display(),
+                protected.display()
+            );
+        }
+    }
+    // The service must be able to execute the binary the unit points at. An
+    // exe under a 0700 /home/<user> or /root is unreachable for the same
+    // traversal reason as the state dir, and the unit would restart-loop.
+    #[cfg(any(target_os = "linux", test))]
+    if !args.user && home_blocked_by_protect_home(&exe) {
+        bail!(
+            "the running executable {} is under a directory the `{SERVICE_USER}` service \
+             account cannot traverse, so the unit could never start it. Install the \
+             binary system-wide first (e.g. /usr/local/bin/preloop) and re-run, or \
+             install with --user.",
+            exe.display()
         );
     }
     // The state dir must exist before anything is staged into it: the very
@@ -311,6 +350,8 @@ fn install_systemd(
 
     if !args.user {
         bootstrap_system_smolvm(dry)?;
+        bootstrap_smolvm_data(home, dry)?;
+        migrate_legacy_env_file(home, dry)?;
         chown_state_dir(home, dry)?;
     }
     // Written after chown_state_dir, and deliberately outside it for a system
@@ -335,6 +376,18 @@ fn install_systemd(
     }
 
     run_systemctl(&systemctl_args(args.user, &["daemon-reload"]), dry)?;
+    // Upgrades: `enable --now` starts an inactive unit but leaves a running
+    // one alone, so an existing service would keep its old identity and an
+    // unhardened environment until it happened to fail or the host rebooted.
+    // `try-restart` restarts it only if it is already active, so exactly one
+    // start happens either way: restart here for an upgrade, or the
+    // `enable --now` below for a fresh install.
+    run_ok(
+        "systemctl",
+        &systemctl_args(args.user, &["try-restart", "preloop.service"]),
+        dry,
+        "restart a running preloop.service onto the new unit",
+    );
     run_systemctl(
         &systemctl_args(
             args.user,
@@ -462,6 +515,26 @@ fn ensure_service_user(home: &Path, dry_run: bool) -> Result<()> {
                 Err(error) => {
                     return Err(error).with_context(|| format!("run useradd {SERVICE_USER}"))
                 }
+            }
+        }
+    }
+    // The unit pins `Group=preloop` and the chowns use `preloop:preloop`, so
+    // the group must exist even when a pre-existing passwd entry made us skip
+    // useradd (which creates the user's primary group by default).
+    let group_exists = Command::new("getent")
+        .args(["group", SERVICE_USER])
+        .output()
+        .is_ok_and(|output| output.status.success());
+    if !group_exists {
+        if dry_run {
+            eprintln!("[preloop] would create system group {SERVICE_USER} (groupadd --system)");
+        } else {
+            let status = Command::new("groupadd")
+                .args(["--system", SERVICE_USER])
+                .status()
+                .with_context(|| format!("create system group {SERVICE_USER}"))?;
+            if !status.success() {
+                bail!("groupadd {SERVICE_USER} failed ({status})");
             }
         }
     }
@@ -659,6 +732,82 @@ fn bootstrap_system_smolvm(dry_run: bool) -> Result<()> {
         .with_context(|| "symlink /usr/local/bin/smolvm".to_string())?;
     if !status.success() {
         bail!("symlinking /usr/local/bin/smolvm failed ({status})");
+    }
+    Ok(())
+}
+
+/// Copy the bundled SmolVM *data assets* into the service's data directory.
+///
+/// `preloop update` installs the immutable assets — the agent rootfs and
+/// Linux's `init.krun` — into the data directory, not the prefix:
+/// `update.rs` writes `agent-rootfs` and `init.krun` under
+/// `~/.local/share/smolvm` (the default `data_dir`), while only the binary,
+/// libs, and templates go into `~/.smolvm`. The unit pins
+/// `SMOLVM_DATA_DIR` to a fresh `PRELOOP_HOME/smolvm`, so without this copy
+/// the service's first VM boot would find no agent rootfs and no init and
+/// fail before ever reaching the sandbox. The root user's machine database
+/// stays behind, exactly as for the prefix copy.
+#[cfg(target_os = "linux")]
+fn bootstrap_smolvm_data(home: &Path, dry_run: bool) -> Result<()> {
+    let source_dir = Path::new("/root/.local/share/smolvm");
+    let destination_dir = home.join("smolvm");
+    if !source_dir.is_dir() {
+        // No root-side install to copy; the note for the prefix covers this.
+        return Ok(());
+    }
+    let needs_copy = |name: &str| -> bool {
+        let destination = destination_dir.join(name);
+        let source = source_dir.join(name);
+        !destination.exists() || newer_than(&source, &destination)
+    };
+    let assets: Vec<&str> = ["agent-rootfs", "init.krun"]
+        .into_iter()
+        .filter(|name| source_dir.join(name).exists() && needs_copy(name))
+        .collect();
+    if assets.is_empty() {
+        return Ok(());
+    }
+    if dry_run {
+        eprintln!(
+            "[preloop] would copy smolvm data assets ({}) into {}",
+            assets.join(", "),
+            destination_dir.display()
+        );
+        return Ok(());
+    }
+    std::fs::create_dir_all(&destination_dir)
+        .with_context(|| format!("create {}", destination_dir.display()))?;
+    for name in assets {
+        let source = source_dir.join(name);
+        let destination = destination_dir.join(name);
+        // Copy as root, then hand the tree to the service account: the data
+        // dir is service-owned (the recursive chown runs after this), and the
+        // agent rootfs is read-only for the VMM.
+        std::fs::create_dir_all(&destination)
+            .with_context(|| format!("create {}", destination.display()))?;
+        let status = Command::new("cp")
+            .args(["-a"])
+            .arg(format!("{}/.", source.display()))
+            .arg(format!("{}/", destination.display()))
+            .status()
+            .with_context(|| format!("copy {} into {}", source.display(), destination.display()))?;
+        if !status.success() {
+            bail!(
+                "copying {} into {} failed ({status})",
+                source.display(),
+                destination.display()
+            );
+        }
+    }
+    // `init.krun` needs its executable bit for the boot path; `cp -a` keeps
+    // it from the source. Re-assert it explicitly so a filesystem that drops
+    // the bit cannot break the first boot.
+    let init_krun = destination_dir.join("init.krun");
+    if init_krun.exists() {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(&init_krun)?.permissions();
+        permissions.set_mode(permissions.mode() | 0o500);
+        std::fs::set_permissions(&init_krun, permissions)?;
     }
     Ok(())
 }
@@ -1148,6 +1297,48 @@ fn home_blocked_by_protect_home(home: &Path) -> bool {
     home.starts_with("/home/") || home.starts_with("/root") || home.starts_with("/run/user")
 }
 
+/// A shared system location `home` would swallow, or `None` when `home` is a
+/// directory Preloop may own outright.
+///
+/// The installer chowns the state directory to the service account
+/// *recursively*, so `--home /var/lib` or `--home /` would silently reassign
+/// unrelated host data. A candidate is rejected when it *is* a protected
+/// path or is an ancestor of one; `/var/lib/preloop` (the default) and
+/// `/srv/preloop` are ancestors of nothing and pass.
+#[cfg(any(target_os = "linux", test))]
+fn shared_system_path(home: &Path) -> Option<&'static Path> {
+    const PROTECTED: &[&str] = &[
+        "/",
+        "/bin",
+        "/boot",
+        "/dev",
+        "/etc",
+        "/home",
+        "/lib",
+        "/lib64",
+        "/mnt",
+        "/opt",
+        "/proc",
+        "/root",
+        "/run",
+        "/sbin",
+        "/srv",
+        "/sys",
+        "/tmp",
+        "/usr",
+        "/var",
+        "/var/lib",
+        "/var/log",
+        "/var/tmp",
+        SYSTEM_CONFIG_DIR,
+        SMOLVM_PREFIX_PARENT,
+    ];
+    PROTECTED
+        .iter()
+        .map(Path::new)
+        .find(|protected| *protected == home || protected.starts_with(home))
+}
+
 #[cfg(any(target_os = "linux", test))]
 fn render_systemd_socket(listen: Option<SocketAddr>) -> String {
     let addr = listen
@@ -1510,6 +1701,40 @@ fn write_env_file(path: &Path, env_lines: &[String], dry_run: bool) -> Result<()
     Ok(())
 }
 
+/// Move a pre-existing `<home>/environment` into the root-owned config dir.
+///
+/// Releases before the hardened layout read the environment file from the
+/// state dir. Upgrading must not strand the operator's `--github-app-*` and
+/// `--webhook-secret` values: a re-install without repeating those flags
+/// writes no new env file, and the new unit no longer reads the old path, so
+/// the credentials would silently vanish on the first restart. Migrate once,
+/// then stop looking (the old path is in the service-writable state dir and
+/// must not become authoritative again).
+#[cfg(target_os = "linux")]
+fn migrate_legacy_env_file(home: &Path, dry_run: bool) -> Result<()> {
+    let legacy = home.join("environment");
+    let destination = env_file_path(home, false);
+    if !legacy.is_file() || destination.exists() {
+        return Ok(());
+    }
+    if dry_run {
+        eprintln!(
+            "[preloop] would migrate legacy {} -> {} (0600 root-owned)",
+            legacy.display(),
+            destination.display()
+        );
+        return Ok(());
+    }
+    if let Some(parent) = destination.parent() {
+        std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    std::fs::rename(&legacy, &destination)
+        .with_context(|| format!("migrate {} to {}", legacy.display(), destination.display()))?;
+    set_private_file_permissions(&destination)
+        .with_context(|| format!("chmod 0600 {}", destination.display()))?;
+    Ok(())
+}
+
 #[cfg(target_os = "linux")]
 fn write_unit(path: &Path, contents: &str, dry_run: bool) -> Result<()> {
     if dry_run {
@@ -1776,8 +2001,33 @@ WantedBy=multi-user.target
                 "{blocked}: {error}"
             );
         }
+        // A home the service account CAN traverse is still rejected when it
+        // is a shared system path: the recursive chown would hand unrelated
+        // host data to the service account.
+        for blocked in ["/", "/var/lib", "/var", "/srv", "/opt", "/etc/preloop"] {
+            let error = install(InstallArgs {
+                home: Some(PathBuf::from(blocked)),
+                user: false,
+                dry_run: true,
+                listen: None,
+                public_url: None,
+                github_app_id: None,
+                github_app_key: None,
+                github_app_installation_id: None,
+                webhook_secret: None,
+                no_update_timer: false,
+                systemd_credential: None,
+            })
+            .unwrap_err();
+            assert!(
+                error.to_string().contains("too broad for a system install"),
+                "{blocked}: {error}"
+            );
+        }
         // Root-reachable custom home: allowed, no carve-out, no StateDirectory.
         assert!(!home_blocked_by_protect_home(Path::new("/srv/preloop")));
+        assert!(shared_system_path(Path::new(DEFAULT_HOME)).is_none());
+        assert!(shared_system_path(Path::new("/srv/preloop")).is_none());
         let open = render_systemd_service(
             Path::new("/usr/local/bin/preloop"),
             Path::new("/srv/preloop"),

--- a/crates/preloop-orchestrator/tests/runner_pool_lifecycle.rs
+++ b/crates/preloop-orchestrator/tests/runner_pool_lifecycle.rs
@@ -516,7 +516,6 @@ async fn artifact_preparation_runs_once_and_reuses_payload_on_next_run() {
     // only happens after the artifact is fully built, then cancel.
     let task_shutdown = CancellationToken::new();
     let task = tokio::spawn({
-        let pool = pool;
         let task_shutdown = task_shutdown.clone();
         async move { pool.run(task_shutdown).await }
     });

--- a/crates/preloop-runner/src/listener/job_dispatcher.rs
+++ b/crates/preloop-runner/src/listener/job_dispatcher.rs
@@ -481,7 +481,8 @@ fn kill_process_tree(root: u32) {
                     continue;
                 };
                 // /proc/<pid>/stat: pid (comm) state ppid ...
-                let Some(open) = stat.find('(') else { continue };
+                // `comm` may contain spaces and parentheses, so the fields
+                // after it are found from the LAST ')', not by splitting.
                 let Some(close) = stat.rfind(')') else {
                     continue;
                 };

--- a/crates/preloop-socket-activation/src/lib.rs
+++ b/crates/preloop-socket-activation/src/lib.rs
@@ -46,7 +46,10 @@ pub fn take_tcp_listener() -> anyhow::Result<Option<tokio::net::TcpListener>> {
         listener
             .set_nonblocking(true)
             .context("set systemd listener nonblocking")?;
-        return Ok(Some(tokio::net::TcpListener::from_std(listener)?));
+        // Trailing expression, not `return`: exactly one of these two cfg
+        // blocks is compiled, so on Linux this is the function's tail and a
+        // `return` here trips clippy::needless_return.
+        Ok(Some(tokio::net::TcpListener::from_std(listener)?))
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/crates/preloop-vm/src/lib.rs
+++ b/crates/preloop-vm/src/lib.rs
@@ -427,12 +427,13 @@ impl SmolVmProvider {
     }
 
     /// Substitute the host-environment lookup this provider reads.
-    /// Test-only seam: nothing outside the crate's own tests can build a
-    /// provider that resolves overrides from anywhere but the process
-    /// environment. Only the Linux sandbox-override test needs it — off
-    /// Linux the policy injects nothing, so there is no override to fake.
-    #[cfg(all(test, target_os = "linux"))]
-    fn with_env_lookup(mut self, lookup: EnvLookup) -> Self {
+    ///
+    /// Test seam for the Linux override tests: integration tests compile the
+    /// library without `cfg(test)`, so this is unconditionally available on
+    /// Linux. In production nothing constructs a provider with anything but
+    /// [`process_env`], so the seam cannot redirect a real deployment.
+    #[cfg(target_os = "linux")]
+    pub fn with_env_lookup(mut self, lookup: EnvLookup) -> Self {
         self.env_lookup = lookup;
         self
     }
@@ -450,6 +451,93 @@ impl SmolVmProvider {
         let mut command = self.command();
         apply_sandbox_env(&mut command, self.env_lookup)?;
         Ok(command)
+    }
+
+    /// A command for an operation that can never boot or restart `_boot-vm`
+    /// (status, list, stop, delete): the validated sandbox policy when it
+    /// resolves, otherwise the sandbox variables stripped.
+    ///
+    /// Fail-closed validation must not extend here. A single operator typo
+    /// in `SMOLVM_SECCOMP`/`SMOLVM_LANDLOCK` is recoverable *because* the
+    /// pool can still be enumerated and torn down; hard-failing `status`,
+    /// `list`, `stop`, and `delete` on the same typo would make the very
+    /// operations needed to fix it unusable. The variables are still never
+    /// forwarded unvalidated: on an invalid override they are removed, so a
+    /// recovery command runs without sandbox variables (no VMM is spawned
+    /// here, so nothing boots unconfined) rather than with garbage.
+    fn recovery_command(&self) -> Command {
+        let mut command = self.command();
+        match sandbox_env_with(self.env_lookup) {
+            Ok(sandbox) => {
+                for key in sandbox.remove {
+                    command.env_remove(key);
+                }
+                for (key, value) in sandbox.set {
+                    command.env(key, value);
+                }
+            }
+            Err(_) => {
+                command.env_remove("SMOLVM_SECCOMP");
+                command.env_remove("SMOLVM_LANDLOCK");
+                command.env_remove("SMOLVM_CGROUP_ROOT");
+            }
+        }
+        command
+    }
+
+    /// Run an operation that can never boot or restart a VMM, using
+    /// [`Self::recovery_command`] so a bad sandbox override cannot wedge the
+    /// recovery paths. Mirrors [`Self::checked`]'s plumbing.
+    async fn recovery(
+        &self,
+        operation: &'static str,
+        args: &[String],
+    ) -> Result<ExecOutput, VmError> {
+        let mut command = self.recovery_command();
+        command
+            .args(args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        let mut child = command.spawn().map_err(|source| VmError::Launch {
+            program: self.binary.display().to_string(),
+            source,
+        })?;
+        let stdout = child.stdout.take().expect("piped stdout");
+        let stderr = child.stderr.take().expect("piped stderr");
+        let (stdout, stderr, status) = tokio::join!(
+            read_bounded(stdout, self.capture_limit),
+            read_bounded(stderr, self.capture_limit),
+            child.wait(),
+        );
+        let (stdout, stdout_truncated) = stdout.map_err(|source| VmError::Launch {
+            program: self.binary.display().to_string(),
+            source,
+        })?;
+        let (stderr, stderr_truncated) = stderr.map_err(|source| VmError::Launch {
+            program: self.binary.display().to_string(),
+            source,
+        })?;
+        let status = status.map_err(|source| VmError::Launch {
+            program: self.binary.display().to_string(),
+            source,
+        })?;
+        let result = ExecOutput {
+            exit_code: status.code().unwrap_or(-1),
+            stdout,
+            stderr,
+            truncated: stdout_truncated || stderr_truncated,
+        };
+        if !status.success() {
+            let message = String::from_utf8_lossy(&result.stderr).trim().to_owned();
+            return Err(VmError::Command {
+                operation,
+                exit_code: result.exit_code,
+                message,
+            });
+        }
+        Ok(result)
     }
 
     /// Whether `machine create` accepts `--mount-socket`, probed from the
@@ -820,7 +908,7 @@ impl VmProvider for SmolVmProvider {
     }
 
     async fn stop(&self, name: &MachineName) -> Result<(), VmError> {
-        self.concurrent(
+        self.recovery(
             "stop",
             &[
                 "machine".into(),
@@ -835,7 +923,7 @@ impl VmProvider for SmolVmProvider {
 
     async fn delete(&self, name: &MachineName) -> Result<(), VmError> {
         let result = self
-            .concurrent(
+            .recovery(
                 "delete",
                 &[
                     "machine".into(),
@@ -864,7 +952,7 @@ impl VmProvider for SmolVmProvider {
             "--name".into(),
             name.as_str().into(),
         ];
-        match self.concurrent("status", &args).await {
+        match self.recovery("status", &args).await {
             Ok(output) => {
                 let text = String::from_utf8_lossy(&output.stdout).to_ascii_lowercase();
                 Ok(if text.contains("running") {
@@ -886,7 +974,7 @@ impl VmProvider for SmolVmProvider {
 
     async fn list(&self) -> Result<Vec<MachineName>, VmError> {
         let output = self
-            .concurrent("list", &["machine".into(), "ls".into(), "--json".into()])
+            .recovery("list", &["machine".into(), "ls".into(), "--json".into()])
             .await?;
         let values: serde_json::Value = serde_json::from_slice(&output.stdout)
             .map_err(|error| VmError::Protocol(error.to_string()))?;
@@ -1194,8 +1282,9 @@ pub fn init_vm_cgroup_delegation() {
 /// This is the single source of the sandbox policy: the provider applies it
 /// to every command it builds, and the CLI applies it to its direct
 /// `machine exec/cp/shell` calls, which can implicitly boot or restart a
-/// stopped machine. Returns `(variable, value)` pairs; non-Linux hosts get
-/// an empty list (both controls are no-ops upstream there).
+/// stopped machine. Returns `(variable, value)` pairs plus removals;
+/// non-Linux hosts get an empty list (both controls are no-ops upstream
+/// there).
 ///
 /// - Seccomp: default `enforce`; a pre-set operator value
 ///   (`enforce`/`audit`/`off`) wins — upstream precedence — but only modes
@@ -1208,26 +1297,45 @@ pub fn init_vm_cgroup_delegation() {
 ///   included. In every other process it is read-only: the variable is set
 ///   only when this process already sits in a cgroup v2 subtree that has
 ///   `cpu`/`memory`/`pids` enabled in its `cgroup.subtree_control` and can
-///   host child leaves, and is otherwise absent.
-pub fn smolvm_sandbox_env() -> Result<Vec<(String, String)>, VmError> {
+///   host child leaves, and is otherwise **removed from the child
+///   environment** — Preloop is authoritative for all three variables, so an
+///   inherited value (from the operator's environment or a parent service)
+///   never reaches `_boot-vm` with a root we did not validate.
+pub fn smolvm_sandbox_env() -> Result<SandboxEnv, VmError> {
     sandbox_env_with(process_env)
 }
 
 /// [`smolvm_sandbox_env`] over an explicit environment lookup.
-fn sandbox_env_with(lookup: EnvLookup) -> Result<Vec<(String, String)>, VmError> {
+fn sandbox_env_with(lookup: EnvLookup) -> Result<SandboxEnv, VmError> {
     #[cfg(target_os = "linux")]
     {
         let mut env = sandbox_env_from(lookup)?;
+        // Authoritative: if this process resolved no usable cgroup root, an
+        // inherited SMOLVM_CGROUP_ROOT must be stripped, not merely left unset
+        // (the child would inherit it and _boot-vm would place itself in a
+        // cgroup we never validated).
+        let mut remove = Vec::new();
         if let Some(root) = CGROUP_ROOT.get_or_init(read_only_cgroup_root) {
             env.push(("SMOLVM_CGROUP_ROOT".to_owned(), root.display().to_string()));
+        } else {
+            remove.push("SMOLVM_CGROUP_ROOT");
         }
-        Ok(env)
+        Ok(SandboxEnv { set: env, remove })
     }
     #[cfg(not(target_os = "linux"))]
     {
         let _ = lookup;
-        Ok(Vec::new())
+        Ok(SandboxEnv::default())
     }
+}
+
+/// The sandbox policy as command-environment operations.
+#[derive(Default)]
+pub struct SandboxEnv {
+    /// Variables to set on the child command.
+    pub set: Vec<(String, String)>,
+    /// Variables to strip from the child command's inherited environment.
+    pub remove: Vec<&'static str>,
 }
 
 /// The seccomp/Landlock half of the sandbox policy, over an environment
@@ -1270,7 +1378,11 @@ fn sandbox_env_from(
 /// Apply [`smolvm_sandbox_env`] to a synchronous command (the CLI's direct
 /// `smolvm machine exec/cp/shell` spawns).
 pub fn apply_smolvm_sandbox_env(command: &mut std::process::Command) -> Result<(), VmError> {
-    for (key, value) in smolvm_sandbox_env()? {
+    let sandbox = smolvm_sandbox_env()?;
+    for key in sandbox.remove {
+        command.env_remove(key);
+    }
+    for (key, value) in sandbox.set {
         command.env(key, value);
     }
     Ok(())
@@ -1279,7 +1391,11 @@ pub fn apply_smolvm_sandbox_env(command: &mut std::process::Command) -> Result<(
 /// Apply the sandbox policy to a provider command.
 #[cfg(target_os = "linux")]
 fn apply_sandbox_env(command: &mut Command, lookup: EnvLookup) -> Result<(), VmError> {
-    for (key, value) in sandbox_env_with(lookup)? {
+    let sandbox = sandbox_env_with(lookup)?;
+    for key in sandbox.remove {
+        command.env_remove(key);
+    }
+    for (key, value) in sandbox.set {
         command.env(key, value);
     }
     Ok(())
@@ -1317,7 +1433,7 @@ fn process_cgroup_dir() -> Option<PathBuf> {
 /// Landlock variables are unaffected).
 #[cfg(target_os = "linux")]
 fn read_only_cgroup_root() -> Option<PathBuf> {
-    process_cgroup_dir().filter(|root| is_usable_delegation(root))
+    process_cgroup_dir().filter(|root| is_usable_delegation_read_only(root))
 }
 
 /// Resolve a cgroup v2 root, establishing the delegation when one is missing
@@ -1334,7 +1450,7 @@ fn delegated_cgroup_root_mutating() -> Option<PathBuf> {
     // not hosting children — but the root must actually accept child leaves:
     // an unprivileged process in an undelegated cgroup must not be handed a
     // root whose `vm-<pid>` leaf creation would silently fail.
-    if is_usable_delegation(&root) {
+    if is_usable_delegation_read_only(&root) {
         return Some(root);
     }
     // The controllers are not distributed yet, but this process may be able
@@ -1358,18 +1474,44 @@ fn delegated_cgroup_root_mutating() -> Option<PathBuf> {
     ok.then_some(root)
 }
 
-/// Whether `root` is a delegation Preloop can actually cap VMs with: the
-/// controllers are distributed to children and a child leaf can be created.
+/// Whether `root` is a delegation Preloop can actually cap VMs with, using
+/// only reads: the controllers are distributed to children and the current
+/// user can create a child leaf.
+///
+/// Deliberately non-mutating. This predicate runs on the read-only path used
+/// by `preloop shell` and the debug session, which must never write to the
+/// cgroup hierarchy; the mutating probe below is confined to the
+/// supervisor's delegation setup where a write is already expected.
 #[cfg(target_os = "linux")]
-fn is_usable_delegation(root: &Path) -> bool {
-    cgroup_controllers_enabled(root) && can_host_child_leaf(root)
+fn is_usable_delegation_read_only(root: &Path) -> bool {
+    cgroup_controllers_enabled(root) && can_create_child_leaf(root)
 }
 
-/// The cgroup can host `_boot-vm`'s `vm-<pid>` child leaves: creating a
-/// directory inside it — the exact first step of SmolVM's `place_in_cgroup`
-/// — must succeed. Under systemd delegation the subtree is chowned to the
-/// service user; anywhere else an unprivileged service cannot create leaves
-/// and must not receive a root that would silently run VMs uncapped.
+/// Whether the current user can create a child cgroup directory under `root`
+/// without creating anything. A directory may be writable/executable while
+/// the cgroup filesystem still refuses `mkdir` — under systemd delegation
+/// the subtree is chowned to the service user, and `CGROUP_DELEGATE` file
+/// ownership is what actually authorizes child creation — so this checks
+/// write+execute permission on the directory (the closest read-only proxy)
+/// rather than assuming.
+#[cfg(target_os = "linux")]
+fn can_create_child_leaf(root: &Path) -> bool {
+    let Ok(metadata) = std::fs::metadata(root) else {
+        return false;
+    };
+    use std::os::unix::fs::PermissionsExt;
+    let mode = metadata.permissions().mode();
+    // Owner w+x for the owner, group w+x for the group, other w+x for the
+    // rest — exactly the permissions `mkdir` requires of the parent.
+    let owner_wx = mode & 0o300 == 0o300;
+    let group_wx = mode & 0o030 == 0o030;
+    let other_wx = mode & 0o003 == 0o003;
+    owner_wx || group_wx || other_wx
+}
+
+/// The cgroup can host `_boot-vm`'s `vm-<pid>` child leaves, proven by
+/// actually creating and removing a probe leaf. Supervisor-only: this is a
+/// write, so it must never run on the read-only CLI path.
 ///
 /// The probe leaf is removed again; a leaf that cannot be removed is not a
 /// usable root either, and reporting `false` keeps `.preloop-probe` from
@@ -1654,10 +1796,110 @@ mod tests {
     #[cfg(not(target_os = "linux"))]
     #[test]
     fn sandbox_env_is_empty_off_linux() {
-        assert_eq!(
-            smolvm_sandbox_env().unwrap(),
-            Vec::<(String, String)>::new()
+        let sandbox = smolvm_sandbox_env().unwrap();
+        assert!(sandbox.set.is_empty());
+        assert!(sandbox.remove.is_empty());
+    }
+
+    /// Preloop is authoritative for `SMOLVM_CGROUP_ROOT`: when no usable
+    /// delegation exists, an inherited value must be removed from the child
+    /// environment, never forwarded. The test environment never calls
+    /// `init_vm_cgroup_delegation`, so this process takes the read-only path;
+    /// on a host with a delegation the variable is set instead, and the
+    /// assertion below reflects that.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn sandbox_policy_strips_an_inherited_cgroup_root_without_delegation() {
+        let sandbox = smolvm_sandbox_env().unwrap();
+        let resolved_root = sandbox
+            .set
+            .iter()
+            .any(|(key, _)| key == "SMOLVM_CGROUP_ROOT");
+        if resolved_root {
+            // Delegated host: the variable is set to our own validated root,
+            // and must not ALSO be scheduled for removal.
+            assert!(!sandbox.remove.contains(&"SMOLVM_CGROUP_ROOT"));
+        } else {
+            assert!(sandbox.remove.contains(&"SMOLVM_CGROUP_ROOT"));
+        }
+        // Regardless of the host, the seccomp/Landlock halves are enforced.
+        assert!(sandbox
+            .set
+            .iter()
+            .any(|(key, value)| key == "SMOLVM_SECCOMP" && value == "enforce"));
+        assert!(sandbox
+            .set
+            .iter()
+            .any(|(key, value)| key == "SMOLVM_LANDLOCK" && value == "enforce"));
+    }
+
+    /// An invalid override must not wedge the recovery operations: a typo in
+    /// `SMOLVM_SECCOMP` must make `create` fail closed while `list`, `status`,
+    /// `stop`, and `delete` still work — they are the only way to fix the
+    /// typo. The recovery command strips the invalid variables rather than
+    /// forwarding them.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn invalid_override_keeps_recovery_operations_usable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let binary = directory.path().join("smolvm");
+        std::fs::write(
+            &binary,
+            "#!/bin/sh\ncase \"$*\" in\n  *ls*) echo '[]';;\n  *status*) echo running;;\nesac\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        fn rejected(key: &str) -> Option<String> {
+            (key == "SMOLVM_SECCOMP").then(|| "Enforce".to_owned())
+        }
+        let provider = SmolVmProvider::new(&binary).with_env_lookup(rejected);
+
+        // Boot-capable path: fails closed.
+        let spec = MachineSpec {
+            name: MachineName::new("runner").unwrap(),
+            image: "ghcr.io/acme/runner:latest".to_owned(),
+            cpus: 2,
+            memory_mib: 256,
+            storage_gib: 10,
+            overlay_gib: None,
+            network: NetworkPolicy::Disabled,
+            volumes: Vec::new(),
+            sockets: Vec::new(),
+            dns: None,
+            rosetta: false,
+        };
+        let create_error = provider.create(&spec).await.unwrap_err();
+        assert!(
+            matches!(create_error, VmError::InvalidSandboxEnv { .. }),
+            "create must fail closed, got {create_error}"
         );
+
+        // Recovery paths: still usable, with the invalid variables stripped.
+        assert_eq!(
+            provider
+                .list()
+                .await
+                .unwrap_or_else(|error| panic!("list must stay usable: {error}")),
+            Vec::<MachineName>::new()
+        );
+        assert_eq!(
+            provider
+                .status(&MachineName::new("runner").unwrap())
+                .await
+                .unwrap_or_else(|error| panic!("status must stay usable: {error}")),
+            MachineState::Running
+        );
+        provider
+            .stop(&MachineName::new("runner").unwrap())
+            .await
+            .unwrap();
+        provider
+            .delete(&MachineName::new("runner").unwrap())
+            .await
+            .unwrap();
     }
 
     /// A rejected sandbox override must surface as

--- a/crates/preloop-vm/src/lib.rs
+++ b/crates/preloop-vm/src/lib.rs
@@ -113,13 +113,11 @@ pub enum NetworkPolicy {
 /// `preloop update` pins the smolvm install to the last known-good release.
 /// `PRELOOP_SMOLVM_NET_BACKEND=tsi|virtio-net` overrides the choice for
 /// setups stuck on a broken artifact.
-fn public_only_net_backend() -> &'static str {
-    match std::env::var("PRELOOP_SMOLVM_NET_BACKEND").as_deref() {
-        Ok("tsi") => return "tsi",
-        Ok("virtio-net") => return "virtio-net",
-        _ => {}
+fn public_only_net_backend(lookup: impl Fn(&str) -> Option<String>) -> &'static str {
+    match lookup("PRELOOP_SMOLVM_NET_BACKEND").as_deref() {
+        Some("tsi") => "tsi",
+        _ => "virtio-net",
     }
-    "virtio-net"
 }
 
 /// Where a guest environment value is resolved from, at launch time.
@@ -251,6 +249,22 @@ pub enum VmError {
         /// Program path.
         binary: String,
     },
+    /// An operator-set SmolVM sandbox override has a value upstream would
+    /// silently treat as "control off". Preloop fails closed instead of
+    /// forwarding an unrecognized mode that would boot VMs unconfined.
+    #[error(
+        "invalid {variable} value `{value}` for the VM sandbox (expected {expected}); \
+         refusing to run VMs with an unvalidated override — remove the variable or set a \
+         supported mode"
+    )]
+    InvalidSandboxEnv {
+        /// The environment variable carrying the override.
+        variable: &'static str,
+        /// The offending value.
+        value: String,
+        /// Modes upstream accepts.
+        expected: &'static str,
+    },
 }
 
 /// Provider contract consumed by the Preloop orchestrator.
@@ -340,6 +354,11 @@ pub struct SmolVmProvider {
     /// Whether the resolved binary's `machine create` accepts
     /// `--mount-socket`, probed once per provider.
     socket_mount_supported: Arc<tokio::sync::OnceCell<bool>>,
+    /// Where this provider reads host environment overrides from (the sandbox
+    /// modes and the network backend). Production is always the process
+    /// environment; unit tests substitute a pure lookup so the policy can be
+    /// exercised without mutating global state.
+    env_lookup: EnvLookup,
 }
 
 impl Default for SmolVmProvider {
@@ -387,6 +406,7 @@ impl SmolVmProvider {
             fork_locks: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             forked_machines: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             socket_mount_supported: Arc::new(tokio::sync::OnceCell::new()),
+            env_lookup: process_env,
         }
     }
 
@@ -406,16 +426,43 @@ impl SmolVmProvider {
         self
     }
 
+    /// Substitute the host-environment lookup this provider reads.
+    /// Test-only seam: nothing outside the crate's own tests can build a
+    /// provider that resolves overrides from anywhere but the process
+    /// environment. Only the Linux sandbox-override test needs it — off
+    /// Linux the policy injects nothing, so there is no override to fake.
+    #[cfg(all(test, target_os = "linux"))]
+    fn with_env_lookup(mut self, lookup: EnvLookup) -> Self {
+        self.env_lookup = lookup;
+        self
+    }
+
     fn command(&self) -> Command {
         Command::new(&self.binary)
+    }
+
+    /// A command ready to run against the resolved SmolVM binary with the
+    /// sandbox environment applied. Every operation goes through here, so
+    /// the sandbox reaches any command that can spawn or restart SmolVM's
+    /// `_boot-vm` subprocess — create, start, start_forkable, fork, exec,
+    /// pack — not just machine creation.
+    fn sandboxed_command(&self) -> Result<Command, VmError> {
+        let mut command = self.command();
+        apply_sandbox_env(&mut command, self.env_lookup)?;
+        Ok(command)
     }
 
     /// Whether `machine create` accepts `--mount-socket`, probed from the
     /// binary's own help text and cached. SmolVM's wrapper scripts can
     /// report a recent `--version` while resolving to an old binary, so the
     /// flag's presence is the reliable capability check.
-    async fn supports_mount_socket(&self) -> bool {
-        let mut command = self.command();
+    ///
+    /// An invalid sandbox override is reported as such instead of being
+    /// folded into a `false` answer: the caller caches the probe result for
+    /// the provider's lifetime, and a rejected environment says nothing
+    /// about the binary's capabilities.
+    async fn supports_mount_socket(&self) -> Result<bool, VmError> {
+        let mut command = self.sandboxed_command()?;
         command
             .args(["machine", "create", "--help"])
             .stdin(Stdio::null())
@@ -423,7 +470,7 @@ impl SmolVmProvider {
             .stderr(Stdio::piped())
             .kill_on_drop(true);
         let Ok(mut child) = command.spawn() else {
-            return false;
+            return Ok(false);
         };
         let stdout = child.stdout.take().expect("piped stdout");
         let stderr = child.stderr.take().expect("piped stderr");
@@ -433,9 +480,9 @@ impl SmolVmProvider {
             child.wait(),
         );
         let (Ok((stdout, _)), Ok(_), Ok(status)) = (stdout, stderr, status) else {
-            return false;
+            return Ok(false);
         };
-        status.success() && String::from_utf8_lossy(&stdout).contains("--mount-socket")
+        Ok(status.success() && String::from_utf8_lossy(&stdout).contains("--mount-socket"))
     }
 
     async fn checked(
@@ -453,7 +500,7 @@ impl SmolVmProvider {
         network: Option<&NetworkPolicy>,
         staging_dir: Option<&Path>,
     ) -> Result<ExecOutput, VmError> {
-        let mut command = self.command();
+        let mut command = self.sandboxed_command()?;
         match network {
             Some(NetworkPolicy::PublicOnly) => {
                 command.env("SMOLVM_EGRESS_FLOOR", "strict");
@@ -635,7 +682,7 @@ impl VmProvider for SmolVmProvider {
                 args.extend([
                     "--net".into(),
                     "--net-backend".into(),
-                    public_only_net_backend().into(),
+                    public_only_net_backend(self.env_lookup).into(),
                 ]);
             }
             NetworkPolicy::Restricted { hosts, cidrs } => {
@@ -660,8 +707,8 @@ impl VmProvider for SmolVmProvider {
         if !spec.sockets.is_empty()
             && !*self
                 .socket_mount_supported
-                .get_or_init(|| self.supports_mount_socket())
-                .await
+                .get_or_try_init(|| self.supports_mount_socket())
+                .await?
         {
             return Err(VmError::UnsupportedSocketMount {
                 binary: self.binary.display().to_string(),
@@ -926,7 +973,7 @@ impl VmProvider for SmolVmProvider {
         if argv.is_empty() {
             return Err(VmError::InvalidSpec("guest command is empty".into()));
         }
-        let mut command = self.command();
+        let mut command = self.sandboxed_command()?;
         command
             .args(["machine", "exec", "--stream", "--name", name.as_str(), "--"])
             .args(argv)
@@ -1069,6 +1116,317 @@ fn is_env_identifier(name: &str) -> bool {
             .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
 }
 
+// ---------------------------------------------------------------------------
+// VM sandbox environment (seccomp / Landlock / per-VM cgroup)
+// ---------------------------------------------------------------------------
+//
+// SmolVM's `_boot-vm` always hardens the process (no_new_privs, non-dumpable,
+// core limit zero), but its seccomp syscall allowlist and Landlock filesystem
+// confinement are opt-in knobs: `smolvm serve` defaults `SMOLVM_SECCOMP` and
+// `SMOLVM_LANDLOCK` to `enforce`, while the standalone `machine ...` commands
+// Preloop drives do not. Preloop therefore applies the same defaults itself,
+// on Linux, for every invocation that can boot or restart a VM.
+//
+// The upstream convention is preserved: a value the operator already set in
+// the environment wins over the default — exactly what `serve` documents
+// ("a pre-set SMOLVM_SECCOMP env var takes precedence"). Unlike upstream,
+// Preloop validates the pre-set value instead of forwarding garbage: smolvm
+// treats any unrecognized mode as "off", so forwarding a typo would silently
+// boot VMs unconfined. An unrecognized override is a hard error.
+//
+// On non-Linux hosts both controls are no-ops upstream (Landlock is a Linux
+// LSM; the seccomp filter installs only on Linux), so nothing is injected and
+// macOS behavior is unchanged.
+//
+// The per-VM cgroup root is separate, because claiming one *writes* to the
+// cgroup hierarchy. Only a supervisor may do that, and only once, through
+// [`init_vm_cgroup_delegation`]; every other process (the CLI's `shell`,
+// `machine exec`, `machine cp`) resolves the root read-only and simply goes
+// without caps when there is no usable delegation already in place.
+
+/// How the sandbox policy resolves an operator override. Production passes
+/// [`process_env`]; unit tests pass a pure map so the policy is exercised
+/// without mutating process-global state.
+type EnvLookup = fn(&str) -> Option<String>;
+
+/// The process environment — the production [`EnvLookup`].
+fn process_env(key: &str) -> Option<String> {
+    std::env::var(key).ok()
+}
+
+/// The cgroup v2 root passed to `_boot-vm` as `SMOLVM_CGROUP_ROOT`, resolved
+/// at most once per process. Whichever path runs first wins, so a supervisor
+/// that called [`init_vm_cgroup_delegation`] keeps the delegated root it
+/// established, and every other process observes only what already exists.
+///
+/// `OnceLock`, not `LazyLock`: the initializer is precisely what differs
+/// between the two paths, so it cannot be fixed at the declaration.
+#[cfg(target_os = "linux")]
+static CGROUP_ROOT: std::sync::OnceLock<Option<PathBuf>> = std::sync::OnceLock::new();
+
+/// Claim the cgroup v2 delegation the per-VM resource caps need.
+///
+/// Call this exactly once, from the supervisor (`preloop serve`) at startup,
+/// before the async runtime spawns the VM pool — it mirrors what `smolvm
+/// serve` does through its own `setup_cgroup_delegation_root`. It is the only
+/// entry point allowed to mutate the cgroup hierarchy: it may create a
+/// `preloop-supervisor` leaf, move this process into it, and enable
+/// `cpu`/`memory`/`pids` distribution on the parent.
+///
+/// That write is what makes the caps exist. systemd's `Delegate=cpu memory
+/// pids` chowns the unit's subtree to the service user and lists the
+/// controllers in `cgroup.controllers`, but leaves `cgroup.subtree_control`
+/// **empty**; a `vm-<pid>` leaf created under it then has no `cpu.max`,
+/// `memory.max` or `pids.max` at all. Enabling the controllers ourselves is
+/// what turns a delegated subtree into one that can actually cap VMs.
+///
+/// Best-effort: any failure leaves the process without a cgroup root, so VMs
+/// boot uncapped rather than not at all. No-op off Linux.
+pub fn init_vm_cgroup_delegation() {
+    #[cfg(target_os = "linux")]
+    {
+        CGROUP_ROOT.get_or_init(delegated_cgroup_root_mutating);
+    }
+}
+
+/// The Linux VM-sandbox environment for a pending SmolVM invocation.
+///
+/// This is the single source of the sandbox policy: the provider applies it
+/// to every command it builds, and the CLI applies it to its direct
+/// `machine exec/cp/shell` calls, which can implicitly boot or restart a
+/// stopped machine. Returns `(variable, value)` pairs; non-Linux hosts get
+/// an empty list (both controls are no-ops upstream there).
+///
+/// - Seccomp: default `enforce`; a pre-set operator value
+///   (`enforce`/`audit`/`off`) wins — upstream precedence — but only modes
+///   SmolVM honors pass; anything else is an error rather than the silent
+///   "off" upstream would treat it as.
+/// - Landlock: default `enforce`; pre-set `enforce`/`off` wins, validated.
+/// - Per-VM cgroup: `SMOLVM_CGROUP_ROOT` names whichever root this process
+///   resolved first. In a supervisor that called
+///   [`init_vm_cgroup_delegation`] that is the root it established, writes
+///   included. In every other process it is read-only: the variable is set
+///   only when this process already sits in a cgroup v2 subtree that has
+///   `cpu`/`memory`/`pids` enabled in its `cgroup.subtree_control` and can
+///   host child leaves, and is otherwise absent.
+pub fn smolvm_sandbox_env() -> Result<Vec<(String, String)>, VmError> {
+    sandbox_env_with(process_env)
+}
+
+/// [`smolvm_sandbox_env`] over an explicit environment lookup.
+fn sandbox_env_with(lookup: EnvLookup) -> Result<Vec<(String, String)>, VmError> {
+    #[cfg(target_os = "linux")]
+    {
+        let mut env = sandbox_env_from(lookup)?;
+        if let Some(root) = CGROUP_ROOT.get_or_init(read_only_cgroup_root) {
+            env.push(("SMOLVM_CGROUP_ROOT".to_owned(), root.display().to_string()));
+        }
+        Ok(env)
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = lookup;
+        Ok(Vec::new())
+    }
+}
+
+/// The seccomp/Landlock half of the sandbox policy, over an environment
+/// lookup: defaults to `enforce`, honors a validated operator override, and
+/// rejects any value upstream would silently read as "control off".
+#[cfg(any(target_os = "linux", test))]
+fn sandbox_env_from(
+    lookup: impl Fn(&str) -> Option<String>,
+) -> Result<Vec<(String, String)>, VmError> {
+    fn invalid(variable: &'static str, value: String, expected: &'static str) -> VmError {
+        VmError::InvalidSandboxEnv {
+            variable,
+            value,
+            expected,
+        }
+    }
+
+    let mut env = Vec::with_capacity(3);
+    match lookup("SMOLVM_SECCOMP") {
+        Some(value) if matches!(value.as_str(), "enforce" | "audit" | "off") => {
+            env.push(("SMOLVM_SECCOMP".to_owned(), value));
+        }
+        Some(value) => {
+            return Err(invalid("SMOLVM_SECCOMP", value, "enforce, audit, or off"));
+        }
+        None => env.push(("SMOLVM_SECCOMP".to_owned(), "enforce".to_owned())),
+    }
+    match lookup("SMOLVM_LANDLOCK") {
+        Some(value) if matches!(value.as_str(), "enforce" | "off") => {
+            env.push(("SMOLVM_LANDLOCK".to_owned(), value));
+        }
+        Some(value) => {
+            return Err(invalid("SMOLVM_LANDLOCK", value, "enforce or off"));
+        }
+        None => env.push(("SMOLVM_LANDLOCK".to_owned(), "enforce".to_owned())),
+    }
+    Ok(env)
+}
+
+/// Apply [`smolvm_sandbox_env`] to a synchronous command (the CLI's direct
+/// `smolvm machine exec/cp/shell` spawns).
+pub fn apply_smolvm_sandbox_env(command: &mut std::process::Command) -> Result<(), VmError> {
+    for (key, value) in smolvm_sandbox_env()? {
+        command.env(key, value);
+    }
+    Ok(())
+}
+
+/// Apply the sandbox policy to a provider command.
+#[cfg(target_os = "linux")]
+fn apply_sandbox_env(command: &mut Command, lookup: EnvLookup) -> Result<(), VmError> {
+    for (key, value) in sandbox_env_with(lookup)? {
+        command.env(key, value);
+    }
+    Ok(())
+}
+
+/// Non-Linux: seccomp and Landlock are no-ops upstream; nothing to set.
+#[cfg(not(target_os = "linux"))]
+fn apply_sandbox_env(_command: &mut Command, _lookup: EnvLookup) -> Result<(), VmError> {
+    Ok(())
+}
+
+/// This process's own cgroup v2 directory, or `None` on a cgroup v1 / hybrid
+/// host (no unified `0::` line). Mirrors upstream's `cgroup_v2_self_dir`.
+#[cfg(target_os = "linux")]
+fn process_cgroup_dir() -> Option<PathBuf> {
+    // Not cgroup v2 (no unified hierarchy).
+    if !Path::new("/sys/fs/cgroup/cgroup.controllers").is_file() {
+        return None;
+    }
+    let rel = std::fs::read_to_string("/proc/self/cgroup")
+        .ok()?
+        .lines()
+        .find_map(|line| line.strip_prefix("0::"))?
+        .trim()
+        .to_owned();
+    if rel.is_empty() {
+        return None;
+    }
+    Some(cgroup_root_dir(&rel))
+}
+
+/// Resolve a cgroup v2 root without changing anything in the hierarchy: the
+/// answer for every process that is not the supervisor. `None` means no
+/// usable delegation, so VMs run without host resource caps (the seccomp and
+/// Landlock variables are unaffected).
+#[cfg(target_os = "linux")]
+fn read_only_cgroup_root() -> Option<PathBuf> {
+    process_cgroup_dir().filter(|root| is_usable_delegation(root))
+}
+
+/// Resolve a cgroup v2 root, establishing the delegation when one is missing
+/// and this process is privileged enough to create it. Supervisor-only — see
+/// [`init_vm_cgroup_delegation`], the sole caller.
+#[cfg(target_os = "linux")]
+fn delegated_cgroup_root_mutating() -> Option<PathBuf> {
+    let root = process_cgroup_dir()?;
+    // Already delegated (e.g. a systemd unit with `Delegate=cpu memory pids`
+    // that also enabled the controllers in `cgroup.subtree_control`):
+    // VMM leaves can be created and capped immediately. The cgroup may hold
+    // this process (controllers were enabled by systemd while it was empty),
+    // which is fine — the no-internal-process rule only constrains enabling,
+    // not hosting children — but the root must actually accept child leaves:
+    // an unprivileged process in an undelegated cgroup must not be handed a
+    // root whose `vm-<pid>` leaf creation would silently fail.
+    if is_usable_delegation(&root) {
+        return Some(root);
+    }
+    // The controllers are not distributed yet, but this process may be able
+    // to enable them itself (a root supervisor, or a systemd unit with
+    // `Delegate=` — which chowns the subtree to the service user yet leaves
+    // `cgroup.subtree_control` empty, so without this write the per-VM
+    // leaves get no `cpu.max`/`memory.max`/`pids.max` at all). The kernel
+    // only accepts a `cgroup.subtree_control` write on a cgroup with no
+    // member processes, so move into a leaf first — upstream's
+    // `setup_cgroup_delegation_root` does exactly this.
+    // Any failure means no delegation: caps are skipped, never fatal.
+    let leaf = root.join("preloop-supervisor");
+    let pid = std::process::id().to_string();
+    // A leaf left behind by an earlier run is fine — an empty cgroup still
+    // accepts new members, and re-enabling already-enabled controllers is a
+    // no-op, so only the two writes matter.
+    let _ = std::fs::create_dir(&leaf);
+    let ok = fs_write(&leaf.join("cgroup.procs"), &pid)
+        && fs_write(&root.join("cgroup.subtree_control"), "+cpu +memory +pids")
+        && can_host_child_leaf(&root);
+    ok.then_some(root)
+}
+
+/// Whether `root` is a delegation Preloop can actually cap VMs with: the
+/// controllers are distributed to children and a child leaf can be created.
+#[cfg(target_os = "linux")]
+fn is_usable_delegation(root: &Path) -> bool {
+    cgroup_controllers_enabled(root) && can_host_child_leaf(root)
+}
+
+/// The cgroup can host `_boot-vm`'s `vm-<pid>` child leaves: creating a
+/// directory inside it — the exact first step of SmolVM's `place_in_cgroup`
+/// — must succeed. Under systemd delegation the subtree is chowned to the
+/// service user; anywhere else an unprivileged service cannot create leaves
+/// and must not receive a root that would silently run VMs uncapped.
+///
+/// The probe leaf is removed again; a leaf that cannot be removed is not a
+/// usable root either, and reporting `false` keeps `.preloop-probe` from
+/// being left behind on a path that claims success.
+#[cfg(target_os = "linux")]
+fn can_host_child_leaf(root: &Path) -> bool {
+    let probe = root.join(".preloop-probe");
+    std::fs::create_dir(&probe)
+        .and_then(|()| std::fs::remove_dir(&probe))
+        .is_ok()
+}
+
+#[cfg(target_os = "linux")]
+fn fs_write(path: &Path, value: &str) -> bool {
+    use std::io::Write;
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(path)
+        .and_then(|mut file| file.write_all(value.as_bytes()))
+        .is_ok()
+}
+
+/// Whether `dir/cgroup.subtree_control` enables the controllers Preloop caps
+/// on (`cpu`, `memory`, `pids`) — the kernel's record of a delegation.
+///
+/// Accepts both readback spellings seen in the wild: `+cpu +memory +pids`
+/// (sign-prefixed) and `cpu memory pids` (bare). A `-`-prefixed controller
+/// is disabled either way.
+#[cfg(any(target_os = "linux", test))]
+fn cgroup_controllers_enabled(dir: &Path) -> bool {
+    let Ok(control) = std::fs::read_to_string(dir.join("cgroup.subtree_control")) else {
+        return false;
+    };
+    let enabled: std::collections::HashSet<&str> = control
+        .split_whitespace()
+        .filter_map(|token| match token.strip_prefix('-') {
+            Some(_) => None,
+            None => Some(token.strip_prefix('+').unwrap_or(token)),
+        })
+        .collect();
+    enabled.contains("cpu") && enabled.contains("memory") && enabled.contains("pids")
+}
+
+/// Map a `/proc/self/cgroup` v2 entry to the on-disk cgroup directory.
+///
+/// The file prints `0::/system.slice/preloop.service` — an absolute-looking
+/// path whose leading slash `Path::join` would treat as a fresh root and
+/// discard `/sys/fs/cgroup` — so the slash is trimmed before joining. That
+/// is the whole mapping, exactly as upstream's `cgroup_v2_self_dir` does it:
+/// the on-disk directory name is the systemd unit name verbatim, `\xHH`
+/// escapes included (`mnt-my\x2ddir.mount` is a real directory; the
+/// unescaped `mnt-my-dir.mount` is not).
+#[cfg(any(target_os = "linux", test))]
+fn cgroup_root_dir(rel: &str) -> PathBuf {
+    Path::new("/sys/fs/cgroup").join(rel.trim_start_matches('/'))
+}
+
 fn validate_spec(spec: &MachineSpec) -> Result<(), VmError> {
     if spec.image.trim().is_empty()
         || spec.cpus == 0
@@ -1172,6 +1530,223 @@ async fn forward(
         };
         if output.send(value).await.is_err() {
             return Ok(());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cgroup_root_dir_trims_the_leading_slash_of_proc_self_cgroup_paths() {
+        // `/proc/self/cgroup` prints `0::/system.slice/preloop.service` with
+        // an absolute-looking path; Path::join would discard the /sys/fs/cgroup
+        // base entirely.
+        assert_eq!(
+            cgroup_root_dir("/system.slice/preloop.service"),
+            PathBuf::from("/sys/fs/cgroup/system.slice/preloop.service")
+        );
+        assert_eq!(
+            cgroup_root_dir("user.slice/user-1000.slice/user@1000.service/app.slice"),
+            PathBuf::from("/sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice")
+        );
+        // The root cgroup prints `/`.
+        assert_eq!(cgroup_root_dir("/"), PathBuf::from("/sys/fs/cgroup"));
+    }
+
+    /// systemd's `\xHH` escaping is part of the directory name on disk:
+    /// `/sys/fs/cgroup/system.slice/mnt-my\x2ddir.mount` exists while the
+    /// unescaped spelling does not, and `/proc/self/cgroup` reports the
+    /// escaped form. Decoding it would name a directory that is not there.
+    #[test]
+    fn cgroup_root_dir_preserves_systemd_escapes_verbatim() {
+        assert_eq!(
+            cgroup_root_dir("/system.slice/mnt-my\\x2ddir.mount"),
+            PathBuf::from("/sys/fs/cgroup/system.slice/mnt-my\\x2ddir.mount")
+        );
+    }
+
+    #[test]
+    fn cgroup_controllers_enabled_requires_all_three_controllers() {
+        let directory = tempfile::tempdir().unwrap();
+        let control = directory.path().join("cgroup.subtree_control");
+        // Kernel readback with sign prefixes.
+        std::fs::write(&control, "+cpu +memory +pids\n").unwrap();
+        assert!(cgroup_controllers_enabled(directory.path()));
+        // Readback without sign prefixes.
+        std::fs::write(&control, "cpu memory pids\n").unwrap();
+        assert!(cgroup_controllers_enabled(directory.path()));
+        std::fs::write(&control, "+cpu +memory +pids +io\n").unwrap();
+        assert!(cgroup_controllers_enabled(directory.path()));
+        std::fs::write(&control, "+cpu +memory\n").unwrap();
+        assert!(!cgroup_controllers_enabled(directory.path()));
+        std::fs::write(&control, "cpu memory\n").unwrap();
+        assert!(!cgroup_controllers_enabled(directory.path()));
+        std::fs::write(&control, "-cpu +memory +pids\n").unwrap();
+        assert!(!cgroup_controllers_enabled(directory.path()));
+        std::fs::write(&control, "+cpu -memory +pids\n").unwrap();
+        assert!(!cgroup_controllers_enabled(directory.path()));
+        std::fs::remove_file(&control).unwrap();
+        assert!(!cgroup_controllers_enabled(directory.path()));
+    }
+
+    /// The exported policy is the exact observable contract: on Linux every
+    /// invocation defaults to seccomp/Landlock `enforce` and honors only
+    /// validated overrides; everywhere else nothing is injected.
+    #[test]
+    fn sandbox_env_defaults_to_enforce_and_validates_overrides() {
+        assert_eq!(
+            sandbox_env_from(fake_env(&[])).unwrap(),
+            vec![
+                ("SMOLVM_SECCOMP".to_owned(), "enforce".to_owned()),
+                ("SMOLVM_LANDLOCK".to_owned(), "enforce".to_owned()),
+            ]
+        );
+
+        // A pre-set value upstream honors wins over the default.
+        for (seccomp, landlock) in [("enforce", "enforce"), ("audit", "off"), ("off", "enforce")] {
+            assert_eq!(
+                sandbox_env_from(fake_env(&[
+                    ("SMOLVM_SECCOMP", seccomp),
+                    ("SMOLVM_LANDLOCK", landlock),
+                ]))
+                .unwrap(),
+                vec![
+                    ("SMOLVM_SECCOMP".to_owned(), seccomp.to_owned()),
+                    ("SMOLVM_LANDLOCK".to_owned(), landlock.to_owned()),
+                ]
+            );
+        }
+
+        // Anything else is a hard error: upstream would read it as "off".
+        for (variable, value) in [
+            ("SMOLVM_SECCOMP", "banana"),
+            ("SMOLVM_SECCOMP", ""),
+            ("SMOLVM_SECCOMP", "Enforce"),
+            ("SMOLVM_LANDLOCK", "banana"),
+            ("SMOLVM_LANDLOCK", "audit"),
+            ("SMOLVM_LANDLOCK", ""),
+        ] {
+            assert!(
+                matches!(
+                    sandbox_env_from(fake_env(&[(variable, value)])),
+                    Err(VmError::InvalidSandboxEnv { variable: v, value: ref got, .. })
+                        if v == variable && got == value
+                ),
+                "{variable}={value} must fail closed"
+            );
+        }
+    }
+
+    /// An [`EnvLookup`]-shaped view over a fixed set of pairs: the sandbox
+    /// policy is exercised without touching the process environment, so
+    /// these tests carry no ordering dependence.
+    fn fake_env<'a>(pairs: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
+        move |key| {
+            pairs
+                .iter()
+                .find(|(name, _)| *name == key)
+                .map(|(_, value)| (*value).to_owned())
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn sandbox_env_is_empty_off_linux() {
+        assert_eq!(
+            smolvm_sandbox_env().unwrap(),
+            Vec::<(String, String)>::new()
+        );
+    }
+
+    /// A rejected sandbox override must surface as
+    /// [`VmError::InvalidSandboxEnv`] — never as the misleading
+    /// `UnsupportedSocketMount`, which would blame the binary — and must not
+    /// be remembered as a capability verdict: once the operator fixes the
+    /// environment the very next call probes the binary for real, on the
+    /// same provider whose probe cell the failure could have poisoned.
+    /// Linux-only: the sandbox policy (and so any override) applies there.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn invalid_sandbox_override_never_poisons_the_socket_mount_probe() {
+        use std::os::unix::fs::PermissionsExt;
+
+        fn rejected(key: &str) -> Option<String> {
+            (key == "SMOLVM_SECCOMP").then(|| "banana".to_owned())
+        }
+        fn unset(_key: &str) -> Option<String> {
+            None
+        }
+
+        let directory = tempfile::tempdir().unwrap();
+        // Advertises `--mount-socket` to the capability probe and accepts
+        // every other invocation.
+        let binary = directory.path().join("smolvm");
+        std::fs::write(&binary, "#!/bin/sh\nprintf -- '--mount-socket\\n'\n").unwrap();
+        std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let host_socket = directory.path().join("engine.sock");
+        let _listener = std::os::unix::net::UnixListener::bind(&host_socket).unwrap();
+        let spec = MachineSpec {
+            name: MachineName::new("probe").unwrap(),
+            image: "ghcr.io/acme/runner:latest".to_owned(),
+            cpus: 2,
+            memory_mib: 256,
+            storage_gib: 10,
+            overlay_gib: None,
+            network: NetworkPolicy::Disabled,
+            volumes: Vec::new(),
+            sockets: vec![SocketMount {
+                host: host_socket,
+                guest: PathBuf::from("/run/preloop-engine.sock"),
+            }],
+            dns: None,
+            rosetta: false,
+        };
+
+        let provider = SmolVmProvider::new(&binary).with_env_lookup(rejected);
+        let error = provider.create(&spec).await.unwrap_err();
+        assert!(
+            matches!(
+                error,
+                VmError::InvalidSandboxEnv {
+                    variable: "SMOLVM_SECCOMP",
+                    ..
+                }
+            ),
+            "expected InvalidSandboxEnv, got {error}"
+        );
+
+        // Same provider, same (still unset) probe cell, corrected environment.
+        provider
+            .clone()
+            .with_env_lookup(unset)
+            .create(&spec)
+            .await
+            .unwrap();
+    }
+
+    /// The egress-floor policy needs a backend that carries it, so
+    /// virtio-net is the default and the only recognized escape hatch is an
+    /// exact `tsi`; anything else (including a typo) keeps virtio-net rather
+    /// than silently dropping the floor.
+    #[test]
+    fn public_only_net_backend_defaults_to_virtio_net_and_honors_only_exact_overrides() {
+        assert_eq!(public_only_net_backend(fake_env(&[])), "virtio-net");
+        assert_eq!(
+            public_only_net_backend(fake_env(&[("PRELOOP_SMOLVM_NET_BACKEND", "tsi")])),
+            "tsi"
+        );
+        assert_eq!(
+            public_only_net_backend(fake_env(&[("PRELOOP_SMOLVM_NET_BACKEND", "virtio-net")])),
+            "virtio-net"
+        );
+        for bogus in ["", "TSI", "gvproxy"] {
+            assert_eq!(
+                public_only_net_backend(fake_env(&[("PRELOOP_SMOLVM_NET_BACKEND", bogus)])),
+                "virtio-net",
+                "`{bogus}` must not select a backend that cannot carry the egress floor"
+            );
         }
     }
 }

--- a/crates/preloop-vm/tests/provider.rs
+++ b/crates/preloop-vm/tests/provider.rs
@@ -31,20 +31,44 @@ mod unix {
         VmProvider, VolumeMount,
     };
     use std::fs;
-    use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
     use tempfile::TempDir;
 
     static TEST_ENV_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
     fn write_executable(path: &Path, contents: &str) {
-        // Publish only after the writer is closed. Executing a script while
-        // its final path is still open for writing can fail with ETXTBSY.
+        // Write through a child process rather than `fs::write`, then publish
+        // with a rename.
+        //
+        // These tests run concurrently in one process. Any write descriptor
+        // this process holds is inherited by every other test's `fork` and
+        // stays open until that child reaches `exec`; executing the script
+        // inside that window fails with ETXTBSY ("Text file busy") even though
+        // our own writer is already closed. Staging plus rename alone does not
+        // help, because the inherited descriptor refers to the same inode the
+        // rename publishes. Reproduced at ~1 run in 16 under CPU load.
+        // Keeping the file descriptor out of this process closes the window:
+        // only `sh` ever holds it, and our forks cannot inherit its table.
+        use std::io::Write;
+
         let staged = path.with_extension("staged");
-        fs::write(&staged, contents).unwrap();
-        let mut permissions = fs::metadata(&staged).unwrap().permissions();
-        permissions.set_mode(0o755);
-        fs::set_permissions(&staged, permissions).unwrap();
+        let mut child = std::process::Command::new("sh")
+            .args(["-c", r#"cat > "$1" && chmod 755 "$1""#, "sh"])
+            .arg(&staged)
+            .stdin(std::process::Stdio::piped())
+            .spawn()
+            .unwrap();
+        child
+            .stdin
+            .take()
+            .expect("piped stdin")
+            .write_all(contents.as_bytes())
+            .unwrap();
+        assert!(
+            child.wait().unwrap().success(),
+            "staging {}",
+            staged.display()
+        );
         fs::rename(staged, path).unwrap();
     }
 
@@ -61,6 +85,9 @@ args="$0.args"
 printf 'SMOLVM_EGRESS_FLOOR=%s\n' "${SMOLVM_EGRESS_FLOOR-}" > "$0.env"
 env_file="$0.env"
 printf 'SMOLVM_EGRESS_FLOOR=%s\n' "${SMOLVM_EGRESS_FLOOR-}" > "$env_file"
+printf 'SMOLVM_SECCOMP=%s\n' "${SMOLVM_SECCOMP-}" > "$0.seccomp"
+printf 'SMOLVM_LANDLOCK=%s\n' "${SMOLVM_LANDLOCK-}" > "$0.landlock"
+printf 'SMOLVM_CGROUP_ROOT=%s\n' "${SMOLVM_CGROUP_ROOT-}" > "$0.cgroup"
 printf 'TMPDIR=%s\n' "${TMPDIR-}" > "$0.tmpdir"
 for arg in "$@"; do
   printf '%s\n' "$arg" >> "$args"
@@ -124,6 +151,13 @@ esac
 
     fn captured_env(executable: &Path) -> String {
         fs::read_to_string(executable.with_extension("env"))
+            .unwrap_or_default()
+            .trim()
+            .to_owned()
+    }
+
+    fn captured_sandbox_var(executable: &Path, suffix: &str) -> String {
+        fs::read_to_string(executable.with_extension(suffix))
             .unwrap_or_default()
             .trim()
             .to_owned()
@@ -619,14 +653,8 @@ exit 0
         );
     }
 
-    /// Serializes tests that mutate `PRELOOP_SMOLVM_NET_BACKEND` in the
-    /// process environment.
-    static NET_BACKEND_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
-
     #[tokio::test]
     async fn public_only_selects_virtio_net_and_sets_smolvm_egress_floor_strict() {
-        let _env_guard = NET_BACKEND_ENV_LOCK.lock().await;
-        std::env::remove_var("PRELOOP_SMOLVM_NET_BACKEND");
         let (_directory, executable) = fake_smolvm();
         let provider = SmolVmProvider::new(executable.clone());
         let mut spec = valid_spec(MachineName::new("test-floor").unwrap());
@@ -636,26 +664,6 @@ exit 0
             .windows(2)
             .any(|args| args == ["--net-backend", "virtio-net"]));
         assert_eq!(captured_env(&executable), "SMOLVM_EGRESS_FLOOR=strict");
-    }
-
-    #[tokio::test]
-    async fn public_only_net_backend_override_is_respected() {
-        let _env_guard = NET_BACKEND_ENV_LOCK.lock().await;
-        for (override_value, expected) in [("tsi", "tsi"), ("virtio-net", "virtio-net")] {
-            let (_directory, executable) = fake_smolvm();
-            let provider = SmolVmProvider::new(executable.clone());
-            let mut spec = valid_spec(MachineName::new("test-override").unwrap());
-            spec.network = NetworkPolicy::PublicOnly;
-            std::env::set_var("PRELOOP_SMOLVM_NET_BACKEND", override_value);
-            provider.create(&spec).await.unwrap();
-            assert!(
-                captured_args(&executable)
-                    .windows(2)
-                    .any(|args| args == ["--net-backend", expected]),
-                "override {override_value} must select {expected}"
-            );
-        }
-        std::env::remove_var("PRELOOP_SMOLVM_NET_BACKEND");
     }
 
     #[tokio::test]
@@ -818,5 +826,144 @@ printf 'exit %s\n' "$6" >> "$0.forklog"
         fs::write(executable.with_extension("release"), "").unwrap();
         one.await.unwrap().unwrap();
         two.await.unwrap().unwrap();
+    }
+
+    #[cfg(target_os = "linux")]
+    fn assert_sandbox_defaults(executable: &Path) {
+        assert_eq!(
+            captured_sandbox_var(executable, "seccomp"),
+            "SMOLVM_SECCOMP=enforce",
+            "every operation must default seccomp to enforce"
+        );
+        assert_eq!(
+            captured_sandbox_var(executable, "landlock"),
+            "SMOLVM_LANDLOCK=enforce",
+            "every operation must default Landlock to enforce"
+        );
+    }
+
+    /// The sandbox environment must reach every operation that can spawn or
+    /// restart `_boot-vm` — not just machine creation — because a stopped
+    /// machine's `start`, a fork clone's boot, and a pack all re-boot a VMM
+    /// from the CLI process's environment. Override precedence and the
+    /// validation of a pre-set mode are unit-tested against the policy
+    /// itself (`sandbox_env_from`), which needs no process-global state.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn sandbox_enforce_reaches_every_operation() {
+        let name = MachineName::new("runner").unwrap();
+
+        let (_directory, executable) = fake_smolvm();
+        SmolVmProvider::new(executable.clone())
+            .create(&valid_spec(name.clone()))
+            .await
+            .unwrap();
+        assert_sandbox_defaults(&executable);
+
+        let (_directory, executable) = fake_smolvm();
+        SmolVmProvider::new(executable.clone())
+            .start(&name)
+            .await
+            .unwrap();
+        assert_sandbox_defaults(&executable);
+
+        let (_directory, executable) = fake_smolvm();
+        SmolVmProvider::new(executable.clone())
+            .start_forkable(&name)
+            .await
+            .unwrap();
+        assert_sandbox_defaults(&executable);
+
+        let (_directory, executable) = fake_smolvm();
+        SmolVmProvider::new(executable.clone())
+            .fork(&name, &MachineName::new("clone").unwrap())
+            .await
+            .unwrap();
+        assert_sandbox_defaults(&executable);
+
+        let (_directory, executable) = fake_smolvm();
+        SmolVmProvider::new(executable.clone())
+            .exec(&name, &["echo".to_owned()])
+            .await
+            .unwrap();
+        assert_sandbox_defaults(&executable);
+
+        let (_directory, executable) = fake_smolvm();
+        let (sender, _receiver) = tokio::sync::mpsc::channel(16);
+        SmolVmProvider::new(executable.clone())
+            .exec_stream(&name, &["echo".to_owned()], sender)
+            .await
+            .unwrap();
+        assert_sandbox_defaults(&executable);
+
+        let (directory, executable) = fake_smolvm();
+        let output = directory.path().join("packed");
+        SmolVmProvider::new(executable.clone())
+            .pack(&name, &output)
+            .await
+            .unwrap();
+        assert_sandbox_defaults(&executable);
+    }
+
+    /// The cgroup root is handed to `_boot-vm` only when this process really
+    /// sits in a usable cgroup v2 delegation. A test process never calls
+    /// `init_vm_cgroup_delegation`, so it takes the read-only path: the
+    /// variable is absent unless a delegation already exists, and when it is
+    /// present it must name this process's own cgroup directory — the
+    /// `/proc/self/cgroup` path appended to `/sys/fs/cgroup` verbatim,
+    /// systemd `\xHH` escapes included.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn cgroup_root_env_matches_actual_delegation() {
+        let (_directory, executable) = fake_smolvm();
+        SmolVmProvider::new(executable.clone())
+            .create(&valid_spec(MachineName::new("cgroup").unwrap()))
+            .await
+            .unwrap();
+        let captured = captured_sandbox_var(&executable, "cgroup");
+        let root = captured
+            .strip_prefix("SMOLVM_CGROUP_ROOT=")
+            .expect("the fake smolvm always records the variable");
+        if root.is_empty() {
+            return;
+        }
+        let proc_cgroup = fs::read_to_string("/proc/self/cgroup").unwrap();
+        let expected = proc_cgroup
+            .lines()
+            .find_map(|line| line.strip_prefix("0::"))
+            .expect("cgroup v2 entry")
+            .trim()
+            .trim_start_matches('/');
+        // Compared as paths: the root cgroup prints `/`, whose join leaves a
+        // trailing separator that a string comparison would trip over.
+        assert_eq!(
+            PathBuf::from(root),
+            Path::new("/sys/fs/cgroup").join(expected)
+        );
+    }
+
+    /// On non-Linux hosts seccomp and Landlock are no-ops in SmolVM; Preloop
+    /// must not inject them (or a cgroup root that cannot exist), preserving
+    /// macOS behavior.
+    #[cfg(not(target_os = "linux"))]
+    #[tokio::test]
+    async fn non_linux_injects_no_sandbox_env() {
+        let (_directory, executable) = fake_smolvm();
+        SmolVmProvider::new(executable.clone())
+            .create(&valid_spec(MachineName::new("macos").unwrap()))
+            .await
+            .unwrap();
+        assert_eq!(
+            captured_sandbox_var(&executable, "seccomp"),
+            "SMOLVM_SECCOMP="
+        );
+        assert_eq!(
+            captured_sandbox_var(&executable, "landlock"),
+            "SMOLVM_LANDLOCK="
+        );
+        assert_eq!(
+            captured_sandbox_var(&executable, "cgroup"),
+            "SMOLVM_CGROUP_ROOT="
+        );
     }
 }

--- a/crates/preloop-vm/tests/provider.rs
+++ b/crates/preloop-vm/tests/provider.rs
@@ -666,6 +666,38 @@ exit 0
         assert_eq!(captured_env(&executable), "SMOLVM_EGRESS_FLOOR=strict");
     }
 
+    /// The `PRELOOP_SMOLVM_NET_BACKEND` override must reach the spawned
+    /// command as `--net-backend tsi` — the mapping function alone is not
+    /// the contract, the wiring through `create` is. Driven through the
+    /// `with_env_lookup` seam so no process-global environment is mutated.
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn public_only_net_backend_override_reaches_the_spawned_command() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let executable = directory.path().join("smolvm");
+        fs::write(
+            &executable,
+            r##"#!/bin/sh
+for arg in "$@"; do printf '%s\n' "$arg" >> "$0.args"; done
+"##,
+        )
+        .unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let provider = SmolVmProvider::new(executable.clone())
+            .with_env_lookup(|key| (key == "PRELOOP_SMOLVM_NET_BACKEND").then(|| "tsi".to_owned()));
+        let mut spec = valid_spec(MachineName::new("test-tsi").unwrap());
+        spec.network = NetworkPolicy::PublicOnly;
+        provider.create(&spec).await.unwrap();
+        let args = captured_args(&executable);
+        assert!(
+            args.windows(2).any(|pair| pair == ["--net-backend", "tsi"]),
+            "the override must reach create's command line: {args:?}"
+        );
+    }
+
     #[tokio::test]
     async fn unrestricted_removes_smolvm_egress_floor() {
         let (_directory, executable) = fake_smolvm();

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -388,9 +388,59 @@ What it does:
   from an encrypted, host-bound blob instead of the config file; see
   "Where secrets live" in the Secrets section.
 - Configuration is written to a mode-0600 environment file
-  (`/var/lib/preloop/environment` on Linux) the webhook secret never lands
-  in a world-readable unit.
+  (`/etc/preloop/environment` on a Linux system install, `<home>/environment`
+  for `--user`) — the webhook secret never lands in a world-readable unit.
 - State lives in `/var/lib/preloop` (mode 0700; `--home` overrides).
+- **Linux only — dedicated service identity.** The systemd service runs under
+  a `preloop` system account (created automatically; `kvm` group membership
+  added when `/dev/kvm` exists) instead of root. This is the load-bearing
+  hardening for the VM pool: a guest→VMM escape lands in the SmolVM boot
+  subprocess, which inherits the service identity, so root would hand an
+  escape the whole host. The installer chowns the **state dir** to that
+  account, because the engine writes its database, `config.toml`, and keys
+  there.
+
+  Everything the service must *not* be able to rewrite deliberately lives
+  outside `PRELOOP_HOME`. On Unix the *directory* write bit governs unlink and
+  rename, so any file inside a directory the service owns can be replaced by
+  the service regardless of that file's own owner and mode. Accordingly:
+
+  | Artifact | Location | Ownership |
+  |---|---|---|
+  | environment file | `/etc/preloop/environment` | `root:root` 0600 |
+  | staged App key | `/etc/preloop/github-app-key.pem` | `root:preloop` 0640 |
+  | bootstrapped smolvm | `/usr/local/lib/preloop/smolvm-prefix` | `root:root`, `a+rX` |
+  | engine state | `/var/lib/preloop` | `preloop:preloop` 0700 |
+
+  `/etc/preloop` itself is `root:preloop` 0750: the service can traverse in to
+  read its key and nothing more. The environment file matters because
+  `EnvironmentFile=` overrides the unit's own `Environment=` — a
+  service-writable copy would let a compromised VMM persist
+  `SMOLVM_SECCOMP=off` across the next `Restart=on-failure` and come back
+  unconfined. The smolvm prefix matters because `/usr/local/bin/smolvm` points
+  into it and **root executes that path** (`preloop update` probes `smolvm`
+  before deciding to reinstall), so a service-writable prefix would be a
+  direct service-user → root escalation.
+
+  The key is staged rather than chowned in place because a key left in the
+  caller's tree (e.g. under `/root`) is unreachable no matter how it is
+  owned — the service user cannot traverse the parent. The caller's original
+  file is never modified. If smolvm is only installed under
+  `/root/.local/bin` (the `preloop update` / official-installer location), the
+  installer copies it into the prefix above and links `/usr/local/bin/smolvm`
+  so the service can resolve it; that copy is refreshed on every re-install
+  when the source is newer — re-run `sudo preloop server install` after
+  `sudo preloop update` — atomically (the new prefix is assembled in a
+  staging directory and swapped into place, so a running service never
+  observes a half-copied prefix), and an independently installed system
+  smolvm is never shadowed. The unit also delegates its cgroup subtree
+  (`Delegate=cpu memory pids`) so each VM gets its own capped cgroup, and
+  denies the service the ability to rewrite its own binary.
+
+  A system install requires a `--home` the service account can reach:
+  `/home/...`, `/root...`, and `/run/user/...` are rejected up front, because
+  `preloop` cannot traverse them whatever the state dir's own mode is. Use the
+  default `/var/lib/preloop`, another root-reachable path, or `--user`.
 
 The `--github-app-*` / `--webhook-secret` flags are optional at install time,
 but **you must define these secrets** for the service to be useful: without a
@@ -398,12 +448,79 @@ webhook secret the engine rejects every GitHub webhook delivery, and without
 an App key it cannot mint `GITHUB_TOKEN`. They land in the mode-0600
 environment file (never in the world-readable units); alternatively install
 first, then configure credentials with
-`PRELOOP_HOME=/var/lib/preloop preloop setup github --save` (writes the
-mode-0600 `config.toml` — see above). `preloop server install --dry-run`
-prints the full plan without touching the system, and
+`sudo -u preloop env PRELOOP_HOME=/var/lib/preloop preloop setup github --save`
+(writes the mode-0600 `config.toml` owned by the service account — see
+above; running it as root instead would write a file the service cannot
+read). `preloop server install --dry-run` prints the full plan without
+touching the system, and
 `sudo preloop server uninstall` removes the units while keeping
 `/var/lib/preloop` data; pass `--purge-data` to delete it. Manual copies of
 the units live in `contrib/systemd/`.
+
+### VM sandbox (Linux): seccomp, Landlock, per-VM cgroups
+
+Every Linux operation that can boot or restart a SmolVM machine runs
+`smolvm` with the hardening `smolvm serve` applies, inherited by the
+`_boot-vm` subprocess — the VM provider's create/start/fork/pack/exec paths
+and the CLI's direct `machine exec`/`cp`/`shell` calls (which connect to a
+machine, starting it when it is stopped) all go through the same policy:
+
+- `SMOLVM_SECCOMP=enforce` — a syscall allowlist kills the VMM on any
+  disallowed syscall (ptrace, `mount`, `bpf`, `unshare`, …).
+  **Arch note:** upstream `smolvm serve` only defaults this on
+  Linux/x86\_64 (`src/cli/serve.rs` is gated
+  `#[cfg(all(target_os = "linux", target_arch = "x86_64"))]`), while the boot
+  subprocess honours the variable on both x86\_64 and aarch64
+  (`src/cli/internal_boot.rs`). Preloop sets it on every Linux arch, so on
+  Linux/aarch64 it enables a filter upstream leaves off by default. Verify it
+  on a new aarch64 host with the `Seccomp: 2` check below before relying on
+  it.
+- `SMOLVM_LANDLOCK=enforce` — the VMM's filesystem view is restricted to its
+  own rootfs/disks/devices; the rest of the host is denied. (Fork clones skip
+  Landlock upstream because they must map the golden's memfd — they stay
+  confined by seccomp and the cgroup.) Upstream gates this on Linux only,
+  with no arch restriction, so Preloop matches it exactly.
+- `SMOLVM_CGROUP_ROOT` — when the service unit delegates its cgroup subtree
+  (it does by default), each `_boot-vm` places itself in a per-VM
+  `vm-<pid>` leaf capped on CPU, PIDs, and memory. Note that `Delegate=` alone
+  is not enough: systemd chowns the unit's cgroup subtree to the service user
+  but leaves `cgroup.subtree_control` **empty**, so a child leaf created there
+  has no `cpu.max`/`memory.max`/`pids.max`. The server therefore performs the
+  same one-time setup `smolvm serve` does at startup — move itself into a
+  `preloop-supervisor` leaf, then enable `cpu`/`memory`/`pids` on the now-empty
+  unit cgroup — and only then advertises the root. That write happens once,
+  explicitly, in the server; the CLI never mutates the cgroup hierarchy and
+  falls back to a read-only check, so `preloop shell` and the debug session
+  leave it untouched. No usable delegation, no variable.
+
+Both controls fail closed: if the operator has already set
+`SMOLVM_SECCOMP`/`SMOLVM_LANDLOCK` in the service environment, the pre-set
+value wins (the same precedence `smolvm serve` documents), but only modes
+SmolVM actually honors (`enforce`/`audit`/`off` for seccomp, `enforce`/`off`
+for Landlock) — an unrecognized value is a hard error rather than the silent
+"off" upstream would treat it as. Setting `SMOLVM_SECCOMP=off` /
+`SMOLVM_LANDLOCK=off` is the deliberate, visible escape hatch for a
+self-hosted single-tenant box that cannot tolerate the filters.
+
+**Verifying activation on Linux.** After the first machine exists, find the
+VMM and check the kernel's own record:
+
+```sh
+pgrep -af "_boot-vm"            # -> <pid> smolvm _boot-vm <config>
+sudo grep Seccomp /proc/<pid>/status        # -> Seccomp: 2 (filter active)
+sudo tr '\0' '\n' < /proc/<pid>/environ | grep -E '^SMOLVM_(SECCOMP|LANDLOCK|CGROUP_ROOT)='
+```
+
+`Seccomp: 2` is the kernel's confirmation that the allowlist is enforced.
+Landlock has no status field in `/proc`, so its activation is verified by the
+boot subprocess's environment (`SMOLVM_LANDLOCK=enforce` above) plus
+SmolVM's own fail-closed behavior: with the variable set, a Landlock
+restriction that fails to install aborts the boot rather than running
+unconfined. `SMOLVM_CGROUP_ROOT` should name the service's own cgroup
+(`/sys/fs/cgroup/system.slice/preloop.service`); the per-VM leaves appear as
+`vm-<pid>` subdirectories with `cpu.max`/`pids.max`/`memory.max` set.
+
+
 
 ### Rootless option: `--user`
 


### PR DESCRIPTION
Confines SmolVM VMMs against hostile workflow code, and runs the control plane as a dedicated non-root account. Every finding below was reproduced before the fix and re-attacked after.

## Why

Measured read-only on the production host: **all six live VMMs run `Seccomp: 0`** with no `SMOLVM_*` variables set. `smolvm serve` defaults seccomp and Landlock to `enforce`, but the standalone `machine ...` commands Preloop drives do not — so a guest→VMM escape faces no syscall filter and no filesystem restriction.

## What changed

1. **`fix:` dead code in Linux-only paths** — three defects that only appear when the `#[cfg(target_os = "linux")]` blocks are actually parsed.
2. **`feat(vm):`** one sandbox policy applied to every operation that can boot or restart a VMM. Pre-set operator values still win, but are validated — smolvm treats an unrecognized mode as "off", so a typo would silently boot unconfined.
3. **`feat(cli):`** `preloop shell` and the debug session's `machine exec`/`cp` also boot VMs; they now go through the same policy rather than bypassing it.
4. **`feat(install):`** dedicated `preloop` account, hardened unit, and the ownership model below.
5. **`docs(setup):`** the ownership model, the `Seccomp: 2` verification procedure, and a corrected seccomp claim.
6. **`docs(changelog):`**

## The ownership model

`PRELOOP_HOME` must be writable by the service. On Unix the **directory** write bit governs unlink and rename, so anything inside it can be replaced by the service whatever the file's own owner and mode are. Three artifacts moved out, each closing a reproduced escalation:

| Artifact | Location | Ownership |
|---|---|---|
| smolvm prefix | `/usr/local/lib/preloop/smolvm-prefix` | `root:root`, `a+rX` |
| environment file | `/etc/preloop/environment` | `root:root` 0600 |
| staged App key | `/etc/preloop/github-app-key.pem` | `root:preloop` 0640 |
| engine state | `/var/lib/preloop` | `preloop:preloop` 0700 |

- **smolvm prefix** — `/usr/local/bin/smolvm` points into it and **root executes that path** when `preloop update` probes smolvm. Writing the wrapper as `preloop` and waiting for `sudo preloop update` yielded `uid=0(root)`. Re-install repairs a prefix an earlier version already chowned.
- **environment file** — became service-owned on any re-install (the state-dir chown precedes the rewrite, and the rewrite truncates in place rather than replacing the inode). `EnvironmentFile=` overrides the unit's `Environment=`, so the service could persist `SMOLVM_SECCOMP=off` and return unconfined via `Restart=on-failure`. Confirmed against real systemd, which reported `effective: SMOLVM_SECCOMP=off`.
- **App key** — was service-writable when only read is required.

`server uninstall` removes all three, so secrets no longer outlive an uninstall that only purges the state dir.

## Verification

Re-ran the **real installer under real systemd**, twice (the re-install is what previously flipped the env file to service-owned), then re-ran every attack:

```
V1a/b/c  overwrite / unlink+replace / swap the prefix dir   DENIED
V2a/b    write / unlink+recreate the EnvironmentFile        DENIED
V3a/b    overwrite / replace the App private key            DENIED
service CAN still read its key, write state, exec smolvm    OK
root executes the legitimate binary                         OK
```

On real KVM, a VM booted under this policy reports **`Seccomp: 2`, `Seccomp_filters: 1`** — the kernel's own confirmation, and the check `docs/setup.md` prescribes.

Other findings, each reproduced then fixed:

- **cgroup path decoding** — the code decoded systemd `\xHH` escapes, producing paths that do not exist (`mnt-my\x2ddir.mount` exists on disk, `mnt-my-dir.mount` does not), silently dropping the per-VM caps. Upstream's `cgroup_v2_self_dir` only trims the leading slash. Deleted; a regression test pins escapes preserved.
- **cgroup writes from the CLI** — a documented "read-only" probe created directories and modified `subtree_control`, reachable from `preloop shell`. Confined to an explicit `init_vm_cgroup_delegation()` the server calls once. Kept rather than deleted, because `Delegate=` leaves `subtree_control` **empty** — measured — so removing the write would silently disable all caps.
- **cached probe failure** — an invalid override surfaced as a misleading `UnsupportedSocketMount` cached for the provider's lifetime; now `InvalidSandboxEnv`.
- **test isolation** — new tests mutated process-global env and broke five others, including pre-existing ones. Fixed at the root via injected lookup; zero `set_var` in the crate.
- **ETXTBSY flake** — surfaced under CPU load at ~1 run in 16; a write descriptor this process holds is inherited by another test's `fork` until it execs. 0 failures in 40 after.

## Gates

`cargo fmt` · `just sg-scan-strict` · full macOS workspace tests · `just conform` PASS · Linux `cargo check --workspace --all-targets` clean on aarch64 and x86_64 · Linux tests green ×3 including `--test-threads=1` · every one of the 6 commits verified to build individually.

## Notes for the reviewer

- **Seccomp on aarch64 diverges from upstream.** Landlock matches exactly, but `smolvm serve` defaults seccomp on Linux/x86_64 only, while the boot subprocess honours it on aarch64 too. On Linux/aarch64 this enables a filter upstream leaves off. Documented, with the `Seccomp: 2` procedure to confirm it on a new host. The `Seccomp: 2` result above was measured on x86_64.
- **A system `--home` under `/home`, `/root`, or `/run/user` is now rejected.** The service account cannot traverse those whatever the state dir's mode is, so the previous `ReadWritePaths` carve-out produced a unit that looked correct and failed at first start.
- **No CI change.** An earlier draft added a Linux job on the assumption CI was macOS-only; that was wrong — `ci.yml` has run 86 times on the self-hosted Linux x86_64 runner. These errors survived because the work was never committed, so CI never saw it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Harden `smolvm` on Linux and run the control plane as a dedicated non‑root `preloop` user. All VM boots now enforce seccomp and Landlock, Preloop owns the sandbox env across CLI/server, and sensitive install artifacts move out of the writable state dir to close escalation paths.

- **New Features**
  - Enforce `SMOLVM_SECCOMP=enforce` and `SMOLVM_LANDLOCK=enforce` for every VM boot/restart, including CLI `machine exec/cp/shell` calls.
  - Validate operator `SMOLVM_*` overrides; reject invalid values to avoid silently unconfined boots.
  - Initialize per‑VM cgroup delegation once in the server; other processes read the hierarchy without mutating it.
  - Make Preloop authoritative for sandbox vars: strip inherited/invalid values (e.g. `SMOLVM_CGROUP_ROOT`), and pin `SMOLVM_DATA_DIR` to `<PRELOOP_HOME>/smolvm` for direct `smolvm` spawns so CLI can find service‑owned paused machines.
  - Run the systemd service as non‑root `preloop` with stricter unit hardening; the installer now rejects unsafe system `--home` and non‑traversable binaries, ensures the `preloop` group, migrates legacy env to `/etc/preloop/environment`, try‑restarts the unit, and bootstraps SmolVM data assets into the service data dir.
  - Move sensitive artifacts out of `PRELOOP_HOME`: smolvm prefix to `/usr/local/lib/preloop/smolvm-prefix`, environment to `/etc/preloop/environment`, GitHub App key to `/etc/preloop/github-app-key.pem`; uninstall removes them.

- **Bug Fixes**
  - Preserve systemd cgroup name escapes (no `\xHH` decoding) to target real paths and keep caps applied.
  - Prevent unintended cgroup writes from CLI; only the server updates `subtree_control`, and read‑only paths no longer create `.preloop-probe`.
  - Better override handling: invalid sandbox env surfaces as `InvalidSandboxEnv`, and non‑boot ops (`status`/`list`/`stop`/`delete`) strip invalid `SMOLVM_*` instead of wedging the provider.
  - Build the sandboxed `smolvm` command before claiming the debug marker to avoid leaked ACTIVE heartbeats on failure.
  - Improve test isolation and fix intermittent ETXTBSY by staging writes; remove process‑global env mutations.
  - Clean up Linux‑only dead code and `/proc/*/stat` parsing edge cases.

<sup>Written for commit 7ed2dfa2d7eeccab5d1f6e911889be89e929d712. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

