### PR TITLE
fix(security): clamp fork PR jobs to GitHub's read-only token profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,36 @@ Releases before v0.27.0 predate the changelog.
   `preloop server uninstall` removes all three, so secrets no longer outlive
   an uninstall that only purges the state dir.
 
+- Enforce GitHub's read-only fork profile for untrusted fork pull requests:
+  fork PR jobs (and fail-closed unknown events) now receive a
+  `GITHUB_TOKEN` permission set clamped to read regardless of the workflow's
+  declared `permissions:` block, never get an OIDC request URL or token
+  grant, and can no longer receive the configured PAT — neither as a
+  mint-failure fallback nor as the build-time PAT override. The special
+  `id-token` permission is excluded rather than advertised as a read scope,
+  and the App installation-token request carries only real App repository
+  permissions (never `id-token`) for trusted jobs too. The trust tier is
+  applied as a single job-authorization policy shared by the runner wire
+  variable, the App installation-token request, the OIDC grant, and the
+  token fallback path, so a fork PR declaring `checks: write` and
+  `id-token: write` is downgraded end to end while `pull_request_target`,
+  internal PRs, push, schedule, and deployment runs keep their declared
+  permissions. Broker claims now keep every runner-visible token alias
+  (`system.github.token`, `github_token`, `GITHUB_TOKEN`, and the `github`
+  context token) on the minted App token, restate narrowed installation
+  grants without erasing a trusted job's `IdToken` metadata, and treat
+  persisted token requests that predate the `untrusted` field as untrusted
+  so a restart can never re-enable the PAT fallback for them.
+
+- A deferred GitHub App token request no longer outlives the job it was built
+  for. It is deliberately retained past the first claim so a re-claim after a
+  runner disconnect re-mints under the build-time permission set instead of
+  rebuilding from the broader defaults, and it is now dropped wherever a job
+  request becomes terminal — the shared completion path (broker `completejob`,
+  the legacy `/_apis` finish endpoints, and the lease-expiry reaper alike) and
+  the scheduler's node retirement for cancelled, skipped, and
+  expansion-failed nodes.
+
 ### Changed
 
 - `preloop server install` (Linux, system scope) creates the `preloop` service
@@ -255,21 +285,6 @@ Releases before v0.27.0 predate the changelog.
 - `macos`/`windows` jobs wait for a registered external host instead of being
   failed by the Linux-only starvation sweep.
 - macOS BSD `tar` missing `--verbatim-files-from` is handled in sync.
-## [0.29.8] - 2026-08-09
-
-### Fixed
-
-- Preserve remote action references across job restarts: the job wire format
-  now uses the canonical `ref` field and still accepts the legacy `version`
-  name when reading.
-- Recover golden runner provisioning when the exact hosted package pins are
-  unavailable by falling back to archive versions.
-- Complete cancellation bookkeeping so cancelled runs settle terminal state
-  and next-job label scheduling stays in sync.
-- Expose the worker half of live debugging (token exchange, session verdict,
-  and close) through the runner control socket.
-- Fall back to direct VM creation when forking the default packed golden
-  fails, without changing the job image for environment-specific goldens.
 
 ## [0.29.7] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,12 @@ Releases before v0.27.0 predate the changelog.
   persisted token requests that predate the `untrusted` field as untrusted
   so a restart can never re-enable the PAT fallback for them.
 
+- Fork PR runs also get GitHub's read-only cache access: cache writes (the
+  `/_apis/artifactcache` reserve/upload/commit routes and the Twirp
+  `CreateCacheEntry`/`FinalizeCacheEntryUpload` handlers) are refused with
+  403 for fork-restricted jobs while restores stay open — a fork can no
+  longer poison cache entries that a trusted run later restores.
+
 - A deferred GitHub App token request no longer outlives the job it was built
   for. It is deliberately retained past the first claim so a re-claim after a
   runner disconnect re-mints under the build-time permission set instead of
@@ -285,6 +291,22 @@ Releases before v0.27.0 predate the changelog.
 - `macos`/`windows` jobs wait for a registered external host instead of being
   failed by the Linux-only starvation sweep.
 - macOS BSD `tar` missing `--verbatim-files-from` is handled in sync.
+
+## [0.29.8] - 2026-08-09
+
+### Fixed
+
+- Preserve remote action references across job restarts: the job wire format
+  now uses the canonical `ref` field and still accepts the legacy `version`
+  name when reading.
+- Recover golden runner provisioning when the exact hosted package pins are
+  unavailable by falling back to archive versions.
+- Complete cancellation bookkeeping so cancelled runs settle terminal state
+  and next-job label scheduling stays in sync.
+- Expose the worker half of live debugging (token exchange, session verdict,
+  and close) through the runner control socket.
+- Fall back to direct VM creation when forking the default packed golden
+  fails, without changing the job image for environment-specific goldens.
 
 ## [0.29.7] - 2026-08-09
 

--- a/crates/preloop-runner-server/src/broker.rs
+++ b/crates/preloop-runner-server/src/broker.rs
@@ -768,8 +768,9 @@ pub(crate) async fn broker_acquire_job(
         // The token request stays registered for the job's lifetime so a
         // re-claim re-mints under the build-time conditions (permission set
         // and fallback restrictions). `fail_unclaimable_request`,
-        // `complete_job_inner` (every completion path funnels there) and
-        // `retire_node_requests` remove it once the job is terminal.
+        // `complete_job_inner` (claimed-job completion paths funnel there)
+        // and `retire_node_requests` remove it once the job is terminal;
+        // see the `distributed_task.rs` completion path for the known gap.
         let mut inner = shared.state.inner.lock().await;
         inner.broker_messages.insert(request_id, message.clone());
     } else {

--- a/crates/preloop-runner-server/src/broker.rs
+++ b/crates/preloop-runner-server/src/broker.rs
@@ -637,7 +637,7 @@ pub(crate) async fn broker_acquire_job(
     Json(request): Json<BrokerAcquireJobRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     authenticated_runner_id(&shared, &headers, Some(runner_id))?;
-    let (request_id, mut message, github_token_request) = {
+    let (request_id, mut message, github_token_request, id_token_granted) = {
         let inner = shared.state.inner.lock().await;
         let request_id = inner
             .agent_job_requests
@@ -650,44 +650,30 @@ pub(crate) async fn broker_acquire_job(
             .get(&request_id)
             .cloned()
             .ok_or_else(|| ApiError::not_found("broker job payload not found"))?;
+        let id_token_granted = inner
+            .job_requests
+            .get(&request_id)
+            .and_then(|record| {
+                inner
+                    .id_token_grants
+                    .get(&(record.run_id, record.job_id.clone()))
+                    .copied()
+            })
+            .unwrap_or(false);
         (
             request_id,
             message,
             inner.github_token_requests.get(&request_id).cloned(),
+            id_token_granted,
         )
     };
-    // The token request is registered at build time and removed after the
-    // first claim's mint. A re-claim after a runner disconnect finds it
-    // consumed; without a re-mint the job keeps the build-time local runtime
-    // token, which cannot authenticate git against github.com (401, prompts
-    // disabled). Rebuild the request from the message in that case.
-    let token_request = github_token_request.or_else(|| {
-        let repository = message
-            .context_data
-            .get("github")
-            .and_then(|github| match github {
-                preloop_gha_protocol::azdo::PipelineContextData::Dict(dict) => {
-                    dict.get("repository")
-                }
-                _ => None,
-            })
-            .and_then(|repository| match repository {
-                preloop_gha_protocol::azdo::PipelineContextData::String(repo) => Some(repo.clone()),
-                _ => None,
-            });
-        repository.map(|repository| {
-            tracing::info!(
-                request_id,
-                %repository,
-                "broker acquire: token request consumed; re-minting from message"
-            );
-            crate::models::GitHubTokenRequest {
-                repository,
-                permissions: preloop_gha_parser::effective_token_permissions(None).into_owned(),
-                declared: false,
-            }
-        })
-    });
+    // The token request is registered at build time and kept until the job
+    // is terminal, so a re-claim after a runner disconnect re-mints under the
+    // *same* conditions the job was built with — the original permission set
+    // (fork profile included) and its fallback restrictions. Rebuilding from
+    // the message would lose both: the default permission set is wider than
+    // many jobs' declared set, and the untrusted flag cannot be recovered.
+    let token_request = github_token_request;
     if let Some(token_request) = token_request {
         tracing::info!(
             request_id,
@@ -722,16 +708,36 @@ pub(crate) async fn broker_acquire_job(
                 "github_token".to_owned(),
                 preloop_gha_protocol::azdo::VariableValue::secret(token.clone()),
             );
+            // The build-time message also injects the token as `GITHUB_TOKEN`
+            // (the `${{ secrets.GITHUB_TOKEN }}` alias). It must follow the
+            // minted token too, or a fork job's hostile step code could read
+            // the stale local runtime token from `secrets.GITHUB_TOKEN`
+            // while `github.token` already carries the scoped mint.
+            message.variables.insert(
+                "GITHUB_TOKEN".to_owned(),
+                preloop_gha_protocol::azdo::VariableValue::secret(token.clone()),
+            );
             // Restate what the token carries when the installation could not
             // grant everything. The message was built with the requested set,
             // and leaving it would print authority the token does not have in
             // the runner's `GITHUB_TOKEN Permissions` group — sending anyone
-            // debugging the resulting 403 to the wrong place.
+            // debugging the resulting 403 to the wrong place. The narrowed
+            // grant replaces only App-scoped entries: Actions-only metadata
+            // (`IdToken: write` for a trusted job whose OIDC grant is still
+            // live) is preserved from the build-time wire set, and a
+            // fork-restricted job's wire set has no IdToken to preserve.
             if let Some(effective) = minted.effective_permissions {
+                let merged = merge_narrowed_wire_permissions(
+                    message
+                        .variables
+                        .get("system.github.token.permissions")
+                        .and_then(|variable| variable.value.as_deref()),
+                    &effective,
+                );
                 message.variables.insert(
                     "system.github.token.permissions".to_owned(),
                     preloop_gha_protocol::azdo::VariableValue::new(
-                        preloop_gha_parser::job_builder::token_permissions_wire_json(&effective),
+                        preloop_gha_parser::job_builder::token_permissions_wire_json(&merged),
                     ),
                 );
             }
@@ -759,8 +765,12 @@ pub(crate) async fn broker_acquire_job(
                 ),
             }
         }
+        // The token request stays registered for the job's lifetime so a
+        // re-claim re-mints under the build-time conditions (permission set
+        // and fallback restrictions). `fail_unclaimable_request`,
+        // `complete_job_inner` (every completion path funnels there) and
+        // `retire_node_requests` remove it once the job is terminal.
         let mut inner = shared.state.inner.lock().await;
-        inner.github_token_requests.remove(&request_id);
         inner.broker_messages.insert(request_id, message.clone());
     } else {
         tracing::warn!(
@@ -816,13 +826,20 @@ pub(crate) async fn broker_acquire_job(
             );
             endpoint.data.insert("ServerId".to_owned(), String::new());
             endpoint.data.insert("ServerName".to_owned(), String::new());
-            endpoint.data.insert(
-                "GenerateIdTokenUrl".to_owned(),
-                format!(
-                    "{}/_apis/distributedtask/hubs/actions/plans/{}/jobs/{}/oidctoken",
-                    run_service_url, message.plan.plan_id, message.job_id
-                ),
-            );
+            // The runner copies GenerateIdTokenUrl into the step environment
+            // as `ACTIONS_ID_TOKEN_REQUEST_URL`; emitting it for a job
+            // without an `id-token: write` grant (fork-restricted jobs
+            // never have one) would invite a token request the endpoint then
+            // refuses. Match the build-time message: URL only when granted.
+            if id_token_granted {
+                endpoint.data.insert(
+                    "GenerateIdTokenUrl".to_owned(),
+                    format!(
+                        "{}/_apis/distributedtask/hubs/actions/plans/{}/jobs/{}/oidctoken",
+                        run_service_url, message.plan.plan_id, message.job_id
+                    ),
+                );
+            }
         }
     }
     message.billing_owner_id = request.billing_owner_id;
@@ -979,6 +996,20 @@ pub(crate) async fn mint_dispatch_github_token(
             effective_permissions,
         })),
         Err(error) => {
+            // An untrusted fork job must never fall back to the PAT: the
+            // PAT is repository-unscoped and ignores `permissions:`, so
+            // handing it to fork PR code would grant authority GitHub's
+            // read-only fork profile (and this job's downgraded request)
+            // never allowed. The job keeps the local runtime token, which
+            // authenticates only against this control plane.
+            if request.untrusted {
+                warn!(
+                    repository = %request.repository,
+                    "GitHub App token minting failed for an untrusted job; \
+                     refusing the PAT fallback, job retains the local runtime token: {error:#}"
+                );
+                return Ok(None);
+            }
             let fallback =
                 crate::github_app::fallback_token(app.mint_failure, app.pat_fallback.clone())
                     .map_err(|refusal| {
@@ -1004,6 +1035,65 @@ pub(crate) async fn mint_dispatch_github_token(
             }))
         }
     }
