### PR TITLE
fix(snapshots): drop gitlinks no .gitmodules url resolves

### DIFF
--- a/crates/preloop-cli/src/update.rs
+++ b/crates/preloop-cli/src/update.rs
@@ -295,13 +295,6 @@ async fn probe_smolvm_version(binary: &Path) -> Option<String> {
         .map(|version| version.trim_start_matches('v').to_owned())
 }
 
-fn smolvm_release_repository() -> String {
-    std::env::var("PRELOOP_SMOLVM_RELEASE_REPOSITORY")
-        .ok()
-        .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| SMOLVM_REPOSITORY.to_owned())
-}
-
 fn smolvm_release_version() -> String {
     std::env::var("PRELOOP_SMOLVM_RELEASE_VERSION")
         .ok()
@@ -328,7 +321,6 @@ async fn ensure_smolvm(client: &Client) -> anyhow::Result<()> {
             std::env::consts::ARCH
         )
     })?;
-    let repository = smolvm_release_repository();
     let release = fetch_release(
         client,
         &format!("https://api.github.com/repos/{SMOLVM_REPOSITORY}/releases"),

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -12778,6 +12778,76 @@ async fn snapshot_drops_unresolvable_gitlinks_but_keeps_registered_submodules() 
 }
 
 #[tokio::test]
