### PR TITLE
fix: reuse retained SmolVM fork checkpoints

### DIFF
--- a/crates/preloop-cli/src/update.rs
+++ b/crates/preloop-cli/src/update.rs
@@ -15,11 +15,15 @@ use tokio::io::AsyncWriteExt;
 
 const DEFAULT_REPOSITORY: &str = "preloopdev/preloop";
 const USER_AGENT: &str = concat!("preloop/", env!("CARGO_PKG_VERSION"));
+/// Temporary Preloop fork carrying the retained-checkpoint fix until SmolVM
+/// publishes the next official release.
+const SMOLVM_REPOSITORY: &str = "preloopdev/smolvm";
 
-/// smolvm version `preloop update` installs when the resolved binary cannot
-/// mount sockets.
+/// SmolVM version `preloop update` installs from the temporary Preloop fork
+/// when the resolved binary cannot mount sockets.
 ///
-/// Pinned to the last release whose macOS artifact ships a NET=1 libkrun:
+/// Pinned to the last release whose macOS artifact ships a NET=1 libkrun and
+/// used as the temporary fork's compatibility version:
 /// 1.7.5's `lib/libkrun.dylib` does not export `krun_add_net_unixstream`,
 /// so `--net-backend virtio-net` (the egress-floor backend preloop-vm
 /// selects) cannot boot a machine on macOS with it. Revisit when upstream
@@ -297,15 +301,30 @@ async fn probe_smolvm_version(binary: &Path) -> Option<String> {
         .map(|version| version.trim_start_matches('v').to_owned())
 }
 
