### PR TITLE
fix(webhooks): explicit body limit above GitHub's payload ceiling

### DIFF
--- a/crates/preloop-runner-server/src/routes.rs
+++ b/crates/preloop-runner-server/src/routes.rs
@@ -389,7 +389,14 @@ pub(crate) fn build_app(
         .route("/api/v1/scheduler/history", get(get_scheduler_history))
         .route(
             "/api/v1/github/webhooks",
-            post(github::handle_github_webhook),
+            post(github::handle_github_webhook)
+                // GitHub's own webhook cap is 25 MiB; without an explicit
+                // limit axum's 2 MiB default aborts the connection mid-body,
+                // which the sender sees as a reset/broken pipe and retries
+                // blindly. Set the limit above GitHub's ceiling so real
+                // deliveries pass and oversized input gets a deterministic
+                // 413 instead of a severed connection.
+                .layer(DefaultBodyLimit::max(32 * 1024 * 1024)),
         )
         .route("/api/v1/github/register", get(github::github_register))
         .route("/api/v1/github/callback", get(github::github_callback))


### PR DESCRIPTION
## Problem

The webhook route (`/api/v1/github/webhooks`) inherited axum's 2 MiB default body limit with no explicit override. For larger deliveries the connection is aborted mid-body — measured live in a stress test: 8 MiB payloads got a **connection reset with no response**, 64 MiB got a **broken pipe**. The sender sees neither 4xx nor 5xx, so GitHub redelivers blindly and every retry fails the same way (an unbounded retry loop against a delivery that can never be processed).

## Fix

An explicit `DefaultBodyLimit::max(32 MiB)` on the webhook route, mirroring the existing pattern used for `/api/v1/runs` (64 MiB). 32 MiB sits above GitHub's own 25 MiB webhook ceiling, so every real delivery passes; anything larger now gets a **deterministic `413`** instead of a severed connection.

## Verification (live, against a throwaway server)

```
 0.001 MiB -> 502 (normal processing; unresolvable-ref redelivery semantics, by design)
   2.1 MiB -> 502 (same)
     8 MiB -> 502 (same — previously a connection reset)
    25 MiB -> 502 (same — previously a reset)
  32.5 MiB -> 413 (clean)
    40 MiB -> 413 (clean, via curl; urllib shows a broken pipe artifact because its
                  single buffered write races the server's early close — server
                  behavior is correct)
healthz -> 200 throughout
```

## Notes

- The 502s above are preloop's correct GitHub-retry semantics for webhook refs with no resolvable commit SHA (the stress payloads used fake SHAs for a repo with no local git data); unrelated to this change.
- The 40 MiB broken-pipe with Python's `urllib` is a client-side artifact of writing the entire body in one buffered write while the server closes after the limit — any body-limiting HTTP server behaves this way against such clients; `curl` receives the `413` cleanly.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 32 MiB body limit to `/api/v1/github/webhooks` to prevent `axum`’s 2 MiB default from aborting large payloads mid-body. Real GitHub deliveries (≤25 MiB) now pass; oversized requests get a clean 413 instead of connection resets and endless redeliveries.

- **Bug Fixes**
  - Added `DefaultBodyLimit::max(32 * 1024 * 1024)` on the webhook route.
  - Oversized payloads now return 413; no more reset/broken pipe loops.
  - Mirrors the existing limit pattern used on `/api/v1/runs` (64 MiB).

<sup>Written for commit fc4dcd5e1b688ef1f4ae817a5f982828b51db7a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