+async fn snapshot_gitlink_resolution_matches_git() {
+    let temp = tempfile::tempdir().unwrap();
+    let (state_dir, workspace) = create_snapshot_fixture(temp.path());
+
+    // The keep/drop decision must mirror git's own resolution: git resolves a
+    // gitlink by the section whose `path` matches it. Three registration
+    // shapes git handles but a naive parser gets wrong:
+    //   `a#b`         git writes and decodes this path QUOTED in .gitmodules
+    //   `mixed`       [SUBMODULE]/Path/URL: config sections and keys are
+    //                 case-insensitive for git
+    //   `logical-only` section name only; its `path` points elsewhere, so a
+    //                 gitlink at the name itself is NOT resolvable
+    for path in ["a#b", "mixed", "logical-only"] {
+        let nested = workspace.join(path);
+        fs::create_dir_all(&nested).unwrap();
+        git_fixture_command(&nested, &["init", "-q", "-b", "main"]);
+        git_fixture_command(&nested, &["config", "user.email", "nested@example.test"]);
+        fs::write(nested.join("payload.txt"), format!("{path}\n")).unwrap();
+        git_fixture_command(&nested, &["add", "payload.txt"]);
+        git_fixture_command(&nested, &["commit", "-qm", path]);
+        let tip = String::from_utf8(git_fixture_output(&nested, &["rev-parse", "HEAD"]))
+            .unwrap()
+            .trim()
+            .to_owned();
+        let cacheinfo = format!("160000,{tip},{path}");
+        git_fixture_command(
+            &workspace,
+            &["update-index", "--add", "--cacheinfo", cacheinfo.as_str()],
+        );
+    }
+    fs::write(
+        workspace.join(".gitmodules"),
+        "[submodule \"a#b\"]\n\tpath = \"a#b\"\n\turl = https://example.test/a-b.git\n\
+         [SUBMODULE \"mixed\"]\n\tPath = mixed\n\tURL = https://example.test/mixed.git\n\
+         [submodule \"logical-only\"]\n\tpath = elsewhere\n\turl = https://example.test/elsewhere.git\n",
+    )
+    .unwrap();
+
+    fs::create_dir_all(&state_dir).unwrap();
+    let run_id: RunId = "77777777-7777-4777-8777-777777777777".parse().unwrap();
+    let snapshot = create_workspace_snapshot(&state_dir, &workspace, run_id, None)
+        .await
+        .expect("snapshot with mixed gitlink registrations should succeed");
+    let repository = state_dir.join(&snapshot.repository);
+    let tree_of = |path: &str| {
+        String::from_utf8(git_fixture_output(
+            &repository,
+            &["ls-tree", snapshot.commit_sha.as_str(), "--", path],
+        ))
+        .unwrap()
+    };
+
+    let quoted = tree_of("a#b");
+    assert!(
+        quoted.starts_with("160000"),
+        "quoted registered path must survive the snapshot: {quoted}"
+    );
+    let mixed = tree_of("mixed");
+    assert!(
+        mixed.starts_with("160000"),
+        "mixed-case registered section must survive the snapshot: {mixed}"
+    );
+    let name_only = tree_of("logical-only");
+    assert!(
+        name_only.is_empty(),
+        "name-only gitlink must be dropped from the snapshot: {name_only}"
+    );
+}
+
+#[tokio::test]
 async fn workspace_snapshot_captures_git_state_without_mutating_source() {
     let temp = tempfile::tempdir().unwrap();
     let (state_dir, workspace) = create_snapshot_fixture(temp.path());

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -12675,6 +12675,79 @@ async fn workspace_snapshot_survives_refs_with_missing_objects() {
 }
 
 #[tokio::test]
+async fn snapshot_drops_unresolvable_gitlinks_but_keeps_registered_submodules() {
+    let temp = tempfile::tempdir().unwrap();
+    let (state_dir, workspace) = create_snapshot_fixture(temp.path());
+
+    // A nested repo added by hand: the parent index gets a gitlink entry
+    // but no `.gitmodules` registers it — the state that makes
+    // `git submodule foreach` inside the VM fail with `fatal: No url found
+    // for submodule path 'stream-docker-output' in .gitmodules`.
+    let nested = workspace.join("stream-docker-output");
+    fs::create_dir_all(&nested).unwrap();
+    git_fixture_command(&nested, &["init", "-q", "-b", "main"]);
+    git_fixture_command(&nested, &["config", "user.email", "nested@example.test"]);
+    fs::write(nested.join("payload.txt"), "nested\n").unwrap();
+    git_fixture_command(&nested, &["add", "payload.txt"]);
+    git_fixture_command(&nested, &["commit", "-qm", "nested"]);
+    let nested_tip = String::from_utf8(git_fixture_output(&nested, &["rev-parse", "HEAD"]))
+        .unwrap()
+        .trim()
+        .to_owned();
+    let cacheinfo = format!("160000,{nested_tip},stream-docker-output");
+    git_fixture_command(
+        &workspace,
+        &["update-index", "--add", "--cacheinfo", cacheinfo.as_str()],
+    );
+
+    fs::create_dir_all(&state_dir).unwrap();
+    let first_run: RunId = "44444444-4444-4444-8444-444444444444".parse().unwrap();
+    let first = create_workspace_snapshot(&state_dir, &workspace, first_run, None)
+        .await
+        .expect("snapshot with an unresolvable gitlink should succeed");
+    let first_repository = state_dir.join(&first.repository);
+    let (_, output) = git_fixture_output_allow_failure(
+        &first_repository,
+        &[
+            "ls-tree",
+            &format!("{}:stream-docker-output", first.commit_sha),
+        ],
+    );
+    assert!(
+        output.is_empty(),
+        "unresolvable gitlink must be dropped from the snapshot: {}",
+        String::from_utf8_lossy(&output)
+    );
+
+    // Register the submodule properly: the gitlink must then survive so a
+    // workflow asking for submodules gets the real structure.
+    fs::write(
+        workspace.join(".gitmodules"),
+        "[submodule \"stream-docker-output\"]\n\tpath = stream-docker-output\n\turl = https://example.test/stream-docker-output.git\n",
+    )
+    .unwrap();
+    let second_run: RunId = "55555555-5555-4555-8555-555555555555".parse().unwrap();
+    let second = create_workspace_snapshot(&state_dir, &workspace, second_run, None)
+        .await
+        .expect("snapshot with a registered submodule should succeed");
+    let second_repository = state_dir.join(&second.repository);
+    let listed = String::from_utf8(git_fixture_output(
+        &second_repository,
+        &[
+            "ls-tree",
+            second.commit_sha.as_str(),
+            "--",
+            "stream-docker-output",
+        ],
+    ))
+    .unwrap();
+    assert!(
+        listed.starts_with("160000"),
+        "a registered submodule gitlink must survive the snapshot: {listed}"
+    );
+}
+
+#[tokio::test]
 async fn workspace_snapshot_captures_git_state_without_mutating_source() {
     let temp = tempfile::tempdir().unwrap();
     let (state_dir, workspace) = create_snapshot_fixture(temp.path());

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -12706,11 +12706,13 @@ async fn snapshot_drops_unresolvable_gitlinks_but_keeps_registered_submodules() 
         .await
         .expect("snapshot with an unresolvable gitlink should succeed");
     let first_repository = state_dir.join(&first.repository);
-    let (_, output) = git_fixture_output_allow_failure(
+    let output = git_fixture_output(
         &first_repository,
         &[
             "ls-tree",
-            &format!("{}:stream-docker-output", first.commit_sha),
+            first.commit_sha.as_str(),
+            "--",
+            "stream-docker-output",
         ],
     );
     assert!(
@@ -12744,6 +12746,34 @@ async fn snapshot_drops_unresolvable_gitlinks_but_keeps_registered_submodules() 
     assert!(
         listed.starts_with("160000"),
         "a registered submodule gitlink must survive the snapshot: {listed}"
+    );
+
+    // A logical submodule name that differs from the checkout path is valid
+    // (`git submodule add --name`): the gitlink must still survive, since git
+    // resolves it by the `path` key, not the section name.
+    fs::write(
+        workspace.join(".gitmodules"),
+        "[submodule \"logical-stream\"]\n\tpath = stream-docker-output\n\turl = https://example.test/stream-docker-output.git\n",
+    )
+    .unwrap();
+    let third_run: RunId = "66666666-6666-4666-8666-666666666666".parse().unwrap();
+    let third = create_workspace_snapshot(&state_dir, &workspace, third_run, None)
+        .await
+        .expect("snapshot with a logically-named submodule should succeed");
+    let third_repository = state_dir.join(&third.repository);
+    let listed = String::from_utf8(git_fixture_output(
+        &third_repository,
+        &[
+            "ls-tree",
+            third.commit_sha.as_str(),
+            "--",
+            "stream-docker-output",
+        ],
+    ))
+    .unwrap();
+    assert!(
+        listed.starts_with("160000"),
+        "a logically-named registered submodule gitlink must survive the snapshot: {listed}"
     );
 }
 

--- a/crates/preloop-runner-server/src/snapshots.rs
+++ b/crates/preloop-runner-server/src/snapshots.rs
@@ -431,6 +431,45 @@ async fn create_workspace_snapshot_inner(
     }
     run_git(&mut add, "stage local workspace state").await?;
 
+    // A local workspace can carry gitlink entries for submodules that were
+    // never registered in `.gitmodules` — a nested clone added by hand, or a
+    // half-removed submodule. Served faithfully, the gitlink makes
+    // `git submodule` operations in the VM (which actions/checkout runs when
+    // a workflow asks for submodules) die with `fatal: No url found for
+    // submodule path '…' in .gitmodules` even though the repository itself
+    // is intact. GitHub-hosted workspaces cannot have this state; local ones
+    // routinely do. Drop gitlinks no `.gitmodules` url resolves so the
+    // checkout behaves as if the path were an ordinary directory.
+    let staged = run_snapshot_git(
+        workspace,
+        staging_repository,
+        staging_index,
+        &cached_objects,
+        ["ls-files", "--stage", "-z"],
+        "list staged paths",
+    )
+    .await?;
+    let gitlinks = gitlink_paths(&staged.stdout);
+    if !gitlinks.is_empty() {
+        let configured = configured_submodule_urls(workspace);
+        let unresolvable: Vec<&str> = gitlinks
+            .iter()
+            .filter(|path| !configured.contains(*path))
+            .map(String::as_str)
+            .collect();
+        if !unresolvable.is_empty() {
+            let mut remove = snapshot_git_command(
+                workspace,
+                staging_repository,
+                staging_index,
+                &cached_objects,
+            );
+            remove.args(["update-index", "--force-remove", "--"]);
+            remove.args(&unresolvable);
+            run_git(&mut remove, "drop unresolvable submodule gitlinks").await?;
+        }
+    }
+
     let tree_output = run_snapshot_git(
         workspace,
         staging_repository,
@@ -845,6 +884,66 @@ fn snapshot_git_command(
         .env("GIT_INDEX_FILE", index)
         .env("GIT_ALTERNATE_OBJECT_DIRECTORIES", source_objects);
     command
+}
+
+/// Paths of gitlink (mode `160000`) entries in a `git ls-files --stage -z`
+/// listing.
+///
+/// Records are NUL-terminated with a TAB between the `mode sha stage` header
+/// and the path; `-z` leaves paths unquoted.
+fn gitlink_paths(staged: &[u8]) -> Vec<String> {
+    let mut paths = Vec::new();
+    for record in staged.split(|byte| *byte == 0) {
+        if record.is_empty() {
+            continue;
+        }
+        let Some(tab) = record.iter().position(|byte| *byte == b'\t') else {
+            continue;
+        };
+        if record[..tab].starts_with(b"160000 ") {
+            if let Ok(path) = std::str::from_utf8(&record[tab + 1..]) {
+                paths.push(path.to_owned());
+            }
+        }
+    }
+    paths
+}
+
+/// Names of submodules that have a `url` configured in the workspace's
+/// `.gitmodules`, or an empty set when the file is absent or unparsable.
+///
+/// Submodule names conventionally equal the gitlink path (that is how
+/// `git submodule add` registers them), and `git submodule` resolves a
+/// gitlink by looking up `submodule.<path>.url` — so a gitlink whose path is
+/// not in this set is exactly the state that dies with `fatal: No url found
+/// for submodule path '…' in .gitmodules`.
+fn configured_submodule_urls(workspace: &FsPath) -> BTreeSet<String> {
+    let Ok(text) = std::fs::read_to_string(workspace.join(".gitmodules")) else {
+        return BTreeSet::new();
+    };
+    let mut configured = BTreeSet::new();
+    let mut current: Option<String> = None;
+    for raw_line in text.lines() {
+        let line = raw_line.trim();
+        if line.starts_with('[') && line.ends_with(']') {
+            let inner = &line[1..line.len() - 1];
+            current = inner
+                .trim()
+                .strip_prefix("submodule")
+                .map(str::trim)
+                .and_then(|rest| rest.strip_prefix('"'))
+                .and_then(|rest| rest.strip_suffix('"'))
+                .map(str::to_owned);
+            continue;
+        }
+        if let (Some(name), Some(rest)) = (current.as_ref(), line.strip_prefix("url")) {
+            let value = rest.trim_start().strip_prefix('=').map(str::trim);
+            if value.is_some_and(|value| !value.is_empty()) {
+                configured.insert(name.clone());
+            }
+        }
+    }
+    configured
 }
 
 /// Whether the workspace's own `.gitignore` rules already exclude `relative`.

--- a/crates/preloop-runner-server/src/snapshots.rs
+++ b/crates/preloop-runner-server/src/snapshots.rs
@@ -909,37 +909,68 @@ fn gitlink_paths(staged: &[u8]) -> Vec<String> {
     paths
 }
 
-/// Names of submodules that have a `url` configured in the workspace's
-/// `.gitmodules`, or an empty set when the file is absent or unparsable.
+/// Paths `git submodule` can resolve in the workspace's `.gitmodules`: the
+/// `path` value of every section that also carries a non-empty `url`, plus the
+/// section names themselves. Empty set when the file is absent or unparsable.
 ///
-/// Submodule names conventionally equal the gitlink path (that is how
-/// `git submodule add` registers them), and `git submodule` resolves a
-/// gitlink by looking up `submodule.<path>.url` — so a gitlink whose path is
-/// not in this set is exactly the state that dies with `fatal: No url found
-/// for submodule path '…' in .gitmodules`.
+/// Git resolves a gitlink by path: it finds the section whose `path` matches
+/// and uses that section's `url`; when no section names the path it falls back
+/// to `submodule.<path>.url`, which is how `git submodule add` registers
+/// submodules (name == path). A gitlink whose path is in neither set is
+/// exactly the state that dies with `fatal: No url found for submodule path
+/// '…' in .gitmodules`.
+///
+/// Matching of `submodule`/`url` is deliberately case-sensitive: git's own
+/// submodule machinery rejects `[SUBMODULE …]` and `URL =` entries, so a file
+/// git cannot parse must not be treated as configuring anything.
 fn configured_submodule_urls(workspace: &FsPath) -> BTreeSet<String> {
     let Ok(text) = std::fs::read_to_string(workspace.join(".gitmodules")) else {
         return BTreeSet::new();
     };
     let mut configured = BTreeSet::new();
-    let mut current: Option<String> = None;
-    for raw_line in text.lines() {
+    let mut name: Option<&str> = None;
+    let mut path: Option<&str> = None;
+    let mut has_url = false;
+    // A `[]` header matches no real section, so chaining it after the file's
+    // lines flushes the trailing section.
+    for raw_line in text.lines().chain(std::iter::once("[]")) {
         let line = raw_line.trim();
         if line.starts_with('[') && line.ends_with(']') {
+            if has_url {
+                if let Some(name) = name {
+                    configured.insert(name.to_owned());
+                }
+                if let Some(path) = path {
+                    configured.insert(path.to_owned());
+                }
+            }
             let inner = &line[1..line.len() - 1];
-            current = inner
+            name = inner
                 .trim()
                 .strip_prefix("submodule")
                 .map(str::trim)
                 .and_then(|rest| rest.strip_prefix('"'))
-                .and_then(|rest| rest.strip_suffix('"'))
-                .map(str::to_owned);
+                .and_then(|rest| rest.strip_suffix('"'));
+            path = None;
+            has_url = false;
             continue;
         }
-        if let (Some(name), Some(rest)) = (current.as_ref(), line.strip_prefix("url")) {
+        if name.is_none() {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("path") {
+            if let Some(value) = rest
+                .trim_start()
+                .strip_prefix('=')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                path = Some(value);
+            }
+        } else if let Some(rest) = line.strip_prefix("url") {
             let value = rest.trim_start().strip_prefix('=').map(str::trim);
             if value.is_some_and(|value| !value.is_empty()) {
-                configured.insert(name.clone());
+                has_url = true;
             }
         }
     }

--- a/crates/preloop-runner-server/src/snapshots.rs
+++ b/crates/preloop-runner-server/src/snapshots.rs
@@ -451,7 +451,7 @@ async fn create_workspace_snapshot_inner(
     .await?;
     let gitlinks = gitlink_paths(&staged.stdout);
     if !gitlinks.is_empty() {
-        let configured = configured_submodule_urls(workspace);
+        let configured = configured_submodule_urls(workspace).await;
         let unresolvable: Vec<&str> = gitlinks
             .iter()
             .filter(|path| !configured.contains(*path))
@@ -910,67 +910,76 @@ fn gitlink_paths(staged: &[u8]) -> Vec<String> {
 }
 
 /// Paths `git submodule` can resolve in the workspace's `.gitmodules`: the
-/// `path` value of every section that also carries a non-empty `url`, plus the
-/// section names themselves. Empty set when the file is absent or unparsable.
+/// `path` value of every section that also carries a non-empty `url`.
 ///
-/// Git resolves a gitlink by path: it finds the section whose `path` matches
-/// and uses that section's `url`; when no section names the path it falls back
-/// to `submodule.<path>.url`, which is how `git submodule add` registers
-/// submodules (name == path). A gitlink whose path is in neither set is
-/// exactly the state that dies with `fatal: No url found for submodule path
-/// '…' in .gitmodules`.
-///
-/// Matching of `submodule`/`url` is deliberately case-sensitive: git's own
-/// submodule machinery rejects `[SUBMODULE …]` and `URL =` entries, so a file
-/// git cannot parse must not be treated as configuring anything.
-fn configured_submodule_urls(workspace: &FsPath) -> BTreeSet<String> {
-    let Ok(text) = std::fs::read_to_string(workspace.join(".gitmodules")) else {
+/// Parsing is delegated to git itself (`git config -f .gitmodules -z
+/// --get-regexp '^submodule\..*\.(path|url)$'`) so quoting, escapes, line
+/// continuations, and case-insensitive section/key names are decoded exactly
+/// as git's submodule machinery decodes them. Git resolves a gitlink by
+/// path: it finds the section whose `path` matches and uses that section's
+/// `url`. A gitlink whose path only equals a section *name* is not
+/// resolvable — it dies with `fatal: No url found for submodule path '…' in
+/// .gitmodules` (verified against git 2.x) — so section names are
+/// deliberately excluded from the set. Empty set when the file is absent or
+/// git cannot parse it, matching git's own treatment of such a file.
+async fn configured_submodule_urls(workspace: &FsPath) -> BTreeSet<String> {
+    let output = Command::new("git")
+        .current_dir(workspace)
+        .args([
+            "config",
+            "-f",
+            ".gitmodules",
+            "-z",
+            "--get-regexp",
+            "^submodule\\..*\\.(path|url)$",
+        ])
+        .output()
+        .await;
+    let Ok(output) = output else {
         return BTreeSet::new();
     };
+    if !output.status.success() {
+        return BTreeSet::new();
+    }
+    // `-z` output is NUL-terminated records of the form `key\nvalue`. Keys
+    // are `submodule.<name>.path|url`; the name itself may contain dots and
+    // spaces, so only the trailing `.path`/`.url` suffix is stripped.
+    let mut path_by_name: std::collections::HashMap<&[u8], &[u8]> =
+        std::collections::HashMap::new();
+    let mut url_names: std::collections::HashSet<&[u8]> = std::collections::HashSet::new();
+    for record in output.stdout.split(|byte| *byte == 0) {
+        let Some(nl) = record.iter().position(|byte| *byte == b'\n') else {
+            continue;
+        };
+        let key = &record[..nl];
+        let value = &record[nl + 1..];
+        let is_url = key.ends_with(b".url");
+        let suffix_len = if is_url {
+            b".url".len()
+        } else {
+            b".path".len()
+        };
+        if !is_url && !key.ends_with(b".path") {
+            continue;
+        }
+        let Some(name) = key.strip_prefix(b"submodule.") else {
+            continue;
+        };
+        let name = &name[..name.len() - suffix_len];
+        if value.is_empty() {
+            continue;
+        }
+        if is_url {
+            url_names.insert(name);
+        } else {
+            path_by_name.insert(name, value);
+        }
+    }
     let mut configured = BTreeSet::new();
-    let mut name: Option<&str> = None;
-    let mut path: Option<&str> = None;
-    let mut has_url = false;
-    // A `[]` header matches no real section, so chaining it after the file's
-    // lines flushes the trailing section.
-    for raw_line in text.lines().chain(std::iter::once("[]")) {
-        let line = raw_line.trim();
-        if line.starts_with('[') && line.ends_with(']') {
-            if has_url {
-                if let Some(name) = name {
-                    configured.insert(name.to_owned());
-                }
-                if let Some(path) = path {
-                    configured.insert(path.to_owned());
-                }
-            }
-            let inner = &line[1..line.len() - 1];
-            name = inner
-                .trim()
-                .strip_prefix("submodule")
-                .map(str::trim)
-                .and_then(|rest| rest.strip_prefix('"'))
-                .and_then(|rest| rest.strip_suffix('"'));
-            path = None;
-            has_url = false;
-            continue;
-        }
-        if name.is_none() {
-            continue;
-        }
-        if let Some(rest) = line.strip_prefix("path") {
-            if let Some(value) = rest
-                .trim_start()
-                .strip_prefix('=')
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-            {
-                path = Some(value);
-            }
-        } else if let Some(rest) = line.strip_prefix("url") {
-            let value = rest.trim_start().strip_prefix('=').map(str::trim);
-            if value.is_some_and(|value| !value.is_empty()) {
-                has_url = true;
+    for (name, path) in path_by_name {
+        if url_names.contains(name) {
+            if let Ok(path) = std::str::from_utf8(path) {
+                configured.insert(path.to_owned());
             }
         }
     }


### PR DESCRIPTION
A local workspace can carry gitlink entries for submodules that were never registered in .gitmodules (a nested clone added by hand, or a half-removed submodule). The snapshot served those faithfully, and git submodule operations in the VM — which actions/checkout runs when a workflow asks for submodules — then died with 'fatal: No url found for submodule path … in .gitmodules' even though the repository was intact.

The snapshot staging now lists staged gitlinks and removes the ones whose path has no submodule.<path>.url in the workspace .gitmodules; registered submodules are untouched. Test covers both directions: an unresolvable gitlink is dropped from the snapshot tree, a gitlink with a .gitmodules url survives.

## What & why

<!-- What this change does and the problem it solves. Link the issue if there is one. -->

## Protocol surface

<!--
Check whether this change touches the core runner protocol interface:
  - registration / `/_apis/...` request and response shapes
  - broker messages (job request, complete, renew) and NDJSON event shapes
  - Twirp results-service / artifact-service payloads
  - check-run or OAuth wire behavior

If it does, the gates below are REQUIRED before merge — preloop's compatibility
contract is byte-for-byte fidelity with the official runner (v2.336.0).
-->

- [ ] I confirm this change touches the runner protocol interface: **YES / NO**

## Required gates

- [ ] `just test-ci` passes locally (fmt-check + clippy `-D` + full test suite + runner-watch conformance)
- [ ] If protocol/wire shapes changed: the change is validated against the official runner (golden replay via `runner-watch`, or a live capture showing the official bytes), not only unit tests
- [ ] If the touched subsystem has property tests (`concurrency_properties`, scheduling, matrix expansion, …): they are extended for the changed contract and pass (`PROPTEST_CASES=256 cargo test -p preloop-runner-server`)
- [ ] New wire fields/events are additive and serde-defaulted where the official runner would not send them
- [ ] No secrets, credentials, or internal/deployment-specific paths are introduced (captures with live tokens must be redacted or excluded)

## Verification performed

<!-- Concrete evidence: commands run, test names, capture outputs. -->

## Checklist

- [ ] Tests added/updated for any new observable contract
- [ ] Docs updated (`docs/`, `CONTRIBUTING.md`) where behavior changed
- [ ] Changelog-worthy user-facing change described in the PR body

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops unregistered submodule gitlinks from workspace snapshots so workflows that request submodules no longer fail with “No url found for submodule path … in .gitmodules.” Previously all gitlinks were preserved; now we remove gitlinks whose path has no url in `.gitmodules`, while keeping registered submodules (including those with a logical name different from their path).

- Resolve gitlinks via git’s own parser: `git config -f .gitmodules -z --get-regexp '^submodule\..*\.(path|url)$'`, keeping only paths that have a non-empty url; section names alone do not count.
- Tests verify drop/keep behavior, name ≠ path, quoted paths (e.g., a#b), mixed-case `[SUBMODULE]/URL`, and that name-only entries are dropped. Also removes dead `smolvm_release_repository` from `preloop-cli`.
- No runner protocol changes or migration steps.

<sup>Written for commit 167e42f30352810fd6e846270dd73508cabd64cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