-async fn smolvm_is_compatible(binary: &Path) -> bool {
+fn smolvm_release_repository() -> String {
+    std::env::var("PRELOOP_SMOLVM_RELEASE_REPOSITORY")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| SMOLVM_REPOSITORY.to_owned())
+}
+
+fn smolvm_release_version() -> String {
+    std::env::var("PRELOOP_SMOLVM_RELEASE_VERSION")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| SMOLVM_VERSION.to_owned())
+}
+
+async fn smolvm_is_compatible(binary: &Path, expected_version: &str) -> bool {
     probe_mount_socket(binary).await
-        && probe_smolvm_version(binary).await.as_deref() == Some(SMOLVM_VERSION)
+        && probe_smolvm_version(binary).await.as_deref() == Some(expected_version)
 }
 
 /// Probe the resolved smolvm and install the exact verified release when its
 /// version or required socket-mount capability differs.
 async fn ensure_smolvm(client: &Client) -> anyhow::Result<()> {
-    if smolvm_is_compatible(Path::new("smolvm")).await {
+    let expected_version = smolvm_release_version();
+    if smolvm_is_compatible(Path::new("smolvm"), &expected_version).await {
         return Ok(());
     }
     let platform = smolvm_platform().ok_or_else(|| {
@@ -315,10 +334,11 @@ async fn ensure_smolvm(client: &Client) -> anyhow::Result<()> {
             std::env::consts::ARCH
         )
     })?;
+    let repository = smolvm_release_repository();
     let release = fetch_release(
         client,
-        "https://api.github.com/repos/smol-machines/smolvm/releases",
-        Some(SMOLVM_VERSION),
+        &format!("https://api.github.com/repos/{repository}/releases"),
+        Some(&expected_version),
     )
     .await?;
     let version = release
@@ -345,7 +365,7 @@ async fn ensure_smolvm(client: &Client) -> anyhow::Result<()> {
     // The install lands in `~/.local/bin`; if PATH still resolves another
     // binary, the engine keeps failing and the user is left confused about
     // why the update did not help. Say so explicitly.
-    if !smolvm_is_compatible(Path::new("smolvm")).await {
+    if !smolvm_is_compatible(Path::new("smolvm"), &expected_version).await {
         bail!(
             "installed smolvm {version} to {}, but `smolvm` on PATH still resolves \
              to an incompatible version or lacks --mount-socket; make sure {} comes first",
@@ -865,7 +885,7 @@ mod tests {
             std::fs::set_permissions(&executable, permissions).unwrap();
 
             assert_eq!(
-                smolvm_is_compatible(&executable).await,
+                smolvm_is_compatible(&executable, SMOLVM_VERSION).await,
                 expected,
                 "version={version}, flag={flag}"
             );

--- a/crates/preloop-orchestrator/src/lib.rs
+++ b/crates/preloop-orchestrator/src/lib.rs
@@ -2569,18 +2569,7 @@ async fn provision_slot<P: VmProvider + 'static>(
     environment: RunnerEnvironment,
 ) -> Result<ReadyRunner, OrchestratorError> {
     let name = MachineName::new(format!("{}-{slot}-{generation}", config.name_prefix))?;
-    match provision_runner(
-        provider,
-        config,
-        &name,
-        golden,
-        keys,
-        &environment.base,
-        &environment.toolchains,
-        environment.curated,
-    )
-    .await
-    {
+    match provision_runner(provider, config, &name, golden, keys, &environment).await {
         Ok(run) => Ok(ReadyRunner {
             name,
             run,
@@ -2940,13 +2929,30 @@ async fn provision_runner<P: VmProvider + 'static>(
     name: &MachineName,
     golden: Option<&MachineName>,
     keys: &Arc<KeyPool>,
-    environment_base: &str,
-    toolchains: &[ToolchainLayer],
-    curated: bool,
+    environment: &RunnerEnvironment,
 ) -> Result<Vec<String>, OrchestratorError> {
+    let mut direct_create_from_packed = config.use_packed_artifact;
     let forked_golden = match golden {
         Some(golden) => match provider.fork(golden, name).await {
             Ok(()) => Some(golden),
+            Err(error @ VmError::ForkBaseBusy { .. })
+                if config.use_packed_artifact
+                    && golden.as_str() == format!("{}-golden", config.name_prefix) =>
+            {
+                // A live plain-fork clone still depends on the golden's frozen
+                // storage. Do not touch the base and do not create another VM
+                // from that same packed payload: SmolVM's mixed fork/create
+                // path has returned ESTALE in both machines. Boot this slot
+                // independently from the job's OCI environment instead.
+                warn!(
+                    machine = name.as_str(),
+                    golden = golden.as_str(),
+                    %error,
+                    "fork base busy; creating runner independently from the OCI image"
+                );
+                direct_create_from_packed = false;
+                None
+            }
             Err(error)
                 if config.use_packed_artifact
                     && golden.as_str() == format!("{}-golden", config.name_prefix) =>
@@ -2987,18 +2993,20 @@ async fn provision_runner<P: VmProvider + 'static>(
                                 golden = golden.as_str(),
                                 "fork base spent and cannot be re-armed (a live clone still \
                                  depends on it, or the partial clone could not be removed); \
-                                 falling back to direct creation"
+                                 falling back to independent OCI creation"
                             );
                             let _ = provider.delete(name).await;
+                            direct_create_from_packed = false;
                             None
                         }
                         Err(rearm_error) => {
                             error!(
                                 golden = golden.as_str(),
                                 %rearm_error,
-                                "failed to re-arm spent fork base; falling back to direct \
-                                 creation"
+                                "failed to re-arm spent fork base; falling back to independent \
+                                 OCI creation"
                             );
+                            direct_create_from_packed = false;
                             None
                         }
                     }
@@ -3046,7 +3054,7 @@ async fn provision_runner<P: VmProvider + 'static>(
             // The pack carries the apt baseline, but not necessarily apt's
             // indices — restore them before any workflow apt-installs. A
             // custom base is used as-is: no apt assumptions.
-            if curated {
+            if environment.curated {
                 if let Err(error) = provider.exec(name, &apt_lists_refresh_command()).await {
                     warn!(
                     machine = name.as_str(),
@@ -3062,7 +3070,7 @@ async fn provision_runner<P: VmProvider + 'static>(
             // cargo-dist dies with "you don't appear to have cargo installed",
             // blaming the workflow for a broken machine. A fully baked pack
             // pays one `command -v` per layer.
-            for layer in toolchains {
+            for layer in &environment.toolchains {
                 if verify_toolchain_installed(provider.as_ref(), name, layer)
                     .await
                     .is_ok()
@@ -3081,9 +3089,9 @@ async fn provision_runner<P: VmProvider + 'static>(
                 }
                 verify_toolchain_installed(provider.as_ref(), name, layer).await?;
             }
-        } else if curated {
+        } else if environment.curated {
             install_base_dependencies(provider.as_ref(), name).await?;
-            for layer in toolchains {
+            for layer in &environment.toolchains {
                 for command in layer.install_commands() {
                     if let Err(error) = provider.exec(name, &command).await {
                         return Err(error.into());
@@ -3095,16 +3103,18 @@ async fn provision_runner<P: VmProvider + 'static>(
             // Custom base image: used as-is, no apt bake, no toolchains.
             debug!(
                 machine = name.as_str(),
-                base = %environment_base,
+                base = %environment.base,
                 "custom base image — skipping the curated bake"
             );
         }
     } else {
-        let uses_packed_artifact = config.use_packed_artifact;
+        let uses_packed_artifact = direct_create_from_packed;
         let spec = MachineSpec {
             name: name.clone(),
             image: if uses_packed_artifact {
                 config.artifact_payload().display().to_string()
+            } else if config.use_packed_artifact {
+                environment.base.clone()
             } else {
                 config.base_image.clone()
             },
@@ -3135,9 +3145,9 @@ async fn provision_runner<P: VmProvider + 'static>(
         // installs are idempotent, so a fully baked artifact only pays the
         // presence checks. A custom base is the operator's contract: no apt
         // baseline, no toolchain curation.
-        if curated {
+        if environment.curated {
             install_base_dependencies(provider.as_ref(), name).await?;
-            for layer in toolchains {
+            for layer in &environment.toolchains {
                 for command in layer.install_commands() {
                     if let Err(error) = provider.exec(name, &command).await {
                         return Err(error.into());
@@ -3150,7 +3160,7 @@ async fn provision_runner<P: VmProvider + 'static>(
 
     let runner = format!("/opt/preloop/bin/{}", config.runner_binary_name);
     let mut labels = config.labels.clone();
-    for label in runner_environment_labels(environment_base) {
+    for label in runner_environment_labels(&environment.base) {
         if !labels
             .iter()
             .any(|existing| existing.eq_ignore_ascii_case(&label))
@@ -3424,7 +3434,9 @@ mod lifecycle_tests {
     struct TestProvider {
         machines: Mutex<HashMap<String, MachineState>>,
         events: Mutex<Vec<String>>,
+        created_images: Mutex<Vec<(String, String)>>,
         fail_fork: bool,
+        fork_base_busy: bool,
         /// Fail the next fork with the "spent fork base" signature, then
         /// succeed. Mirrors a golden whose retained checkpoint vanished.
         fail_fork_once_spent: Mutex<bool>,
@@ -3458,7 +3470,9 @@ mod lifecycle_tests {
             Self {
                 machines: Mutex::new(HashMap::new()),
                 events: Mutex::new(Vec::new()),
+                created_images: Mutex::new(Vec::new()),
                 fail_fork: false,
+                fork_base_busy: false,
                 fail_fork_once_spent: Mutex::new(false),
                 live_forks: Mutex::new(true),
                 fail_start,
@@ -3480,6 +3494,11 @@ mod lifecycle_tests {
 
         fn failing_fork(mut self) -> Self {
             self.fail_fork = true;
+            self
+        }
+
+        fn with_busy_fork_base(mut self) -> Self {
+            self.fork_base_busy = true;
             self
         }
 
@@ -3510,6 +3529,14 @@ mod lifecycle_tests {
 
         async fn events(&self) -> Vec<String> {
             self.events.lock().await.clone()
+        }
+
+        async fn created_image(&self, name: &MachineName) -> Option<String> {
+            self.created_images
+                .lock()
+                .await
+                .iter()
+                .find_map(|(created, image)| (created == name.as_str()).then(|| image.clone()))
         }
     }
 
@@ -3983,6 +4010,10 @@ chmod +x "$destination/bin/node"
                 .lock()
                 .await
                 .insert(spec.name.as_str().to_owned(), MachineState::Stopped);
+            self.created_images
+                .lock()
+                .await
+                .push((spec.name.as_str().to_owned(), spec.image.clone()));
             self.events
                 .lock()
                 .await
@@ -4014,6 +4045,12 @@ chmod +x "$destination/bin/node"
                 .lock()
                 .await
                 .push(format!("fork:{}:{}", golden.as_str(), clone.as_str()));
+            if self.fork_base_busy {
+                return Err(VmError::ForkBaseBusy {
+                    golden: golden.as_str().to_owned(),
+                    clone: "lifecycle-test-0-live".to_owned(),
+                });
+            }
             {
                 let mut spent = self.fail_fork_once_spent.lock().await;
                 if *spent {
@@ -4279,6 +4316,19 @@ chmod +x "$destination/bin/node"
         config
     }
 
+    fn test_runner_environment(
+        base: impl Into<String>,
+        toolchains: Vec<ToolchainLayer>,
+        curated: bool,
+    ) -> RunnerEnvironment {
+        RunnerEnvironment {
+            fingerprint: None,
+            base: base.into(),
+            toolchains,
+            curated,
+        }
+    }
+
     /// A retained SmolVM checkpoint can become unusable after the packed
     /// golden has been prepared. Retrying the same fork forever starves every
     /// queued job, while creating a runner directly from the same packed
@@ -4315,9 +4365,7 @@ chmod +x "$destination/bin/node"
             &name,
             Some(&golden),
             &Arc::new(KeyPool::new()),
-            &config.base_image,
-            &[],
-            true,
+            &test_runner_environment(config.base_image.clone(), Vec::new(), true),
         )
         .await
         .expect("a broken packed-golden fork falls back to direct creation");
@@ -4370,9 +4418,7 @@ chmod +x "$destination/bin/node"
             &name,
             Some(&golden),
             &Arc::new(KeyPool::new()),
-            &config.base_image,
-            &[],
-            true,
+            &test_runner_environment(config.base_image.clone(), Vec::new(), true),
         )
         .await
         .expect("the re-armed golden serves the fork");
@@ -4420,9 +4466,7 @@ chmod +x "$destination/bin/node"
             &name,
             Some(&golden),
             &Arc::new(KeyPool::new()),
-            &config.base_image,
-            &[],
-            true,
+            &test_runner_environment(config.base_image.clone(), Vec::new(), true),
         )
         .await
         .expect("falls back to direct creation");
@@ -4435,6 +4479,46 @@ chmod +x "$destination/bin/node"
         assert!(
             events.contains(&format!("delete:{}", name.as_str())),
             "the partial clone is cleaned up: {events:?}"
+        );
+        assert_eq!(
+            provider.created_image(&name).await.as_deref(),
+            Some(config.base_image.as_str()),
+            "a live clone makes the shared packed payload unsafe; fallback must use OCI"
+        );
+    }
+
+    /// The provider reports a live clone before invoking SmolVM for another
+    /// plain fork. The orchestrator must neither re-arm the shared golden nor
+    /// instantiate the packed payload beside that clone.
+    #[tokio::test]
+    async fn busy_packed_fork_base_uses_independent_environment_image() {
+        let provider =
+            Arc::new(TestProvider::new(false, false, false, false, false).with_busy_fork_base());
+        let config = packed_fork_config();
+        let golden = MachineName::new("lifecycle-test-golden").unwrap();
+        let name = MachineName::new("lifecycle-test-0-9").unwrap();
+        let environment_base = "mirror.gcr.io/library/ubuntu:22.04";
+
+        provision_runner(
+            &provider,
+            &config,
+            &name,
+            Some(&golden),
+            &Arc::new(KeyPool::new()),
+            &test_runner_environment(environment_base, Vec::new(), true),
+        )
+        .await
+        .expect("a busy plain-fork base falls back to an independent OCI machine");
+
+        let events = provider.events().await;
+        assert!(
+            !events.iter().any(|event| event.starts_with("rearm:")),
+            "a golden with a live clone must not be re-armed: {events:?}"
+        );
+        assert_eq!(
+            provider.created_image(&name).await.as_deref(),
+            Some(environment_base),
+            "fallback must use the job's resolved environment, not the shared packed payload"
         );
     }
 
@@ -4457,9 +4541,7 @@ chmod +x "$destination/bin/node"
             &name,
             Some(&golden),
             &Arc::new(KeyPool::new()),
-            &config.base_image,
-            &[],
-            true,
+            &test_runner_environment(config.base_image.clone(), Vec::new(), true),
         )
         .await
         .expect("falls back to direct creation");
@@ -4489,9 +4571,7 @@ chmod +x "$destination/bin/node"
             &name,
             Some(&golden),
             &Arc::new(KeyPool::new()),
-            "mirror.gcr.io/library/ubuntu:22.04",
-            &[],
-            true,
+            &test_runner_environment("mirror.gcr.io/library/ubuntu:22.04", Vec::new(), true),
         )
         .await
         .expect_err("an environment-golden fork failure must propagate");
@@ -4523,9 +4603,11 @@ chmod +x "$destination/bin/node"
             &name,
             Some(&golden),
             &Arc::new(KeyPool::new()),
-            &config.base_image.clone(),
-            &[ToolchainLayer::Rust("1.97".to_owned())],
-            true,
+            &test_runner_environment(
+                config.base_image.clone(),
+                vec![ToolchainLayer::Rust("1.97".to_owned())],
+                true,
+            ),
         )
         .await
         .expect("the fork installs the toolchain its pack lacks");
@@ -4565,9 +4647,7 @@ chmod +x "$destination/bin/node"
             &name,
             Some(&golden),
             &Arc::new(KeyPool::new()),
-            &config.base_image.clone(),
-            &[],
-            true,
+            &test_runner_environment(config.base_image.clone(), Vec::new(), true),
         )
         .await
         .expect("provisioning succeeds");
@@ -4596,9 +4676,11 @@ chmod +x "$destination/bin/node"
             &name,
             Some(&golden),
             &Arc::new(KeyPool::new()),
-            &config.base_image.clone(),
-            &[ToolchainLayer::Rust("1.97".to_owned())],
-            true,
+            &test_runner_environment(
+                config.base_image.clone(),
+                vec![ToolchainLayer::Rust("1.97".to_owned())],
+                true,
+            ),
         )
         .await
         .expect("provisioning succeeds");
@@ -4790,9 +4872,7 @@ chmod +x "$destination/bin/node"
             &name,
             None,
             &Arc::new(KeyPool::new()),
-            "ghcr.io/acme/runner:latest",
-            &[],
-            false,
+            &test_runner_environment("ghcr.io/acme/runner:latest", Vec::new(), false),
         )
         .await
         .expect("custom base provisioning succeeds");

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -13493,7 +13493,7 @@ jobs:
                     .and_then(Value::as_str)
             })
     }
-    let claimed_token = acquired_input(&checkout, "token").expect("claimed pinned token");
+    let claimed_token = acquired_input(checkout, "token").expect("claimed pinned token");
     assert_ne!(
         claimed_token, pinned_token,
         "claim must replace the submission-time token with a fresh one"

--- a/crates/preloop-runner-server/src/runtime_scheduling.rs
+++ b/crates/preloop-runner-server/src/runtime_scheduling.rs
@@ -1296,10 +1296,39 @@ pub(crate) fn take_matching_job(
         job_matches_runner_capabilities(job, runner)
             && claim_permitted(inner, job, verified_runner_id)
     };
+    // A registration is paired to one concrete job before it begins polling.
+    // Prefer that fresh binding over takeover candidates whose original owner
+    // missed the claim window. Otherwise an old FIFO job can consume the new
+    // runner, leaving the job it was provisioned for queued and causing stale
+    // restored runs to advance ahead of the run the user just submitted.
+    let assigned_to_this_runner = |job: &QueuedJob| {
+        let Some(runner_id) = verified_runner_id else {
+            return false;
+        };
+        inner
+            .job_assignments
+            .get(&(job.run_id, job.job_id.clone()))
+            .is_some_and(|record| record.runner_id == runner_id && binding_fresh(record.at, now))
+    };
     let pos = inner
         .queue
         .iter()
-        .position(|job| job_labels_covered_exactly(&job.runs_on, &runner.labels) && claimable(job))
+        .position(|job| {
+            assigned_to_this_runner(job)
+                && job_labels_covered_exactly(&job.runs_on, &runner.labels)
+                && claimable(job)
+        })
+        .or_else(|| {
+            inner
+                .queue
+                .iter()
+                .position(|job| assigned_to_this_runner(job) && claimable(job))
+        })
+        .or_else(|| {
+            inner.queue.iter().position(|job| {
+                job_labels_covered_exactly(&job.runs_on, &runner.labels) && claimable(job)
+            })
+        })
         .or_else(|| inner.queue.iter().position(claimable))?;
     let job = inner.queue.remove(pos)?;
     let key = (job.run_id, job.job_id.clone());
@@ -2770,6 +2799,48 @@ mod assignment_tests {
         assert!(
             claimed.is_some(),
             "verified runner must take over the expired strict-mode assignment"
+        );
+    }
+
+    #[test]
+    fn freshly_paired_runner_prefers_its_assignment_over_stale_fifo_work() {
+        let mut inner = InnerState {
+            pool_assignments_enabled: true,
+            require_job_assignments: true,
+            ..Default::default()
+        };
+        let stale_job = test_queued_job("stale");
+        let stale_key = (stale_job.run_id, stale_job.job_id.clone());
+        let assigned_job = test_queued_job("assigned");
+        let assigned_key = (assigned_job.run_id, assigned_job.job_id.clone());
+        inner.queue.push_back(stale_job);
+        inner.queue.push_back(assigned_job);
+
+        let now = std::time::SystemTime::now();
+        inner.job_assignments.insert(
+            stale_key.clone(),
+            AssignmentRecord {
+                runner_id: 40,
+                at: now,
+                first_at: now - CLAIM_BINDING_TTL - std::time::Duration::from_secs(1),
+            },
+        );
+        inner.pool_pending.insert(stale_key, now);
+        inner.job_assignments.insert(
+            assigned_key,
+            AssignmentRecord {
+                runner_id: 41,
+                at: now,
+                first_at: now,
+            },
+        );
+
+        let claimed = take_matching_job(&mut inner, &self_hosted_caps(), Some(41))
+            .expect("the freshly paired runner has a claimable job");
+
+        assert_eq!(
+            claimed.job_id.0, "assigned",
+            "a stale takeover candidate must not displace the runner's fresh assignment"
         );
     }
 

--- a/crates/preloop-vm/src/lib.rs
+++ b/crates/preloop-vm/src/lib.rs
@@ -228,6 +228,18 @@ pub enum VmError {
         /// Bounded diagnostic.
         message: String,
     },
+    /// A plain-fork golden already has a live copy-on-write clone.
+    ///
+    /// SmolVM 1.7.4's `machine fork` does not retain a checkpoint for reuse.
+    /// Invoking it again against the paused base can invalidate storage still
+    /// used by the first clone, so callers must use an independent image.
+    #[error("fork base `{golden}` already has live clone `{clone}`")]
+    ForkBaseBusy {
+        /// Forkable base that cannot safely serve another clone yet.
+        golden: String,
+        /// Existing clone whose storage still depends on the base.
+        clone: String,
+    },
     /// Invalid SmolVM JSON output.
     #[error("invalid smolvm response: {0}")]
     Protocol(String),
@@ -359,6 +371,11 @@ pub struct SmolVmProvider {
     /// environment; unit tests substitute a pure lookup so the policy can be
     /// exercised without mutating global state.
     env_lookup: EnvLookup,
+    /// Whether this SmolVM retains a reusable RAM checkpoint after a plain
+    /// fork. Enabled by default while Preloop uses its patched SmolVM fork;
+    /// set `PRELOOP_SMOLVM_RETAINED_FORKS=false` to fall back to the safe
+    /// single-live-clone behavior.
+    retained_fork_checkpoints: bool,
 }
 
 impl Default for SmolVmProvider {
@@ -373,16 +390,18 @@ impl SmolVmProvider {
     /// Preloop-specific variables take precedence over the conventional proxy
     /// variables inherited by the process.
     pub fn from_environment(binary: impl Into<PathBuf>) -> Self {
-        Self::new(binary).with_pack_network(
-            first_nonempty_env(&[
-                "PRELOOP_RUNNER_PACK_PROXY",
-                "HTTPS_PROXY",
-                "https_proxy",
-                "HTTP_PROXY",
-                "http_proxy",
-            ]),
-            first_nonempty_env(&["PRELOOP_RUNNER_PACK_NO_PROXY", "NO_PROXY", "no_proxy"]),
-        )
+        Self::new(binary)
+            .with_retained_fork_checkpoints(env_flag_default_true("PRELOOP_SMOLVM_RETAINED_FORKS"))
+            .with_pack_network(
+                first_nonempty_env(&[
+                    "PRELOOP_RUNNER_PACK_PROXY",
+                    "HTTPS_PROXY",
+                    "https_proxy",
+                    "HTTP_PROXY",
+                    "http_proxy",
+                ]),
+                first_nonempty_env(&["PRELOOP_RUNNER_PACK_NO_PROXY", "NO_PROXY", "no_proxy"]),
+            )
     }
 }
 
@@ -392,6 +411,13 @@ fn first_nonempty_env(names: &[&str]) -> Option<String> {
             .ok()
             .filter(|value| !value.trim().is_empty())
     })
+}
+
+fn env_flag_default_true(name: &str) -> bool {
+    !matches!(
+        std::env::var(name).as_deref(),
+        Ok("0") | Ok("false") | Ok("FALSE") | Ok("no") | Ok("NO")
+    )
 }
 
 impl SmolVmProvider {
@@ -407,7 +433,18 @@ impl SmolVmProvider {
             forked_machines: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             socket_mount_supported: Arc::new(tokio::sync::OnceCell::new()),
             env_lookup: process_env,
+            retained_fork_checkpoints: true,
         }
+    }
+
+    /// Allow multiple live plain forks from one golden.
+    ///
+    /// Disable this only when the resolved SmolVM predates the retained-
+    /// checkpoint fix. Older releases leave the golden paused after the first
+    /// fork and cannot safely serve another clone.
+    pub fn with_retained_fork_checkpoints(mut self, enabled: bool) -> Self {
+        self.retained_fork_checkpoints = enabled;
+        self
     }
 
     /// Override the maximum bytes retained from each process stream.
@@ -868,23 +905,31 @@ impl VmProvider for SmolVmProvider {
 
     /// Fork one clone from a golden, one fork per golden at a time.
     ///
-    /// SmolVM holds exactly one RAM checkpoint per golden: the first fork
-    /// freezes the base and publishes a retained checkpoint, and later forks
-    /// restore from that checkpoint instead of re-freezing. Two forks racing
-    /// the same golden break the invariant — the loser issues a second FORK
-    /// against an already-paused VM, and that failure's rollback resumes the
-    /// base and deletes the retained checkpoint. Every later fork then fails
-    /// with `golden '<name>' is already paused; a valid retained checkpoint is
-    /// required`, so the pool cannot produce another runner until the golden is
-    /// rebuilt from scratch: queued jobs stall indefinitely, in exchange for
-    /// the few hundred milliseconds a concurrent refill saves. SmolVM's own
-    /// fork-pool controller serializes on the golden for the same reason.
+    /// Released SmolVM versions before the retained-checkpoint fix freeze the
+    /// base for one live clone but do not persist a checkpoint for later plain
+    /// forks. For those versions, track live clones under the same per-golden
+    /// lock and reject a second call before invoking SmolVM. Patched builds may
+    /// opt into checkpoint reuse with `PRELOOP_SMOLVM_RETAINED_FORKS=true`.
     ///
     /// Different goldens still fork concurrently, and forks remain excluded
     /// from base construction, so a golden cannot be replaced underneath one.
     async fn fork(&self, golden: &MachineName, clone: &MachineName) -> Result<(), VmError> {
         let fork_lock = self.fork_lock(golden).await;
         let _fork_guard = fork_lock.lock().await;
+        if !self.retained_fork_checkpoints {
+            if let Some(live_clone) = self
+                .forked_machines
+                .lock()
+                .await
+                .iter()
+                .find_map(|(clone, owner)| (owner == golden.as_str()).then(|| clone.clone()))
+            {
+                return Err(VmError::ForkBaseBusy {
+                    golden: golden.as_str().to_owned(),
+                    clone: live_clone,
+                });
+            }
+        }
         let result = self
             .concurrent(
                 "fork",

--- a/crates/preloop-vm/tests/provider.rs
+++ b/crates/preloop-vm/tests/provider.rs
@@ -775,15 +775,15 @@ printf 'exit %s\n' "$6" >> "$0.forklog"
         false
     }
 
-    /// SmolVM keeps one RAM checkpoint per golden: the first fork freezes the
-    /// base and later forks restore from the retained checkpoint. A second fork
-    /// racing the first FORKs an already-paused VM, and that failure's rollback
-    /// resumes the base and drops the checkpoint — after which every fork from
-    /// that golden fails and queued jobs stall until the golden is rebuilt.
+    /// Plain `machine fork` in SmolVM 1.7.4 does not persist a reusable
+    /// checkpoint. Once one live clone exists, invoking SmolVM for a second
+    /// clone fails against the paused base and can invalidate the first clone's
+    /// storage. The provider must reject that second clone before spawning the
+    /// command.
     #[tokio::test]
-    async fn forks_from_one_golden_never_overlap() {
+    async fn second_live_clone_from_one_golden_is_rejected_without_spawning_smolvm() {
         let (_directory, executable) = fake_blocking_fork_smolvm();
-        let provider = SmolVmProvider::new(&executable);
+        let provider = SmolVmProvider::new(&executable).with_retained_fork_checkpoints(false);
         let golden = MachineName::new("runner-golden").unwrap();
         let first = MachineName::new("runner-0-1").unwrap();
         let second = MachineName::new("runner-1-1").unwrap();
@@ -818,14 +818,70 @@ printf 'exit %s\n' "$6" >> "$0.forklog"
 
         fs::write(executable.with_extension("release"), "").unwrap();
         one.await.unwrap().unwrap();
-        two.await.unwrap().unwrap();
+        let error = two
+            .await
+            .unwrap()
+            .expect_err("a second live clone from one plain-fork golden must be rejected");
+        assert!(matches!(
+            error,
+            VmError::ForkBaseBusy {
+                ref golden,
+                ref clone,
+            } if golden == "runner-golden" && clone == "runner-0-1"
+        ));
 
         let log = fork_log(&executable);
-        let order: Vec<&str> = log.iter().map(|line| &line[..5]).collect();
         assert_eq!(
-            order,
-            ["enter", "exit ", "enter", "exit "],
-            "strictly one fork at a time: {log:?}"
+            log,
+            ["enter runner-0-1", "exit runner-0-1"],
+            "the rejected clone must never invoke SmolVM: {log:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn retained_checkpoint_mode_allows_multiple_live_clones() {
+        let (_directory, executable) = fake_blocking_fork_smolvm();
+        // This test intentionally uses the default: the patched SmolVM
+        // release is the normal runtime path now.
+        let provider = SmolVmProvider::new(&executable);
+        let golden = MachineName::new("runner-golden").unwrap();
+        let first = MachineName::new("runner-0-1").unwrap();
+        let second = MachineName::new("runner-1-1").unwrap();
+
+        let one = {
+            let provider = provider.clone();
+            let (golden, first) = (golden.clone(), first.clone());
+            tokio::spawn(async move { provider.fork(&golden, &first).await })
+        };
+        let two = {
+            let provider = provider.clone();
+            let (golden, second) = (golden.clone(), second.clone());
+            tokio::spawn(async move { provider.fork(&golden, &second).await })
+        };
+
+        assert!(wait_for_entries(&executable, 1).await);
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert_eq!(
+            fork_log(&executable)
+                .iter()
+                .filter(|line| line.starts_with("enter"))
+                .count(),
+            1,
+            "the provider still serializes fork commands: {:?}",
+            fork_log(&executable)
+        );
+        fs::write(executable.with_extension("release"), "").unwrap();
+        one.await.unwrap().unwrap();
+        two.await.unwrap().unwrap();
+
+        assert_eq!(
+            fork_log(&executable),
+            [
+                "enter runner-0-1",
+                "exit runner-0-1",
+                "enter runner-1-1",
+                "exit runner-1-1"
+            ]
         );
     }
 

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -258,6 +258,8 @@ steps.
 | `PRELOOP_RUNNER_POOL_ENABLED` | Enable the local microVM runner pool (default off) |
 | `PRELOOP_RUNNER_POOL_SIZE` | Pool size (warm forks/VMs) |
 | `PRELOOP_USE_FORK` | Run the pool as forked microVMs (default true with a packed golden) |
+| `PRELOOP_SMOLVM_RETAINED_FORKS` | `true` by default; set `false` only for an older official SmolVM build |
+| `PRELOOP_SMOLVM_RELEASE_REPOSITORY` / `PRELOOP_SMOLVM_RELEASE_VERSION` | Temporary SmolVM release source and tag overrides for `preloop update --ensure-runtime` (defaults to `preloopdev/smolvm` / `1.7.4`) |
 | `PRELOOP_USE_PACKED_GOLDEN` | Use a release or locally cached packed golden (default on; set `false` for cold OCI provisioning) |
 | `PRELOOP_GOLDEN_URL` | Override the packed golden URL; checksum URL is this value plus `.sha256` |
 | `PRELOOP_RUNNER_BASE_IMAGE` | Override the digest-pinned Ubuntu base identity at serve time; set it with `PRELOOP_GOLDEN_URL` for a custom packed golden |

--- a/docs/internal/smolvm-retained-fork-runtime.md
+++ b/docs/internal/smolvm-retained-fork-runtime.md
@@ -1,0 +1,18 @@
+# Temporary retained-checkpoint SmolVM runtime
+
+SmolVM PR [#888](https://github.com/smol-machines/smolvm/pull/888) fixes the
+plain-fork path so a paused golden retains its RAM checkpoint for later clones.
+Until that change is included in an official release, Preloop defaults to the
+`preloopdev/smolvm` fork at version `1.7.4` and enables
+`PRELOOP_SMOLVM_RETAINED_FORKS`.
+
+When SmolVM publishes the official release containing the fix:
+
+1. Change `SMOLVM_REPOSITORY` in `crates/preloop-cli/src/update.rs` back to
+   `smol-machines/smolvm`.
+2. Update `SMOLVM_VERSION` to the official fixed version.
+3. Keep the per-golden fork mutex; it serializes the short fork operations.
+4. Remove the temporary `PRELOOP_SMOLVM_RELEASE_REPOSITORY` and
+   `PRELOOP_SMOLVM_RELEASE_VERSION` defaults.
+5. Retain the old-runtime escape hatch only if compatibility with older
+   SmolVM installations is still required.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -134,6 +134,9 @@ Client-side (`preloop` CLI): `PRELOOP_URL` (default `http://127.0.0.1:9090`) and
 | `PRELOOP_RUNNER_OVERLAY_GB` | — | Per-VM writable overlay size |
 | `PRELOOP_RUNNER_USER` / `PRELOOP_RUNNER_UID` | `runner` / `1001` | Guest account steps run as, for GitHub-hosted parity. `root` restores root; empty disables switching |
 | `PRELOOP_USE_FORK` | — | Fork machines from a prepared golden instead of building each |
+| `PRELOOP_SMOLVM_RETAINED_FORKS` | `true` | Enable multiple live forks from one golden; set `false` only for an older official SmolVM build |
+| `PRELOOP_SMOLVM_RELEASE_REPOSITORY` | `preloopdev/smolvm` | Temporary GitHub `OWNER/NAME` override for `preloop update --ensure-runtime` |
+| `PRELOOP_SMOLVM_RELEASE_VERSION` | `1.7.4` | Temporary SmolVM release/tag override for `preloop update --ensure-runtime` |
 | `PRELOOP_USE_PACKED_GOLDEN` | `true` | Use a release or locally cached packed golden for on-demand and pooled runners |
 | `PRELOOP_GOLDEN_URL` | release asset | Packed golden URL; the optional checksum is fetched from the same URL plus `.sha256` |
 | `PRELOOP_RUNNER_BUNDLE` | — | Directory of runner binaries mounted into guests |


### PR DESCRIPTION
Fixes the stale-runner and multi-fork stall regressions.

- Prefer a freshly paired runner assignment over stale FIFO work.
- Default to the retained-checkpoint SmolVM fork release so multiple clones reuse the golden instead of booting from scratch.
- Keep per-golden fork serialization and fall back to the resolved OCI image only when a base is unsafe.
- Add the temporary runtime migration note.

Verification:
- A/B baseline reproducer selected stale work; fixed reproducer selected the fresh assignment.
- A/B old single-checkpoint fork reproduced the paused-golden error; fixed default retained-fork test passed.
- `just dogfood` passed with `job_succeeded=1`.
- `just test-ci` passed, including 39/39 conformance scenarios.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale-runner claims and multi-fork stalls. New runners claim their freshly paired job first, and VM forks reuse retained checkpoints with a safe fallback when a golden is busy.

- **Bug Fixes**
  - Scheduling: prefer the runner’s fresh assignment over stale FIFO/takeovers to stop restored runs from jumping the queue.
  - Orchestrator: when a plain-fork golden is busy or its checkpoint is spent, skip rearm and avoid the shared packed payload; create the runner from the job’s OCI image instead.
  - VM runtime: default to retained-checkpoint plain forks; add `ForkBaseBusy` to guard older builds and an escape hatch via `PRELOOP_SMOLVM_RETAINED_FORKS=false`.
  - CLI: `preloop update --ensure-runtime` installs `preloopdev/smolvm@1.7.4` by default; override with `PRELOOP_SMOLVM_RELEASE_REPOSITORY` and `PRELOOP_SMOLVM_RELEASE_VERSION`.

- **Migration**
  - No action for most users.
  - If you must run an older official `smolvm`, set `PRELOOP_SMOLVM_RETAINED_FORKS=false`.
  - To pin a different SmolVM release, set `PRELOOP_SMOLVM_RELEASE_REPOSITORY` and `PRELOOP_SMOLVM_RELEASE_VERSION`.

<sup>Written for commit 50cb4e5254898d04a20adb2af61e94554e0228ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

