### PR TITLE
Strengthen golden VM image provenance

### DIFF
--- a/.github/workflows/release-golden.yml
+++ b/.github/workflows/release-golden.yml
@@ -43,11 +43,10 @@ jobs:
             --pattern 'preloop-ubuntu-24.04-*' \
             --dir dist \
             --repo "$GITHUB_REPOSITORY"
+          # Preserve the signatures, attestations, and base-evidence sidecars
+          # when a release intentionally reuses an earlier golden.
           gh release upload "$TARGET_TAG" \
-            dist/preloop-ubuntu-24.04-aarch64 \
-            dist/preloop-ubuntu-24.04-aarch64.sha256 \
-            dist/preloop-ubuntu-24.04-x86_64 \
-            dist/preloop-ubuntu-24.04-x86_64.sha256 \
+            dist/preloop-ubuntu-24.04-* \
             --clobber \
             --repo "$GITHUB_REPOSITORY"
 
@@ -70,6 +69,16 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Resolve golden identity and base
+        run: |
+          set -euo pipefail
+          echo "RUNNER_TARGET=aarch64-unknown-linux-gnu" >> "$GITHUB_ENV"
+          echo "GOLDEN_ARCH=aarch64" >> "$GITHUB_ENV"
+          echo "GOLDEN_PLATFORM=linux/arm64" >> "$GITHUB_ENV"
+          BASE_IMAGE="$(awk -F'"' '/^ubuntu_24_04_base = / { print $2; exit }' versions.toml)"
+          test -n "$BASE_IMAGE"
+          echo "BASE_IMAGE=$BASE_IMAGE" >> "$GITHUB_ENV"
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
@@ -146,14 +155,21 @@ jobs:
       - name: Build Preloop binaries
         run: |
           cargo build --release -p preloop-cli -p preloop-runner-server
-          case $(uname -m) in
-            x86_64) RUNNER_TARGET=x86_64-unknown-linux-gnu; GOLDEN_ARCH=x86_64 ;;
-            aarch64|arm64) RUNNER_TARGET=aarch64-unknown-linux-gnu; GOLDEN_ARCH=aarch64 ;;
-            *) echo "unsupported arch: $(uname -m)" >&2; exit 1 ;;
-          esac
           cargo build --release -p preloop-runner --target "$RUNNER_TARGET"
-          echo "GOLDEN_ARCH=$GOLDEN_ARCH" >> "$GITHUB_ENV"
-          echo "RUNNER_TARGET=$RUNNER_TARGET" >> "$GITHUB_ENV"
+
+      - name: Capture pinned base provenance
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          GOLDEN_NAME="preloop-ubuntu-24.04-$GOLDEN_ARCH"
+          python3 scripts/capture-base-provenance.py \
+            --image "$BASE_IMAGE" \
+            --platform "$GOLDEN_PLATFORM" \
+            --output "dist/$GOLDEN_NAME.base-provenance.json" \
+            --sbom-output "dist/$GOLDEN_NAME.base-sbom.spdx.json" \
+            --require-sbom \
+            --require-source-prefix \
+              "https://git.launchpad.net/cloud-images/+oci/ubuntu-base"
 
       - name: Pack Golden MicroVM Artifact
         env:
@@ -161,11 +177,23 @@ jobs:
         run: |
           mkdir -p dist
           rm -f "dist/$GOLDEN_NAME"
+          export PRELOOP_REQUIRE_BASE_DIGEST=1
+          export PRELOOP_RUNNER_BASE_IMAGE="$BASE_IMAGE"
           ./target/release/preloop build-golden \
             --runner-bundle "target/$RUNNER_TARGET/release" \
             --output "dist/$GOLDEN_NAME"
           test -s "dist/$GOLDEN_NAME"
           sha256sum "dist/$GOLDEN_NAME" > "dist/$GOLDEN_NAME.sha256"
+
+      - name: Write golden provenance manifest
+        env:
+          GOLDEN_NAME: preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}
+        run: |
+          python3 scripts/write-golden-provenance.py \
+            --golden "dist/$GOLDEN_NAME" \
+            --base-evidence "dist/$GOLDEN_NAME.base-provenance.json" \
+            --base-sbom "dist/$GOLDEN_NAME.base-sbom.spdx.json" \
+            --output "dist/$GOLDEN_NAME.provenance.json"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -191,7 +219,14 @@ jobs:
       - name: Attest golden (GitHub provenance)
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
-          subject-path: dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}
+          # Attest the golden and the immutable base-evidence sidecars in one
+          # signed statement. The provenance manifest binds their hashes and
+          # records the exact base/platform digest used for the bake.
+          subject-path: |
+            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}
+            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.base-provenance.json
+            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.base-sbom.spdx.json
+            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.provenance.json
 
       - name: Upload Golden Artifact to Release
         env:
@@ -206,7 +241,10 @@ jobs:
           fi
           gh release upload "$TARGET_TAG" \
             "dist/$GOLDEN_NAME" "dist/$GOLDEN_NAME.sha256" \
