### PR TITLE
fix(security): fail closed on cache writes when the job no longer resolves

### DIFF
--- a/.runner-watch/state.json
+++ b/.runner-watch/state.json
@@ -3,5 +3,5 @@
   "phase": "conformed",
   "from": "v2.322.0",
   "to": "v2.335.1",
-  "updated_at_unix": 1786672290
+  "updated_at_unix": 1786734865
 }

--- a/.runner-watch/state.json
+++ b/.runner-watch/state.json
@@ -3,5 +3,5 @@
   "phase": "conformed",
   "from": "v2.322.0",
   "to": "v2.335.1",
-  "updated_at_unix": 1786386225
+  "updated_at_unix": 1786672290
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Releases before v0.27.0 predate the changelog.
 
 ## [Unreleased]
 
+### Security
+
+- Fail closed on cache writes when the calling job no longer resolves. A
+  fork PR job's runtime JWT survives the job's retirement
+  (`RequestRetirement::Purge` drops the correlation records the fork-tier
+  lookup walks); treating that unresolvable token as a control-plane caller
+  let a fork worker smuggle a cache write past the read-only guard with a
+  leaked token. `fork_restricted_from_token` now denies any job-shaped
+  token whose subject/scope no longer resolves to a live job, instead of
+  only when it positively resolves to a fork-restricted tier. Non-job
+  bearers (system token, runner-listen, debug-worker) are unaffected.
+
 ## [0.30.2] - 2026-08-13
 
 ### Added

--- a/crates/preloop-runner-server/src/events/trust_tier.rs
+++ b/crates/preloop-runner-server/src/events/trust_tier.rs
@@ -122,22 +122,55 @@ pub(crate) fn tier_of(submission: &preloop_gha_protocol::WorkflowSubmission) -> 
 /// Whether the job a results/cache request authenticates as is
 /// fork-restricted, resolved from its bearer runtime token.
 ///
-/// `Some(true)`/`Some(false)` when the token names a live job; `None` when it
-/// is the system token or no job resolves (the control plane's own calls) —
-/// those are never fork-restricted. This is what lets the cache write
-/// handlers deny fork PR runs the same read-only cache access GitHub gives
-/// them (restore allowed, save refused) without touching the read path.
+/// `Some(true)`/`Some(false)` when the token names a job that still resolves
+/// to a run. `None` when the token does not identify a job at all (system
+/// token or another control-plane surface) — those are never fork-restricted.
+/// This is what lets the cache write handlers deny fork PR runs the same
+/// read-only cache access GitHub gives them (restore allowed, save refused)
+/// without touching the read path.
+///
+/// A job-shaped token whose job no longer resolves — the request was retired
+/// or purged while the worker still holds the runtime JWT — fails closed to
+/// `Some(true)`: the tier can no longer be proven, so the write is refused
+/// rather than granted on the strength of a bookkeeping gap.
 pub(crate) async fn fork_restricted_from_token(
     state: &crate::state::AppState,
     token: &str,
 ) -> Option<bool> {
-    let job = state.job_uuid_from_token(token)?;
+    let payload = state.verify_local_jwt_claims(token)?;
+    // Only job runtime tokens carry the fork restriction. Anything not shaped
+    // like one (system token, runner-listen, debug-worker surfaces) belongs
+    // to the control plane and keeps its existing access.
+    let job_shaped = payload
+        .get("sub")
+        .and_then(|value| value.as_str())
+        .is_some_and(|sub| sub.starts_with("preloop-job-"))
+        && payload
+            .get("scp")
+            .and_then(|value| value.as_str())
+            .is_some_and(|scope| scope.starts_with("Actions.Results:"));
+    let Some(job) = state.job_uuid_from_token(token) else {
+        // Signed like a job token but its subject/scope no longer parse to a
+        // job: nothing left to prove it trusted, so refuse.
+        return job_shaped.then_some(true);
+    };
     let inner = state.inner.lock().await;
-    let request_id = inner.agent_job_requests.get(&job).copied()?;
-    let record = inner.job_requests.get(&request_id)?;
-    let run = inner.runs.get(&record.run_id)?;
-    let tier = tier_of(&run.submission)?;
-    Some(tier.is_fork_restricted())
+    // Every hop of the correlation must survive. When the job is retired or
+    // purged mid-flight the worker still holds a valid JWT, and the missing
+    // record must widen the denial, not the access.
+    let Some(request_id) = inner.agent_job_requests.get(&job).copied() else {
+        return Some(true);
+    };
+    let Some(record) = inner.job_requests.get(&request_id) else {
+        return Some(true);
+    };
+    let Some(run) = inner.runs.get(&record.run_id) else {
+        return Some(true);
+    };
+    // A submission without a tier field is a native (trusted) submission and
+    // stays allowed; `tier_of`'s parse-failure-is-trusted convention matches
+    // the secret policy.
+    Some(tier_of(&run.submission).is_some_and(|tier| tier.is_fork_restricted()))
 }
 
 /// Reject a cache write when the calling job is a fork-restricted run.