+}
+
+/// Merge a minted token's effective (App-scoped) permission set into the
+/// runner-visible wire permissions.
+///
+/// `original_wire` is the `system.github.token.permissions` variable the
+/// message carried at claim time — the policy set built in
+/// `build_job_artifacts`. The effective grant is authoritative for App
+/// repository scopes (a scope the installation dropped disappears from the
+/// wire, so the runner's `GITHUB_TOKEN Permissions` group never overstates
+/// the token), but Actions-only scopes (`id-token`, `models`) never appear
+/// in an installation grant, so their build-time metadata is preserved:
+/// a trusted job declared `id-token: write` keeps `IdToken: write` while its
+/// OIDC grant is live, and a fork-restricted job's wire set has no IdToken
+/// entry to preserve. Never reconstructs from broader defaults: a missing or
+/// unparseable original wire set degrades to the effective grant alone.
+fn merge_narrowed_wire_permissions(
+    original_wire: Option<&str>,
+    effective: &BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
+    let mut merged: BTreeMap<String, String> = effective.clone();
+    let Some(original_wire) = original_wire else {
+        return merged;
+    };
+    let Ok(original) = serde_json::from_str::<BTreeMap<String, String>>(original_wire) else {
+        return merged;
+    };
+    for (scope, level) in original {
+        let scope = wire_scope_to_kebab(&scope);
+        if crate::github_app::ACTIONS_ONLY_SCOPES.contains(&scope.as_str()) {
+            // Keyed kebab-case so the merged map stays consistent with the
+            // effective grant, whose keys come from the requested set;
+            // `token_permissions_wire_json` pascal-cases them for the wire.
+            merged.insert(scope, level);
+        }
+    }
+    merged
+}
+
+/// `Checks` → `checks`, `PullRequests` → `pull-requests`: the workflow
+/// (kebab-case) spelling of a PascalCase wire permission scope.
+///
+/// Not snake_case: the installation-token API spells the same scopes with
+/// underscores (`pull_requests`), and mixing the two would silently drop
+/// entries — see `github_app::clamp_to_grants`, which bridges kebab to
+/// underscore explicitly.
+fn wire_scope_to_kebab(scope: &str) -> String {
+    let mut out = String::with_capacity(scope.len());
+    for ch in scope.chars() {
+        if ch.is_ascii_uppercase() {
+            if !out.is_empty() {
+                out.push('-');
+            }
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
 }
 
 pub(crate) async fn broker_renew_job(
@@ -1198,5 +1288,83 @@ mod tests {
             execution_status_from_runner_result("Abandoned"),
             Some(ExecutionStatus::Failure)
         );
+    }
+
+    #[test]
+    fn narrowed_grants_preserve_trusted_actions_only_metadata() {
+        // Trusted job declared `checks: write` + `id-token: write`; the
+        // installation granted only `pull-requests: read`. The effective
+        // grant replaces App-scoped entries (checks disappears — the token
+        // does not carry it) while `IdToken: write` metadata survives.
+        let merged = merge_narrowed_wire_permissions(
+            Some(r#"{"Checks":"write","IdToken":"write"}"#),
+            &BTreeMap::from([("pull-requests".to_owned(), "read".to_owned())]),
+        );
+        assert_eq!(
+            merged,
+            BTreeMap::from([
+                ("pull-requests".to_owned(), "read".to_owned()),
+                ("id-token".to_owned(), "write".to_owned()),
+            ]),
+            "App scopes come from the effective grant; Actions-only metadata is preserved"
+        );
+    }
+
+    #[test]
+    fn narrowed_grants_never_add_actions_metadata_to_a_fork() {
+        // Fork job's build-time wire set has no IdToken; the merge must not
+        // invent one. The installation lacks `checks`, so the wire loses it.
+        let merged = merge_narrowed_wire_permissions(
+            Some(r#"{"Checks":"read","PullRequests":"read"}"#),
+            &BTreeMap::from([("pull-requests".to_owned(), "read".to_owned())]),
+        );
+        assert_eq!(
+            merged,
+            BTreeMap::from([("pull-requests".to_owned(), "read".to_owned())]),
+            "fork wire keeps no IdToken and drops ungranted App scopes"
+        );
+    }
+
+    #[test]
+    fn narrowed_grants_lower_declared_writes_to_the_granted_level() {
+        let merged = merge_narrowed_wire_permissions(
+            Some(r#"{"Contents":"write","IdToken":"write"}"#),
+            &BTreeMap::from([
+                ("contents".to_owned(), "read".to_owned()),
+                ("metadata".to_owned(), "read".to_owned()),
+            ]),
+        );
+        assert_eq!(
+            merged,
+            BTreeMap::from([
+                ("contents".to_owned(), "read".to_owned()),
+                ("metadata".to_owned(), "read".to_owned()),
+                ("id-token".to_owned(), "write".to_owned()),
+            ]),
+            "declared write is lowered to the granted read; metadata survives"
+        );
+    }
+
+    #[test]
+    fn missing_or_unparseable_original_wire_degrades_to_the_effective_grant() {
+        let effective = BTreeMap::from([("metadata".to_owned(), "read".to_owned())]);
+        assert_eq!(
+            merge_narrowed_wire_permissions(None, &effective),
+            effective,
+            "no original wire set: nothing to preserve"
+        );
+        assert_eq!(
+            merge_narrowed_wire_permissions(Some("not json"), &effective),
+            effective,
+            "unparseable wire set must not reconstruct from broader defaults"
+        );
+    }
+
+    #[test]
+    fn wire_scope_to_kebab_round_trips_pascal_scopes() {
+        assert_eq!(wire_scope_to_kebab("Checks"), "checks");
+        assert_eq!(wire_scope_to_kebab("PullRequests"), "pull-requests");
+        assert_eq!(wire_scope_to_kebab("IdToken"), "id-token");
+        assert_eq!(wire_scope_to_kebab("Contents"), "contents");
     }
 }

--- a/crates/preloop-runner-server/src/cache_artifacts.rs
+++ b/crates/preloop-runner-server/src/cache_artifacts.rs
@@ -115,8 +115,10 @@ pub(crate) async fn cache_get(
 
 pub(crate) async fn cache_reserve(
     State(shared): State<Arc<SharedState>>,
+    headers: axum::http::HeaderMap,
     Json(request): Json<CacheReserveRequest>,
-) -> Json<CacheReserveResponse> {
+) -> Result<Json<CacheReserveResponse>, ApiError> {
+    crate::events::trust_tier::ensure_cache_write_allowed(&shared.state, &headers).await?;
     let mut inner = shared.state.inner.lock().await;
     inner.next_cache_id += 1;
     let cache_id = inner.next_cache_id;
@@ -132,14 +134,16 @@ pub(crate) async fn cache_reserve(
     if let Err(error) = shared.state.store.store_meta_only(&meta).await {
         tracing::warn!(?error, "failed to persist cache reservation");
     }
-    Json(CacheReserveResponse { cache_id })
+    Ok(Json(CacheReserveResponse { cache_id }))
 }
 
 pub(crate) async fn cache_upload(
     State(shared): State<Arc<SharedState>>,
+    headers: axum::http::HeaderMap,
     Path(cache_id): Path<i64>,
     bytes: Bytes,
 ) -> Result<StatusCode, ApiError> {
+    crate::events::trust_tier::ensure_cache_write_allowed(&shared.state, &headers).await?;
     let mut inner = shared.state.inner.lock().await;
     let pending = inner
         .pending_caches
@@ -155,9 +159,11 @@ pub(crate) async fn cache_upload(
 
 pub(crate) async fn cache_commit(
     State(shared): State<Arc<SharedState>>,
+    headers: axum::http::HeaderMap,
     Path(cache_id): Path<i64>,
     Json(request): Json<CacheCommitRequest>,
 ) -> Result<Json<CacheLookupResponse>, ApiError> {
+    crate::events::trust_tier::ensure_cache_write_allowed(&shared.state, &headers).await?;
     let pending = {
         let mut inner = shared.state.inner.lock().await;
         inner

--- a/crates/preloop-runner-server/src/distributed_task.rs
+++ b/crates/preloop-runner-server/src/distributed_task.rs
@@ -666,6 +666,12 @@ pub(crate) async fn complete_job_inner(
             .session_active_requests
             .retain(|_, &mut rid| rid != *request_id);
         inner.inflight_requests.remove(request_id);
+        // The job is terminal, so its deferred App-token request must not
+        // outlive it: a re-claim re-mints from this record, and every
+        // completion path funnels through here (broker `completejob`, the
+        // legacy `/_apis` finish endpoints, `agent_request_patch`, and the
+        // lease-expiry reaper), so this is the one place that sees them all.
+        inner.github_token_requests.remove(request_id);
     }
     // Evict live-log state for this job to prevent unbounded memory growth.
     // The durable step-log blob has already been uploaded by the runner.

--- a/crates/preloop-runner-server/src/distributed_task.rs
+++ b/crates/preloop-runner-server/src/distributed_task.rs
@@ -667,10 +667,14 @@ pub(crate) async fn complete_job_inner(
             .retain(|_, &mut rid| rid != *request_id);
         inner.inflight_requests.remove(request_id);
         // The job is terminal, so its deferred App-token request must not
-        // outlive it: a re-claim re-mints from this record, and every
-        // completion path funnels through here (broker `completejob`, the
-        // legacy `/_apis` finish endpoints, `agent_request_patch`, and the
-        // lease-expiry reaper), so this is the one place that sees them all.
+        // outlive it: a re-claim re-mints from this record. Claimed-job
+        // completions funnel through here (broker `completejob`, the legacy
+        // `/_apis` finish endpoints, `agent_request_patch`, and the
+        // lease-expiry reaper), and the scheduler's node retirement covers
+        // cancelled, skipped, and expansion-failed nodes. Known gap: the
+        // starvation sweep and the cancel of a never-claimed queued job turn
+        // terminal without reaching either site; the record leaks but is
+        // unreachable — the job is out of every dispatchable collection.
         inner.github_token_requests.remove(request_id);
     }
     // Evict live-log state for this job to prevent unbounded memory growth.

--- a/crates/preloop-runner-server/src/events/trust_tier.rs
+++ b/crates/preloop-runner-server/src/events/trust_tier.rs
@@ -119,6 +119,50 @@ pub(crate) fn tier_of(submission: &preloop_gha_protocol::WorkflowSubmission) -> 
         .and_then(|value| serde_json::from_value::<TrustTier>(serde_json::json!(value)).ok())
 }
 
+/// Whether the job a results/cache request authenticates as is
+/// fork-restricted, resolved from its bearer runtime token.
+///
+/// `Some(true)`/`Some(false)` when the token names a live job; `None` when it
+/// is the system token or no job resolves (the control plane's own calls) —
+/// those are never fork-restricted. This is what lets the cache write
+/// handlers deny fork PR runs the same read-only cache access GitHub gives
+/// them (restore allowed, save refused) without touching the read path.
+pub(crate) async fn fork_restricted_from_token(
+    state: &crate::state::AppState,
+    token: &str,
+) -> Option<bool> {
+    let job = state.job_uuid_from_token(token)?;
+    let inner = state.inner.lock().await;
+    let request_id = inner.agent_job_requests.get(&job).copied()?;
+    let record = inner.job_requests.get(&request_id)?;
+    let run = inner.runs.get(&record.run_id)?;
+    let tier = tier_of(&run.submission)?;
+    Some(tier.is_fork_restricted())
+}
+
+/// Reject a cache write when the calling job is a fork-restricted run.
+///
+/// GitHub gives fork PR runs read-only cache access (restore allowed, save
+/// refused) so a fork cannot poison cache entries that trusted runs later
+/// restore. Mirroring that here applies to every cache write surface (the
+/// cache v2 Twirp handlers and the legacy `/_apis/artifactcache` ones alike);
+/// the read handlers never call this. The system token and unresolvable
+/// tokens are the control plane's own calls and always pass.
+pub(crate) async fn ensure_cache_write_allowed(
+    state: &crate::state::AppState,
+    headers: &axum::http::HeaderMap,
+) -> Result<(), crate::ApiError> {
+    let Some(token) = crate::auth::bearer_from_headers(headers) else {
+        return Ok(());
+    };
+    if fork_restricted_from_token(state, token).await == Some(true) {
+        return Err(crate::ApiError::forbidden(
+            "cache writes are read-only for fork pull request runs",
+        ));
+    }
+    Ok(())
+}
+
 /// The effective job-authorization policy for a submission tier and a job's
 /// resolved permission declarations.
 ///

--- a/crates/preloop-runner-server/src/events/trust_tier.rs
+++ b/crates/preloop-runner-server/src/events/trust_tier.rs
@@ -4,6 +4,9 @@
 //! security model. Each tier corresponds to a combination of event source and
 //! repository relationship.
 
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 /// Trust tier stamped on every webhook-driven run.
@@ -53,5 +56,288 @@ impl TrustTier {
             self,
             TrustTier::UntrustedForkPullRequest | TrustTier::Untrusted
         )
+    }
+
+    /// Returns true if the tier runs code that GitHub would run with its
+    /// restricted fork profile: a `pull_request` from a fork, or a fail-closed
+    /// unknown event.
+    ///
+    /// GitHub gives these jobs a read-only `GITHUB_TOKEN` *regardless* of the
+    /// workflow's declared `permissions:` block ("Pull requests from public
+    /// forks are still considered a special case and will receive a read
+    /// token regardless of these settings" — GitHub Changelog, 2021-04-20),
+    /// and never issues OIDC tokens to them. The declared block can only
+    /// remove read scopes from the fork profile, never add write.
+    pub fn is_fork_restricted(&self) -> bool {
+        matches!(
+            self,
+            TrustTier::UntrustedForkPullRequest | TrustTier::Untrusted
+        )
+    }
+}
+
+/// The single effective job-authorization policy for a trust tier.
+///
+/// Every job-facing authority decision is derived from one call to
+/// [`job_authorization`]: whether stored secrets are injected, what
+/// `GITHUB_TOKEN` permission set the runner-visible wire variable and the
+/// GitHub App installation-token request carry, and whether `id-token: write`
+/// yields an OIDC request URL and token grant. Nothing downstream re-derives
+/// the tier ad hoc, so a handler special case cannot drift from this policy.
+pub(crate) struct JobAuthorization {
+    /// Stored repository secrets may be injected into the job.
+    pub(crate) allows_secrets: bool,
+    /// The runner-visible `GITHUB_TOKEN` permission set (the
+    /// `system.github.token.permissions` wire variable). `id-token` appears
+    /// here only for trusted tiers, where the declared `IdToken: write` is
+    /// the metadata that accompanies the separately granted OIDC request
+    /// URL; fork-restricted tiers never advertise it.
+    pub(crate) token_permissions: BTreeMap<String, String>,
+    /// The permission set sent to the GitHub App installation-token mint.
+    /// Excludes the Actions-only scopes (`id-token`, `models`) that the
+    /// installation API rejects, so the registered request carries only real
+    /// App repository permissions — for trusted and fork jobs alike.
+    pub(crate) app_permissions: BTreeMap<String, String>,
+    /// `id-token: write` is honored: an OIDC request URL is emitted and the
+    /// `oidctoken` endpoint will mint for this job.
+    pub(crate) id_token_granted: bool,
+    /// The job runs code from an untrusted source; its token authority is
+    /// restricted to the GitHub fork profile and no fallback may widen it.
+    pub(crate) fork_restricted: bool,
+}
+
+/// Resolve a submission's trust tier.
+///
+/// Native submissions carry no tier (`None` is therefore trusted); a tier
+/// that fails to parse is treated the same way, matching the pre-existing
+/// secret policy. The webhook dispatcher is the only producer of tier
+/// strings and always writes a serialized [`TrustTier`].
+pub(crate) fn tier_of(submission: &preloop_gha_protocol::WorkflowSubmission) -> Option<TrustTier> {
+    submission
+        .trust_tier
+        .as_deref()
+        .and_then(|value| serde_json::from_value::<TrustTier>(serde_json::json!(value)).ok())
+}
+
+/// The effective job-authorization policy for a submission tier and a job's
+/// resolved permission declarations.
+///
+/// For fork-restricted tiers the declared (or default) permission set is
+/// clamped to GitHub's fork profile: every scope is held at `read` and write
+/// never survives, `id-token` — a special workflow permission with write/none
+/// semantics, not a repository read permission — is dropped from the wire set
+/// rather than advertised as `read`, `id-token: write` produces no OIDC
+/// grant, and stored secrets stay denied. All other tiers keep the declared
+/// set verbatim.
+pub(crate) fn job_authorization(
+    tier: Option<TrustTier>,
+    declared_permissions: Option<&BTreeMap<String, String>>,
+    declared_id_token_granted: bool,
+) -> JobAuthorization {
+    let fork_restricted = tier.is_some_and(|tier| tier.is_fork_restricted());
+    let allows_secrets = tier.map(|tier| tier.allows_secrets()).unwrap_or(true);
+    let token_permissions = fork_permission_set(
+        fork_restricted,
+        preloop_gha_parser::effective_token_permissions(declared_permissions),
+    );
+    let app_permissions = token_permissions
+        .iter()
+        .filter(|(scope, _)| !crate::github_app::ACTIONS_ONLY_SCOPES.contains(&scope.as_str()))
+        .map(|(scope, level)| (scope.clone(), level.clone()))
+        .collect();
+    JobAuthorization {
+        allows_secrets,
+        token_permissions,
+        app_permissions,
+        id_token_granted: declared_id_token_granted && !fork_restricted,
+        fork_restricted,
+    }
+}
+
+/// Clamp an effective permission set to GitHub's read-only fork profile.
+///
+/// Every non-withheld repository scope is lowered to `read`; `none` (already
+/// withheld) is preserved. `id-token` never survives: it is not a repository
+/// read permission, so a fork job must not be told it holds `IdToken: read`.
+/// The remaining scope set is untouched, so the declared block still removes
+/// read scopes exactly as GitHub allows.
+fn fork_permission_set(
+    fork_restricted: bool,
+    effective: Cow<'_, BTreeMap<String, String>>,
+) -> BTreeMap<String, String> {
+    if !fork_restricted {
+        return effective.into_owned();
+    }
+    effective
+        .iter()
+        .filter(|(scope, _)| scope.as_str() != "id-token")
+        .map(|(scope, level)| {
+            let clamped = if level.eq_ignore_ascii_case("none") {
+                "none"
+            } else {
+                "read"
+            };
+            (scope.clone(), clamped.to_owned())
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn perms(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(scope, level)| (scope.to_string(), level.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn fork_restricted_tiers_clamp_every_write_to_read() {
+        for tier in [TrustTier::UntrustedForkPullRequest, TrustTier::Untrusted] {
+            let policy = job_authorization(
+                Some(tier),
+                Some(&perms(&[("checks", "write"), ("pull-requests", "write")])),
+                true,
+            );
+            assert_eq!(
+                policy.token_permissions,
+                perms(&[("checks", "read"), ("pull-requests", "read")]),
+                "{tier:?}: write must not survive"
+            );
+            assert!(!policy.allows_secrets, "{tier:?}: secrets stay denied");
+            assert!(!policy.id_token_granted, "{tier:?}: OIDC stays denied");
+            assert!(policy.fork_restricted);
+        }
+    }
+
+    #[test]
+    fn fork_profile_preserves_reads_and_withheld_scopes() {
+        let policy = job_authorization(
+            Some(TrustTier::UntrustedForkPullRequest),
+            Some(&perms(&[
+                ("contents", "read"),
+                ("pull-requests", "none"),
+                ("checks", "write"),
+            ])),
+            false,
+        );
+        assert_eq!(
+            policy.token_permissions,
+            perms(&[
+                ("contents", "read"),
+                ("pull-requests", "none"),
+                ("checks", "read"),
+            ]),
+            "read stays read, none stays withheld, write clamps to read"
+        );
+    }
+
+    #[test]
+    fn fork_id_token_is_never_advertised_as_read() {
+        let policy = job_authorization(
+            Some(TrustTier::UntrustedForkPullRequest),
+            Some(&perms(&[("checks", "write"), ("id-token", "write")])),
+            true,
+        );
+        assert_eq!(
+            policy.token_permissions,
+            perms(&[("checks", "read")]),
+            "id-token is not a repository read permission: no IdToken key on the wire"
+        );
+        assert_eq!(
+            policy.app_permissions,
+            perms(&[("checks", "read")]),
+            "the App request map carries no id-token either"
+        );
+        assert!(
+            !policy.id_token_granted,
+            "the OIDC grant stays denied for the fork"
+        );
+
+        // Declaring *only* id-token leaves an empty set: the fork must not be
+        // handed any permission metadata at all.
+        let only_oidc = job_authorization(
+            Some(TrustTier::UntrustedForkPullRequest),
+            Some(&perms(&[("id-token", "write")])),
+            true,
+        );
+        assert!(only_oidc.token_permissions.is_empty());
+        assert!(only_oidc.app_permissions.is_empty());
+    }
+
+    #[test]
+    fn trusted_id_token_stays_wire_metadata_but_not_in_the_app_request() {
+        let policy = job_authorization(
+            Some(TrustTier::Trusted),
+            Some(&perms(&[("checks", "write"), ("id-token", "write")])),
+            true,
+        );
+        assert_eq!(
+            policy.token_permissions,
+            perms(&[("checks", "write"), ("id-token", "write")]),
+            "trusted wire metadata keeps IdToken: write for the OIDC URL/grant"
+        );
+        assert_eq!(
+            policy.app_permissions,
+            perms(&[("checks", "write")]),
+            "the App installation-token request excludes the non-App id-token scope"
+        );
+        assert!(policy.id_token_granted);
+    }
+
+    #[test]
+    fn fork_profile_with_empty_declared_set_stays_empty() {
+        let policy = job_authorization(
+            Some(TrustTier::UntrustedForkPullRequest),
+            Some(&BTreeMap::new()),
+            false,
+        );
+        assert!(
+            policy.token_permissions.is_empty(),
+            "`permissions: {{}}` on a fork must not gain the default back"
+        );
+    }
+
+    #[test]
+    fn fork_profile_applies_to_the_implicit_default_too() {
+        let policy = job_authorization(Some(TrustTier::UntrustedForkPullRequest), None, false);
+        assert_eq!(
+            policy.token_permissions,
+            preloop_gha_parser::DEFAULT_TOKEN_PERMISSIONS
+                .iter()
+                .map(|&(scope, level)| (scope.to_owned(), level.to_owned()))
+                .collect::<BTreeMap<_, _>>(),
+            "the default set is already read-only, so the fork keeps it"
+        );
+    }
+
+    #[test]
+    fn trusted_tiers_keep_declared_permissions_and_grants() {
+        for tier in [
+            None,
+            Some(TrustTier::Trusted),
+            Some(TrustTier::Internal),
+            Some(TrustTier::InternalPullRequest),
+            Some(TrustTier::PullRequestTarget),
+            Some(TrustTier::AdminManual),
+            Some(TrustTier::Deployment),
+            Some(TrustTier::Schedule),
+        ] {
+            let policy = job_authorization(
+                tier,
+                Some(&perms(&[("checks", "write"), ("contents", "read")])),
+                true,
+            );
+            assert_eq!(
+                policy.token_permissions,
+                perms(&[("checks", "write"), ("contents", "read")]),
+                "{tier:?}: declared writes must survive"
+            );
+            assert!(policy.allows_secrets, "{tier:?}: secrets allowed");
+            assert!(policy.id_token_granted, "{tier:?}: OIDC granted");
+            assert!(!policy.fork_restricted);
+        }
     }
 }

--- a/crates/preloop-runner-server/src/github_app.rs
+++ b/crates/preloop-runner-server/src/github_app.rs
@@ -56,7 +56,12 @@ const INSTALLATIONS_PER_PAGE: usize = 100;
 /// both are runtime-only, and forwarding either makes the installation-token
 /// request fail with HTTP 422 — which would push the job onto whatever
 /// [`MintFailurePolicy`] allows instead of the token it asked for.
-const ACTIONS_ONLY_SCOPES: [&str; 2] = ["id-token", "models"];
+///
+/// The authorization policy excludes these scopes from the App token request
+/// map before the request is even built (see
+/// [`crate::events::trust_tier::JobAuthorization::app_permissions`]), so a
+/// job's registered request carries only real App repository permissions.
+pub(crate) const ACTIONS_ONLY_SCOPES: [&str; 2] = ["id-token", "models"];
 
 /// The narrowest scope GitHub will issue an installation token for.
 ///

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -5042,7 +5042,15 @@ jobs:
 
 #[tokio::test]
 async fn cancel_run_completes_github_checks_and_terminal_metadata() {
-    let check_completions = Arc::new(std::sync::Mutex::new(Vec::<serde_json::Value>::new()));
+    // Keyed by check-run id: `PRELOOP_GITHUB_API_URL` is process-global, and
+    // `owner/repo` is the suite's default repository, so a co-scheduled test
+    // that submits a run lands its own check-run PATCH on this stub. Counting
+    // every request would make the assertion depend on the rest of the suite;
+    // this test's contract is about the check run it pinned below.
+    const CHECK_RUN_ID: u64 = 7;
+    let check_completions = Arc::new(parking_lot::Mutex::new(
+        Vec::<(u64, serde_json::Value)>::new(),
+    ));
     let mock_app = Router::new().route(
         "/repos/owner/repo/check-runs/:id",
         axum::routing::patch({
@@ -5050,7 +5058,7 @@ async fn cancel_run_completes_github_checks_and_terminal_metadata() {
             move |Path(id): Path<u64>, body: axum::extract::Json<Value>| {
                 let check_completions = check_completions.clone();
                 async move {
-                    check_completions.lock().unwrap().push(body.0);
+                    check_completions.lock().push((id, body.0));
                     Json(json!({"id": id}))
                 }
             }
@@ -5062,9 +5070,12 @@ async fn cancel_run_completes_github_checks_and_terminal_metadata() {
         axum::serve(listener, mock_app).await.unwrap();
     });
 
+    // `TestEnvVar` restores both on drop, so a panicking assertion below
+    // cannot leak this stub's address (or its token) onto the rest of the run.
     let _env = crate::state::GITHUB_ENV_LOCK.lock().await;
-    std::env::set_var("PRELOOP_GITHUB_API_URL", format!("http://127.0.0.1:{port}"));
-    std::env::set_var("PRELOOP_GITHUB_TOKEN", "cancel-test-token");
+    let _api_url =
+        crate::state::TestEnvVar::set("PRELOOP_GITHUB_API_URL", format!("http://127.0.0.1:{port}"));
+    let _token = crate::state::TestEnvVar::set("PRELOOP_GITHUB_TOKEN", "cancel-test-token");
 
     let temp = tempfile::tempdir().unwrap();
     let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
@@ -5084,7 +5095,8 @@ async fn cancel_run_completes_github_checks_and_terminal_metadata() {
     {
         let mut inner = state.inner.lock().await;
         let run = inner.runs.get_mut(&run_id).unwrap();
-        run.job_check_run_ids.insert(JobId("build".into()), 7);
+        run.job_check_run_ids
+            .insert(JobId("build".into()), CHECK_RUN_ID);
     }
 
     let cancelled = request_json(
@@ -5095,19 +5107,21 @@ async fn cancel_run_completes_github_checks_and_terminal_metadata() {
     )
     .await;
 
-    std::env::remove_var("PRELOOP_GITHUB_API_URL");
-    std::env::remove_var("PRELOOP_GITHUB_TOKEN");
-
     assert_eq!(cancelled["status"], "cancelled");
     assert_eq!(cancelled["conclusion"], "cancelled");
     assert!(
         cancelled["completed_at"].is_string(),
         "cancelled run must carry terminal completion metadata"
     );
-    let completions = check_completions.lock().unwrap();
-    assert_eq!(completions.len(), 1);
-    assert_eq!(completions[0]["status"], "completed");
-    assert_eq!(completions[0]["conclusion"], "cancelled");
+    let completions = check_completions.lock();
+    let mine: Vec<&serde_json::Value> = completions
+        .iter()
+        .filter(|(id, _)| *id == CHECK_RUN_ID)
+        .map(|(_, body)| body)
+        .collect();
+    assert_eq!(mine.len(), 1, "one cancel, one check-run completion");
+    assert_eq!(mine[0]["status"], "completed");
+    assert_eq!(mine[0]["conclusion"], "cancelled");
 }
 
 #[tokio::test]
@@ -5638,6 +5652,1060 @@ async fn the_wire_token_permissions_match_the_declared_policy() {
             "wire permissions for {declaration:?}"
         );
     }
+}
+
+/// GitHub's fork profile is the single effective job-authorization policy for
+/// fork-restricted tiers. A fork PR declaring `checks: write` and
+/// `id-token: write` must come out read-only on the runner-visible wire
+/// variable, read-only in the App installation-token request, with no OIDC
+/// request URL and no OIDC grant — while a trusted push and a
+/// `pull_request_target` keep the declared writes and OIDC untouched.
+#[tokio::test]
+async fn fork_pr_jobs_are_downgraded_to_read_only_and_oidc_denied() {
+    use crate::github_app::{GitHubAppCredentials, MintFailurePolicy};
+
+    let private_key = rsa::RsaPrivateKey::new(&mut rand::thread_rng(), 2048).unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let mut state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    state.github_app = Some(GitHubAppCredentials::for_tests(
+        "424",
+        private_key,
+        MintFailurePolicy::LocalJwt,
+    ));
+    let app = app(state.clone(), CancellationToken::new());
+
+    let yaml = "on: pull_request\npermissions:\n  checks: write\n  id-token: write\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n";
+    let payload = json!({
+        "action": "opened",
+        "number": 7,
+        "pull_request": {
+            "head": {"ref": "feature", "sha": "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3"},
+            "base": {"ref": "main", "sha": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"}
+        },
+        "repository": {"full_name": "owner/repo", "default_branch": "main"}
+    });
+    let submit = |tier: Option<&str>| {
+        request_json(
+            &app,
+            Method::POST,
+            "/api/v1/runs",
+            json!({
+                "workflow_yaml": yaml,
+                "event": "pull_request",
+                "repository": "owner/repo",
+                "payload": payload,
+                "trust_tier": tier,
+            }),
+        )
+    };
+
+    // Fork PR: declared writes must not survive, OIDC must not be granted.
+    let fork = submit(Some("untrusted-fork-pull-request")).await;
+    let fork_run_id = fork["run_id"].as_str().unwrap();
+    let trusted = submit(None).await;
+    let trusted_run_id = trusted["run_id"].as_str().unwrap();
+    let target = submit(Some("pull-request-target")).await;
+    let target_run_id = target["run_id"].as_str().unwrap();
+
+    let inner = state.inner.lock().await;
+    let fork_message = queued_message_for(&inner, fork_run_id);
+    assert_eq!(
+        variable_value(&fork_message, "system.github.token.permissions"),
+        Some(r#"{"Checks":"read"}"#),
+        "fork PR: declared checks write must be clamped to read, and id-token \
+         must not be advertised as a read permission"
+    );
+    assert!(
+        !variable_value(&fork_message, "system.github.token.permissions")
+            .is_some_and(|wire| wire.contains("IdToken")),
+        "fork PR: the wire permissions must carry no IdToken metadata"
+    );
+    let fork_endpoint = fork_message
+        .resources
+        .endpoints
+        .iter()
+        .find(|endpoint| endpoint.name.eq_ignore_ascii_case("SystemVssConnection"))
+        .expect("SystemVssConnection endpoint present");
+    assert!(
+        !fork_endpoint
+            .data
+            .get("GenerateIdTokenUrl")
+            .is_some_and(|url| !url.is_empty()),
+        "fork PR: no OIDC request URL may be emitted"
+    );
+    let fork_request = inner
+        .github_token_requests
+        .get(&fork_message.request_id)
+        .expect("fork PR job defers an App token request");
+    assert_eq!(
+        fork_request.permissions,
+        BTreeMap::from([("checks".to_owned(), "read".to_owned())]),
+        "fork PR: App token request carries only the read-only fork profile"
+    );
+    assert!(
+        !fork_request.permissions.contains_key("id-token"),
+        "fork PR: the App token request must not name the non-App id-token scope"
+    );
+    assert!(
+        fork_request.untrusted,
+        "fork PR: token request must be marked untrusted so no fallback widens it"
+    );
+    let fork_job_record = inner
+        .job_requests
+        .get(&fork_message.request_id)
+        .expect("fork job request record present");
+    assert_eq!(
+        inner
+            .id_token_grants
+            .get(&(fork_job_record.run_id, fork_job_record.job_id.clone())),
+        Some(&false),
+        "fork PR: no OIDC grant may be recorded"
+    );
+
+    // Trusted push: declared writes and OIDC survive verbatim.
+    let trusted_message = queued_message_for(&inner, trusted_run_id);
+    assert_eq!(
+        variable_value(&trusted_message, "system.github.token.permissions"),
+        Some(r#"{"Checks":"write","IdToken":"write"}"#),
+        "trusted job keeps the declared write profile"
+    );
+    let trusted_endpoint = trusted_message
+        .resources
+        .endpoints
+        .iter()
+        .find(|endpoint| endpoint.name.eq_ignore_ascii_case("SystemVssConnection"))
+        .expect("SystemVssConnection endpoint present");
+    assert!(
+        trusted_endpoint
+            .data
+            .get("GenerateIdTokenUrl")
+            .is_some_and(|url| !url.is_empty()),
+        "trusted job keeps the OIDC request URL"
+    );
+    let trusted_request = inner
+        .github_token_requests
+        .get(&trusted_message.request_id)
+        .expect("trusted job defers an App token request");
+    assert_eq!(
+        trusted_request.permissions,
+        BTreeMap::from([("checks".to_owned(), "write".to_owned())]),
+        "trusted job's App token request carries only real App repository permissions"
+    );
+    assert!(
+        !trusted_request.permissions.contains_key("id-token"),
+        "the App installation-token request must exclude the non-App id-token scope"
+    );
+    assert!(
+        !trusted_request.untrusted,
+        "trusted job is not marked untrusted"
+    );
+
+    // pull_request_target: base-repo trust, declared writes untouched.
+    let target_message = queued_message_for(&inner, target_run_id);
+    assert_eq!(
+        variable_value(&target_message, "system.github.token.permissions"),
+        Some(r#"{"Checks":"write","IdToken":"write"}"#),
+        "pull_request_target keeps base-repo trust"
+    );
+    drop(inner);
+
+    // The OIDC endpoint enforces the same grant: refused for the fork,
+    // minted for the trusted job.
+    let fork_uri = format!(
+        "/runner/server/_apis/distributedtask/hubs/actions/plans/{}/jobs/{}/oidctoken?audience=api://test",
+        fork_message.plan.plan_id, fork_message.job_id
+    );
+    let (status, _) = try_req(&app, Method::GET, &fork_uri, Value::Null).await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "fork PR: OIDC token request must be refused"
+    );
+    let trusted_uri = format!(
+        "/runner/server/_apis/distributedtask/hubs/actions/plans/{}/jobs/{}/oidctoken?audience=api://test",
+        trusted_message.plan.plan_id, trusted_message.job_id
+    );
+    let token = request_json(&app, Method::GET, &trusted_uri, Value::Null).await;
+    assert!(
+        token["value"]
+            .as_str()
+            .is_some_and(|jwt| jwt.split('.').count() == 3),
+        "trusted job still mints an OIDC JWT"
+    );
+}
+
+/// A mint failure for an untrusted fork job must never reach the configured
+/// `PRELOOP_GITHUB_TOKEN` PAT fallback: the PAT is repository-unscoped and
+/// ignores `permissions:`, so handing it to fork PR code would grant
+/// authority GitHub's read-only fork profile never allowed. The job keeps the
+/// local runtime token instead — while a trusted job under the same `pat`
+/// policy still receives the PAT.
+#[tokio::test]
+async fn untrusted_job_mint_failure_never_falls_back_to_the_pat() {
+    use crate::github_app::{GitHubAppCredentials, MintFailurePolicy};
+
+    let private_key = rsa::RsaPrivateKey::new(&mut rand::thread_rng(), 2048).unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let mut state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let mut creds = GitHubAppCredentials::for_tests("424", private_key, MintFailurePolicy::Pat);
+    creds.pat_fallback = Some("github_pat_broad".to_owned());
+    state.github_app = Some(creds);
+    let shutdown = CancellationToken::new();
+    let app = app(state.clone(), shutdown.clone());
+
+    // `local-workspace-only` carries no `owner/repo` slug, so the mint fails
+    // before it signs anything or opens a socket — exactly like
+    // `app_token_mint_failure_follows_the_configured_policy`.
+    let yaml = "on: push\npermissions:\n  checks: write\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n";
+    let fork = request_json(
+        &app,
+        Method::POST,
+        "/api/v1/runs",
+        json!({
+            "workflow_yaml": yaml,
+            "event": "push",
+            "repository": "local-workspace-only",
+            "trust_tier": "untrusted-fork-pull-request",
+        }),
+    )
+    .await;
+    let trusted = request_json(
+        &app,
+        Method::POST,
+        "/api/v1/runs",
+        json!({
+            "workflow_yaml": yaml,
+            "event": "push",
+            "repository": "local-workspace-only",
+        }),
+    )
+    .await;
+
+    {
+        let inner = state.inner.lock().await;
+        let fork_message = queued_message_for(&inner, fork["run_id"].as_str().unwrap());
+        let fork_request = inner
+            .github_token_requests
+            .get(&fork_message.request_id)
+            .cloned()
+            .expect("fork job defers a token request");
+        let trusted_message = queued_message_for(&inner, trusted["run_id"].as_str().unwrap());
+        let trusted_request = inner
+            .github_token_requests
+            .get(&trusted_message.request_id)
+            .cloned()
+            .expect("trusted job defers a token request");
+        assert!(fork_request.untrusted);
+        assert!(!trusted_request.untrusted);
+        let shared = Arc::new(SharedState {
+            state: state.clone(),
+            shutdown: shutdown.clone(),
+        });
+        let fork_mint = crate::broker::mint_dispatch_github_token(&shared, &fork_request).await;
+        assert!(
+            matches!(fork_mint, Ok(None)),
+            "fork job must not receive the PAT fallback under the `pat` policy"
+        );
+        let trusted_mint =
+            crate::broker::mint_dispatch_github_token(&shared, &trusted_request).await;
+        assert_eq!(
+            trusted_mint
+                .expect("trusted job's mint failure is not a dispatch error")
+                .expect("pat policy hands the PAT to a trusted job")
+                .token,
+            "github_pat_broad",
+            "the PAT fallback still applies to trusted jobs"
+        );
+    }
+}
+
+/// The broker claim swaps the build-time token for the minted App token.
+/// Every runner-visible alias must follow coherently — `system.github.token`
+/// (the `${{ github.token }}` variable), `github_token`, the
+/// `${{ secrets.GITHUB_TOKEN }}` alias, and the `github` context's `token`
+/// entry — or workflow code would read a stale local runtime token from one
+/// alias while the others carry the scoped mint.
+#[tokio::test]
+async fn broker_claim_patches_every_token_alias_with_the_minted_token() {
+    use crate::github_app::{GitHubAppCredentials, MintFailurePolicy};
+    use axum::routing::{get, post};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let api_base = format!("http://{}", listener.local_addr().unwrap());
+    let stub = Router::new()
+        .route(
+            "/app/installations",
+            get(|| async { Json(json!([{"id": 4242, "account": {"login": "owner"}}])) }),
+        )
+        .route(
+            "/app/installations/:installation_id/access_tokens",
+            post(
+                |Path(installation_id): Path<u64>, body: Json<Value>| async move {
+                    assert_eq!(installation_id, 4242);
+                    assert_eq!(body.0["permissions"], json!({"checks": "write"}));
+                    assert!(
+                        body.0["permissions"].get("id-token").is_none(),
+                        "id-token is not an installation-token scope and must not be requested"
+                    );
+                    Json(json!({
+                        "token": "ghs_minted_alias_token",
+                        "expires_at": "2999-01-01T00:00:00Z"
+                    }))
+                },
+            ),
+        );
+    tokio::spawn(async move { axum::serve(listener, stub).await.unwrap() });
+
+    // Held for the whole test: `PRELOOP_GITHUB_API_URL` is process-global.
+    // `TestEnvVar` restores it even if an assertion below panics — a bare
+    // `remove_var` at the end of the body leaks this stub's address to every
+    // later test when the test fails, which turns one failure into a cascade.
+    let _env = crate::state::GITHUB_ENV_LOCK.lock().await;
+    let _api_url = crate::state::TestEnvVar::set("PRELOOP_GITHUB_API_URL", api_base);
+
+    let private_key = rsa::RsaPrivateKey::new(&mut rand::thread_rng(), 2048).unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let mut state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    state.github_app = Some(GitHubAppCredentials::for_tests(
+        "424",
+        private_key,
+        MintFailurePolicy::LocalJwt,
+    ));
+    let app = app(state.clone(), CancellationToken::new());
+
+    let registered = request_json(
+        &app,
+        Method::POST,
+        "/runner/server/_apis/v1/Agent/1/0",
+        json!({"name": "alias-runner", "version": "2.335.1"}),
+    )
+    .await;
+    let runner_id = registered["id"].as_i64().unwrap();
+    let runner_token = state
+        .local_jwt(json!({
+            "sub": format!("preloop-runner-listen-{runner_id}"),
+            "scp": "ActionsRuntime.RunnerListen",
+        }))
+        .unwrap();
+
+    request_json(
+        &app,
+        Method::POST,
+        "/api/v1/runs",
+        json!({
+            "workflow_yaml": "on: push\npermissions:\n  checks: write\n  id-token: write\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n",
+            "event": "push",
+            "payload": {"ref": "refs/heads/main", "commits": []},
+            "repository": "owner/repo",
+            "git_ref": "refs/heads/main",
+        }),
+    )
+    .await;
+
+    let session = request_json_with_bearer(
+        &app,
+        Method::POST,
+        "/runner/server/session",
+        json!({}),
+        &runner_token,
+    )
+    .await;
+    let session_id = session["sessionId"].as_str().unwrap();
+    let job_ref = request_json_with_bearer(
+        &app,
+        Method::GET,
+        &format!("/runner/server/message?sessionId={session_id}&status=Online&waitSeconds=0"),
+        Value::Null,
+        &runner_token,
+    )
+    .await;
+    let body: Value = serde_json::from_str(job_ref["body"].as_str().unwrap()).unwrap();
+    let runner_request_id = body["runner_request_id"].as_str().unwrap();
+
+    let acquired = request_json_with_bearer(
+        &app,
+        Method::POST,
+        &format!("/broker/{runner_id}/acquirejob"),
+        json!({"jobMessageId": runner_request_id, "billingOwnerId": "local", "runnerOS": "Linux"}),
+        &runner_token,
+    )
+    .await;
+    for name in ["system.github.token", "github_token", "GITHUB_TOKEN"] {
+        assert_eq!(
+            acquired["variables"][name]["value"], "ghs_minted_alias_token",
+            "{name} must carry the minted App token after the claim"
+        );
+        assert_eq!(
+            acquired["variables"][name]["isSecret"], true,
+            "{name} must stay marked secret"
+        );
+    }
+    // `${{ github.token }}` in the workflow context must see the same mint.
+    let context_pairs = acquired["contextData"]["github"]["d"].as_array().unwrap();
+    let context_token = context_pairs
+        .iter()
+        .find(|pair| pair["k"] == "token")
+        .expect("github context carries a token entry")
+        .clone();
+    assert_eq!(
+        context_token["v"], "ghs_minted_alias_token",
+        "the github context token must be the minted App token"
+    );
+    // No narrowing occurred, so the wire permissions keep the declared set
+    // (including the OIDC metadata for this trusted job).
+    assert_eq!(
+        acquired["variables"]["system.github.token.permissions"]["value"],
+        r#"{"Checks":"write","IdToken":"write"}"#,
+        "an un-narrowed mint leaves the declared wire permissions intact"
+    );
+}
+
+/// When the App installation grants fewer repository permissions than the
+/// job requested, the broker narrows the mint and must restate the wire
+/// permissions: App-scoped entries come from the effective grant (a scope
+/// the installation lacks disappears), while a trusted job's Actions-only
+/// metadata (`IdToken: write`, whose OIDC grant is still live) survives.
+/// A fork-restricted job's wire set has no IdToken and must not gain one.
+#[tokio::test]
+async fn broker_claim_merges_narrowed_grants_with_actions_only_metadata() {
+    use crate::github_app::{GitHubAppCredentials, MintFailurePolicy};
+    use axum::routing::{get, post};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let api_base = format!("http://{}", listener.local_addr().unwrap());
+    // The installation grants `contents`, `metadata` and `pull-requests` at
+    // read — but NOT `checks`. The first mint for each claim therefore 422s
+    // (checks is ungranted), the grants are fetched, the request is clamped,
+    // and the second mint succeeds with only the granted scope.
+    let access_token_calls = Arc::new(AtomicUsize::new(0));
+    let stub = Router::new()
+        .route(
+            "/app/installations",
+            get(|| async { Json(json!([{"id": 4242, "account": {"login": "owner"}}])) }),
+        )
+        .route(
+            "/app/installations/:installation_id",
+            get(|Path(installation_id): Path<u64>| async move {
+                assert_eq!(installation_id, 4242);
+                Json(json!({
+                    "permissions": {
+                        "contents": "read",
+                        "metadata": "read",
+                        "pull_requests": "read"
+                    }
+                }))
+            }),
+        )
+        .route(
+            "/app/installations/:installation_id/access_tokens",
+            post({
+                let access_token_calls = access_token_calls.clone();
+                move |Path(installation_id): Path<u64>, body: Json<Value>| {
+                    let access_token_calls = access_token_calls.clone();
+                    async move {
+                        assert_eq!(installation_id, 4242);
+                        let call = access_token_calls.fetch_add(1, Ordering::SeqCst);
+                        match call {
+                            // First attempt per claim: the ungranted `checks`
+                            // scope makes GitHub reject the whole request.
+                            0 | 2 => axum::response::Response::builder()
+                                .status(StatusCode::UNPROCESSABLE_ENTITY)
+                                .body(Body::from(
+                                    json!({"message": "checks is not granted"}).to_string(),
+                                ))
+                                .unwrap(),
+                            _ => {
+                                // The clamped request names only the granted
+                                // scope, and never the Actions-only id-token.
+                                assert_eq!(body.0["permissions"], json!({"pull_requests": "read"}));
+                                assert!(body.0["permissions"].get("id-token").is_none());
+                                axum::Json(json!({
+                                    "token": format!("ghs_narrowed_{call}"),
+                                    "expires_at": "2999-01-01T00:00:00Z"
+                                }))
+                                .into_response()
+                            }
+                        }
+                    }
+                }
+            }),
+        );
+    tokio::spawn(async move { axum::serve(listener, stub).await.unwrap() });
+
+    // Held for the whole test: `PRELOOP_GITHUB_API_URL` is process-global, and
+    // `TestEnvVar` restores it through a panicking assertion.
+    let _env = crate::state::GITHUB_ENV_LOCK.lock().await;
+    let _api_url = crate::state::TestEnvVar::set("PRELOOP_GITHUB_API_URL", api_base);
+
+    let private_key = rsa::RsaPrivateKey::new(&mut rand::thread_rng(), 2048).unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let mut state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    state.github_app = Some(GitHubAppCredentials::for_tests(
+        "424",
+        private_key,
+        MintFailurePolicy::LocalJwt,
+    ));
+    let app = app(state.clone(), CancellationToken::new());
+    let registered = request_json(
+        &app,
+        Method::POST,
+        "/runner/server/_apis/v1/Agent/1/0",
+        json!({"name": "narrow-runner", "version": "2.335.1"}),
+    )
+    .await;
+    let runner_id = registered["id"].as_i64().unwrap();
+    let runner_token = state
+        .local_jwt(json!({
+            "sub": format!("preloop-runner-listen-{runner_id}"),
+            "scp": "ActionsRuntime.RunnerListen",
+        }))
+        .unwrap();
+
+    let yaml = "on: push\npermissions:\n  checks: write\n  pull-requests: write\n  id-token: write\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n";
+    let submit = |tier: Option<&'static str>| {
+        let app = app.clone();
+        async move {
+            request_json(
+                &app,
+                Method::POST,
+                "/api/v1/runs",
+                json!({
+                    "workflow_yaml": yaml,
+                    "event": "push",
+                    "payload": {"ref": "refs/heads/main", "commits": []},
+                    "repository": "owner/repo",
+                    "git_ref": "refs/heads/main",
+                    "trust_tier": tier,
+                }),
+            )
+            .await
+        }
+    };
+
+    async fn claim_and_return(app: &Router, runner_id: i64, runner_token: &str) -> Value {
+        let session = request_json_with_bearer(
+            app,
+            Method::POST,
+            "/runner/server/session",
+            json!({}),
+            runner_token,
+        )
+        .await;
+        let session_id = session["sessionId"].as_str().unwrap();
+        let job_ref = request_json_with_bearer(
+            app,
+            Method::GET,
+            &format!("/runner/server/message?sessionId={session_id}&status=Online&waitSeconds=0"),
+            Value::Null,
+            runner_token,
+        )
+        .await;
+        let body: Value = serde_json::from_str(job_ref["body"].as_str().unwrap()).unwrap();
+        let runner_request_id = body["runner_request_id"].as_str().unwrap();
+        request_json_with_bearer(
+            app,
+            Method::POST,
+            &format!("/broker/{runner_id}/acquirejob"),
+            json!({"jobMessageId": runner_request_id, "billingOwnerId": "local", "runnerOS": "Linux"}),
+            runner_token,
+        )
+        .await
+    }
+
+    // Trusted job first (claim 1): declared writes are clamped to the
+    // installation's grant, `checks` disappears entirely, and `IdToken: write`
+    // survives because the OIDC grant is still live.
+    submit(None).await;
+    let trusted = claim_and_return(&app, runner_id, &runner_token).await;
+    assert_eq!(
+        trusted["variables"]["system.github.token.permissions"]["value"],
+        r#"{"IdToken":"write","PullRequests":"read"}"#,
+        "trusted wire keeps the OIDC metadata and reflects the narrowed App grant"
+    );
+    let trusted_endpoint = trusted["resources"]["endpoints"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|endpoint| {
+            endpoint["name"]
+                .as_str()
+                .is_some_and(|name| name.eq_ignore_ascii_case("SystemVssConnection"))
+        })
+        .expect("SystemVssConnection endpoint present");
+    assert!(
+        trusted_endpoint["data"]["GenerateIdTokenUrl"]
+            .as_str()
+            .is_some_and(|url| !url.is_empty()),
+        "trusted job's OIDC grant survives the narrowing"
+    );
+    assert_eq!(
+        trusted["variables"]["system.github.token"]["value"], "ghs_narrowed_1",
+        "trusted job carries the minted token"
+    );
+
+    // Fork job (claim 3): same declared workflow, but the fork profile never
+    // carried IdToken — the narrowed restatement must not invent one.
+    submit(Some("untrusted-fork-pull-request")).await;
+    let fork = claim_and_return(&app, runner_id, &runner_token).await;
+    assert_eq!(
+        fork["variables"]["system.github.token.permissions"]["value"], r#"{"PullRequests":"read"}"#,
+        "fork wire reflects the narrowed grant with no IdToken metadata"
+    );
+    assert!(
+        !fork["variables"]["system.github.token.permissions"]["value"]
+            .as_str()
+            .is_some_and(|wire| wire.contains("IdToken")),
+        "fork wire must not advertise IdToken"
+    );
+    let fork_endpoint = fork["resources"]["endpoints"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|endpoint| {
+            endpoint["name"]
+                .as_str()
+                .is_some_and(|name| name.eq_ignore_ascii_case("SystemVssConnection"))
+        })
+        .expect("SystemVssConnection endpoint present");
+    assert!(
+        !fork_endpoint["data"]["GenerateIdTokenUrl"]
+            .as_str()
+            .is_some_and(|url| !url.is_empty()),
+        "fork job gets no OIDC request URL"
+    );
+    assert_eq!(
+        fork["variables"]["system.github.token"]["value"], "ghs_narrowed_3",
+        "fork job carries the minted token"
+    );
+}
+
+/// The deferred App-token request is deliberately kept past the first claim so
+/// a re-claim after a runner disconnect re-mints under the build-time
+/// conditions (the original permission set and its fallback restrictions).
+/// It must not outlive the *job*, though: the record pins a repository and a
+/// permission set, it is persisted into the store snapshot, and a stale entry
+/// would let a re-claim mint fresh GitHub authority for work that is over.
+///
+/// Clearing it inside the broker's own `completejob` handler is not enough —
+/// the legacy `/_apis` completion endpoints and the lease-expiry reaper never
+/// run that handler. Every completion path does funnel through
+/// `complete_job_inner`, so that is where the record is dropped, and this test
+/// completes through the non-broker compat route to prove it.
+#[tokio::test]
+async fn a_completed_job_drops_its_deferred_token_request() {
+    use crate::github_app::{GitHubAppCredentials, MintFailurePolicy};
+
+    // A port nothing listens on: the mint fails on connect, so the claim
+    // exercises the retention path without any network round trip. Under
+    // `LocalJwt` the job simply keeps its local runtime token.
+    let closed_port = {
+        let probe = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        probe.local_addr().unwrap().port()
+    };
+
+    // Held for the whole test: `PRELOOP_GITHUB_API_URL` is process-global.
+    let _env = crate::state::GITHUB_ENV_LOCK.lock().await;
+    let _api_url = crate::state::TestEnvVar::set(
+        "PRELOOP_GITHUB_API_URL",
+        format!("http://127.0.0.1:{closed_port}"),
+    );
+
+    let private_key = rsa::RsaPrivateKey::new(&mut rand::thread_rng(), 2048).unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let mut state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    state.github_app = Some(GitHubAppCredentials::for_tests(
+        "424",
+        private_key,
+        MintFailurePolicy::LocalJwt,
+    ));
+    let app = app(state.clone(), CancellationToken::new());
+
+    let registered = request_json(
+        &app,
+        Method::POST,
+        "/runner/server/_apis/v1/Agent/1/0",
+        json!({"name": "lifetime-runner", "version": "2.335.1"}),
+    )
+    .await;
+    let runner_id = registered["id"].as_i64().unwrap();
+    let runner_token = state
+        .local_jwt(json!({
+            "sub": format!("preloop-runner-listen-{runner_id}"),
+            "scp": "ActionsRuntime.RunnerListen",
+        }))
+        .unwrap();
+
+    let accepted = request_json(
+        &app,
+        Method::POST,
+        "/api/v1/runs",
+        json!({
+            "workflow_yaml": "on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n",
+            "event": "push",
+            "payload": {"ref": "refs/heads/main", "commits": []},
+            "repository": "owner/repo",
+            "git_ref": "refs/heads/main",
+        }),
+    )
+    .await;
+    let run_id: RunId = accepted["run_id"].as_str().unwrap().parse().unwrap();
+
+    let session = request_json_with_bearer(
+        &app,
+        Method::POST,
+        "/runner/server/session",
+        json!({}),
+        &runner_token,
+    )
+    .await;
+    let session_id = session["sessionId"].as_str().unwrap();
+    let job_ref = request_json_with_bearer(
+        &app,
+        Method::GET,
+        &format!("/runner/server/message?sessionId={session_id}&status=Online&waitSeconds=0"),
+        Value::Null,
+        &runner_token,
+    )
+    .await;
+    let body: Value = serde_json::from_str(job_ref["body"].as_str().unwrap()).unwrap();
+    let runner_request_id = body["runner_request_id"].as_str().unwrap();
+
+    let _acquired = request_json_with_bearer(
+        &app,
+        Method::POST,
+        &format!("/broker/{runner_id}/acquirejob"),
+        json!({"jobMessageId": runner_request_id, "billingOwnerId": "local", "runnerOS": "Linux"}),
+        &runner_token,
+    )
+    .await;
+
+    // The internal request id is deliberately not on the wire (the broker
+    // zeroes `requestId` because run-service payloads use the DTO default),
+    // so read it from the correlation table the submit path populates.
+    let request_id = {
+        let inner = state.inner.lock().await;
+        let ids: Vec<i64> = inner.job_requests.keys().copied().collect();
+        assert_eq!(ids.len(), 1, "one job means one request record: {ids:?}");
+        // Half one: the claim must NOT consume the record, or a re-claim after
+        // a disconnect would rebuild it from defaults and lose both the
+        // declared permission set and the fork profile.
+        assert!(
+            inner.github_token_requests.contains_key(&ids[0]),
+            "the token request must survive the claim so a re-claim re-mints \
+             under the build-time permission set and fallback restrictions"
+        );
+        ids[0]
+    };
+
+    // Half two: complete through the legacy compat route — the broker's own
+    // `completejob` handler never runs here, exactly as for a lease-expiry
+    // reap or an `/_apis` finish callback.
+    request_json(
+        &app,
+        Method::PATCH,
+        &format!("/runner/server/_apis/distributedtask/hubs/actions/plans/{run_id}/jobs/build"),
+        json!({"status": "succeeded"}),
+    )
+    .await;
+
+    let inner = state.inner.lock().await;
+    assert!(
+        !inner.github_token_requests.contains_key(&request_id),
+        "a terminal job must not leave its App-token request registered: \
+         {:?}",
+        inner.github_token_requests
+    );
+    assert!(
+        inner
+            .job_requests
+            .get(&request_id)
+            .is_some_and(|record| record.result.is_some()),
+        "the completion must have settled the job request"
+    );
+}
+
+/// A `GitHubTokenRequest` persisted by a pre-upgrade server has no
+/// `untrusted` field. Deserializing it as trusted would silently re-enable
+/// the PAT fallback after a restart, so missing trust metadata must fail
+/// closed — and the mint path must then refuse the PAT for such a request.
+#[tokio::test]
+async fn persisted_token_request_without_trust_metadata_fails_closed() {
+    use crate::github_app::{GitHubAppCredentials, MintFailurePolicy};
+
+    // The exact shape a pre-upgrade store snapshot would carry: no
+    // `untrusted` key at all.
+    let old: crate::models::GitHubTokenRequest = serde_json::from_str(
+        r#"{"repository":"owner/repo","permissions":{"checks":"write"},"declared":true}"#,
+    )
+    .unwrap();
+    assert!(
+        old.untrusted,
+        "missing persisted trust metadata must deserialize as untrusted"
+    );
+
+    // Newly created trusted requests serialize the field explicitly, so the
+    // fail-closed default only ever applies to genuinely old state.
+    let trusted = crate::models::GitHubTokenRequest {
+        repository: "owner/repo".to_owned(),
+        permissions: BTreeMap::from([("checks".to_owned(), "write".to_owned())]),
+        declared: true,
+        untrusted: false,
+    };
+    let wire = serde_json::to_string(&trusted).unwrap();
+    assert!(
+        wire.contains("\"untrusted\":false"),
+        "trusted requests must persist their trust metadata explicitly: {wire}"
+    );
+    let round_tripped: crate::models::GitHubTokenRequest = serde_json::from_str(&wire).unwrap();
+    assert!(!round_tripped.untrusted);
+
+    // Broker/mint assertion: an old request (untrusted by fail-closed
+    // default) under the `pat` policy must not receive the PAT when the mint
+    // fails — `local-workspace-only` fails before any network I/O.
+    let private_key = rsa::RsaPrivateKey::new(&mut rand::thread_rng(), 2048).unwrap();
+    let temp = tempfile::tempdir().unwrap();
+    let mut state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let mut creds = GitHubAppCredentials::for_tests("424", private_key, MintFailurePolicy::Pat);
+    creds.pat_fallback = Some("github_pat_broad".to_owned());
+    state.github_app = Some(creds);
+    let shared = Arc::new(SharedState {
+        state,
+        shutdown: CancellationToken::new(),
+    });
+    let old_request = crate::models::GitHubTokenRequest {
+        repository: "local-workspace-only".to_owned(),
+        permissions: old.permissions.clone(),
+        declared: true,
+        untrusted: old.untrusted,
+    };
+    let mint = crate::broker::mint_dispatch_github_token(&shared, &old_request).await;
+    assert!(
+        matches!(mint, Ok(None)),
+        "a request whose trust metadata was never recorded must not receive the PAT fallback"
+    );
+}
+
+/// A PAT-only deployment embeds the static PAT into job messages at build
+/// time. That override must never reach a fork-restricted job: the job keeps
+/// the local job-scoped runtime token, which authenticates only against this
+/// control plane.
+#[tokio::test]
+async fn fork_job_never_receives_the_configured_pat_override() {
+    let temp = tempfile::tempdir().unwrap();
+    let config_path = temp.path().join("config.toml");
+    std::fs::write(&config_path, "[github]\npat = \"github_pat_testvalue\"\n").unwrap();
+    let state = AppState::new_with_config(temp.path().to_path_buf(), config_path)
+        .await
+        .unwrap();
+    assert!(
+        state.github_app.is_none(),
+        "config declares no app id or pem"
+    );
+    // The effective PAT is env-then-config (state.rs), and other tests mutate
+    // `PRELOOP_GITHUB_TOKEN` without the env lock — so assert against the
+    // effective value rather than the config literal to stay race-proof.
+    let pat = state
+        .static_github_pat()
+        .expect("config declares a PAT")
+        .to_owned();
+    let app = app(state.clone(), CancellationToken::new());
+
+    let yaml =
+        "on: push\njobs:\n  probe:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n";
+    let fork = request_json(
+        &app,
+        Method::POST,
+        "/api/v1/runs",
+        json!({
+            "workflow_yaml": yaml,
+            "event": "push",
+            "repository": "owner/repo",
+            "trust_tier": "untrusted-fork-pull-request",
+        }),
+    )
+    .await;
+    let trusted = request_json(
+        &app,
+        Method::POST,
+        "/api/v1/runs",
+        json!({
+            "workflow_yaml": yaml,
+            "event": "push",
+            "repository": "owner/repo",
+        }),
+    )
+    .await;
+
+    let inner = state.inner.lock().await;
+    let fork_message = queued_message_for(&inner, fork["run_id"].as_str().unwrap());
+    let runtime_token = state.mint_runtime_token(&fork_message.plan.plan_id, &fork_message.job_id);
+    for name in ["system.github.token", "github_token", "GITHUB_TOKEN"] {
+        assert_eq!(
+            variable_value(&fork_message, name),
+            Some(runtime_token.as_str()),
+            "fork job must carry the local runtime token, not the PAT ({name})"
+        );
+    }
+    assert_ne!(
+        variable_value(&fork_message, "system.github.token"),
+        Some(pat.as_str()),
+        "the static PAT must not reach a fork-restricted job"
+    );
+
+    let trusted_message = queued_message_for(&inner, trusted["run_id"].as_str().unwrap());
+    assert_eq!(
+        variable_value(&trusted_message, "system.github.token"),
+        Some(pat.as_str()),
+        "trusted jobs still receive the configured PAT"
+    );
+}
+
+/// End-to-end through the webhook adapter: a fork `pull_request` delivery is
+/// stamped `UntrustedForkPullRequest` and the queued job must show the
+/// downgraded profile and no OIDC URL, and stored secrets stay denied.
+#[tokio::test]
+async fn fork_pull_request_webhook_jobs_are_downgraded_and_secrets_denied() {
+    // The webhook path creates check runs, and it only takes its mock branch
+    // while no GitHub credential is visible. `PRELOOP_GITHUB_TOKEN` and
+    // `PRELOOP_GITHUB_API_URL` are process-global, so a co-scheduled test that
+    // points them at its own stub would send this run's check-run POST there
+    // and turn the webhook 200 into a 502. Serialize on the same lock those
+    // tests hold, and guarantee the mock branch for this body.
+    let _env = crate::state::GITHUB_ENV_LOCK.lock().await;
+    let _no_token = crate::state::TestEnvVar::unset("PRELOOP_GITHUB_TOKEN");
+    let _no_api_url = crate::state::TestEnvVar::unset("PRELOOP_GITHUB_API_URL");
+
+    let temp = tempfile::tempdir().unwrap();
+    let ws_dir = temp.path().join("workspace");
+    tokio::fs::create_dir_all(ws_dir.join(".github/workflows"))
+        .await
+        .unwrap();
+    tokio::fs::write(
+        ws_dir.join(".github/workflows/test.yml"),
+        "on: pull_request\npermissions:\n  checks: write\n  id-token: write\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n",
+    )
+    .await
+    .unwrap();
+
+    let mut state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    state.webhook_secret = Some("super-secret".to_owned());
+    state.local_workspace = Some(ws_dir);
+    {
+        let mut secrets = state.secrets.write();
+        secrets.repo.insert(
+            "owner/repo".to_owned(),
+            BTreeMap::from([("REPO_TOKEN".to_owned(), "repo-value".to_owned())]),
+        );
+    }
+    let app = app(state.clone(), CancellationToken::new());
+
+    // `head.repo.fork` absent defaults to fork — the same shape the existing
+    // webhook test delivers, now asserting the downgrade.
+    let payload = serde_json::json!({
+        "action": "opened",
+        "number": 42,
+        "pull_request": {
+            "head": {
+                "ref": "feature-branch",
+                "sha": "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3"
+            },
+            "base": {
+                "ref": "main",
+                "sha": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+            }
+        },
+        "repository": {
+            "full_name": "owner/repo",
+            "default_branch": "main"
+        }
+    });
+    let payload_bytes = serde_json::to_vec(&payload).unwrap();
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+    type HmacSha256 = Hmac<Sha256>;
+    let mut mac = HmacSha256::new_from_slice(b"super-secret").unwrap();
+    mac.update(&payload_bytes);
+    let sig_bytes = mac.finalize().into_bytes();
+    let sig_hex = sig_bytes
+        .iter()
+        .map(|b| format!("{:02x}", b))
+        .collect::<String>();
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/v1/github/webhooks")
+                .header("x-github-event", "pull_request")
+                .header("x-hub-signature-256", format!("sha256={sig_hex}"))
+                .header("content-type", "application/json")
+                .body(Body::from(payload_bytes))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let inner = state.inner.lock().await;
+    let (_, run_record) = inner.runs.iter().next().unwrap();
+    assert_eq!(
+        run_record.submission.trust_tier.as_deref(),
+        Some("untrusted-fork-pull-request"),
+        "the webhook adapter must stamp the fork tier"
+    );
+    let run_id = run_record.run_id.to_string();
+    let message = queued_message_for(&inner, &run_id);
+    assert_eq!(
+        variable_value(&message, "system.github.token.permissions"),
+        Some(r#"{"Checks":"read"}"#),
+        "webhook-delivered fork PR job is downgraded to read-only with no IdToken metadata"
+    );
+    let endpoint = message
+        .resources
+        .endpoints
+        .iter()
+        .find(|endpoint| endpoint.name.eq_ignore_ascii_case("SystemVssConnection"))
+        .expect("SystemVssConnection endpoint present");
+    assert!(
+        !endpoint
+            .data
+            .get("GenerateIdTokenUrl")
+            .is_some_and(|url| !url.is_empty()),
+        "webhook-delivered fork PR job gets no OIDC request URL"
+    );
+    assert_eq!(
+        variable_value(&message, "REPO_TOKEN"),
+        None,
+        "stored secrets stay denied for the fork PR job"
+    );
+    drop(inner);
+
+    // Trusted control through the same build path: the same stored secret is
+    // injected and the declared writes survive.
+    let trusted = request_json(
+        &app,
+        Method::POST,
+        "/api/v1/runs",
+        json!({
+            "workflow_yaml": "on: push\npermissions:\n  checks: write\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n",
+            "event": "push",
+            "repository": "owner/repo",
+        }),
+    )
+    .await;
+    let inner = state.inner.lock().await;
+    let trusted_message = queued_message_for(&inner, trusted["run_id"].as_str().unwrap());
+    assert_eq!(
+        variable_value(&trusted_message, "REPO_TOKEN"),
+        Some("repo-value"),
+        "trusted jobs still receive stored secrets"
+    );
+    assert_eq!(
+        variable_value(&trusted_message, "system.github.token.permissions"),
+        Some(r#"{"Checks":"write"}"#),
+        "trusted jobs keep declared writes"
+    );
 }
 
 /// A failed installation-token mint must never silently reach for the broad
@@ -7576,6 +8644,13 @@ async fn runner_lease_expiration_disconnect_reaper() {
 
 #[tokio::test]
 async fn github_webhook_flows_with_signature_and_check_runs() {
+    // This test asserts the mock check-run path (`check_run_id > 0` with no
+    // GitHub server involved). A co-scheduled test's `PRELOOP_GITHUB_TOKEN`
+    // would flip it to a live API call that fails, leaving zero check runs.
+    let _env = crate::state::GITHUB_ENV_LOCK.lock().await;
+    let _no_token = crate::state::TestEnvVar::unset("PRELOOP_GITHUB_TOKEN");
+    let _no_api_url = crate::state::TestEnvVar::unset("PRELOOP_GITHUB_API_URL");
+
     let temp = tempfile::tempdir().unwrap();
 
     // 1. Create a dummy workflow file in a local workspace
@@ -7701,24 +8776,8 @@ async fn check_run_ids_survive_a_restart_before_any_job_event() {
     // parallel test's token would flip the check-run path from mock to a real
     // GitHub API call. The mock path is the contract under test.
     let _env = crate::state::GITHUB_ENV_LOCK.lock().await;
-    let saved_token = std::env::var_os("PRELOOP_GITHUB_TOKEN");
-    let saved_api_url = std::env::var_os("PRELOOP_GITHUB_API_URL");
-    std::env::remove_var("PRELOOP_GITHUB_TOKEN");
-    std::env::remove_var("PRELOOP_GITHUB_API_URL");
-    struct RestoreGitHubEnv(Option<std::ffi::OsString>, Option<std::ffi::OsString>);
-    impl Drop for RestoreGitHubEnv {
-        fn drop(&mut self) {
-            match &self.0 {
-                Some(value) => std::env::set_var("PRELOOP_GITHUB_TOKEN", value),
-                None => std::env::remove_var("PRELOOP_GITHUB_TOKEN"),
-            }
-            match &self.1 {
-                Some(value) => std::env::set_var("PRELOOP_GITHUB_API_URL", value),
-                None => std::env::remove_var("PRELOOP_GITHUB_API_URL"),
-            }
-        }
-    }
-    let _restore = RestoreGitHubEnv(saved_token, saved_api_url);
+    let _no_token = crate::state::TestEnvVar::unset("PRELOOP_GITHUB_TOKEN");
+    let _no_api_url = crate::state::TestEnvVar::unset("PRELOOP_GITHUB_API_URL");
 
     let temp = tempfile::tempdir().unwrap();
     let ws_dir = temp.path().join("workspace");
@@ -8065,6 +9124,11 @@ async fn github_webhook_concurrent_duplicate_delivery_creates_one_run() {
 
 #[tokio::test]
 async fn github_webhook_pull_request_event() {
+    // The webhook path reads `PRELOOP_GITHUB_TOKEN` / `PRELOOP_GITHUB_API_URL`
+    // live for check-run reporting. Hold the env lock so a concurrent
+    // env-mutating test cannot point those at a foreign credential or stub
+    // and turn this 200 into a 502.
+    let _env = crate::state::GITHUB_ENV_LOCK.lock().await;
     let temp = tempfile::tempdir().unwrap();
 
     // Create a dummy workflow file in a local workspace
@@ -13891,6 +14955,12 @@ async fn snapshot_401_advertises_a_bearer_challenge() {
 
 #[tokio::test]
 async fn local_workspace_checkout_acquires_synthetic_repository_and_serves_git_http() {
+    // `AppState::new` captures `PRELOOP_GITHUB_TOKEN` / `PRELOOP_GITHUB_APP_*`
+    // from the process env, and the claim path reads `PRELOOP_GITHUB_API_URL`
+    // live. Hold the env lock so a concurrent env-mutating test cannot make
+    // this job carry a foreign PAT (which would 401 the snapshot Git auth
+    // instead of 403 on the wrong-run probe).
+    let _env = crate::state::GITHUB_ENV_LOCK.lock().await;
     let temp = tempfile::tempdir().unwrap();
     let (state_dir, workspace) = create_snapshot_fixture(temp.path());
     let mut state = AppState::new(state_dir.clone()).await.unwrap();

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -6486,6 +6486,173 @@ async fn persisted_token_request_without_trust_metadata_fails_closed() {
     );
 }
 
+/// GitHub gives fork PR runs read-only cache access: they can restore from
+/// the base repository's cache but cannot save to it, so a fork cannot poison
+/// entries a trusted run later restores. Every cache write surface must deny
+/// fork-restricted jobs while reads stay open.
+#[tokio::test]
+async fn fork_pr_runs_get_read_only_cache_access() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+
+    let submit = |tier: Option<&'static str>| {
+        let app = app.clone();
+        async move {
+            request_json(
+                &app,
+                Method::POST,
+                "/api/v1/runs",
+                json!({
+                    "workflow_yaml": "on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n",
+                    "event": "push",
+                    "payload": {"ref": "refs/heads/main", "commits": []},
+                    "repository": "owner/repo",
+                    "git_ref": "refs/heads/main",
+                    "trust_tier": tier,
+                }),
+            )
+            .await
+        }
+    };
+
+    let fork = submit(Some("untrusted-fork-pull-request")).await;
+    let trusted = submit(None).await;
+
+    let (fork_token, fork_plan, fork_job) = {
+        let inner = state.inner.lock().await;
+        let message = queued_message_for(&inner, fork["run_id"].as_str().unwrap());
+        (
+            state.mint_runtime_token(&message.plan.plan_id, &message.job_id),
+            message.plan.plan_id.clone(),
+            message.job_id,
+        )
+    };
+    let trusted_token = {
+        let inner = state.inner.lock().await;
+        let message = queued_message_for(&inner, trusted["run_id"].as_str().unwrap());
+        state.mint_runtime_token(&message.plan.plan_id, &message.job_id)
+    };
+
+    async fn status_with_bearer(
+        app: &Router,
+        bearer: &str,
+        method: Method,
+        uri: &str,
+        body: Value,
+    ) -> StatusCode {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(method)
+                    .uri(uri)
+                    .header(header::AUTHORIZATION, format!("Bearer {bearer}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        response.status()
+    }
+
+    let create_uri = "/twirp/github.actions.results.api.v1.CacheService/CreateCacheEntry";
+    let finalize_uri = "/twirp/github.actions.results.api.v1.CacheService/FinalizeCacheEntryUpload";
+    let restore_uri = "/twirp/github.actions.results.api.v1.CacheService/GetCacheEntryDownloadURL";
+    let cache_body = json!({"key": "shared-key", "version": "v1"});
+
+    // Fork: writes refused on both the reserve (create) and finalize paths.
+    assert_eq!(
+        status_with_bearer(
+            &app,
+            &fork_token,
+            Method::POST,
+            create_uri,
+            cache_body.clone()
+        )
+        .await,
+        StatusCode::FORBIDDEN,
+        "fork PR run must not reserve a cache entry"
+    );
+    assert_eq!(
+        status_with_bearer(
+            &app,
+            &fork_token,
+            Method::POST,
+            finalize_uri,
+            cache_body.clone()
+        )
+        .await,
+        StatusCode::FORBIDDEN,
+        "fork PR run must not finalize a cache upload"
+    );
+    // Fork: restore stays open (a miss is a normal 200 `ok: false`).
+    assert_eq!(
+        status_with_bearer(
+            &app,
+            &fork_token,
+            Method::POST,
+            restore_uri,
+            cache_body.clone()
+        )
+        .await,
+        StatusCode::OK,
+        "fork PR run may still restore from the shared cache"
+    );
+    // Trusted control: the same write succeeds and returns an upload URL.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri(create_uri)
+                .header(header::AUTHORIZATION, format!("Bearer {trusted_token}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(cache_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(body["ok"], true);
+    assert!(
+        body["signed_upload_url"]
+            .as_str()
+            .is_some_and(|url| !url.is_empty()),
+        "trusted job still gets a cache upload URL"
+    );
+
+    // Legacy v1 surface (`actions/cache@v3`): the reserve write is denied too.
+    assert_eq!(
+        status_with_bearer(
+            &app,
+            &fork_token,
+            Method::POST,
+            "/_apis/artifactcache/cache",
+            json!({"key": "legacy-key", "version": "v1"}),
+        )
+        .await,
+        StatusCode::FORBIDDEN,
+        "fork PR run must not reserve through the v1 cache API"
+    );
+
+    // The runtime token genuinely names the fork job (not a blanket reject):
+    // the OIDC surface proves it by refusing this token's job.
+    let oidc_uri = format!(
+        "/runner/server/_apis/distributedtask/hubs/actions/plans/{fork_plan}/jobs/{fork_job}/oidctoken"
+    );
+    assert_eq!(
+        status_with_bearer(&app, &fork_token, Method::GET, &oidc_uri, Value::Null).await,
+        StatusCode::FORBIDDEN,
+        "the fork job's runtime token is real and its OIDC grant is denied"
+    );
+}
+
 /// A PAT-only deployment embeds the static PAT into job messages at build
 /// time. That override must never reach a fork-restricted job: the job keeps
 /// the local job-scoped runtime token, which authenticates only against this

--- a/crates/preloop-runner-server/src/models.rs
+++ b/crates/preloop-runner-server/src/models.rs
@@ -189,6 +189,27 @@ pub(crate) struct GitHubTokenRequest {
     /// A declared set must be minted verbatim or fail visibly; the implicit
     /// default may be narrowed to what the App installation actually grants.
     pub(crate) declared: bool,
+    /// Whether the job's trust tier restricts GitHub authority (fork PR or
+    /// fail-closed unknown event). Such jobs carry only the read-only fork
+    /// profile, and a mint failure never falls back to the broad
+    /// `PRELOOP_GITHUB_TOKEN` PAT: the job keeps the local runtime token
+    /// instead of receiving authority GitHub would not grant the fork.
+    ///
+    /// Missing persisted metadata fails closed: a request written by a
+    /// pre-upgrade server has no `untrusted` field, and deserializing it as
+    /// trusted would silently re-enable the PAT fallback after a restart for
+    /// a job whose tier was never recorded. Newly created requests always
+    /// serialize the field explicitly (`false` for trusted jobs), so only
+    /// genuinely old state hits the fail-closed default.
+    #[serde(default = "default_untrusted")]
+    pub(crate) untrusted: bool,
+}
+
+/// Fail-closed default for persisted [`GitHubTokenRequest`]s that predate
+/// the `untrusted` field: no recorded trust metadata means the request may
+/// have belonged to an untrusted job, so it is treated as untrusted.
+fn default_untrusted() -> bool {
+    true
 }
 
 /// Runner metadata used by dispatch matching.

--- a/crates/preloop-runner-server/src/results_twirp.rs
+++ b/crates/preloop-runner-server/src/results_twirp.rs
@@ -409,8 +409,10 @@ pub(crate) struct CacheV2GetDlUrlRequest {
 
 pub(crate) async fn twirp_cache_v2_create(
     State(shared): State<Arc<SharedState>>,
+    headers: axum::http::HeaderMap,
     Json(request): Json<CacheV2CreateRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
+    crate::events::trust_tier::ensure_cache_write_allowed(&shared.state, &headers).await?;
     let storage_key = scoped_cache_key(
         &request.key,
         request.scope.as_deref(),
@@ -480,8 +482,10 @@ pub(crate) async fn twirp_cache_v2_create(
 
 pub(crate) async fn twirp_cache_v2_finalize(
     State(shared): State<Arc<SharedState>>,
+    headers: axum::http::HeaderMap,
     Json(request): Json<CacheV2FinalizeRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
+    crate::events::trust_tier::ensure_cache_write_allowed(&shared.state, &headers).await?;
     let t0 = std::time::Instant::now();
     let storage_key = scoped_cache_key(
         &request.key,

--- a/crates/preloop-runner-server/src/runs.rs
+++ b/crates/preloop-runner-server/src/runs.rs
@@ -110,12 +110,7 @@ fn validate_schedule_crons(workflow: &preloop_gha_parser::Workflow) -> Result<()
 /// (repo/global/environment tiers). Native submissions carry no trust tier —
 /// `None` is therefore trusted.
 fn submission_allows_secrets(submission: &WorkflowSubmission) -> bool {
-    submission
-        .trust_tier
-        .as_deref()
-        .and_then(|value| {
-            serde_json::from_value::<crate::events::trust_tier::TrustTier>(json!(value)).ok()
-        })
+    crate::events::trust_tier::tier_of(submission)
         .map(|tier| tier.allows_secrets())
         .unwrap_or(true)
 }
@@ -1563,6 +1558,19 @@ pub(crate) fn build_job_artifacts(
     job: &preloop_gha_protocol::JobPlan,
     github_token_override: Option<String>,
 ) -> Result<BuiltJobArtifacts, ApiError> {
+    // One policy drives every job-facing authority decision for this tier:
+    // stored secrets, the runner-visible `system.github.token.permissions`
+    // variable, the GitHub App installation-token request, the OIDC grant,
+    // and which external token (if any) the job may receive. Fork-restricted
+    // tiers (fork PRs, fail-closed unknown events) get GitHub's read-only
+    // fork profile no matter what the workflow declared.
+    let tier = crate::events::trust_tier::tier_of(submission);
+    let policy = crate::events::trust_tier::job_authorization(
+        tier,
+        job.permissions.as_ref(),
+        job.oidc_id_token_granted,
+    );
+
     // Environment secrets are per-job: a job's `environment:` selects the
     // tier, so the overlay happens here, not in the submission-level merge.
     // Precedence per name: submission-provided > environment > repo > global,
@@ -1572,7 +1580,7 @@ pub(crate) fn build_job_artifacts(
     // map can be large — copying it per job would be pure allocation cost.
     // The original map is borrowed directly in that case.
     let mut env_overlay: Option<BTreeMap<String, String>> = None;
-    if submission_allows_secrets(submission) {
+    if policy.allows_secrets {
         if let Some(env_name) = job.oidc_environment.as_deref() {
             let env_secrets = shared
                 .state
@@ -1606,6 +1614,22 @@ pub(crate) fn build_job_artifacts(
         .map_err(|e| ApiError::bad_request(format!("failed to build job message: {e}")))?;
 
     agent_msg.preloop_preserve_on_failure = submission.preserve_on_failure.then_some(true);
+
+    // The message builder already wrote the declared permission set into the
+    // wire variable; for a fork-restricted job that set must be restated as
+    // the downgraded fork profile, because the runner prints this variable
+    // as its `GITHUB_TOKEN Permissions` group and it must not claim write
+    // authority the job's token will not carry.
+    if policy.fork_restricted {
+        agent_msg.variables.insert(
+            "system.github.token.permissions".to_owned(),
+            preloop_gha_protocol::azdo::VariableValue::new(
+                preloop_gha_parser::job_builder::token_permissions_wire_json(
+                    &policy.token_permissions,
+                ),
+            ),
+        );
+    }
 
     // Pre-allocate request ID atomically (no lock needed).
     let request_id = shared
@@ -1652,7 +1676,10 @@ pub(crate) fn build_job_artifacts(
         }
     }
 
-    let id_token_granted = job.oidc_id_token_granted;
+    // Fork-restricted jobs never receive an OIDC grant: no request URL is
+    // emitted here (and the broker restates it only for granted jobs), and
+    // the `oidctoken` endpoint refuses via `id_token_grants`.
+    let id_token_granted = policy.id_token_granted;
     if id_token_granted {
         let oidc_url = format!(
             "{}/runner/server/_apis/distributedtask/hubs/actions/plans/{}/jobs/{}/oidctoken?api-version=2.0",
@@ -1669,7 +1696,16 @@ pub(crate) fn build_job_artifacts(
         }
     }
 
-    let github_token = github_token_override.unwrap_or_else(|| runtime_token.clone());
+    // The PAT override (used when no GitHub App is configured) is a static,
+    // repository-unscoped credential: embedding it in a fork-restricted job's
+    // message would hand hostile code authority GitHub would never grant the
+    // fork. Such jobs keep the local job-scoped runtime token, which
+    // authenticates only against this control plane.
+    let github_token = if policy.fork_restricted {
+        runtime_token.clone()
+    } else {
+        github_token_override.unwrap_or_else(|| runtime_token.clone())
+    };
     agent_msg.variables.insert(
         "system.github.token".to_owned(),
         preloop_gha_protocol::azdo::VariableValue::secret(github_token.clone()),
@@ -1811,9 +1847,9 @@ pub(crate) fn build_job_artifacts(
         .as_ref()
         .map(|_| GitHubTokenRequest {
             repository: submission.repository.clone(),
-            permissions: preloop_gha_parser::effective_token_permissions(job.permissions.as_ref())
-                .into_owned(),
+            permissions: policy.app_permissions,
             declared: job.permissions.is_some(),
+            untrusted: policy.fork_restricted,
         });
 
     Ok(BuiltJobArtifacts {

--- a/crates/preloop-runner-server/src/runtime_scheduling.rs
+++ b/crates/preloop-runner-server/src/runtime_scheduling.rs
@@ -2348,6 +2348,10 @@ fn retire_node_requests(
             .session_active_requests
             .retain(|_, &mut rid| rid != request_id);
         inner.inflight_requests.remove(&request_id);
+        // Terminal either way: a settled node stays in the run as a finished
+        // job and a purged one no longer exists, and neither can be claimed
+        // again. The deferred App-token request must not survive either.
+        inner.github_token_requests.remove(&request_id);
         match retirement {
             RequestRetirement::Settle(status) => {
                 if let Some(record) = inner.job_requests.get_mut(&request_id) {
@@ -2357,7 +2361,6 @@ fn retire_node_requests(
                 }
             }
             RequestRetirement::Purge => {
-                inner.github_token_requests.remove(&request_id);
                 let Some(record) = inner.job_requests.remove(&request_id) else {
                     continue;
                 };

--- a/crates/preloop-runner-server/src/state.rs
+++ b/crates/preloop-runner-server/src/state.rs
@@ -327,6 +327,20 @@ impl TestEnvVar {
         std::env::set_var(key, value);
         Self { key, previous }
     }
+
+    /// Clear a variable for the duration of a test.
+    ///
+    /// The counterpart to [`TestEnvVar::set`] for tests whose contract is the
+    /// *absence* of a value — a configured `PRELOOP_GITHUB_TOKEN` flips the
+    /// check-run path from its mock to a live GitHub call, so a test asserting
+    /// the mock path has to guarantee no token is visible. Restores on drop,
+    /// so a panicking test cannot leak the cleared state onto the rest of the
+    /// suite.
+    pub(crate) fn unset(key: &'static str) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::remove_var(key);
+        Self { key, previous }
+    }
 }
 
 #[cfg(test)]

--- a/docs/fidelity-gap.md
+++ b/docs/fidelity-gap.md
@@ -650,6 +650,42 @@ adopts the shared `build_job_artifacts` helper.
 
 ---
 
+### 3c. Fork trust isolation (2026-08-12)
+
+The fork-PR token hardening (commit `47278c2b`) makes untrusted fork runs
+behave like GitHub's: read-only `GITHUB_TOKEN`, no secrets, no OIDC, and no
+fallback that can widen the credential. Two per-repository features remain to
+be compared with GitHub:
+
+**Cache access — conformant (resolved 2026-08-12).** GitHub gives fork PR runs
+read-only cache access: they can restore from the base repository's cache but
+cannot save to it (actions/cache README: "Some workflow runs only have
+read-only access to the cache. A common case is a workflow triggered by a pull
+request from a fork"), so a fork cannot poison entries a trusted run later
+restores. Preloop previously allowed fork writes on both the cache v2 Twirp
+surface (`CacheService/CreateCacheEntry`, `FinalizeCacheEntryUpload`) and the
+legacy `/_apis/artifactcache` surface. All cache *write* handlers now reject
+fork-restricted jobs (403, resolved via the job runtime token →
+`events::trust_tier::fork_restricted_from_token`); restore handlers are
+unchanged. Reads stay open for everyone.
+
+**Concurrency groups — at parity, suggested divergence (not implemented).**
+Concurrency groups are keyed `(lowercased repo, lowercased group name)`
+(`concurrency::concurrency_key`, no trust tier), matching GitHub's documented
+per-repository model ("using the same concurrency group in the repository").
+GitHub documents no fork isolation for concurrency, so a fork PR can declare a
+static group name (e.g. `prod-deploy`) with `cancel-in-progress: true` and
+cancel a trusted run — on GitHub and preloop alike. Suggested divergence,
+strictly safer than GitHub: key groups by `(repo, fork_restricted, group)` so
+fork runs contend only with fork runs and can never cancel a trusted holder.
+Tradeoffs: breaks cross-trust serialization for deliberately shared groups
+(use distinct group names per trust domain); the persisted key shape in
+`store.rs` needs a migration; and it does not bound resource abuse (a fork can
+still flood the pool with runs — that needs queue/run limits, separate from
+concurrency). Not implemented; documented here for parity tracking.
+
+---
+
 ## 4. Pluggable backends &amp; deployment modes
 
 The official runner protocol already decouples execution from the control plane: the runner

--- a/docs/fidelity-gap.md
+++ b/docs/fidelity-gap.md
@@ -657,7 +657,7 @@ behave like GitHub's: read-only `GITHUB_TOKEN`, no secrets, no OIDC, and no
 fallback that can widen the credential. Two per-repository features remain to
 be compared with GitHub:
 
-**Cache access — conformant (resolved 2026-08-12).** GitHub gives fork PR runs
+**Cache access — conformant (resolved 2026-08-13).** GitHub gives fork PR runs
 read-only cache access: they can restore from the base repository's cache but
 cannot save to it (actions/cache README: "Some workflow runs only have
 read-only access to the cache. A common case is a workflow triggered by a pull


### PR DESCRIPTION
## Problem

Untrusted fork pull requests (and fail-closed unknown events) could obtain GitHub authority GitHub itself would never grant them:

- the workflow's declared `permissions:` block was honoured verbatim, so a fork PR declaring `checks: write` got a write token;
- `id-token: write` produced a live OIDC request URL **and** grant;
- a mint failure under `PRELOOP_GITHUB_APP_MINT_FAILURE=pat`, or a PAT-only deployment with no App configured at all, handed the job the repository-unscoped `PRELOOP_GITHUB_TOKEN`.

GitHub's own rule: *"Pull requests from public forks are still considered a special case and will receive a read token regardless of these settings"* ([Changelog, 2021-04-20](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/)).

## Change

Every job-facing authority decision is derived from **one** policy keyed on the submission's trust tier — `events::trust_tier::job_authorization`:

| decision | source |
|---|---|
| stored secret injection | `policy.allows_secrets` |
| `system.github.token.permissions` wire variable | `policy.token_permissions` |
| App installation-token request | `policy.app_permissions` |
| OIDC request URL + grant | `policy.id_token_granted` |
| which external token the job may receive | `policy.fork_restricted` |

Fork-restricted tiers are clamped to the read-only fork profile; `id-token` is **dropped** rather than advertised as `IdToken: read` (it is a workflow permission with write/none semantics, not a repository read scope); no fallback may widen the result. `pull_request_target`, internal PRs, push, schedule and deployment runs keep their declared permissions.

Broker claims additionally:

- keep **every** runner-visible token alias on the minted App token — `system.github.token`, `github_token`, `GITHUB_TOKEN` (the `${{ secrets.GITHUB_TOKEN }}` alias) and the `github` context token. Previously `GITHUB_TOKEN` kept the build-time local runtime token, so hostile step code could read a stale credential from `secrets.GITHUB_TOKEN` while `github.token` already carried the scoped mint;
- restate a narrowed installation grant without erasing a trusted job's `IdToken` metadata (`merge_narrowed_wire_permissions`);
- emit `GenerateIdTokenUrl` **only** for granted jobs.

The App installation-token request now carries only real App repository permissions (never `id-token`/`models`) for trusted jobs too, and a persisted `GitHubTokenRequest` that predates the `untrusted` field **fails closed**, so a restart cannot re-enable the PAT fallback for a job whose tier was never recorded.

## Protocol fidelity: `GenerateIdTokenUrl`

Making this key conditional is safe **and necessary**. The runner reads it with `TryGetValue` + a non-empty guard and has no `else` branch, and applies **no permission gating of its own** — the server is solely responsible for withholding it (all at `v2.336.0`, commit `98aabcd`):

- `src/Runner.Worker/Handlers/NodeScriptActionHandler.cs:66-70`
- `src/Runner.Worker/Handlers/ScriptHandler.cs:315-319`
- `src/Runner.Worker/Handlers/ContainerActionHandler.cs:232-236`

Omitting it simply leaves `ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN` unset in the step environment.

## Token-request lifetime

The deferred token request is retained past the first claim **on purpose**, so a re-claim after a runner disconnect re-mints under the build-time conditions rather than rebuilding from the broader defaults (which would lose both the declared set and the untrusted flag). It must not outlive the *job*, though — the record pins a repository and a permission set and is persisted into the store snapshot.

It is now dropped wherever a job request becomes terminal:

- `complete_job_inner` — the funnel every completion path reaches (broker `completejob`, the legacy `/_apis` finish endpoints, `agent_request_patch`, and the lease-expiry reaper);
- `retire_node_requests` — both `Settle` and `Purge`, covering cancelled, skipped and expansion-failed nodes.

Clearing it inside the broker handler alone would have leaked the record for every job finished off the broker path.

## Test determinism

Tests that depend on the process-global GitHub env now serialize on `GITHUB_ENV_LOCK` and mutate it through `TestEnvVar`, which restores on drop. A bare `remove_var` placed after the assertions leaks a dead stub's address to the rest of the suite whenever a test fails — that is what turned one failure into a three-test cascade. `cancel_run_completes_github_checks_and_terminal_metadata` now counts only its own check-run id instead of every request reaching its process-global stub, and the ad-hoc `RestoreGitHubEnv` guard is folded into `TestEnvVar::unset`.

## Verification

- `just test-ci` — fmt, `clippy -D warnings`, **0 failures** across the workspace (515 + 521 + … all green).
- `just sg-scan-strict` — clean.
- `just conform` — **PASS**, 38 golden `v2.336.0` scenarios replayed against this server under runner-watch's strict normalized endpoint/status/header/body-schema diff, including `15-oidc-id-token`.
- **Reproduction (11/11).** Each guard was reverted individually and the test that defends it was required to fail:

| mutation | test that failed |
|---|---|
| token-request lifetime | `a_completed_job_drops_its_deferred_token_request` |
| fork wire clamp | `fork_pr_jobs_are_downgraded_to_read_only_and_oidc_denied` |
| OIDC grant gate | `fork_pr_jobs_are_downgraded_to_read_only_and_oidc_denied` |
| PAT override | `fork_job_never_receives_the_configured_pat_override` |
| untrusted PAT fallback | `untrusted_job_mint_failure_never_falls_back_to_the_pat` |
| `GITHUB_TOKEN` alias | `broker_claim_patches_every_token_alias_with_the_minted_token` |
| narrowed-grant merge | `broker_claim_merges_narrowed_grants_with_actions_only_metadata` |
| `GenerateIdTokenUrl` gate | `broker_claim_merges_narrowed_grants_with_actions_only_metadata` |
| `untrusted` fail-closed default | `persisted_token_request_without_trust_metadata_fails_closed` |
| fork drops `id-token` | `trust_tier::tests::fork_id_token_is_never_advertised_as_read` |
| App request excludes Actions-only scopes | `trust_tier::tests::trusted_id_token_stays_wire_metadata_but_not_in_the_app_request` |

## Notes for the reviewer

Two pre-existing issues found while reviewing and deliberately **left alone** to keep the diff scoped:

1. `github_app::clamp_to_grants`'s doc says it is "applied only to the implicit default permission set", but `mint_for_repository` applies it for declared sets too — only the warning text differs. Doc is stale, behaviour is safe (it only ever removes authority).
2. A cancelled *queued* (non-deferred) job leaves its `job_requests` record with `result: None`. The correlation entry is unreachable (`ensure_broker_request_owner` rejects a request with no session binding), so it is not a security issue, but it is still state that never gets collected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp untrusted fork PR jobs (and fail-closed unknown events) to GitHub’s read-only token profile and deny cache writes. Previously forks could get a write `GITHUB_TOKEN`, OIDC grants, PAT fallbacks, and save caches; now they get a read-only `GITHUB_TOKEN`, no OIDC or external tokens, and cache saves return 403 while restores still work.

- One trust-tier policy drives secrets access, `system.github.token.permissions`, App installation-token minting (excluding Actions-only scopes `id-token`/`models`), OIDC grant, and which external token is allowed; no fallback widens access.
- Trusted runs (`pull_request_target`, internal PRs, push/schedule/deploy) keep declared permissions.
- Broker sets every runner-visible token alias to the minted App token (`system.github.token`, `github_token`, `GITHUB_TOKEN`, and the `github` context token) and emits `GenerateIdTokenUrl` only when OIDC is granted; forks drop `id-token`.
- Deny cache writes for fork PR runs on both cache v2 Twirp and legacy `/_apis/artifactcache` surfaces; restore endpoints remain open.
- Clear deferred token requests on all terminal job paths; persisted requests missing the `untrusted` flag fail closed.

<sup>Written for commit 41d62bfe1985885ebbfedac4bdeae4d91e89d5c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