-            "dist/$GOLDEN_NAME.bundle" --clobber
+            "dist/$GOLDEN_NAME.bundle" \
+            "dist/$GOLDEN_NAME.base-provenance.json" \
+            "dist/$GOLDEN_NAME.base-sbom.spdx.json" \
+            "dist/$GOLDEN_NAME.provenance.json" --clobber
 
       # A dispatched build has no release to upload to; without this the
       # golden would sit only on the runner's workspace and be lost. Keep it
@@ -221,6 +259,9 @@ jobs:
             dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}
             dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.sha256
             dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.bundle
+            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.base-provenance.json
+            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.base-sbom.spdx.json
+            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.provenance.json
           retention-days: 90
           if-no-files-found: error
 
@@ -239,6 +280,16 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Resolve golden identity and base
+        run: |
+          set -euo pipefail
+          echo "RUNNER_TARGET=aarch64-unknown-linux-gnu" >> "$GITHUB_ENV"
+          echo "GOLDEN_ARCH=aarch64" >> "$GITHUB_ENV"
+          echo "GOLDEN_PLATFORM=linux/arm64" >> "$GITHUB_ENV"
+          BASE_IMAGE="$(awk -F'"' '/^ubuntu_24_04_base = / { print $2; exit }' versions.toml)"
+          test -n "$BASE_IMAGE"
+          echo "BASE_IMAGE=$BASE_IMAGE" >> "$GITHUB_ENV"
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
@@ -263,7 +314,7 @@ jobs:
       - name: Build Linux runner bundle
         run: |
           cargo zigbuild --release \
-            --target aarch64-unknown-linux-gnu \
+            --target "$RUNNER_TARGET" \
             -p preloop-runner
 
       - name: Install pinned smolvm
@@ -307,17 +358,43 @@ jobs:
           brew install e2fsprogs
           echo "$(brew --prefix e2fsprogs)/sbin" >> "$GITHUB_PATH"
 
+      - name: Capture pinned base provenance
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          GOLDEN_NAME="preloop-ubuntu-24.04-$GOLDEN_ARCH"
+          python3 scripts/capture-base-provenance.py \
+            --image "$BASE_IMAGE" \
+            --platform "$GOLDEN_PLATFORM" \
+            --output "dist/$GOLDEN_NAME.base-provenance.json" \
+            --sbom-output "dist/$GOLDEN_NAME.base-sbom.spdx.json" \
+            --require-sbom \
+            --require-source-prefix \
+              "https://git.launchpad.net/cloud-images/+oci/ubuntu-base"
+
       - name: Pack Golden MicroVM Artifact
         env:
           GOLDEN_NAME: preloop-ubuntu-24.04-aarch64
         run: |
           mkdir -p dist
           rm -f "dist/$GOLDEN_NAME"
+          export PRELOOP_REQUIRE_BASE_DIGEST=1
+          export PRELOOP_RUNNER_BASE_IMAGE="$BASE_IMAGE"
           ./target/release/preloop build-golden \
-            --runner-bundle "target/aarch64-unknown-linux-gnu/release" \
+            --runner-bundle "target/$RUNNER_TARGET/release" \
             --output "dist/$GOLDEN_NAME"
           test -s "dist/$GOLDEN_NAME"
           shasum -a 256 "dist/$GOLDEN_NAME" > "dist/$GOLDEN_NAME.sha256"
+
+      - name: Write golden provenance manifest
+        env:
+          GOLDEN_NAME: preloop-ubuntu-24.04-aarch64
+        run: |
+          python3 scripts/write-golden-provenance.py \
+            --golden "dist/$GOLDEN_NAME" \
+            --base-evidence "dist/$GOLDEN_NAME.base-provenance.json" \
+            --base-sbom "dist/$GOLDEN_NAME.base-sbom.spdx.json" \
+            --output "dist/$GOLDEN_NAME.provenance.json"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -343,7 +420,14 @@ jobs:
       - name: Attest golden (GitHub provenance)
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
-          subject-path: dist/preloop-ubuntu-24.04-aarch64
+          # Attest the golden and the immutable base-evidence sidecars in one
+          # signed statement. The provenance manifest binds their hashes and
+          # records the exact base/platform digest used for the bake.
+          subject-path: |
+            dist/preloop-ubuntu-24.04-aarch64
+            dist/preloop-ubuntu-24.04-aarch64.base-provenance.json
+            dist/preloop-ubuntu-24.04-aarch64.base-sbom.spdx.json
+            dist/preloop-ubuntu-24.04-aarch64.provenance.json
 
       - name: Upload Golden Artifact to Release
         env:
@@ -358,7 +442,10 @@ jobs:
           fi
           gh release upload "$TARGET_TAG" \
             "dist/$GOLDEN_NAME" "dist/$GOLDEN_NAME.sha256" \
-            "dist/$GOLDEN_NAME.bundle" --clobber
+            "dist/$GOLDEN_NAME.bundle" \
+            "dist/$GOLDEN_NAME.base-provenance.json" \
+            "dist/$GOLDEN_NAME.base-sbom.spdx.json" \
+            "dist/$GOLDEN_NAME.provenance.json" --clobber
 
       - name: Retain Golden Artifact for non-release builds
         if: github.event_name != 'release'
