### PR TITLE
fix(update): verify installed binary content, not just version, before declaring up to date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Releases before v0.27.0 predate the changelog.
 
 ## [Unreleased]
 
+### Fixed
+
+- `preloop update` is now content-aware when the remote release version
+  equals the installed version: it downloads the checksummed release asset,
+  verifies its SHA-256, and byte-compares the extracted binary against the
+  installed executable, reinstalling on mismatch. A version string is
+  self-reported and can lie (a source build or tampered binary claiming a
+  release version), so the old version-only gate declared such installs up
+  to date forever — this is how the v0.30.2 deaf-runner fix never reached
+  production. Lower versions still never downgrade; a failed content check
+  (fetch/checksum error) keeps the installed binary and retries next run.
+
 ### Security
 
 - Fail closed on cache writes when the calling job no longer resolves. A

--- a/crates/preloop-cli/src/update.rs
+++ b/crates/preloop-cli/src/update.rs
@@ -139,19 +139,66 @@ pub(crate) async fn run(args: UpdateArgs) -> anyhow::Result<()> {
         }
     }
 
-    if remote_version <= current_version {
+    if remote_version < current_version {
         println!("preloop {} is already up to date", current_version);
         return Ok(());
     }
     let target = target_triple();
-    let selected = select_asset(&release.assets, &remote_version, target)
-        .with_context(|| format!("release {} has no asset for {target}", release.tag_name))?;
-    println!(
-        "preloop {} -> {} ({target})",
-        current_version, remote_version
-    );
-    if args.check {
-        return Ok(());
+    let selected = match select_asset(&release.assets, &remote_version, target) {
+        Some(selected) => selected,
+        // Same version with no asset for this target: nothing to compare
+        // against, so keep the installed binary (the version gate above
+        // already ruled out a downgrade).
+        None if remote_version == current_version => {
+            println!("preloop {} is already up to date", current_version);
+            return Ok(());
+        }
+        None => bail!("release {} has no asset for {target}", release.tag_name),
+    };
+    if remote_version == current_version {
+        // The version string is self-reported and can lie: a source build or
+        // a tampered binary claims the release version while its bytes
+        // differ, and a version-only gate then declares it up to date
+        // forever (this is how the v0.30.2 deaf-runner fix never reached
+        // production). Verify the installed binary against the checksummed
+        // release asset and reinstall on mismatch.
+        match installed_matches_release(&client, &selected).await {
+            Ok(true) => {
+                println!("preloop {} is already up to date", current_version);
+                return Ok(());
+            }
+            Ok(false) => println!(
+                "preloop {} does not match release {}; {} ({target})",
+                current_version,
+                release.tag_name,
+                if args.check {
+                    "would reinstall"
+                } else {
+                    "reinstalling"
+                }
+            ),
+            Err(error) => {
+                // A transient failure to fetch or verify the asset must not
+                // fail the hourly update timer; the next run retries.
+                println!(
+                    "warning: could not verify the installed binary against release {}: {error:#}",
+                    release.tag_name
+                );
+                println!("preloop {} is already up to date", current_version);
+                return Ok(());
+            }
+        }
+        if args.check {
+            return Ok(());
+        }
+    } else {
+        println!(
+            "preloop {} -> {} ({target})",
+            current_version, remote_version
+        );
+        if args.check {
+            return Ok(());
+        }
     }
 
     let lock_path = update_lock_path()?;
@@ -593,7 +640,18 @@ async fn verify_checksum(
     }
     .ok_or_else(|| anyhow::anyhow!("release asset {} has no SHA-256 checksum", archive.name))?;
 
-    let mut file = std::fs::File::open(archive_path)?;
+    let actual = sha256_file(archive_path)?;
+    if !actual.eq_ignore_ascii_case(&expected) {
+        bail!(
+            "checksum mismatch for {}: expected {expected}, got {actual}",
+            archive.name
+        );
+    }
+    Ok(())
+}
+
+fn sha256_file(path: &Path) -> anyhow::Result<String> {
+    let mut file = std::fs::File::open(path)?;
     let mut hasher = Sha256::new();
     let mut buffer = [0_u8; 128 * 1024];
     loop {
@@ -603,14 +661,47 @@ async fn verify_checksum(
         }
         hasher.update(&buffer[..read]);
     }
-    let actual = format!("{:x}", hasher.finalize());
-    if !actual.eq_ignore_ascii_case(&expected) {
-        bail!(
-            "checksum mismatch for {}: expected {expected}, got {actual}",
-            archive.name
-        );
-    }
-    Ok(())
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Compare the installed binary against the checksummed release asset.
+///
+/// `Ok(true)` only when every byte of the installed executable matches the
+/// binary extracted from the release archive (whose own SHA-256 was already
+/// verified against the release checksum). Any fetch, checksum, or extract
+/// failure is an `Err` so the caller can distinguish "unknown" from
+/// "definitely equal".
+async fn installed_matches_release(
+    client: &Client,
+    selected: &SelectedAsset<'_>,
+) -> anyhow::Result<bool> {
+    let staging = tempfile::tempdir().context("create content-check staging directory")?;
+    let archive_path = staging.path().join(&selected.archive.name);
+    download(
+        client,
+        &selected.archive.browser_download_url,
+        &archive_path,
+    )
+    .await?;
+    verify_checksum(client, selected.archive, selected.checksum, &archive_path).await?;
+    let staged_binary = staging.path().join(binary_name());
+    extract_binary(&archive_path, &staged_binary)?;
+
+    let installed = std::env::current_exe().context("locate running preloop executable")?;
+    // macOS installs are launched through the `preloop` symlink into
+    // `<prefix>/bin/preloop`; canonicalize so a future compare of paths
+    // (and anyone reading this) sees the real file.
+    let installed =
+        fs::canonicalize(&installed).with_context(|| format!("resolve {}", installed.display()))?;
+    installed_binary_matches(&installed, &staged_binary)
+}
+
+/// Content comparison behind the same-version check: `true` only when the
+/// installed binary is byte-identical to the release binary. A missing or
+/// unreadable file is an `Err`, never a silent `true` — the caller treats
+/// "unknown" as "keep what is installed and retry later", not "matches".
+fn installed_binary_matches(installed: &Path, release_binary: &Path) -> anyhow::Result<bool> {
+    Ok(sha256_file(installed)? == sha256_file(release_binary)?)
 }
 
 fn extract_binary(archive_path: &Path, destination: &Path) -> anyhow::Result<()> {
@@ -1215,5 +1306,73 @@ mod tests {
 
         extract_binary(&archive_path, &output_path).expect("extract binary");
         assert_eq!(std::fs::read(output_path).expect("binary"), contents);
+    }
+
+    #[test]
+    fn content_check_detects_same_version_drift() {
+        // The v0.30.2 incident: a locally built binary claimed the release
+        // version string, so the version-only gate declared it up to date
+        // and the shipped fix never installed. The same-version check must
+        // compare bytes, not versions: identical content matches, drifted
+        // content (same claimed version) does not, and an unreadable file is
+        // an error rather than a silent match.
+        let temp = tempfile::tempdir().expect("staging directory");
+        let installed = temp.path().join("installed");
+        let release = temp.path().join("release");
+        std::fs::write(&installed, b"installed-build").unwrap();
+        std::fs::write(&release, b"installed-build").unwrap();
+        assert!(
+            installed_binary_matches(&installed, &release).expect("both files readable"),
+            "byte-identical binaries must match"
+        );
+        std::fs::write(&release, b"release-build").unwrap();
+        assert!(
+            !installed_binary_matches(&installed, &release).expect("both files readable"),
+            "drifted content at the same version must be detected"
+        );
+        assert!(
+            installed_binary_matches(&installed, &temp.path().join("missing")).is_err(),
+            "an unreadable binary must not be reported as matching"
+        );
+    }
+
+    #[test]
+    fn extract_then_content_check_rejects_a_tampered_archive_payload() {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+
+        let temp = tempfile::tempdir().expect("staging directory");
+        let archive_path = temp.path().join("preloop-cli-aarch64-apple-darwin.tar.gz");
+        let file = std::fs::File::create(&archive_path).expect("archive");
+        let encoder = GzEncoder::new(file, Compression::default());
+        let mut builder = tar::Builder::new(encoder);
+        // Same archive layout, different payload bytes than the "installed"
+        // binary that claims the same version.
+        let payload = b"drifted-release-payload";
+        let mut header = tar::Header::new_gnu();
+        header.set_size(payload.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        builder
+            .append_data(
+                &mut header,
+                "preloop-cli-aarch64-apple-darwin/preloop",
+                &payload[..],
+            )
+            .expect("binary entry");
+        builder
+            .into_inner()
+            .expect("gzip stream")
+            .finish()
+            .expect("archive");
+
+        let installed = temp.path().join("installed");
+        std::fs::write(&installed, b"local-build-claiming-same-version").unwrap();
+        let extracted = temp.path().join(binary_name());
+        extract_binary(&archive_path, &extracted).expect("extract binary");
+        assert!(
+            !installed_binary_matches(&installed, &extracted).expect("both files readable"),
+            "a drifted payload at the same version must trigger reinstall"
+        );
     }
 }

--- a/crates/preloop-cli/src/update.rs
+++ b/crates/preloop-cli/src/update.rs
@@ -162,21 +162,35 @@ pub(crate) async fn run(args: UpdateArgs) -> anyhow::Result<()> {
         // forever (this is how the v0.30.2 deaf-runner fix never reached
         // production). Verify the installed binary against the checksummed
         // release asset and reinstall on mismatch.
-        match installed_matches_release(&client, &selected).await {
-            Ok(true) => {
+        match check_same_version_content(&client, &selected).await {
+            Ok(ContentCheck::Matches) => {
                 println!("preloop {} is already up to date", current_version);
                 return Ok(());
             }
-            Ok(false) => println!(
-                "preloop {} does not match release {}; {} ({target})",
-                current_version,
-                release.tag_name,
+            Ok(ContentCheck::Drift(staged)) => {
+                println!(
+                    "preloop {} does not match release {}; {} ({target})",
+                    current_version,
+                    release.tag_name,
+                    if args.check {
+                        "would reinstall"
+                    } else {
+                        "reinstalling"
+                    }
+                );
                 if args.check {
-                    "would reinstall"
-                } else {
-                    "reinstalling"
+                    return Ok(());
                 }
-            ),
+                let lock_path = update_lock_path()?;
+                let _lock = UpdateLock::acquire(&lock_path)?;
+                let executable =
+                    std::env::current_exe().context("locate running preloop executable")?;
+                self_replace::self_replace(&staged.binary_path)
+                    .with_context(|| format!("atomically replace {}", executable.display()))?;
+                println!("installed preloop {}", remote_version);
+                restart_systemd_service().await?;
+                return Ok(());
+            }
             Err(error) => {
                 // A transient failure to fetch or verify the asset must not
                 // fail the hourly update timer; the next run retries.
@@ -187,9 +201,6 @@ pub(crate) async fn run(args: UpdateArgs) -> anyhow::Result<()> {
                 println!("preloop {} is already up to date", current_version);
                 return Ok(());
             }
-        }
-        if args.check {
-            return Ok(());
         }
     } else {
         println!(
@@ -203,20 +214,9 @@ pub(crate) async fn run(args: UpdateArgs) -> anyhow::Result<()> {
 
     let lock_path = update_lock_path()?;
     let _lock = UpdateLock::acquire(&lock_path)?;
-    let temp_dir = tempfile::tempdir().context("create update staging directory")?;
-    let archive_path = temp_dir.path().join(&selected.archive.name);
-    download(
-        &client,
-        &selected.archive.browser_download_url,
-        &archive_path,
-    )
-    .await?;
-    verify_checksum(&client, selected.archive, selected.checksum, &archive_path).await?;
-
-    let staged_binary = temp_dir.path().join(binary_name());
-    extract_binary(&archive_path, &staged_binary)?;
+    let staged = stage_release(&client, &selected).await?;
     let executable = std::env::current_exe().context("locate running preloop executable")?;
-    self_replace::self_replace(&staged_binary)
+    self_replace::self_replace(&staged.binary_path)
         .with_context(|| format!("atomically replace {}", executable.display()))?;
 
     println!("installed preloop {}", remote_version);
@@ -241,7 +241,8 @@ async fn update_linux_runner_bundle(client: &Client, release: &Release) -> anyho
         .iter()
         .find(|asset| asset.name == format!("{asset_name}.sha256"));
     let staging = tempfile::tempdir().context("create runner bundle staging directory")?;
-    let bundle_path = staging.path().join(&asset.name);
+    let file_name = safe_asset_filename(&asset.name)?;
+    let bundle_path = staging.path().join(file_name);
     download(client, &asset.browser_download_url, &bundle_path).await?;
     verify_checksum(client, asset, checksum, &bundle_path).await?;
 
@@ -664,19 +665,35 @@ fn sha256_file(path: &Path) -> anyhow::Result<String> {
     Ok(format!("{:x}", hasher.finalize()))
 }
 
-/// Compare the installed binary against the checksummed release asset.
-///
-/// `Ok(true)` only when every byte of the installed executable matches the
-/// binary extracted from the release archive (whose own SHA-256 was already
-/// verified against the release checksum). Any fetch, checksum, or extract
-/// failure is an `Err` so the caller can distinguish "unknown" from
-/// "definitely equal".
-async fn installed_matches_release(
+/// Validate that an asset name is a single, safe relative filename without
+/// traversal components (`..`) or absolute path prefixes.
+fn safe_asset_filename(name: &str) -> anyhow::Result<&Path> {
+    let path = Path::new(name);
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("release asset name {name:?} has no valid filename"))?;
+    if file_name != path.as_os_str() {
+        bail!("release asset name {name:?} contains path separators or traversal");
+    }
+    Ok(Path::new(file_name))
+}
+
+/// A downloaded, verified, and extracted release ready for `self_replace`.
+/// Retains the temporary directory so the extracted binary remains valid on
+/// disk until dropped.
+struct StagedRelease {
+    _temp_dir: tempfile::TempDir,
+    binary_path: PathBuf,
+}
+
+/// Download a release asset, verify its checksum, and extract the binary.
+async fn stage_release(
     client: &Client,
     selected: &SelectedAsset<'_>,
-) -> anyhow::Result<bool> {
-    let staging = tempfile::tempdir().context("create content-check staging directory")?;
-    let archive_path = staging.path().join(&selected.archive.name);
+) -> anyhow::Result<StagedRelease> {
+    let temp_dir = tempfile::tempdir().context("create update staging directory")?;
+    let file_name = safe_asset_filename(&selected.archive.name)?;
+    let archive_path = temp_dir.path().join(file_name);
     download(
         client,
         &selected.archive.browser_download_url,
@@ -684,8 +701,25 @@ async fn installed_matches_release(
     )
     .await?;
     verify_checksum(client, selected.archive, selected.checksum, &archive_path).await?;
-    let staged_binary = staging.path().join(binary_name());
+    let staged_binary = temp_dir.path().join(binary_name());
     extract_binary(&archive_path, &staged_binary)?;
+    Ok(StagedRelease {
+        _temp_dir: temp_dir,
+        binary_path: staged_binary,
+    })
+}
+
+enum ContentCheck {
+    Matches,
+    Drift(StagedRelease),
+}
+
+/// Compare the installed binary against the checksummed release asset.
+async fn check_same_version_content(
+    client: &Client,
+    selected: &SelectedAsset<'_>,
+) -> anyhow::Result<ContentCheck> {
+    let staged = stage_release(client, selected).await?;
 
     let installed = std::env::current_exe().context("locate running preloop executable")?;
     // macOS installs are launched through the `preloop` symlink into
@@ -693,7 +727,11 @@ async fn installed_matches_release(
     // (and anyone reading this) sees the real file.
     let installed =
         fs::canonicalize(&installed).with_context(|| format!("resolve {}", installed.display()))?;
-    installed_binary_matches(&installed, &staged_binary)
+    if installed_binary_matches(&installed, &staged.binary_path)? {
+        Ok(ContentCheck::Matches)
+    } else {
+        Ok(ContentCheck::Drift(staged))
+    }
 }
 
 /// Content comparison behind the same-version check: `true` only when the
@@ -1374,5 +1412,13 @@ mod tests {
             !installed_binary_matches(&installed, &extracted).expect("both files readable"),
             "a drifted payload at the same version must trigger reinstall"
         );
+    }
+
+    #[test]
+    fn safe_asset_filename_rejects_traversal_and_absolute_paths() {
+        assert!(safe_asset_filename("preloop-v0.30.2-aarch64-apple-darwin.tar.gz").is_ok());
+        assert!(safe_asset_filename("../evil.tar.gz").is_err());
+        assert!(safe_asset_filename("/etc/passwd").is_err());
+        assert!(safe_asset_filename("").is_err());
     }
 }


### PR DESCRIPTION
The auto-updater compared only semantic versions: when the remote release
version equals the installed one, it declared the install up to date and
stopped. A version string is self-reported and can lie about contents — a
source build (or a tampered binary) claiming a release version never
receives that release's actual bytes, because the gate never looks at them.

This is exactly how the v0.30.2 deaf-runner fix never reached production:
the installed build claimed 0.30.2, `preloop update` said "already up to
date", and the hourly timer moved on while the pool kept respawning deaf
VMs.

## Change

When `remote == installed`, `preloop update` now downloads the release
asset for this target, verifies its SHA-256 against the release checksum,
extracts the binary, and byte-compares it with the installed executable
(`sha256_file` streaming comparison).

- mismatch → reinstalls and restarts `preloop.service`
- match → "already up to date", binary untouched
- fetch/checksum failure → warns, keeps the installed binary; the hourly
  timer retries
- lower remote version → still never installed (no downgrade)
- no asset for this target at the same version → keeps the install
- `--check` reports drift without installing

## Verification

- Unit: `content_check_detects_same_version_drift` and
  `extract_then_content_check_rejects_a_tampered_archive_payload`
- Smoke against a mock releases API serving v0.30.2 for aarch64-apple-darwin:
  drifted payload at the same version → reinstalled byte-for-byte
  (installed SHA-256 becomes the payload's), matching payload → no-op,
  lower remote version → binary untouched.
- `just test-ci` (incl. runner-watch conformance replay): PASS
- `just sg-scan-strict`: clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verifies installed binary bytes when versions match and sanitizes asset filenames, preventing false “up to date” and path traversal; drift reinstalls using the already staged binary.

- Equal-version path: `preloop update` downloads the asset, verifies SHA-256, extracts, and byte-compares; mismatch reinstalls and restarts `preloop.service`, match reports up to date; `--check` reports drift only; fetch/verify/extract failures warn and keep installed (timer retries).
- Asset selection: if no asset for this target at the same version, keep installed; if upgrading and no asset exists, error.
- Downgrades: remote < installed prints “already up to date”; no downgrade.
- Safety and efficiency: reject asset names with traversal or absolute paths; reuse the staged, verified binary on reinstall to avoid a second download.

<sup>Written for commit 4e3908c78b6aa33d6f40657a9534b96b4110a721. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update checks for releases matching the installed version.
  * Reinstalls the executable when its contents differ from the verified release.
  * Preserves the current installation when verification fails, allowing a later retry.
  * Prevents downgrades to older releases.
  * Treats matching versions without a corresponding release asset as up to date.
  * Added safeguards to detect tampered release contents and unsafe asset names before installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->