@@ -146,8 +179,9 @@ pub(crate) async fn fork_restricted_from_token(
 /// refused) so a fork cannot poison cache entries that trusted runs later
 /// restore. Mirroring that here applies to every cache write surface (the
 /// cache v2 Twirp handlers and the legacy `/_apis/artifactcache` ones alike);
-/// the read handlers never call this. The system token and unresolvable
-/// tokens are the control plane's own calls and always pass.
+/// the read handlers never call this. The system token and other
+/// non-job-shaped bearers are the control plane's own calls and always pass;
+/// a job-shaped token that no longer resolves fails closed instead.
 pub(crate) async fn ensure_cache_write_allowed(
     state: &crate::state::AppState,
     headers: &axum::http::HeaderMap,

--- a/crates/preloop-runner-server/src/events/trust_tier.rs
+++ b/crates/preloop-runner-server/src/events/trust_tier.rs
@@ -138,18 +138,29 @@ pub(crate) async fn fork_restricted_from_token(
     token: &str,
 ) -> Option<bool> {
     let payload = state.verify_local_jwt_claims(token)?;
+    let subject = payload.get("sub").and_then(|value| value.as_str());
+    let scope = payload.get("scp").and_then(|value| value.as_str());
     // Only job runtime tokens carry the fork restriction. Anything not shaped
     // like one (system token, runner-listen, debug-worker surfaces) belongs
     // to the control plane and keeps its existing access.
-    let job_shaped = payload
-        .get("sub")
-        .and_then(|value| value.as_str())
-        .is_some_and(|sub| sub.starts_with("preloop-job-"))
-        && payload
-            .get("scp")
-            .and_then(|value| value.as_str())
-            .is_some_and(|scope| scope.starts_with("Actions.Results:"));
-    let Some(job) = state.job_uuid_from_token(token) else {
+    let job_shaped = subject.is_some_and(|sub| sub.starts_with("preloop-job-"))
+        && scope.is_some_and(|scope| scope.starts_with("Actions.Results:"));
+    // Same agreement rule as `AppState::job_uuid_from_token` — `sub` is the
+    // job, `scp` is `Actions.Results:{plan_id}:{job_id}`, both must name the
+    // same job — but derived from the payload we already verified, so the
+    // HMAC/expiry checks run once per cache write instead of twice.
+    let job = subject
+        .and_then(|sub| sub.strip_prefix("preloop-job-"))
+        .and_then(|sub| sub.parse::<uuid::Uuid>().ok())
+        .zip(
+            scope
+                .and_then(|scope| scope.strip_prefix("Actions.Results:"))
+                .and_then(|scope| scope.rsplit(':').next())
+                .and_then(|job| job.parse::<uuid::Uuid>().ok()),
+        )
+        .filter(|(subject_job, scope_job)| subject_job == scope_job)
+        .map(|(subject_job, _)| subject_job);
+    let Some(job) = job else {
         // Signed like a job token but its subject/scope no longer parse to a
         // job: nothing left to prove it trusted, so refuse.
         return job_shaped.then_some(true);

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -6534,29 +6534,6 @@ async fn fork_pr_runs_get_read_only_cache_access() {
         state.mint_runtime_token(&message.plan.plan_id, &message.job_id)
     };
 
-    async fn status_with_bearer(
-        app: &Router,
-        bearer: &str,
-        method: Method,
-        uri: &str,
-        body: Value,
-    ) -> StatusCode {
-        let response = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .method(method)
-                    .uri(uri)
-                    .header(header::AUTHORIZATION, format!("Bearer {bearer}"))
-                    .header(header::CONTENT_TYPE, "application/json")
-                    .body(Body::from(body.to_string()))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        response.status()
-    }
-
     let create_uri = "/twirp/github.actions.results.api.v1.CacheService/CreateCacheEntry";
     let finalize_uri = "/twirp/github.actions.results.api.v1.CacheService/FinalizeCacheEntryUpload";
     let restore_uri = "/twirp/github.actions.results.api.v1.CacheService/GetCacheEntryDownloadURL";
@@ -6750,29 +6727,6 @@ async fn fork_cache_writes_fail_closed_when_the_job_no_longer_resolves() {
     {
         let mut inner = state.inner.lock().await;
         inner.agent_job_requests.remove(&fork_job);
-    }
-
-    async fn status_with_bearer(
-        app: &Router,
-        bearer: &str,
-        method: Method,
-        uri: &str,
-        body: Value,
-    ) -> StatusCode {
-        let response = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .method(method)
-                    .uri(uri)
-                    .header(header::AUTHORIZATION, format!("Bearer {bearer}"))
-                    .header(header::CONTENT_TYPE, "application/json")
-                    .body(Body::from(body.to_string()))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        response.status()
     }
 
     // Both write surfaces reject the now-unresolvable fork token.
@@ -10623,6 +10577,32 @@ async fn repo_scoped_secrets_override_global_and_stay_scoped() {
         Some("submitted-value"),
         "submission-provided secrets outrank both stored tiers"
     );
+}
+
+/// Send a request carrying a specific bearer token and return just the status
+/// code — the shared counterpart the cache-gating tests use, so a
+/// request-shape change lands in one place.
+async fn status_with_bearer(
+    app: &Router,
+    bearer: &str,
+    method: Method,
+    uri: &str,
+    body: Value,
+) -> StatusCode {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(method)
+                .uri(uri)
+                .header(header::AUTHORIZATION, format!("Bearer {bearer}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    response.status()
 }
 
 /// Like `request_json` but returns the status instead of asserting success.

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -6627,7 +6627,9 @@ async fn fork_pr_runs_get_read_only_cache_access() {
         "trusted job still gets a cache upload URL"
     );
 
-    // Legacy v1 surface (`actions/cache@v3`): the reserve write is denied too.
+    // Legacy v1 surface (`actions/cache@v3`): every write endpoint is denied,
+    // not just the reserve. Reserve a trusted entry first so the upload and
+    // commit guards run against a real cache id.
     assert_eq!(
         status_with_bearer(
             &app,
@@ -6640,6 +6642,46 @@ async fn fork_pr_runs_get_read_only_cache_access() {
         StatusCode::FORBIDDEN,
         "fork PR run must not reserve through the v1 cache API"
     );
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/_apis/artifactcache/cache")
+                .header(header::AUTHORIZATION, format!("Bearer {trusted_token}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({"key": "legacy-key", "version": "v1"}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let cache_id = serde_json::from_slice::<Value>(&bytes).unwrap()["cacheId"]
+        .as_i64()
+        .expect("trusted legacy reserve returns a cache id");
+    let legacy_uri = format!("/_apis/artifactcache/cache/{cache_id}");
+    assert_eq!(
+        status_with_bearer(
+            &app,
+            &fork_token,
+            Method::PATCH,
+            &legacy_uri,
+            json!("fork upload payload"),
+        )
+        .await,
+        StatusCode::FORBIDDEN,
+        "fork PR run must not upload through the v1 cache API"
+    );
+    assert_eq!(
+        status_with_bearer(&app, &fork_token, Method::POST, &legacy_uri, json!({})).await,
+        StatusCode::FORBIDDEN,
+        "fork PR run must not commit through the v1 cache API"
+    );
 
     // The runtime token genuinely names the fork job (not a blanket reject):
     // the OIDC surface proves it by refusing this token's job.
@@ -6650,6 +6692,127 @@ async fn fork_pr_runs_get_read_only_cache_access() {
         status_with_bearer(&app, &fork_token, Method::GET, &oidc_uri, Value::Null).await,
         StatusCode::FORBIDDEN,
         "the fork job's runtime token is real and its OIDC grant is denied"
+    );
+}
+
+/// A fork job's runtime JWT must not smuggle a cache write in after the
+/// job's request was retired. Retirement (`RequestRetirement::Purge` in
+/// `retire_node_requests`) removes the correlation records
+/// `fork_restricted_from_token` walks, and treating an unresolvable job
+/// token as a control-plane caller would let a fork worker poison cache
+/// entries with a leaked token. Unresolvable job tokens fail closed instead.
+#[tokio::test]
+async fn fork_cache_writes_fail_closed_when_the_job_no_longer_resolves() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+
+    let submit = |tier: Option<&'static str>| {
+        let app = app.clone();
+        async move {
+            request_json(
+                &app,
+                Method::POST,
+                "/api/v1/runs",
+                json!({
+                    "workflow_yaml": "on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n",
+                    "event": "push",
+                    "payload": {"ref": "refs/heads/main", "commits": []},
+                    "repository": "owner/repo",
+                    "git_ref": "refs/heads/main",
+                    "trust_tier": tier,
+                }),
+            )
+            .await
+        }
+    };
+
+    let fork = submit(Some("untrusted-fork-pull-request")).await;
+    let trusted = submit(None).await;
+
+    let (fork_token, fork_job) = {
+        let inner = state.inner.lock().await;
+        let message = queued_message_for(&inner, fork["run_id"].as_str().unwrap());
+        (
+            state.mint_runtime_token(&message.plan.plan_id, &message.job_id),
+            message.job_id,
+        )
+    };
+    let trusted_token = {
+        let inner = state.inner.lock().await;
+        let message = queued_message_for(&inner, trusted["run_id"].as_str().unwrap());
+        state.mint_runtime_token(&message.plan.plan_id, &message.job_id)
+    };
+
+    // The same surgery `RequestRetirement::Purge` performs: drop the
+    // job-to-request correlation while the worker still holds the runtime
+    // JWT.
+    {
+        let mut inner = state.inner.lock().await;
+        inner.agent_job_requests.remove(&fork_job);
+    }
+
+    async fn status_with_bearer(
+        app: &Router,
+        bearer: &str,
+        method: Method,
+        uri: &str,
+        body: Value,
+    ) -> StatusCode {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(method)
+                    .uri(uri)
+                    .header(header::AUTHORIZATION, format!("Bearer {bearer}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        response.status()
+    }
+
+    // Both write surfaces reject the now-unresolvable fork token.
+    assert_eq!(
+        status_with_bearer(
+            &app,
+            &fork_token,
+            Method::POST,
+            "/_apis/artifactcache/cache",
+            json!({"key": "poison-key", "version": "v1"}),
+        )
+        .await,
+        StatusCode::FORBIDDEN,
+        "an unresolvable job token must not reserve through the v1 cache API"
+    );
+    assert_eq!(
+        status_with_bearer(
+            &app,
+            &fork_token,
+            Method::POST,
+            "/twirp/github.actions.results.api.v1.CacheService/CreateCacheEntry",
+            json!({"key": "poison-key", "version": "v1"}),
+        )
+        .await,
+        StatusCode::FORBIDDEN,
+        "an unresolvable job token must not create through the cache v2 API"
+    );
+    // The fail-closed rule fires for job tokens only: a live trusted job's
+    // token still reserves without trouble.
+    assert_eq!(
+        status_with_bearer(
+            &app,
+            &trusted_token,
+            Method::POST,
+            "/_apis/artifactcache/cache",
+            json!({"key": "trusted-key", "version": "v1"}),
+        )
+        .await,
+        StatusCode::OK,
+        "a resolvable trusted job token keeps write access"
     );
 }
 


### PR DESCRIPTION
Follow-up to #126. Cubic's post-merge review (`7a43d7e9`) flagged a real hole in the fork-cache read-only guard; this closes it.

### Problem (P1)

`ensure_cache_write_allowed` resolves the caller's fork tier through `fork_restricted_from_token`, which walks bearer JWT → `agent_job_requests` → `job_requests` → `runs` → `tier_of(submission)`. Any missing hop returned `None`, and `None` was treated as "control-plane call → allow".

`RequestRetirement::Purge` (in `retire_node_requests`) removes exactly those correlation records while the worker still holds a valid runtime JWT. A fork job's token is handed to attacker-controlled workflow code; exfiltrated and replayed after the job's retirement, it writes cache entries — defeating the #126 hardening.

### Fix

`fork_restricted_from_token` now fails closed for job-shaped tokens:
- a bearer shaped like a job runtime token (`sub: preloop-job-*`, `scp: Actions.Results:*`) whose job no longer resolves at any hop → deny (`Some(true)`), not allow;
- non-job bearers (system token, runner-listen, debug-worker) are untouched — control-plane calls keep working;
- live trusted jobs still resolve end-to-end to `Some(false)`. `Settle` retirement preserves `job_requests`/`agent_job_requests`/`runs`, so completed trusted jobs are unaffected.

### Tests

- New `fork_cache_writes_fail_closed_when_the_job_no_longer_resolves`: mints a fork job token, performs the exact surgery `Purge` does (`agent_job_requests.remove`), asserts 403 on both the legacy v1 reserve and cache-v2 `CreateCacheEntry` surfaces, and asserts a live trusted token still writes. Verified the test fails against the pre-fix guard and passes with it.
- Extended `fork_pr_runs_get_read_only_cache_access` (cubic P2): the legacy-surface assertion previously covered only `POST /_apis/artifactcache/cache`; it now reserves a trusted entry and asserts 403 for the fork token on `PATCH /_apis/artifactcache/cache/:cache_id` (upload) and `POST /_apis/artifactcache/cache/:cache_id` (commit) as well.

### Changelog

`[Unreleased] → Security` entry documenting the fail-closed behavior.

### Verification

- `just test-ci` — pass, incl. runner-watch conformance replay vs v2.336.0 (`conform: PASS`)
- `just sg-scan-strict` — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail closed on cache writes when a job-shaped runtime token no longer resolves. Previously, unresolvable tokens were treated as control-plane and allowed writes; now they are denied, blocking replayed fork tokens after retirement. Non-job tokens and read paths are unchanged.

**Review notes**
- `fork_restricted_from_token` verifies the JWT once, checks `sub` starts with `preloop-job-` and `scp` with `Actions.Results:*`, and requires both to name the same job. Job-shaped tokens that fail parsing or lose any hop (job → request → run → tier) return `Some(true)` and are denied; non-job tokens return `None` and pass.
- `ensure_cache_write_allowed` applies the new fail-closed semantics; control-plane callers are unaffected.
- Tests: added `fork_cache_writes_fail_closed_when_the_job_no_longer_resolves` (covers v1 reserve and cache-v2 create); extended `fork_pr_runs_get_read_only_cache_access` to deny v1 upload/commit; factored a shared `status_with_bearer` helper.
- Changelog documents the security change. No migration; expect 403s for replayed fork tokens after retirement.

<sup>Written for commit b6ac17e1f8d9b070986ea88777f043891f46a410. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved cache-write protection for fork-restricted jobs.
  * Unresolved or invalid job tokens are now denied access to cache operations.
  * Trusted jobs continue to be authorized, while non-job access remains unaffected.
  * Protection applies consistently when reserving, uploading, or committing cache entries.

* **Documentation**
  * Added an Unreleased security note describing the fail-closed cache behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->