@@ -369,5 +456,8 @@ jobs:
             dist/preloop-ubuntu-24.04-aarch64
             dist/preloop-ubuntu-24.04-aarch64.sha256
             dist/preloop-ubuntu-24.04-aarch64.bundle
+            dist/preloop-ubuntu-24.04-aarch64.base-provenance.json
+            dist/preloop-ubuntu-24.04-aarch64.base-sbom.spdx.json
+            dist/preloop-ubuntu-24.04-aarch64.provenance.json
           retention-days: 90
           if-no-files-found: error

--- a/.github/workflows/release-golden.yml
+++ b/.github/workflows/release-golden.yml
@@ -70,16 +70,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Resolve golden identity and base
-        run: |
-          set -euo pipefail
-          echo "RUNNER_TARGET=aarch64-unknown-linux-gnu" >> "$GITHUB_ENV"
-          echo "GOLDEN_ARCH=aarch64" >> "$GITHUB_ENV"
-          echo "GOLDEN_PLATFORM=linux/arm64" >> "$GITHUB_ENV"
-          BASE_IMAGE="$(awk -F'"' '/^ubuntu_24_04_base = / { print $2; exit }' versions.toml)"
-          test -n "$BASE_IMAGE"
-          echo "BASE_IMAGE=$BASE_IMAGE" >> "$GITHUB_ENV"
-
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
         with:
