### PR TITLE
fix(ci): bound golden release build jobs; document the pool memory ceiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,14 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 60
     env:
-      # 2 parallel rustc jobs keep peak memory under the runner VM's 6 GiB
-      # ceiling (4 jobs in a VM plus a 4-VM pool OOM-killed the host).
+      # 2 parallel debug rustc jobs peak around 3 GiB, inside the pool's
+      # 4.5 GiB VM ceiling. Unbounded parallelism OOM-killed the host once
+      # (4 jobs in a VM plus an oversized pool); the pool memory ceiling
+      # must stay above this or the guest OOM-kills rustc (SIGKILL).
       CARGO_BUILD_JOBS: "2"
       # The dedicated property job carries the 256-case profile. Keep this
       # workspace gate aligned with `just test-ci` and bound libtest
-      # concurrency so the 6 GiB dogfood VM survives preloop-runner's suite.
+      # concurrency so the dogfood VM survives preloop-runner's suite.
       PROPTEST_CASES: "8"
       RUST_TEST_THREADS: "2"
     steps:

--- a/.github/workflows/release-golden.yml
+++ b/.github/workflows/release-golden.yml
@@ -126,6 +126,12 @@ jobs:
     # `preloop:skip-golden` marker to the release notes for those releases.
     if: (github.event_name == 'workflow_dispatch' && !inputs.reuse_previous_goldens) || (github.event_name == 'release' && !contains(github.event.release.body, '<!-- preloop:skip-golden -->'))
     runs-on: [self-hosted, Linux, X64]
+    env:
+      # Release rustc peaks far past the pool's 4.5 GiB VM ceiling when the
+      # workspace compiles several crates at once; the golden job's release
+      # build must stay serial or the guest OOM-kills rustc (SIGKILL). The
+      # bake step dominates the job's wall time anyway, so this costs little.
+      CARGO_BUILD_JOBS: "1"
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION


The self-hosted pool host (22 GiB) was OOM-killed twice on 2026-08-12 while the rust job's cargo test ran: two 6 GiB VMs plus a booting replacement and disk page cache peaked the unit at 23.5 GiB. The control plane restarted, orphaning the in-flight job claim; no liveness sweep requeued it, so the check sat in_progress until the 60-minute timeout closed it red with no logs. The rerun passed — the code was never broken.

Prevent recurrence on the host side by lowering PRELOOP_RUNNER_MEMORY_MIB to 4608; this side keeps the workflows honest with that ceiling:
- release-golden: cap the golden job's release build to one rustc job (release rustc peaks past a 4.5 GiB guest at default parallelism; the bake step dominates wall time anyway).
- ci.yml: refresh the stale '6 GiB ceiling' comment with the measured numbers (2 parallel debug rustc jobs peak ~3 GiB).

## What & why

<!-- What this change does and the problem it solves. Link the issue if there is one. -->

## Protocol surface

<!--
Check whether this change touches the core runner protocol interface:
  - registration / `/_apis/...` request and response shapes
  - broker messages (job request, complete, renew) and NDJSON event shapes
  - Twirp results-service / artifact-service payloads
  - check-run or OAuth wire behavior

If it does, the gates below are REQUIRED before merge — preloop's compatibility
contract is byte-for-byte fidelity with the official runner (v2.336.0).
-->

- [ ] I confirm this change touches the runner protocol interface: **YES / NO**

## Required gates

- [ ] `just test-ci` passes locally (fmt-check + clippy `-D` + full test suite + runner-watch conformance)
- [ ] If protocol/wire shapes changed: the change is validated against the official runner (golden replay via `runner-watch`, or a live capture showing the official bytes), not only unit tests
- [ ] If the touched subsystem has property tests (`concurrency_properties`, scheduling, matrix expansion, …): they are extended for the changed contract and pass (`PROPTEST_CASES=256 cargo test -p preloop-runner-server`)
- [ ] New wire fields/events are additive and serde-defaulted where the official runner would not send them
- [ ] No secrets, credentials, or internal/deployment-specific paths are introduced (captures with live tokens must be redacted or excluded)

## Verification performed

<!-- Concrete evidence: commands run, test names, capture outputs. -->

## Checklist

- [ ] Tests added/updated for any new observable contract
- [ ] Docs updated (`docs/`, `CONTRIBUTING.md`) where behavior changed
- [ ] Changelog-worthy user-facing change described in the PR body


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the golden release build to one `rustc` job and documents the pool’s 4.5 GiB VM ceiling to prevent OOMs on the self-hosted runners. Previously the golden release used default parallelism and could SIGKILL `rustc`; now it compiles serially with minimal wall-time impact since the bake step dominates.

- release-golden.yml: set `CARGO_BUILD_JOBS: "1"` to keep release builds within a 4.5 GiB VM.
- ci.yml: update comments to reflect measured memory use; keep `CARGO_BUILD_JOBS: "2"` for debug, with `RUST_TEST_THREADS: "2"` and `PROPTEST_CASES: "8"` to stay under the ceiling.

<sup>Written for commit 6cd794ba8ffeacb58a0105cdd696a4a6200fae08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

