### PR TITLE
fix(cli): warn when queued jobs can never start (offline or runners control plane)

### DIFF
--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use base64::Engine as _;
 use clap::{Parser, Subcommand};
 use futures_util::StreamExt;
-use preloop_gha_protocol::{ExecutionStatus, NdjsonEvent, RunAccepted, WorkflowSubmission};
+use preloop_gha_protocol::{ExecutionStatus, NdjsonEvent, RunAccepted, RunId, WorkflowSubmission};
 use preloop_orchestrator::environment::{is_stock_base_image, DEFAULT_BASE_IMAGE};
 use preloop_orchestrator::{RunnerPool, RunnerPoolConfig};
 use preloop_vm::SmolVmProvider;
@@ -1666,8 +1666,11 @@ async fn cmd_run(args: RunArgs) -> anyhow::Result<()> {
     // folded into "no session".
     let mut poll_warned = false;
     // Warn once (not every backpressure tick) when the control plane is
-    // unreachable or has no registered runners, so a queued run does not
-    // stream `still waiting` forever without the one fact that explains it.
+    // unreachable or no registered runner can claim the queued jobs, so a
+    // queued run does not stream `still waiting` forever without the one
+    // fact that explains it. The check is repeated while a claimable runner
+    // exists (one can die between ticks) and latches only once a warning
+    // actually prints.
     let mut runner_warned = false;
     // Set when the run loop leaves through the debug prompt (abort, detach,
     // or a session error). The run is not terminal in those cases — the job
@@ -1765,21 +1768,37 @@ async fn cmd_run(args: RunArgs) -> anyhow::Result<()> {
                                          (preloop debug <id> to inspect)"
                                     );
                                     if !runner_warned {
-                                        runner_warned = true;
-                                        match registered_runner_count(&client, &url).await {
-                                            Ok(0) => eprintln!(
-                                                "[preloop] warning: no runners are registered \
-                                                 on {url}; queued jobs will never start unless \
-                                                 one appears. Is `preloop serve` running with \
-                                                 its runner pool?"
-                                            ),
+                                        match runner_capacity(&client, &url, accepted.run_id).await
+                                        {
+                                            Ok(Some((queued, claimable)))
+                                                if queued > 0 && claimable == 0 =>
+                                            {
+                                                runner_warned = true;
+                                                eprintln!(
+                                                    "[preloop] warning: no registered runner on \
+                                                     {url} can claim the queued jobs (their \
+                                                     `runs-on:` labels match no runner). If \
+                                                     `preloop serve` is still provisioning its \
+                                                     runner pool this is expected; otherwise the \
+                                                     jobs will never start — register a runner \
+                                                     with matching labels."
+                                                );
+                                            }
+                                            // A claimable runner exists (or nothing
+                                            // runner-bound is queued): keep checking on
+                                            // later ticks instead of latching a premature
+                                            // "all quiet" state.
                                             Ok(_) => {}
-                                            Err(error) => eprintln!(
-                                                "[preloop] warning: cannot check for runners on \
-                                                 {url} ({error:#}); queued jobs will not start \
-                                                 unless the control plane is back. Is \
-                                                 `preloop serve` still running?"
-                                            ),
+                                            Err(error) => {
+                                                runner_warned = true;
+                                                eprintln!(
+                                                    "[preloop] warning: cannot determine runner \
+                                                     availability on {url} ({error:#}); older \
+                                                     control plane without /api/v1/runners or a \
+                                                     transient error. Queued jobs may still \
+                                                     start if a runner is registered."
+                                                );
+                                            }
                                         }
                                     }
                                     last_backpressure = std::time::Instant::now();
@@ -1912,14 +1931,21 @@ fn same_file_path(left: &std::path::Path, right: &std::path::Path) -> bool {
     }
 }
 
-/// Number of runners currently registered with the control plane.
+/// Registered-runner capacity for a run's queued jobs, when the control
+/// plane supports the run-scoped runners query.
 ///
-/// The `preloop run` watcher uses this to distinguish "waiting for pool
-/// capacity" from "nothing will ever pick the job up": zero registered
-/// runners means the queued jobs are stuck no matter how long the stream is
-/// held open.
-async fn registered_runner_count(client: &reqwest::Client, url: &str) -> anyhow::Result<usize> {
-    let mut request = client.get(format!("{url}/api/v1/runners"));
+/// Returns `(queued, claimable)`: the run's ready-queue job count, and how
+/// many registered runners could claim at least one of them (the same
+/// `job_matches_runner` predicate the scheduler dispatches with). `None`
+/// when the server ignores `run_id` and returns the plain list — the caller
+/// then falls back to the raw count so a zero-runner control plane still
+/// gets the warning.
+async fn runner_capacity(
+    client: &reqwest::Client,
+    url: &str,
+    run_id: RunId,
+) -> anyhow::Result<Option<(usize, usize)>> {
+    let mut request = client.get(format!("{url}/api/v1/runners?run_id={run_id}"));
     if let Some(token) = api_token() {
         request = request.bearer_auth(token);
     }
@@ -1928,10 +1954,22 @@ async fn registered_runner_count(client: &reqwest::Client, url: &str) -> anyhow:
         anyhow::bail!("server returned {}", response.status());
     }
     let body: serde_json::Value = response.json().await?;
-    Ok(body
-        .get("count")
-        .and_then(serde_json::Value::as_u64)
-        .unwrap_or(0) as usize)
+    match (
+        body.get("queued").and_then(serde_json::Value::as_u64),
+        body.get("claimable").and_then(serde_json::Value::as_u64),
+    ) {
+        (Some(queued), Some(claimable)) => Ok(Some((queued as usize, claimable as usize))),
+        // Older server (or one ignoring the query): only the raw count is
+        // available; treat every registered runner as claimable so the
+        // check degrades to the pre-run-scoped behavior.
+        _ => {
+            let count = body
+                .get("count")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0) as usize;
+            Ok(Some((count, count)))
+        }
+    }
 }
 
 fn update_run_status(current: &mut Option<ExecutionStatus>, next: Option<ExecutionStatus>) {

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -1633,7 +1633,9 @@ async fn cmd_run(args: RunArgs) -> anyhow::Result<()> {
     if let Some(token) = api_token() {
         request = request.bearer_auth(token);
     }
-    let response = request.send().await?;
+    let response = request.send().await.with_context(|| {
+        format!("cannot reach control plane at {url}; is `preloop serve` running?")
+    })?;
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
@@ -1663,6 +1665,10 @@ async fn cmd_run(args: RunArgs) -> anyhow::Result<()> {
     // explanation, so the first poll failure is reported instead of being
     // folded into "no session".
     let mut poll_warned = false;
+    // Warn once (not every backpressure tick) when the control plane is
+    // unreachable or has no registered runners, so a queued run does not
+    // stream `still waiting` forever without the one fact that explains it.
+    let mut runner_warned = false;
     // Set when the run loop leaves through the debug prompt (abort, detach,
     // or a session error). The run is not terminal in those cases — the job
     // is paused and reattachable — so the generic conclusion below must not
@@ -1681,7 +1687,9 @@ async fn cmd_run(args: RunArgs) -> anyhow::Result<()> {
         if let Some(token) = api_token() {
             events_request = events_request.bearer_auth(token);
         }
-        let events_response = events_request.send().await?;
+        let events_response = events_request.send().await.with_context(|| {
+            format!("cannot reach control plane at {url}; is `preloop serve` still running?")
+        })?;
         if !events_response.status().is_success() {
             let status = events_response.status();
             let body = events_response.text().await.unwrap_or_default();
@@ -1756,6 +1764,24 @@ async fn cmd_run(args: RunArgs) -> anyhow::Result<()> {
                                          {paused_total} debug session(s) paused on the server \
                                          (preloop debug <id> to inspect)"
                                     );
+                                    if !runner_warned {
+                                        runner_warned = true;
+                                        match registered_runner_count(&client, &url).await {
+                                            Ok(0) => eprintln!(
+                                                "[preloop] warning: no runners are registered \
+                                                 on {url}; queued jobs will never start unless \
+                                                 one appears. Is `preloop serve` running with \
+                                                 its runner pool?"
+                                            ),
+                                            Ok(_) => {}
+                                            Err(error) => eprintln!(
+                                                "[preloop] warning: cannot check for runners on \
+                                                 {url} ({error:#}); queued jobs will not start \
+                                                 unless the control plane is back. Is \
+                                                 `preloop serve` still running?"
+                                            ),
+                                        }
+                                    }
                                     last_backpressure = std::time::Instant::now();
                                 }
                             }
@@ -1884,6 +1910,28 @@ fn same_file_path(left: &std::path::Path, right: &std::path::Path) -> bool {
         (Ok(left), Ok(right)) => left == right,
         _ => left == right,
     }
+}
+
+/// Number of runners currently registered with the control plane.
+///
+/// The `preloop run` watcher uses this to distinguish "waiting for pool
+/// capacity" from "nothing will ever pick the job up": zero registered
+/// runners means the queued jobs are stuck no matter how long the stream is
+/// held open.
+async fn registered_runner_count(client: &reqwest::Client, url: &str) -> anyhow::Result<usize> {
+    let mut request = client.get(format!("{url}/api/v1/runners"));
+    if let Some(token) = api_token() {
+        request = request.bearer_auth(token);
+    }
+    let response = request.send().await?;
+    if !response.status().is_success() {
+        anyhow::bail!("server returned {}", response.status());
+    }
+    let body: serde_json::Value = response.json().await?;
+    Ok(body
+        .get("count")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0) as usize)
 }
 
 fn update_run_status(current: &mut Option<ExecutionStatus>, next: Option<ExecutionStatus>) {

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -1960,14 +1960,19 @@ async fn runner_capacity(
     ) {
         (Some(queued), Some(claimable)) => Ok(Some((queued as usize, claimable as usize))),
         // Older server (or one ignoring the query): only the raw count is
-        // available; treat every registered runner as claimable so the
-        // check degrades to the pre-run-scoped behavior.
+        // available. When count is zero, represent that as 0 claimable runners
+        // for the queued jobs so the dead-pool warning fires. When count > 0,
+        // treat runners as claimable (optimistic fallback).
         _ => {
             let count = body
                 .get("count")
                 .and_then(serde_json::Value::as_u64)
                 .unwrap_or(0) as usize;
-            Ok(Some((count, count)))
+            if count == 0 {
+                Ok(Some((1, 0)))
+            } else {
+                Ok(Some((count, count)))
+            }
         }
     }
 }

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -749,7 +749,17 @@ async fn openapi_document_lists_native_surface_and_excludes_runner_protocol() {
     assert!(!paths.keys().any(|path| path.starts_with("/_apis/")));
     assert!(!paths.keys().any(|path| path.starts_with("/broker/")));
     assert!(!paths.contains_key("/api/v1/scheduler/history"));
-    assert!(!paths.contains_key("/api/v1/runners"));
+    // The read-only runner listing is native operator surface (the CLI uses
+    // it to diagnose a dead pool); registration itself stays undocumented.
+    assert!(paths.contains_key("/api/v1/runners"));
+    assert_eq!(
+        paths["/api/v1/runners"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .collect::<Vec<_>>(),
+        vec!["get"]
+    );
 }
 
 #[tokio::test]
@@ -2609,6 +2619,59 @@ async fn registration_persists_runner_public_key_material() {
     let inner = state.inner.lock().await;
     assert_eq!(inner.runner_public_keys.get(&runner_id), Some(&public_key));
     assert!(inner.runner_rsa_public_keys.contains_key(&runner_id));
+}
+
+#[tokio::test]
+async fn native_runner_list_reports_registered_runners() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+
+    // No runners yet: the CLI must be able to distinguish this from a
+    // healthy pool before it prints `still waiting` forever.
+    let empty = request_json(&app, Method::GET, "/api/v1/runners", Value::Null).await;
+    assert_eq!(empty["count"].as_u64(), Some(0));
+    assert_eq!(empty["runners"].as_array().map(Vec::len), Some(0));
+
+    let runner = request_json(
+        &app,
+        Method::POST,
+        "/api/v1/runners",
+        json!({
+            "name": "local",
+            "labels": ["self-hosted", "linux", "x64"]
+        }),
+    )
+    .await;
+    let runner_id = runner["id"].as_i64().unwrap();
+
+    let listed = request_json(&app, Method::GET, "/api/v1/runners", Value::Null).await;
+    assert_eq!(listed["count"].as_u64(), Some(1));
+    let runners = listed["runners"].as_array().unwrap();
+    assert_eq!(runners.len(), 1);
+    assert_eq!(runners[0]["id"].as_i64(), Some(runner_id));
+    assert_eq!(runners[0]["name"].as_str(), Some("local"));
+    let labels: Vec<&str> = runners[0]["labels"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|label| label.as_str())
+        .collect();
+    assert_eq!(labels, vec!["self-hosted", "linux", "x64"]);
+
+    // The endpoint is native-bearer gated.
+    let unauthorized = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/v1/runners")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
 }
 
 #[tokio::test]

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -2740,6 +2740,31 @@ async fn native_runner_list_run_scoped_claimable() {
     assert_eq!(listed["count"].as_u64(), Some(1));
     assert_eq!(listed["queued"].as_u64(), Some(1));
     assert_eq!(listed["claimable"].as_u64(), Some(0));
+
+    // Unclaimable: a job requiring a specific runner group when the registered
+    // runner belongs to a different group (here, default group) is unclaimable.
+    let accepted = request_json(
+        &app,
+        Method::POST,
+        "/api/v1/runs",
+        json!({
+            "workflow_yaml": "on: push\njobs:\n  build:\n    runs-on:\n      group: specialized-group\n      labels: [linux]\n    steps:\n      - run: echo hi\n",
+            "event": "push",
+            "repository": "owner/repo",
+        }),
+    )
+    .await;
+    let run_id = accepted["run_id"].as_str().unwrap().to_owned();
+    let listed = request_json(
+        &app,
+        Method::GET,
+        &format!("/api/v1/runners?run_id={run_id}"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(listed["count"].as_u64(), Some(1));
+    assert_eq!(listed["queued"].as_u64(), Some(1));
+    assert_eq!(listed["claimable"].as_u64(), Some(0));
 }
 
 #[tokio::test]

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -2675,6 +2675,74 @@ async fn native_runner_list_reports_registered_runners() {
 }
 
 #[tokio::test]
+async fn native_runner_list_run_scoped_claimable() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+
+    // A Linux pool runner is registered, so the raw runner count is positive.
+    // The CLI's dead-pool warning must key off runners that can actually
+    // claim the queued work, not the count.
+    request_json(
+        &app,
+        Method::POST,
+        "/api/v1/runners",
+        json!({"name": "pool-linux", "labels": ["self-hosted", "linux"]}),
+    )
+    .await;
+
+    // Claimable: a `runs-on: linux` job matches the registered runner.
+    let accepted = request_json(
+        &app,
+        Method::POST,
+        "/api/v1/runs",
+        json!({
+            "workflow_yaml": "on: push\njobs:\n  build:\n    runs-on: linux\n    steps:\n      - run: echo hi\n",
+            "event": "push",
+            "repository": "owner/repo",
+        }),
+    )
+    .await;
+    let run_id = accepted["run_id"].as_str().unwrap().to_owned();
+    let listed = request_json(
+        &app,
+        Method::GET,
+        &format!("/api/v1/runners?run_id={run_id}"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(listed["count"].as_u64(), Some(1));
+    assert_eq!(listed["queued"].as_u64(), Some(1));
+    assert_eq!(listed["claimable"].as_u64(), Some(1));
+
+    // Unclaimable: a job whose `runs-on` labels no registered runner carries
+    // (here a custom label) stays queued — the scheduler only fails jobs with
+    // no OS runner — so the raw count alone would hide the dead end.
+    let accepted = request_json(
+        &app,
+        Method::POST,
+        "/api/v1/runs",
+        json!({
+            "workflow_yaml": "on: push\njobs:\n  build:\n    runs-on: custom-runs-on\n    steps:\n      - run: echo hi\n",
+            "event": "push",
+            "repository": "owner/repo",
+        }),
+    )
+    .await;
+    let run_id = accepted["run_id"].as_str().unwrap().to_owned();
+    let listed = request_json(
+        &app,
+        Method::GET,
+        &format!("/api/v1/runners?run_id={run_id}"),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(listed["count"].as_u64(), Some(1));
+    assert_eq!(listed["queued"].as_u64(), Some(1));
+    assert_eq!(listed["claimable"].as_u64(), Some(0));
+}
+
+#[tokio::test]
 async fn session_key_uses_registered_runner_public_key() {
     let temp = tempfile::tempdir().unwrap();
     let runner_keypair = AgentRsaKeypair::generate().unwrap();

--- a/crates/preloop-runner-server/src/openapi.rs
+++ b/crates/preloop-runner-server/src/openapi.rs
@@ -597,6 +597,9 @@ fn github_callback() {}
 /// Registered runners (read-only; used by the CLI to detect a dead pool).
 #[utoipa::path(
     get, path = "/api/v1/runners", tag = "Runners",
+    params(
+        ("run_id" = Option<String>, Query, description = "Run UUID; when present, `queued` and `claimable` report how many of the run's queued jobs no registered runner could claim")
+    ),
     responses(
         (status = 200, description = "Registered runners with labels", body = JsonValue)
     ),

--- a/crates/preloop-runner-server/src/openapi.rs
+++ b/crates/preloop-runner-server/src/openapi.rs
@@ -598,7 +598,7 @@ fn github_callback() {}
 #[utoipa::path(
     get, path = "/api/v1/runners", tag = "Runners",
     params(
-        ("run_id" = Option<String>, Query, description = "Run UUID; when present, `queued` and `claimable` report how many of the run's queued jobs no registered runner could claim")
+        ("run_id" = Option<String>, Query, description = "Run UUID; when present, `queued` is the number of the run's jobs awaiting a runner and `claimable` is the number of registered runners matching at least one of those queued jobs")
     ),
     responses(
         (status = 200, description = "Registered runners with labels", body = JsonValue)

--- a/crates/preloop-runner-server/src/openapi.rs
+++ b/crates/preloop-runner-server/src/openapi.rs
@@ -174,7 +174,8 @@ pub(crate) struct RunResponse {
         artifact,
         github_webhook,
         github_register,
-        github_callback
+        github_callback,
+        list_runners
     ),
     components(
         schemas(
@@ -592,3 +593,13 @@ fn github_register() {}
     responses((status = 200, content_type = "text/html", description = "App credentials page", body = String))
 )]
 fn github_callback() {}
+
+/// Registered runners (read-only; used by the CLI to detect a dead pool).
+#[utoipa::path(
+    get, path = "/api/v1/runners", tag = "Runners",
+    responses(
+        (status = 200, description = "Registered runners with labels", body = JsonValue)
+    ),
+    security(("native_bearer" = []))
+)]
+fn list_runners() {}

--- a/crates/preloop-runner-server/src/routes.rs
+++ b/crates/preloop-runner-server/src/routes.rs
@@ -554,10 +554,12 @@ pub(crate) fn build_app(
         )
         .route(
             "/api/v1/runners",
-            post(register_runner_native).route_layer(middleware::from_fn_with_state(
-                shared.clone(),
-                require_native_bearer,
-            )),
+            post(register_runner_native)
+                .get(list_runners_native)
+                .route_layer(middleware::from_fn_with_state(
+                    shared.clone(),
+                    require_native_bearer,
+                )),
         )
         .route(
             "/api/v1/runners/purge",

--- a/crates/preloop-runner-server/src/runner_lifecycle.rs
+++ b/crates/preloop-runner-server/src/runner_lifecycle.rs
@@ -153,12 +153,10 @@ pub(crate) async fn list_runners_native(
             .runners
             .values()
             .filter(|runner| {
+                let caps = crate::runtime_scheduling::capabilities_of(runner);
                 inner.queue.iter().any(|job| {
                     job.run_id == run_id
-                        && crate::runtime_scheduling::job_matches_runner(
-                            &job.runs_on,
-                            &runner.labels,
-                        )
+                        && crate::runtime_scheduling::job_matches_runner_capabilities(job, &caps)
                 })
             })
             .count();

--- a/crates/preloop-runner-server/src/runner_lifecycle.rs
+++ b/crates/preloop-runner-server/src/runner_lifecycle.rs
@@ -104,14 +104,26 @@ pub(crate) async fn register_runner_native(
     Ok(Json(runner))
 }
 
+/// Optional run-scoped query for [`list_runners_native`].
+#[derive(Debug, Deserialize)]
+pub(crate) struct RunnerListQuery {
+    #[serde(default)]
+    run_id: Option<RunId>,
+}
+
 /// GET /api/v1/runners — list the runners currently registered with the
 /// control plane.
 ///
 /// Read-only operator surface (native bearer). The CLI uses it to tell a
-/// queued run apart from a dead one: zero runners means no job will ever be
-/// picked up, however long `still waiting` prints.
+/// queued run apart from a dead one: with `?run_id=`, `queued` and
+/// `claimable` report whether any registered runner could actually claim the
+/// run's ready-queue jobs. Zero claimable means no job will ever be picked
+/// up, however long `still waiting` prints — even when other runners are
+/// registered whose labels match nothing in the queue. Without `run_id` the
+/// response is the plain list.
 pub(crate) async fn list_runners_native(
     State(shared): State<Arc<SharedState>>,
+    Query(query): Query<RunnerListQuery>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let inner = shared.state.inner.lock().await;
     let runners: Vec<serde_json::Value> = inner
@@ -125,10 +137,35 @@ pub(crate) async fn list_runners_native(
             })
         })
         .collect();
-    Ok(Json(json!({
+    let mut response = json!({
         "count": runners.len(),
         "runners": runners,
-    })))
+    });
+    if let Some(run_id) = query.run_id {
+        let queued = inner
+            .queue
+            .iter()
+            .filter(|job| job.run_id == run_id)
+            .count();
+        // A runner is claimable when it matches at least one of the run's
+        // queued jobs under the same predicate the scheduler dispatches with.
+        let claimable = inner
+            .runners
+            .values()
+            .filter(|runner| {
+                inner.queue.iter().any(|job| {
+                    job.run_id == run_id
+                        && crate::runtime_scheduling::job_matches_runner(
+                            &job.runs_on,
+                            &runner.labels,
+                        )
+                })
+            })
+            .count();
+        response["queued"] = json!(queued);
+        response["claimable"] = json!(claimable);
+    }
+    Ok(Json(response))
 }
 
 pub(crate) async fn create_session(

--- a/crates/preloop-runner-server/src/runner_lifecycle.rs
+++ b/crates/preloop-runner-server/src/runner_lifecycle.rs
@@ -104,6 +104,33 @@ pub(crate) async fn register_runner_native(
     Ok(Json(runner))
 }
 
+/// GET /api/v1/runners — list the runners currently registered with the
+/// control plane.
+///
+/// Read-only operator surface (native bearer). The CLI uses it to tell a
+/// queued run apart from a dead one: zero runners means no job will ever be
+/// picked up, however long `still waiting` prints.
+pub(crate) async fn list_runners_native(
+    State(shared): State<Arc<SharedState>>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let inner = shared.state.inner.lock().await;
+    let runners: Vec<serde_json::Value> = inner
+        .runners
+        .values()
+        .map(|runner| {
+            json!({
+                "id": runner.id,
+                "name": runner.name,
+                "labels": runner.labels,
+            })
+        })
+        .collect();
+    Ok(Json(json!({
+        "count": runners.len(),
+        "runners": runners,
+    })))
+}
+
 pub(crate) async fn create_session(
     State(shared): State<Arc<SharedState>>,
     Json(request): Json<RunnerSessionRequest>,

--- a/crates/preloop-runner-server/src/runtime_scheduling.rs
+++ b/crates/preloop-runner-server/src/runtime_scheduling.rs
@@ -1585,7 +1585,7 @@ pub(crate) fn clear_assignment(inner: &mut InnerState, run_id: RunId, job_id: &J
         .any(|job| job.run_id == run_id && job.job_id == *job_id)
 }
 
-fn capabilities_of(runner: &RegisteredRunner) -> RunnerCapabilities {
+pub(crate) fn capabilities_of(runner: &RegisteredRunner) -> RunnerCapabilities {
     RunnerCapabilities {
         known: true,
         labels: runner.labels.clone(),


### PR DESCRIPTION


preloop run streamed '[preloop] still waiting: N job(s) queued' forever when no runner was registered, or failed with a bare connection error when serve was down.

- Add GET /api/v1/runners (native bearer): registered runners with labels; documented in the native OpenAPI surface.
- cmd_run now wraps the submit and event-stream sends with a 'cannot reach control plane at {url}; is preloop serve running?' context, and on the first backpressure tick checks runner registration: zero runners gets an explicit warning that queued jobs will never start unless one appears.

## What & why

<!-- What this change does and the problem it solves. Link the issue if there is one. -->

## Protocol surface

<!--
Check whether this change touches the core runner protocol interface:
  - registration / `/_apis/...` request and response shapes
  - broker messages (job request, complete, renew) and NDJSON event shapes
  - Twirp results-service / artifact-service payloads
  - check-run or OAuth wire behavior

If it does, the gates below are REQUIRED before merge — preloop's compatibility
contract is byte-for-byte fidelity with the official runner (v2.336.0).
-->

- [ ] I confirm this change touches the runner protocol interface: **YES / NO**

## Required gates

- [ ] `just test-ci` passes locally (fmt-check + clippy `-D` + full test suite + runner-watch conformance)
- [ ] If protocol/wire shapes changed: the change is validated against the official runner (golden replay via `runner-watch`, or a live capture showing the official bytes), not only unit tests
- [ ] If the touched subsystem has property tests (`concurrency_properties`, scheduling, matrix expansion, …): they are extended for the changed contract and pass (`PROPTEST_CASES=256 cargo test -p preloop-runner-server`)
- [ ] New wire fields/events are additive and serde-defaulted where the official runner would not send them
- [ ] No secrets, credentials, or internal/deployment-specific paths are introduced (captures with live tokens must be redacted or excluded)

## Verification performed

<!-- Concrete evidence: commands run, test names, capture outputs. -->

## Checklist

- [ ] Tests added/updated for any new observable contract
- [ ] Docs updated (`docs/`, `CONTRIBUTING.md`) where behavior changed
- [ ] Changelog-worthy user-facing change described in the PR body

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warns when queued runs can never start due to an offline control plane or no claimable runners. Previously `preloop run` streamed “still waiting” forever or failed with a bare connection error.

- CLI: wraps run submission and event-stream sends with a “cannot reach control plane at {url}” context; on backpressure ticks queries `GET /api/v1/runners?run_id=` and prints a one-time warning when `queued > 0` and `claimable == 0`; keeps rechecking while any claimable runner exists; falls back on older servers to `count` (including `count == 0` triggers the dead‑pool warning).
- Server: adds `GET /api/v1/runners` (native bearer). With `run_id`, returns `queued` and `claimable` computed with the scheduler’s `job_matches_runner_capabilities` and runner group constraints; documents the endpoint in OpenAPI; exposes `capabilities_of` for consistent matching; tests cover listing, auth gating, and run‑scoped claimability.

<sup>Written for commit 1013dacf7b9e345c378f570941a74377adad2392. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated runner-listing endpoint showing registered runners, IDs, labels, and availability.
  * Added optional run-specific capacity details, including queued jobs and runners able to claim them.
  * CLI now displays warnings when queued jobs have no available matching runner capacity.

* **Bug Fixes**
  * Improved error messages when run submissions or event-stream requests cannot reach the control plane.

* **Tests**
  * Expanded coverage for runner listings, authentication, filtering, and capacity reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->