@@ -148,6 +138,16 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Resolve golden identity and base
+        run: |
+          set -euo pipefail
+          echo "RUNNER_TARGET=x86_64-unknown-linux-gnu" >> "$GITHUB_ENV"
+          echo "GOLDEN_ARCH=x86_64" >> "$GITHUB_ENV"
+          echo "GOLDEN_PLATFORM=linux/amd64" >> "$GITHUB_ENV"
+          BASE_IMAGE="$(awk -F'"' '/^ubuntu_24_04_base = / { print $2; exit }' versions.toml)"
+          test -n "$BASE_IMAGE"
+          echo "BASE_IMAGE=$BASE_IMAGE" >> "$GITHUB_ENV"
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -525,6 +525,9 @@ async fn cmd_build_golden(args: BuildGoldenArgs) -> anyhow::Result<()> {
     {
         verify_base_image(&args.base_image).await?;
     }
+    if env_flag("PRELOOP_REQUIRE_BASE_DIGEST", false) {
+        require_digest_pinned_base(&args.base_image)?;
+    }
     let config = RunnerPoolConfig {
         size: 1,
         use_fork: false,
@@ -599,6 +602,7 @@ async fn verify_base_image(base_image: &str) -> anyhow::Result<()> {
     if !base_image.contains('/') || base_image.starts_with('.') || base_image.starts_with('/') {
         anyhow::bail!("base image `{base_image}` is not a registry reference; nothing to verify");
     }
+    require_digest_pinned_base(base_image)?;
     verify_base_image_with(&repo, base_image)
 }
 
@@ -623,6 +627,29 @@ fn verify_base_image_with(repo: &str, base_image: &str) -> anyhow::Result<()> {
         ],
         "cosign signature",
     )
+}
+
+fn require_digest_pinned_base(base_image: &str) -> anyhow::Result<()> {
+    // Packed artifacts and local paths are already immutable inputs; this
+    // policy applies to registry references only. Release workflows enable
+    // this before baking so a mutable tag cannot silently become the golden's
+    // input after the provenance sidecars were captured.
+    if base_image.starts_with('.') || base_image.starts_with('/') {
+        return Ok(());
+    }
+    let digest = base_image
+        .split_once("@sha256:")
+        .map(|(_, digest)| digest)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "base image `{base_image}` must use an immutable @sha256:<digest> reference"
+            )
+        })?;
+    anyhow::ensure!(
+        digest.len() == 64 && digest.bytes().all(|byte| byte.is_ascii_hexdigit()),
+        "base image `{base_image}` has an invalid sha256 digest"
+    );
+    Ok(())
 }
 
 fn run_verifier(binary: &str, args: &[&str], what: &str) -> anyhow::Result<()> {
@@ -2351,6 +2378,17 @@ mod tests {
             "ghcr.io/acme/runner-images:ubuntu24-runner-large-latest-arm64"
         );
         assert_eq!(args.storage_gib, Some(80));
+    }
+
+    #[test]
+    fn base_digest_policy_rejects_mutable_registry_references() {
+        assert!(require_digest_pinned_base(
+            "mirror.gcr.io/library/ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90"
+        )
+        .is_ok());
+        assert!(require_digest_pinned_base("/tmp/preloop.smolmachine").is_ok());
+        assert!(require_digest_pinned_base("ghcr.io/acme/base:latest").is_err());
+        assert!(require_digest_pinned_base("ghcr.io/acme/base@sha256:not-a-digest").is_err());
     }
 
     #[test]

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -634,7 +634,10 @@ fn require_digest_pinned_base(base_image: &str) -> anyhow::Result<()> {
     // policy applies to registry references only. Release workflows enable
     // this before baking so a mutable tag cannot silently become the golden's
     // input after the provenance sidecars were captured.
-    if base_image.starts_with('.') || base_image.starts_with('/') {
+    if base_image.starts_with('.')
+        || base_image.starts_with('/')
+        || std::path::Path::new(base_image).exists()
+    {
         return Ok(());
     }
     let digest = base_image

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -261,6 +261,8 @@ steps.
 | `PRELOOP_USE_PACKED_GOLDEN` | Use a release or locally cached packed golden (default on; set `false` for cold OCI provisioning) |
 | `PRELOOP_GOLDEN_URL` | Override the packed golden URL; checksum URL is this value plus `.sha256` |
 | `PRELOOP_RUNNER_BASE_IMAGE` | Override the digest-pinned Ubuntu base identity at serve time; set it with `PRELOOP_GOLDEN_URL` for a custom packed golden |
+| `PRELOOP_VERIFY_BASE_IMAGE` / `PRELOOP_VERIFY_BASE_IMAGE_REPO` | Require a digest-pinned OCI base's GitHub attestation and Cosign signature before `build-golden` |
+| `PRELOOP_REQUIRE_BASE_DIGEST` | Reject mutable registry tags during `build-golden` (used by release provenance builds) |
 | `PRELOOP_RUNNER_STORAGE_GB` | Persistent guest storage per runner and golden build (default 20 GiB; use 80 or more for full hosted-image snapshots) |
 | `PRELOOP_RUNNER_PACK_PROXY` | HTTP proxy for smolvm's separate registry export VM during golden packing; standard HTTP(S) proxy variables are fallbacks |
 | `PRELOOP_RUNNER_PACK_NO_PROXY` | Proxy bypass list for golden packing; `NO_PROXY` and `no_proxy` are fallbacks |

--- a/docs/vm-images.md
+++ b/docs/vm-images.md
@@ -199,13 +199,53 @@ before the golden is built:
 ```sh
 PRELOOP_VERIFY_BASE_IMAGE=1 \
 PRELOOP_VERIFY_BASE_IMAGE_REPO=acme/runner-image-blobs \
-preloop build-golden --base-image 'ghcr.io/acme/runner-images:ubuntu24-runner-large-latest-arm64' ...
+preloop build-golden --base-image 'ghcr.io/acme/runner-images@sha256:<digest>' ...
 ```
 
 `gh` and `cosign` must be installed on the build host. The signature identity
 is pinned to the publishing repository's `dump.yml` workflow on the default
 branch; override with `PRELOOP_BASE_IMAGE_IDENTITY_REGEXP` if the publishing
 workflow differs.
+
+### Golden provenance
+
+The stock base in `versions.toml` is served from `mirror.gcr.io`, Google's
+cache of the Docker Official Ubuntu image. It is not a Google-built Ubuntu
+image. The release workflow resolves the pinned digest, records the selected
+platform manifest and its OCI attestation descriptors, and preserves the
+upstream SPDX SBOM beside the golden. The cache is useful for availability and
+rate-limit avoidance; the digest and the upstream image metadata are the
+provenance inputs.
+
+Each release golden then receives:
+
+1. a SHA-256 checksum;
+2. a Cosign keyless blob signature (`<golden>.bundle`);
+3. a GitHub SLSA provenance attestation over the golden, the base evidence,
+   the upstream SBOM, and a signed provenance manifest;
+4. a `<golden>.provenance.json` record binding the golden hash to the exact
+   base index/platform digest and release workflow.
+
+Verify the golden's two independent signatures from an online build host:
+
+```sh
+cosign verify-blob \
+  --bundle preloop-ubuntu-24.04-aarch64.bundle \
+  --certificate-identity-regexp \
+    '^https://github.com/preloopdev/preloop/.github/workflows/release-golden.yml@refs/(heads/main|tags/)' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  preloop-ubuntu-24.04-aarch64
+
+gh attestation verify \
+  preloop-ubuntu-24.04-aarch64 \
+  --repo preloopdev/preloop
+```
+
+Release builds require the base to be digest-pinned with
+`PRELOOP_REQUIRE_BASE_DIGEST=1`. This protects the golden cache and the
+provenance record from mutable image tags. The stock image's attached SPDX
+SBOM is evidence about the upstream input; it is not treated as a Google
+signature or as a substitute for the Preloop golden attestation.
 
 ### Using a snapshot of the official hosted image
 

--- a/scripts/capture-base-provenance.py
+++ b/scripts/capture-base-provenance.py
@@ -80,6 +80,13 @@ def blob_url(registry: str, repository: str, digest: str) -> str:
     )
 
 
+def referrers_url(registry: str, repository: str, subject_digest: str) -> str:
+    return (
+        f"https://{registry}/v2/{quote(repository, safe='/')}/referrers/"
+        f"{quote(subject_digest, safe=':')}"
+    )
+
+
 def fetch(url: str, accept: str) -> bytes:
     try:
         result = subprocess.run(
@@ -164,6 +171,34 @@ def fetch_attestation(
     return fetch_manifest(registry, repository, digest)
 
 
+def is_attestation_descriptor(descriptor: dict, subject_digest: str) -> bool:
+    annotations = descriptor.get("annotations") or {}
+    return (
+        annotations.get("vnd.docker.reference.type") == "attestation-manifest"
+        and annotations.get("vnd.docker.reference.digest") == subject_digest
+    )
+
+
+def fetch_referrers(
+    registry: str, repository: str, subject_digest: str
+) -> list[dict]:
+    body = fetch(
+        referrers_url(registry, repository, subject_digest), ACCEPT_MANIFEST
+    )
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as error:
+        fail(f"referrers response for {subject_digest} is not valid JSON: {error}")
+    manifests = payload.get("manifests", [])
+    if not isinstance(manifests, list):
+        fail(f"referrers response for {subject_digest} has no manifests list")
+    return [
+        descriptor
+        for descriptor in manifests
+        if is_attestation_descriptor(descriptor, subject_digest)
+    ]
+
+
 def copy_spdx_blob(
     registry: str,
     repository: str,
@@ -178,14 +213,31 @@ def copy_spdx_blob(
     if actual != digest:
         fail(f"registry returned {actual} for SPDX blob {digest}")
     try:
-        json.loads(body)
+        parsed = json.loads(body)
     except json.JSONDecodeError as error:
         fail(f"SPDX blob {digest} is not valid JSON: {error}")
+    # BuildKit attaches the SPDX document as the predicate of an in-toto
+    # statement; consumers of the sidecar expect a bare SPDX JSON document,
+    # so unwrap the predicate before publishing it.
+    if isinstance(parsed, dict) and isinstance(parsed.get("predicate"), dict):
+        statement_type = parsed.get("_type")
+        if not isinstance(statement_type, str) or not statement_type.startswith(
+            "https://in-toto.io/Statement/"
+        ):
+            fail(
+                f"SPDX blob {digest} has a predicate but is not an in-toto "
+                "statement; refusing to guess its structure"
+            )
+        parsed = parsed["predicate"]
+    body = json.dumps(parsed, indent=2, sort_keys=True).encode("utf-8")
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_bytes(body)
     return {
         "path": output.name,
-        "digest": digest,
+        # The digest of the published sidecar (post-unwrap); the registry
+        # blob digest is kept as `source_digest` for the integrity check.
+        "digest": digest_bytes(body),
+        "source_digest": digest,
         "size": len(body),
         "media_type": layer.get("mediaType"),
         "predicate_type": (layer.get("annotations") or {}).get(
@@ -223,26 +275,31 @@ def main() -> None:
 
     source_annotations = platform_descriptor.get("annotations") or {}
     source = source_annotations.get("org.opencontainers.image.source")
-    if args.require_source_prefix and (
-        not isinstance(source, str) or not source.startswith(args.require_source_prefix)
-    ):
-        fail(
-            "base source annotation does not match the required prefix: "
-            f"{source!r} (expected {args.require_source_prefix!r})"
+    if args.require_source_prefix:
+        prefix = args.require_source_prefix
+        # Match the prefix itself or a path below it (`/` boundary) so a
+        # lookalike URL sharing the prefix string is not accepted.
+        matches = isinstance(source, str) and (
+            source == prefix or source.startswith(prefix + "/")
         )
+        if not matches:
+            fail(
+                "base source annotation does not match the required prefix: "
+                f"{source!r} (expected {prefix!r})"
+            )
 
-    attestation_descriptors = [
-        descriptor
-        for descriptor in index.get("manifests", [])
-        if (descriptor.get("annotations") or {}).get(
-            "vnd.docker.reference.type"
-        )
-        == "attestation-manifest"
-        and (descriptor.get("annotations") or {}).get(
-            "vnd.docker.reference.digest"
-        )
-        == platform_digest
-    ]
+    # Prefer the OCI referrers API: cosign-attached attestations (SBOMs,
+    # signatures) are registered as referrers of the platform manifest and
+    # are not necessarily listed in the (unmodified) index. Fall back to
+    # index-listed attestation descriptors for registries without referrers
+    # support.
+    attestation_descriptors = fetch_referrers(registry, repository, platform_digest)
+    if not attestation_descriptors:
+        attestation_descriptors = [
+            descriptor
+            for descriptor in index.get("manifests", [])
+            if is_attestation_descriptor(descriptor, platform_digest)
+        ]
 
     attestations = []
     sbom = None

--- a/scripts/capture-base-provenance.py
+++ b/scripts/capture-base-provenance.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Capture the immutable OCI evidence used to build a Preloop golden.
+
+The stock Ubuntu image is served from mirror.gcr.io, which is a Docker Hub
+cache rather than a Google-built image. This helper records the digest-pinned
+index, the selected platform manifest, and any OCI attestation manifests
+attached to that platform. When the image exposes an SPDX attestation, its
+SBOM blob is copied locally as well.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+from typing import NoReturn
+from urllib.parse import quote
+
+
+ACCEPT_MANIFEST = ", ".join(
+    [
+        "application/vnd.oci.image.index.v1+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.docker.distribution.manifest.v2+json",
+    ]
+)
+USER_AGENT = "preloop-base-provenance/1"
+
+
+def fail(message: str) -> NoReturn:
+    raise SystemExit(message)
+
+
+def digest_bytes(body: bytes) -> str:
+    return "sha256:" + hashlib.sha256(body).hexdigest()
+
+
+def parse_image(reference: str) -> tuple[str, str, str, str]:
+    name, separator, digest = reference.rpartition("@")
+    if not separator or not digest.startswith("sha256:"):
+        fail(f"{reference!r} must be pinned with @sha256:<digest>")
+    if len(digest.removeprefix("sha256:")) != 64 or any(
+        character not in "0123456789abcdef"
+        for character in digest.removeprefix("sha256:")
+    ):
+        fail(f"{reference!r} has an invalid sha256 digest")
+
+    parts = name.split("/")
+    if len(parts) == 1 or (
+        "." not in parts[0] and ":" not in parts[0] and parts[0] != "localhost"
+    ):
+        registry = "docker.io"
+        repository = "/".join(parts if len(parts) > 1 else ["library", parts[0]])
+    else:
+        registry = parts[0]
+        repository = "/".join(parts[1:])
+    if not repository:
+        fail(f"{reference!r} has no repository path")
+    repository_parts = repository.rsplit("/", 1)
+    if ":" in repository_parts[-1]:
+        repository_parts[-1] = repository_parts[-1].split(":", 1)[0]
+        repository = "/".join(repository_parts)
+    return registry, repository, digest, name
+
+
+def manifest_url(registry: str, repository: str, reference: str) -> str:
+    return (
+        f"https://{registry}/v2/{quote(repository, safe='/')}/manifests/"
+        f"{quote(reference, safe=':@')}"
+    )
+
+
+def blob_url(registry: str, repository: str, digest: str) -> str:
+    return (
+        f"https://{registry}/v2/{quote(repository, safe='/')}/blobs/"
+        f"{quote(digest, safe=':')}"
+    )
+
+
+def fetch(url: str, accept: str) -> bytes:
+    try:
+        result = subprocess.run(
+            [
+                "curl",
+                "--fail",
+                "--silent",
+                "--show-error",
+                "--location",
+                "--retry",
+                "4",
+                "--retry-all-errors",
+                "--connect-timeout",
+                "15",
+                "--max-time",
+                "120",
+                "--header",
+                f"Accept: {accept}",
+                "--user-agent",
+                USER_AGENT,
+                url,
+            ],
+            check=True,
+            capture_output=True,
+        )
+    except FileNotFoundError:
+        fail("curl is required to capture OCI base provenance")
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.decode("utf-8", "replace").strip()
+        fail(f"registry request failed for {url}: {detail}")
+    return result.stdout
+
+
+def fetch_manifest(registry: str, repository: str, digest: str) -> tuple[dict, str]:
+    body = fetch(manifest_url(registry, repository, digest), ACCEPT_MANIFEST)
+    actual = digest_bytes(body)
+    if actual != digest:
+        fail(f"registry returned {actual} for requested manifest {digest}")
+    try:
+        return json.loads(body), actual
+    except json.JSONDecodeError as error:
+        fail(f"registry returned invalid JSON for {digest}: {error}")
+
+
+def descriptor_summary(descriptor: dict) -> dict:
+    annotations = descriptor.get("annotations") or {}
+    platform = descriptor.get("platform") or {}
+    return {
+        key: value
+        for key, value in {
+            "digest": descriptor.get("digest"),
+            "media_type": descriptor.get("mediaType"),
+            "size": descriptor.get("size"),
+            "platform": platform or None,
+            "annotations": annotations or None,
+            "reference_type": annotations.get("vnd.docker.reference.type"),
+            "reference_digest": annotations.get("vnd.docker.reference.digest"),
+        }.items()
+        if value is not None
+    }
+
+
+def select_platform_descriptor(index: dict, os_name: str, architecture: str) -> dict:
+    for descriptor in index.get("manifests", []):
+        platform = descriptor.get("platform") or {}
+        annotations = descriptor.get("annotations") or {}
+        if (
+            platform.get("os") == os_name
+            and platform.get("architecture") == architecture
+            and annotations.get("vnd.docker.reference.type") != "attestation-manifest"
+        ):
+            return descriptor
+    fail(f"no {os_name}/{architecture} platform manifest found in the base index")
+
+
+def fetch_attestation(
+    registry: str, repository: str, descriptor: dict
+) -> tuple[dict, str]:
+    digest = descriptor.get("digest")
+    if not isinstance(digest, str):
+        fail("attestation descriptor has no digest")
+    return fetch_manifest(registry, repository, digest)
+
+
+def copy_spdx_blob(
+    registry: str,
+    repository: str,
+    layer: dict,
+    output: Path,
+) -> dict:
+    digest = layer.get("digest")
+    if not isinstance(digest, str):
+        fail("SPDX layer has no digest")
+    body = fetch(blob_url(registry, repository, digest), "application/json")
+    actual = digest_bytes(body)
+    if actual != digest:
+        fail(f"registry returned {actual} for SPDX blob {digest}")
+    try:
+        json.loads(body)
+    except json.JSONDecodeError as error:
+        fail(f"SPDX blob {digest} is not valid JSON: {error}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(body)
+    return {
+        "path": output.name,
+        "digest": digest,
+        "size": len(body),
+        "media_type": layer.get("mediaType"),
+        "predicate_type": (layer.get("annotations") or {}).get(
+            "in-toto.io/predicate-type"
+        ),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--image", required=True)
+    parser.add_argument("--platform", required=True, help="for example linux/amd64")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--sbom-output", type=Path, required=True)
+    parser.add_argument("--require-sbom", action="store_true")
+    parser.add_argument("--require-source-prefix")
+    args = parser.parse_args()
+
+    try:
+        os_name, architecture = args.platform.split("/", 1)
+    except ValueError:
+        fail(f"invalid platform {args.platform!r}; expected OS/ARCH")
+    if not os_name or not architecture:
+        fail(f"invalid platform {args.platform!r}; expected OS/ARCH")
+
+    registry, repository, index_digest, image_name = parse_image(args.image)
+    index, index_hash = fetch_manifest(registry, repository, index_digest)
+    platform_descriptor = select_platform_descriptor(index, os_name, architecture)
+    platform_digest = platform_descriptor.get("digest")
+    if not isinstance(platform_digest, str):
+        fail("platform descriptor has no digest")
+    platform_manifest, platform_hash = fetch_manifest(
+        registry, repository, platform_digest
+    )
+
+    source_annotations = platform_descriptor.get("annotations") or {}
+    source = source_annotations.get("org.opencontainers.image.source")
+    if args.require_source_prefix and (
+        not isinstance(source, str) or not source.startswith(args.require_source_prefix)
+    ):
+        fail(
+            "base source annotation does not match the required prefix: "
+            f"{source!r} (expected {args.require_source_prefix!r})"
+        )
+
+    attestation_descriptors = [
+        descriptor
+        for descriptor in index.get("manifests", [])
+        if (descriptor.get("annotations") or {}).get(
+            "vnd.docker.reference.type"
+        )
+        == "attestation-manifest"
+        and (descriptor.get("annotations") or {}).get(
+            "vnd.docker.reference.digest"
+        )
+        == platform_digest
+    ]
+
+    attestations = []
+    sbom = None
+    for descriptor in attestation_descriptors:
+        manifest, manifest_hash = fetch_attestation(
+            registry, repository, descriptor
+        )
+        layers = []
+        for layer in manifest.get("layers", []):
+            annotations = layer.get("annotations") or {}
+            predicate_type = annotations.get("in-toto.io/predicate-type")
+            summary = {
+                key: value
+                for key, value in {
+                    "digest": layer.get("digest"),
+                    "media_type": layer.get("mediaType"),
+                    "size": layer.get("size"),
+                    "predicate_type": predicate_type,
+                    "annotations": annotations or None,
+                }.items()
+                if value is not None
+            }
+            layers.append(summary)
+            if (
+                sbom is None
+                and predicate_type == "https://spdx.dev/Document"
+            ):
+                sbom = copy_spdx_blob(
+                    registry,
+                    repository,
+                    layer,
+                    args.sbom_output,
+                )
+        attestations.append(
+            {
+                "descriptor": descriptor_summary(descriptor),
+                "manifest_digest": descriptor.get("digest"),
+                "manifest_sha256": manifest_hash,
+                "layers": layers,
+            }
+        )
+
+    if args.require_sbom and sbom is None:
+        fail(
+            f"base {args.image} has no SPDX attestation for "
+            f"{os_name}/{architecture}"
+        )
+
+    evidence = {
+        "schema_version": 1,
+        "image": {
+            "reference": args.image,
+            "registry": registry,
+            "repository": repository,
+            "name_without_digest": image_name,
+            "index_digest": index_digest,
+            "index_sha256": index_hash,
+            "media_type": index.get("mediaType"),
+        },
+        "platform": {
+            "os": os_name,
+            "architecture": architecture,
+            "descriptor": descriptor_summary(platform_descriptor),
+            "manifest_digest": platform_digest,
+            "manifest_sha256": platform_hash,
+            "media_type": platform_manifest.get("mediaType"),
+            "annotations": source_annotations,
+        },
+        "attestations": attestations,
+        "sbom": sbom,
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(evidence, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(evidence, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/write-golden-provenance.py
+++ b/scripts/write-golden-provenance.py
@@ -35,6 +35,18 @@ def main() -> None:
     args = parser.parse_args()
 
     evidence = json.loads(args.base_evidence.read_text(encoding="utf-8"))
+    sbom_evidence = evidence.get("sbom")
+    if not isinstance(sbom_evidence, dict) or not sbom_evidence.get("digest"):
+        fail(
+            "base evidence has no SBOM record; refusing to bind an unrelated "
+            "SBOM to the golden"
+        )
+    sbom_sha = sha256(args.base_sbom)
+    if sbom_sha != sbom_evidence["digest"]:
+        fail(
+            f"base SBOM {args.base_sbom} sha256 {sbom_sha} does not match "
+            f"the base evidence digest {sbom_evidence['digest']}"
+        )
     platform = evidence["platform"]
     image = evidence["image"]
     predicate = {

--- a/scripts/write-golden-provenance.py
+++ b/scripts/write-golden-provenance.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Write the signed input/output manifest for one Preloop golden."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def file_record(path: Path) -> dict:
+    return {
+        "name": path.name,
+        "sha256": sha256(path),
+        "size": path.stat().st_size,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--golden", type=Path, required=True)
+    parser.add_argument("--base-evidence", type=Path, required=True)
+    parser.add_argument("--base-sbom", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    evidence = json.loads(args.base_evidence.read_text(encoding="utf-8"))
+    platform = evidence["platform"]
+    image = evidence["image"]
+    predicate = {
+        "schema_version": 1,
+        "type": "https://preloop.dev/provenance/golden/v1",
+        "subject": file_record(args.golden),
+        "base_image": {
+            "reference": image["reference"],
+            "index_digest": image["index_digest"],
+            "platform": f'{platform["os"]}/{platform["architecture"]}',
+            "platform_manifest_digest": platform["manifest_digest"],
+            "source": platform.get("annotations", {}).get(
+                "org.opencontainers.image.source"
+            ),
+            "source_revision": platform.get("annotations", {}).get(
+                "org.opencontainers.image.revision"
+            ),
+        },
+        "base_evidence": file_record(args.base_evidence),
+        "base_sbom": file_record(args.base_sbom),
+        "workflow": {
+            key: value
+            for key, value in {
+                "repository": os.environ.get("GITHUB_REPOSITORY"),
+                "workflow_ref": os.environ.get("GITHUB_WORKFLOW_REF"),
+                "commit": os.environ.get("GITHUB_SHA"),
+                "ref": os.environ.get("GITHUB_REF"),
+                "run_id": os.environ.get("GITHUB_RUN_ID"),
+                "run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT"),
+            }.items()
+            if value
+        },
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(predicate, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(predicate, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Capture digest-verified OCI index, selected platform manifest, attached attestation descriptors, and upstream SPDX SBOM for each Linux golden base.
- Fail closed on mutable base references for release golden builds and bind the exact base evidence to a deterministic provenance manifest.
- Sign and GitHub-attest the golden plus its base-evidence, SBOM, and provenance sidecars; preserve and publish those sidecars when reusing prior goldens.
- Document the mirror.gcr.io provenance model, verification commands, and the new digest policy.

## Validation

- `cargo test -p preloop-cli` — 142 passed.
- `just test-ci` — passed fmt-check, clippy, workspace tests, and conformance.
- `PRELOOP_PORT=63990 just dogfood` — passed; `job_succeeded=1`, `e2e_latency_ms=350815` (the default port was already occupied by an existing local server).
- Direct amd64/arm64 base-evidence capture, SPDX extraction, provenance-manifest smoke test, Python compilation, and release-workflow YAML parsing passed.

No live release publication was performed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens golden VM image provenance by capturing exact base image evidence and SBOM, digest‑pinning release bases, and signing/attesting all artifacts. Previously we allowed mutable tags and lacked base evidence; now we bind the golden to the exact base index/platform digest and publish verifiable sidecars without changing build outputs.

- Adds `scripts/capture-base-provenance.py` to record the digest‑verified index, selected platform manifest, and attached attestations; discovers via the OCI referrers API, unwraps in‑toto SPDX predicates to a bare SPDX JSON sidecar, and enforces a source‑prefix match on a path boundary.
- Adds `scripts/write-golden-provenance.py` to emit a deterministic `<golden>.provenance.json` that ties the golden hash to the base index/platform digest and workflow; verifies the base SBOM’s digest against captured evidence before binding.
- Release workflow resolves the golden identity/base where consumed, captures base evidence and SBOM, attests the golden plus sidecars in one GitHub attestation, and uploads/preserves sidecars (`.base-provenance.json`, `.base-sbom.spdx.json`, `.provenance.json`) including when reusing a prior golden.
- Enforces digest‑pinned bases for releases via `PRELOOP_REQUIRE_BASE_DIGEST=1`; local file inputs are exempt. Docs add verification commands and clarify the `mirror.gcr.io` cache model; CLI docs add `PRELOOP_VERIFY_BASE_IMAGE` and `PRELOOP_REQUIRE_BASE_DIGEST`.

- Migration
  - Use digest‑pinned base references (`...@sha256:<digest>`). Set `PRELOOP_REQUIRE_BASE_DIGEST=1` to fail local builds on mutable tags; local file bases continue to work.
  - To verify a release, run `cosign verify-blob` on the `.bundle` and `gh attestation verify` on the golden.

<sup>Written for commit 9243fbee829aea6f9384fc0afb885597133a1ad8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

