### PR TITLE
chore: release v0.30.3 — official runner image golden

### DIFF
--- a/.github/workflows/release-golden.yml
+++ b/.github/workflows/release-golden.yml
@@ -233,6 +233,25 @@ jobs:
             dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.base-sbom.spdx.json
             dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.provenance.json
 
+      # The packed golden routinely exceeds GitHub's 2 GiB release-asset
+      # limit (the official-image golden is ~10-15 GiB), so the golden is
+      # always retained as a workflow artifact BEFORE the (failing) upload:
+      # download from the run page for pool installs, or point
+      # PRELOOP_GOLDEN_URL at a custom host.
+      - name: Retain Golden Artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: golden-${{ env.GOLDEN_ARCH }}
+          path: |
+            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}
+            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.sha256
+            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.bundle
+            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.base-provenance.json
+            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.base-sbom.spdx.json
+            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.provenance.json
+          retention-days: 90
+          if-no-files-found: error
+
       - name: Upload Golden Artifact to Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -255,25 +274,6 @@ jobs:
       # golden would sit only on the runner's workspace and be lost. Keep it
       # as a downloadable workflow artifact so the pool can be updated from
       # the run page.
-      # The packed golden routinely exceeds GitHub's 2 GiB release-asset
-      # limit (the official-image golden is ~10-15 GiB), so the golden is
-      # always retained as a workflow artifact: release builds can no longer
-      # rely on the release asset alone. Download from the run page and
-      # install into the pool, or point PRELOOP_GOLDEN_URL at a custom host.
-      - name: Retain Golden Artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: golden-${{ env.GOLDEN_ARCH }}
-          path: |
-            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}
-            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.sha256
-            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.bundle
-            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.base-provenance.json
-            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.base-sbom.spdx.json
-            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.provenance.json
-          retention-days: 90
-          if-no-files-found: error
-
   # The aarch64 golden can only be built on an arm64 host (the guest VM runs
   # on the host's own architecture). GitHub-hosted Apple Silicon runners do
   # not support nested virtualization, so this must run on a bare-metal
@@ -449,6 +449,25 @@ jobs:
             dist/preloop-ubuntu-24.04-aarch64.base-sbom.spdx.json
             dist/preloop-ubuntu-24.04-aarch64.provenance.json
 
+      # The packed golden routinely exceeds GitHub's 2 GiB release-asset
+      # limit (the official-image golden is ~10-15 GiB), so the golden is
+      # always retained as a workflow artifact BEFORE the (failing) upload:
+      # download from the run page for pool installs, or point
+      # PRELOOP_GOLDEN_URL at a custom host.
+      - name: Retain Golden Artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: golden-${{ env.GOLDEN_ARCH }}
+          path: |
+            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}
+            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.sha256
+            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.bundle
+            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.base-provenance.json
+            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.base-sbom.spdx.json
+            dist/preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}.provenance.json
+          retention-days: 90
+          if-no-files-found: error
+
       - name: Upload Golden Artifact to Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -466,22 +485,3 @@ jobs:
             "dist/$GOLDEN_NAME.base-provenance.json" \
             "dist/$GOLDEN_NAME.base-sbom.spdx.json" \
             "dist/$GOLDEN_NAME.provenance.json" --clobber
-
-      # The packed golden routinely exceeds GitHub's 2 GiB release-asset
-      # limit (the official-image golden is ~10-15 GiB), so the golden is
-      # always retained as a workflow artifact: release builds can no longer
-      # rely on the release asset alone. Download from the run page and
-      # install into the pool, or point PRELOOP_GOLDEN_URL at a custom host.
-      - name: Retain Golden Artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: golden-aarch64
-          path: |
-            dist/preloop-ubuntu-24.04-aarch64
-            dist/preloop-ubuntu-24.04-aarch64.sha256
-            dist/preloop-ubuntu-24.04-aarch64.bundle
-            dist/preloop-ubuntu-24.04-aarch64.base-provenance.json
-            dist/preloop-ubuntu-24.04-aarch64.base-sbom.spdx.json
-            dist/preloop-ubuntu-24.04-aarch64.provenance.json
-          retention-days: 90
-          if-no-files-found: error

--- a/.github/workflows/release-golden.yml
+++ b/.github/workflows/release-golden.yml
@@ -208,6 +208,7 @@ jobs:
         env:
           GOLDEN_NAME: preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}
         run: |
+          set -euo pipefail
           mkdir -p dist
           rm -f "dist/$GOLDEN_NAME"
           export PRELOOP_REQUIRE_BASE_DIGEST=1
@@ -215,9 +216,47 @@ jobs:
           # The official runner snapshot extracts to ~60 GB; the bake VM must
           # be larger than the stock 20 GiB default.
           export PRELOOP_RUNNER_STORAGE_GB=120
-          ./target/release/preloop build-golden \
-            --runner-bundle "target/$RUNNER_TARGET/release" \
-            --output "dist/$GOLDEN_NAME"
+          # This runner is also the production smolvm-host: the CI pool runs
+          # several 5 GiB runner VMs on the same 22 GiB box. The builder guest
+          # needs 4 GiB of *committable* RAM, and smolvm boots it only AFTER
+          # the ~20 minute, 60 GB base-image pull — so a pool burst turns the
+          # whole pull into a wasted `EAGAIN` ("Resource temporarily
+          # unavailable"). Gate every attempt on measured headroom and retry,
+          # so a job landing mid-pull costs one retry instead of the run.
+          need_mib=6144
+          attempts=3
+          headroom() { awk '/^MemAvailable:/ { print int($2 / 1024) }' /proc/meminfo; }
+          for attempt in $(seq 1 "$attempts"); do
+            for _ in $(seq 1 45); do
+              waiting="$(headroom)"
+              if [ "$waiting" -ge "$need_mib" ]; then break; fi
+              echo "waiting for host headroom: ${waiting} MiB < ${need_mib} MiB"
+              sleep 60
+            done
+            available="$(headroom)"
+            if [ "$available" -lt "$need_mib" ]; then
+              echo "host never freed ${need_mib} MiB (last ${available} MiB);" \
+                "the CI pool is saturating this runner" >&2
+              exit 1
+            fi
+            echo "attempt ${attempt}/${attempts} with ${available} MiB available"
+            # A failed boot leaves the builder machine registered; drop it so
+            # the retry cannot collide with the previous attempt's disks.
+            smolvm machine delete --name preloop-release-golden-builder \
+              --force --cascade >/dev/null 2>&1 || true
+            if ./target/release/preloop build-golden \
+                --runner-bundle "target/$RUNNER_TARGET/release" \
+                --output "dist/$GOLDEN_NAME"; then
+              break
+            fi
+            if [ "$attempt" -eq "$attempts" ]; then
+              echo "build-golden failed after ${attempts} attempts" >&2
+              exit 1
+            fi
+            echo "build-golden failed; backing off before retry"
+            rm -f "dist/$GOLDEN_NAME"
+            sleep $((attempt * 120))
+          done
           test -s "dist/$GOLDEN_NAME"
           sha256sum "dist/$GOLDEN_NAME" > "dist/$GOLDEN_NAME.sha256"
 

--- a/.github/workflows/release-golden.yml
+++ b/.github/workflows/release-golden.yml
@@ -173,6 +173,37 @@ jobs:
             --require-source-prefix \
               "https://github.com/preloopdev/runner-image-blobs/tree"
 
+      - name: Install pinned smolvm
+        env:
+          SMOLVM_VERSION: "1.7.7"
+        run: |
+          set -euo pipefail
+          ARCHIVE="smolvm-${SMOLVM_VERSION}-linux-x86_64.tar.gz"
+          BASE="https://github.com/smol-machines/smolvm/releases/download/v${SMOLVM_VERSION}"
+          curl -fsSL -o "$ARCHIVE" "$BASE/$ARCHIVE"
+          curl -fsSL -o checksums.sha256 "$BASE/checksums.sha256"
+          grep -F "$ARCHIVE" checksums.sha256 | sha256sum -c -
+          tar -xzf "$ARCHIVE"
+          SRC="smolvm-${SMOLVM_VERSION}-linux-x86_64"
+          mkdir -p "$HOME/.smolvm"
+          rm -rf "$HOME/.smolvm/lib"
+          cp -R "$SRC/lib" "$HOME/.smolvm/lib"
+          rm -f "$HOME/.smolvm"/storage-template.ext4 "$HOME/.smolvm"/overlay-template.ext4 \
+            "$HOME/.smolvm"/storage-template.ext4.zst "$HOME/.smolvm"/overlay-template.ext4.zst
+          for f in smolvm smolvm-bin storage-template.ext4 overlay-template.ext4 \
+              storage-template.ext4.zst overlay-template.ext4.zst; do
+            [ -f "$SRC/$f" ] && cp "$SRC/$f" "$HOME/.smolvm/"
+          done
+          echo "$SMOLVM_VERSION" > "$HOME/.smolvm/.version"
+          DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/smolvm"
+          mkdir -p "$DATA_DIR"
+          rm -rf "$DATA_DIR/agent-rootfs"
+          cp -R "$SRC/agent-rootfs" "$DATA_DIR/agent-rootfs"
+          [ -f "$SRC/init.krun" ] && cp "$SRC/init.krun" "$DATA_DIR/init.krun"
+          mkdir -p "$HOME/.local/bin"
+          ln -sf "$HOME/.smolvm/smolvm" "$HOME/.local/bin/smolvm"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Pack Golden MicroVM Artifact
         env:
           GOLDEN_NAME: preloop-ubuntu-24.04-${{ env.GOLDEN_ARCH }}

--- a/.github/workflows/release-golden.yml
+++ b/.github/workflows/release-golden.yml
@@ -175,7 +175,7 @@ jobs:
 
       - name: Install pinned smolvm
         env:
-          SMOLVM_VERSION: "1.7.7"
+          SMOLVM_VERSION: "1.8.2"
         run: |
           set -euo pipefail
           ARCHIVE="smolvm-${SMOLVM_VERSION}-linux-x86_64.tar.gz"

--- a/.github/workflows/release-golden.yml
+++ b/.github/workflows/release-golden.yml
@@ -255,8 +255,12 @@ jobs:
       # golden would sit only on the runner's workspace and be lost. Keep it
       # as a downloadable workflow artifact so the pool can be updated from
       # the run page.
-      - name: Retain Golden Artifact for non-release builds
-        if: github.event_name != 'release'
+      # The packed golden routinely exceeds GitHub's 2 GiB release-asset
+      # limit (the official-image golden is ~10-15 GiB), so the golden is
+      # always retained as a workflow artifact: release builds can no longer
+      # rely on the release asset alone. Download from the run page and
+      # install into the pool, or point PRELOOP_GOLDEN_URL at a custom host.
+      - name: Retain Golden Artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: golden-${{ env.GOLDEN_ARCH }}
@@ -463,8 +467,12 @@ jobs:
             "dist/$GOLDEN_NAME.base-sbom.spdx.json" \
             "dist/$GOLDEN_NAME.provenance.json" --clobber
 
-      - name: Retain Golden Artifact for non-release builds
-        if: github.event_name != 'release'
+      # The packed golden routinely exceeds GitHub's 2 GiB release-asset
+      # limit (the official-image golden is ~10-15 GiB), so the golden is
+      # always retained as a workflow artifact: release builds can no longer
+      # rely on the release asset alone. Download from the run page and
+      # install into the pool, or point PRELOOP_GOLDEN_URL at a custom host.
+      - name: Retain Golden Artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: golden-aarch64

--- a/.github/workflows/release-golden.yml
+++ b/.github/workflows/release-golden.yml
@@ -135,6 +135,8 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      # The provenance capture exchanges the token against the registry.
+      packages: read
     steps:
       - name: Check out repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -145,7 +147,7 @@ jobs:
           echo "RUNNER_TARGET=x86_64-unknown-linux-gnu" >> "$GITHUB_ENV"
           echo "GOLDEN_ARCH=x86_64" >> "$GITHUB_ENV"
           echo "GOLDEN_PLATFORM=linux/amd64" >> "$GITHUB_ENV"
-          BASE_IMAGE="$(awk -F'"' '/^ubuntu_24_04_base = / { print $2; exit }' versions.toml)"
+          BASE_IMAGE="$(awk -F'"' '/^official_runner_image_base_amd64 = / { print $2; exit }' versions.toml)"
           test -n "$BASE_IMAGE"
           echo "BASE_IMAGE=$BASE_IMAGE" >> "$GITHUB_ENV"
 
@@ -169,7 +171,7 @@ jobs:
             --sbom-output "dist/$GOLDEN_NAME.base-sbom.spdx.json" \
             --require-sbom \
             --require-source-prefix \
-              "https://git.launchpad.net/cloud-images/+oci/ubuntu-base"
+              "https://github.com/preloopdev/runner-image-blobs/tree"
 
       - name: Pack Golden MicroVM Artifact
         env:
@@ -179,6 +181,9 @@ jobs:
           rm -f "dist/$GOLDEN_NAME"
           export PRELOOP_REQUIRE_BASE_DIGEST=1
           export PRELOOP_RUNNER_BASE_IMAGE="$BASE_IMAGE"
+          # The official runner snapshot extracts to ~60 GB; the bake VM must
+          # be larger than the stock 20 GiB default.
+          export PRELOOP_RUNNER_STORAGE_GB=80
           ./target/release/preloop build-golden \
             --runner-bundle "target/$RUNNER_TARGET/release" \
             --output "dist/$GOLDEN_NAME"
@@ -277,6 +282,8 @@ jobs:
       contents: write
       id-token: write
       attestations: write
+      # The provenance capture exchanges the token against the registry.
+      packages: read
     steps:
       - name: Check out repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -287,7 +294,7 @@ jobs:
           echo "RUNNER_TARGET=aarch64-unknown-linux-gnu" >> "$GITHUB_ENV"
           echo "GOLDEN_ARCH=aarch64" >> "$GITHUB_ENV"
           echo "GOLDEN_PLATFORM=linux/arm64" >> "$GITHUB_ENV"
-          BASE_IMAGE="$(awk -F'"' '/^ubuntu_24_04_base = / { print $2; exit }' versions.toml)"
+          BASE_IMAGE="$(awk -F'"' '/^official_runner_image_base_arm64 = / { print $2; exit }' versions.toml)"
           test -n "$BASE_IMAGE"
           echo "BASE_IMAGE=$BASE_IMAGE" >> "$GITHUB_ENV"
 
@@ -376,7 +383,7 @@ jobs:
             --sbom-output "dist/$GOLDEN_NAME.base-sbom.spdx.json" \
             --require-sbom \
             --require-source-prefix \
-              "https://git.launchpad.net/cloud-images/+oci/ubuntu-base"
+              "https://github.com/preloopdev/runner-image-blobs/tree"
 
       - name: Pack Golden MicroVM Artifact
         env:
@@ -386,6 +393,9 @@ jobs:
           rm -f "dist/$GOLDEN_NAME"
           export PRELOOP_REQUIRE_BASE_DIGEST=1
           export PRELOOP_RUNNER_BASE_IMAGE="$BASE_IMAGE"
+          # The official runner snapshot extracts to ~60 GB; the bake VM must
+          # be larger than the stock 20 GiB default.
+          export PRELOOP_RUNNER_STORAGE_GB=80
           ./target/release/preloop build-golden \
             --runner-bundle "target/$RUNNER_TARGET/release" \
             --output "dist/$GOLDEN_NAME"

--- a/.github/workflows/release-golden.yml
+++ b/.github/workflows/release-golden.yml
@@ -183,7 +183,7 @@ jobs:
           export PRELOOP_RUNNER_BASE_IMAGE="$BASE_IMAGE"
           # The official runner snapshot extracts to ~60 GB; the bake VM must
           # be larger than the stock 20 GiB default.
-          export PRELOOP_RUNNER_STORAGE_GB=80
+          export PRELOOP_RUNNER_STORAGE_GB=120
           ./target/release/preloop build-golden \
             --runner-bundle "target/$RUNNER_TARGET/release" \
             --output "dist/$GOLDEN_NAME"
@@ -395,7 +395,7 @@ jobs:
           export PRELOOP_RUNNER_BASE_IMAGE="$BASE_IMAGE"
           # The official runner snapshot extracts to ~60 GB; the bake VM must
           # be larger than the stock 20 GiB default.
-          export PRELOOP_RUNNER_STORAGE_GB=80
+          export PRELOOP_RUNNER_STORAGE_GB=120
           ./target/release/preloop build-golden \
             --runner-bundle "target/$RUNNER_TARGET/release" \
             --output "dist/$GOLDEN_NAME"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ Releases before v0.27.0 predate the changelog.
 
 ## [Unreleased]
 
-<<<<<<< HEAD
+## [0.30.3] - 2026-08-13
+
 ### Fixed
 
 - `preloop update` is now content-aware when the remote release version
@@ -21,9 +22,6 @@ Releases before v0.27.0 predate the changelog.
   to date forever — this is how the v0.30.2 deaf-runner fix never reached
   production. Lower versions still never downgrade; a failed content check
   (fetch/checksum error) keeps the installed binary and retries next run.
-=======
-## [0.30.3] - 2026-08-13
->>>>>>> 759b5243 (chore: release prep v0.30.3 — official runner image golden)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Releases before v0.27.0 predate the changelog.
 
 ## [Unreleased]
 
+<<<<<<< HEAD
 ### Fixed
 
 - `preloop update` is now content-aware when the remote release version
@@ -20,6 +21,9 @@ Releases before v0.27.0 predate the changelog.
   to date forever — this is how the v0.30.2 deaf-runner fix never reached
   production. Lower versions still never downgrade; a failed content check
   (fetch/checksum error) keeps the installed binary and retries next run.
+=======
+## [0.30.3] - 2026-08-13
+>>>>>>> 759b5243 (chore: release prep v0.30.3 — official runner image golden)
 
 ### Security
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1849,7 +1849,7 @@ dependencies = [
 
 [[package]]
 name = "preloop-cli"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/preloop-cli/Cargo.toml
+++ b/crates/preloop-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "preloop-cli"
-version = "0.30.2"
+version = "0.30.3"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -646,11 +646,7 @@ fn verify_base_image_with(repo: &str, base_image: &str) -> anyhow::Result<()> {
         attest_args.extend(["--key", key]);
     }
     attest_args.extend(identity_args.iter().copied());
-    run_verifier(
-        "cosign",
-        &attest_args,
-        "cosign SPDX SBOM attestation",
-    )
+    run_verifier("cosign", &attest_args, "cosign SPDX SBOM attestation")
 }
 
 fn require_digest_pinned_base(base_image: &str) -> anyhow::Result<()> {

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -563,7 +563,13 @@ async fn cmd_build_golden(args: BuildGoldenArgs) -> anyhow::Result<()> {
         runner_key_dir: None,
         pending_jobs: None,
         preload_images: Vec::new(),
-        runner_user: None,
+        // The golden bake provisions the image (runner install, apt, service
+        // files); it must run as root. The official runner image declares
+        // USER=runner, so the machine's default exec user is not root.
+        runner_user: std::env::var("PRELOOP_RUNNER_USER")
+            .ok()
+            .filter(|value| !value.is_empty())
+            .or_else(|| Some("root".to_owned())),
         runner_uid: None,
         next_job_runs_on: None,
         pending_registrations: None,

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -607,25 +607,43 @@ async fn verify_base_image(base_image: &str) -> anyhow::Result<()> {
 }
 
 fn verify_base_image_with(repo: &str, base_image: &str) -> anyhow::Result<()> {
-    run_verifier(
-        "gh",
-        &["attestation", "verify", base_image, "--repo", repo],
-        "GitHub attestation",
-    )?;
     let identity = std::env::var("PRELOOP_BASE_IMAGE_IDENTITY_REGEXP").unwrap_or_else(|_| {
-        format!("^https://github.com/{repo}/.github/workflows/dump.yml@refs/heads/")
+        format!(
+            "^https://github.com/{repo}/.github/workflows/(dump|attest-local)\\.yml@refs/heads/"
+        )
     });
-    run_verifier(
-        "cosign",
-        &[
-            "verify",
-            base_image,
+    // The dump pipeline's images carry cosign signatures and in-toto
+    // attestations (SLSA provenance + SPDX SBOM). They are keyless-signed by
+    // the publishing workflow's OIDC identity; a mirror can instead publish
+    // signatures under a long-lived key and point PRELOOP_BASE_IMAGE_PUBKEY
+    // at the public key file. `gh attestation verify` only understands
+    // GitHub-API attestations (attest-build-provenance), which the dump does
+    // not produce, so verification is cosign-based.
+    let key = std::env::var("PRELOOP_BASE_IMAGE_PUBKEY").ok();
+    let identity_args: Vec<&str> = match &key {
+        Some(_) => vec![],
+        None => vec![
             "--certificate-identity-regexp",
             &identity,
             "--certificate-oidc-issuer",
             "https://token.actions.githubusercontent.com",
         ],
-        "cosign signature",
+    };
+    let mut verify_args: Vec<&str> = vec!["verify", base_image];
+    if let Some(key) = &key {
+        verify_args.extend(["--key", key]);
+    }
+    verify_args.extend(identity_args.iter().copied());
+    run_verifier("cosign", &verify_args, "cosign signature")?;
+    let mut attest_args: Vec<&str> = vec!["verify-attestation", base_image, "--type", "spdx"];
+    if let Some(key) = &key {
+        attest_args.extend(["--key", key]);
+    }
+    attest_args.extend(identity_args.iter().copied());
+    run_verifier(
+        "cosign",
+        &attest_args,
+        "cosign SPDX SBOM attestation",
     )
 }
 

--- a/crates/preloop-orchestrator/src/environment.rs
+++ b/crates/preloop-orchestrator/src/environment.rs
@@ -586,8 +586,10 @@ mod tests {
             "no duplicate toolchains"
         );
         // Rust is the one toolchain the base bake does not cover, so it is
-        // the deliberate member of the curated set.
-        assert!(first.contains(&ToolchainLayer::Rust("stable".into())));
+        // the deliberate member of the curated set (pinned for CI-Bench
+        // reproducibility; Go rides along).
+        assert!(first.contains(&ToolchainLayer::Rust("1.88.0".into())));
+        assert!(first.contains(&ToolchainLayer::Go("1.26".into())));
     }
 
     #[test]

--- a/crates/preloop-orchestrator/src/environment.rs
+++ b/crates/preloop-orchestrator/src/environment.rs
@@ -161,7 +161,7 @@ impl ToolchainLayer {
                          esac\n\
                          curl -fsSL \"https://static.rust-lang.org/rustup/archive/{}/$RUST_ARCH-unknown-linux-gnu/rustup-init\" -o /tmp/rustup-init\n\
                          chmod +x /tmp/rustup-init\n\
-                         /tmp/rustup-init -y --profile minimal --default-toolchain {}\n\
+                         /tmp/rustup-init -y --profile minimal --default-toolchain {} --component rustfmt,clippy\n\
                          rm -f /tmp/rustup-init",
                         crate::RUSTUP_VERSION,
                         safe_component(channel)
@@ -250,7 +250,14 @@ impl ToolchainLayer {
 /// so it is baked for everyone. `setup-*` actions download any other version
 /// a job asks for at job time — the same model GitHub-hosted runners use.
 pub fn curated_toolchains() -> Vec<ToolchainLayer> {
-    vec![ToolchainLayer::Rust("stable".into())]
+    // CI-Bench pins its corpus toolchains: Rust 1.88.0 (the version every
+    // task was authored and validated against) and Go 1.26.x. Baking them
+    // into every golden keeps the per-job VMs identical instead of
+    // re-installing per job.
+    vec![
+        ToolchainLayer::Rust("1.88.0".into()),
+        ToolchainLayer::Go("1.26".into()),
+    ]
 }
 
 /// Digest-pinned Ubuntu base images.

--- a/crates/preloop-orchestrator/src/lib.rs
+++ b/crates/preloop-orchestrator/src/lib.rs
@@ -1542,9 +1542,23 @@ async fn prepare_packed_golden<P: VmProvider + 'static>(
     if provider.status(golden).await? != MachineState::Missing {
         provider.delete(golden).await?;
     }
+    // smolvm's `machine create --from` consumes the SMOLPACK sidecar
+    // (`<payload>.smolmachine`), not the ELF launcher stub written at the
+    // payload path itself. Passing the stub fails with "invalid magic:
+    // expected SMOLPACK" and the pool silently falls back to a slow
+    // create-per-runner rebuild.
+    let payload = config.artifact_payload();
+    let pack = if payload.extension().is_some_and(|ext| ext == "smolmachine") {
+        payload
+    } else {
+        // Append, not `with_extension`: artifact names embed dots (the
+        // normalized `ghcr.io/...` base), so `with_extension` would replace
+        // everything after the last dot and produce a truncated path.
+        PathBuf::from(format!("{}.smolmachine", payload.display()))
+    };
     let spec = MachineSpec {
         name: golden.clone(),
-        image: config.artifact_payload().display().to_string(),
+        image: pack.display().to_string(),
         cpus: config.cpus,
         memory_mib: config.memory_mib,
         storage_gib: config.storage_gib,
@@ -3109,10 +3123,16 @@ async fn provision_runner<P: VmProvider + 'static>(
         }
     } else {
         let uses_packed_artifact = direct_create_from_packed;
+        let payload = config.artifact_payload();
+        let pack = if payload.extension().is_some_and(|ext| ext == "smolmachine") {
+            payload.clone()
+        } else {
+            PathBuf::from(format!("{}.smolmachine", payload.display()))
+        };
         let spec = MachineSpec {
             name: name.clone(),
             image: if uses_packed_artifact {
-                config.artifact_payload().display().to_string()
+                pack.display().to_string()
             } else if config.use_packed_artifact {
                 environment.base.clone()
             } else {

--- a/crates/preloop-vm/src/lib.rs
+++ b/crates/preloop-vm/src/lib.rs
@@ -829,17 +829,17 @@ impl VmProvider for SmolVmProvider {
             args.extend(["--from".into(), spec.image.clone()]);
         } else {
             args.extend(["--image".into(), spec.image.clone()]);
-            args.extend([
-                "--cpus".into(),
-                spec.cpus.to_string(),
-                "--mem".into(),
-                spec.memory_mib.to_string(),
-                "--storage".into(),
-                spec.storage_gib.to_string(),
-            ]);
-            if let Some(overlay_gib) = spec.overlay_gib {
-                args.extend(["--overlay".into(), overlay_gib.to_string()]);
-            }
+        }
+        args.extend([
+            "--cpus".into(),
+            spec.cpus.to_string(),
+            "--mem".into(),
+            spec.memory_mib.to_string(),
+            "--storage".into(),
+            spec.storage_gib.to_string(),
+        ]);
+        if let Some(overlay_gib) = spec.overlay_gib {
+            args.extend(["--overlay".into(), overlay_gib.to_string()]);
         }
         match &spec.network {
             NetworkPolicy::Disabled => {}

--- a/crates/preloop-vm/src/lib.rs
+++ b/crates/preloop-vm/src/lib.rs
@@ -673,6 +673,9 @@ impl SmolVmProvider {
         network: Option<&NetworkPolicy>,
         staging_dir: Option<&Path>,
     ) -> Result<ExecOutput, VmError> {
+        if operation == "create" {
+            eprintln!("[preloop-vm:create] {:?}", args);
+        }
         let mut command = self.sandboxed_command()?;
         match network {
             Some(NetworkPolicy::PublicOnly) => {
@@ -689,6 +692,9 @@ impl SmolVmProvider {
             // archive. Keep that scratch space beside the output instead of
             // falling back to a small host /tmp tmpfs.
             command.env("TMPDIR", staging_dir);
+            // Pack export streams multi-GiB flattened layers; the general 4 GiB
+            // file-transfer cap would abort a large golden pack.
+            command.env("SMOLVM_FILE_TRANSFER_MAX_BYTES", "64GiB");
         }
         command
             .args(args)
@@ -823,30 +829,17 @@ impl VmProvider for SmolVmProvider {
             args.extend(["--from".into(), spec.image.clone()]);
         } else {
             args.extend(["--image".into(), spec.image.clone()]);
-            // A bare rootfs directory carries no OCI metadata, so the image
-            // defines no entrypoint/CMD and `machine start` refuses to run a
-            // detached workload. Everything this provider does runs through
-            // `machine exec` anyway, so pin a harmless keep-alive workload
-            // for directory images. Registry images keep their own CMD.
-            if Path::new(&spec.image).is_dir() {
-                args.extend([
-                    "--".into(),
-                    "/bin/sh".into(),
-                    "-c".into(),
-                    "sleep infinity".into(),
-                ]);
+            args.extend([
+                "--cpus".into(),
+                spec.cpus.to_string(),
+                "--mem".into(),
+                spec.memory_mib.to_string(),
+                "--storage".into(),
+                spec.storage_gib.to_string(),
+            ]);
+            if let Some(overlay_gib) = spec.overlay_gib {
+                args.extend(["--overlay".into(), overlay_gib.to_string()]);
             }
-        }
-        args.extend([
-            "--cpus".into(),
-            spec.cpus.to_string(),
-            "--mem".into(),
-            spec.memory_mib.to_string(),
-            "--storage".into(),
-            spec.storage_gib.to_string(),
-        ]);
-        if let Some(overlay_gib) = spec.overlay_gib {
-            args.extend(["--overlay".into(), overlay_gib.to_string()]);
         }
         match &spec.network {
             NetworkPolicy::Disabled => {}
@@ -891,6 +884,22 @@ impl VmProvider for SmolVmProvider {
             args.extend([
                 "--mount-socket".into(),
                 format!("{}:{}", mount.host.display(), mount.guest.display()),
+            ]);
+        }
+        if !is_pack {
+            // Everything this provider does runs through `machine exec`, so
+            // pin a harmless keep-alive workload for every image. Without it,
+            // machines whose record carries no entrypoint/cmd (local
+            // archives, the official runner image's bare `bash` CMD) fail to
+            // start with libkrun's EINVAL once the memory ceiling is raised.
+            // The workload must be the LAST positional block: `machine create`
+            // treats everything after `--` as the workload, so any flags
+            // appended later would be swallowed into it.
+            args.extend([
+                "--".into(),
+                "/bin/sh".into(),
+                "-c".into(),
+                "sleep infinity".into(),
             ]);
         }
         self.exclusive_with_network("create", &args, &spec.network)
@@ -1107,6 +1116,8 @@ impl VmProvider for SmolVmProvider {
             "exec".into(),
             "--name".into(),
             name.as_str().into(),
+            "--user".into(),
+            "root".into(),
             "--".into(),
         ];
         args.extend_from_slice(argv);
@@ -1127,6 +1138,8 @@ impl VmProvider for SmolVmProvider {
             "exec".into(),
             "--name".into(),
             name.as_str().into(),
+            "--user".into(),
+            "root".into(),
         ];
         for (guest, source) in secrets {
             if !is_env_identifier(guest) {
@@ -1174,7 +1187,7 @@ impl VmProvider for SmolVmProvider {
         }
         let mut command = self.sandboxed_command()?;
         command
-            .args(["machine", "exec", "--stream", "--name", name.as_str(), "--"])
+            .args(["machine", "exec", "--stream", "--name", name.as_str(), "--user", "root", "--"])
             .args(argv)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())

--- a/crates/preloop-vm/src/lib.rs
+++ b/crates/preloop-vm/src/lib.rs
@@ -1187,7 +1187,16 @@ impl VmProvider for SmolVmProvider {
         }
         let mut command = self.sandboxed_command()?;
         command
-            .args(["machine", "exec", "--stream", "--name", name.as_str(), "--user", "root", "--"])
+            .args([
+                "machine",
+                "exec",
+                "--stream",
+                "--name",
+                name.as_str(),
+                "--user",
+                "root",
+                "--",
+            ])
             .args(argv)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())

--- a/crates/preloop-vm/tests/provider.rs
+++ b/crates/preloop-vm/tests/provider.rs
@@ -125,7 +125,7 @@ case "${1-}:${2-}" in
     if [ "${3-}" = "--stream" ]; then
       printf 'stream-out\n'
       printf 'stream-err\n' >&2
-    elif [ "${6-}" = "large-output" ]; then
+    elif [ "${8-}" = "large-output" ]; then
       printf '%200000s' ''
       printf '%200000s' '' >&2
     else
@@ -290,6 +290,10 @@ exit 0
                 format!("{}:/cache:ro", host_ro.display()),
                 "--mount-socket".to_owned(),
                 format!("{}:/run/preloop-engine.sock", host_socket.display()),
+                "--".to_owned(),
+                "/bin/sh".to_owned(),
+                "-c".to_owned(),
+                "sleep infinity".to_owned(),
             ]
         );
     }
@@ -646,6 +650,8 @@ exit 0
                 "exec".to_owned(),
                 "--name".to_owned(),
                 "runner".to_owned(),
+                "--user".to_owned(),
+                "root".to_owned(),
                 "--".to_owned(),
                 "echo".to_owned(),
                 hostile,

--- a/docs/vm-images.md
+++ b/docs/vm-images.md
@@ -192,9 +192,10 @@ Provisioning currently assumes an Ubuntu 24.04 or 22.04 userspace and uses
 
 For enterprise use, `build-golden` can refuse to bake from a base image whose
 provenance does not check out. The dump-style images published by the
-snapshot pipeline carry a GitHub-signed SLSA attestation (stored in GHCR) and
-a Sigstore keyless signature from the publishing workflow; both are verified
-before the golden is built:
+snapshot pipeline carry Sigstore keyless signatures plus in-toto attestations
+(SLSA provenance and an SPDX SBOM), all signed by the publishing workflow's
+GitHub Actions OIDC identity and stored as OCI referrers in GHCR; they are
+verified before the golden is built:
 
 ```sh
 PRELOOP_VERIFY_BASE_IMAGE=1 \
@@ -202,10 +203,12 @@ PRELOOP_VERIFY_BASE_IMAGE_REPO=acme/runner-image-blobs \
 preloop build-golden --base-image 'ghcr.io/acme/runner-images@sha256:<digest>' ...
 ```
 
-`gh` and `cosign` must be installed on the build host. The signature identity
+`cosign` must be installed on the build host. The signature identity
 is pinned to the publishing repository's `dump.yml` workflow on the default
 branch; override with `PRELOOP_BASE_IMAGE_IDENTITY_REGEXP` if the publishing
-workflow differs.
+workflow differs. A mirror that signs with a long-lived key instead of
+keyless OIDC can set `PRELOOP_BASE_IMAGE_PUBKEY` to the public key file;
+verification then uses `cosign verify --key` rather than the identity check.
 
 ### Golden provenance
 
@@ -248,6 +251,15 @@ SBOM is evidence about the upstream input; it is not treated as a Google
 signature or as a substitute for the Preloop golden attestation.
 
 ### Using a snapshot of the official hosted image
+
+Since v0.30.3 the release golden is baked directly from the official
+GitHub-hosted runner image snapshot (republished as OCI by the
+[preloopdev/runner-image-blobs](https://github.com/preloopdev/runner-image-blobs)
+dump pipeline, then scanned, signed, and SLSA-attested before the floating tag
+advances). The release assets (`preloop-ubuntu-24.04-x86_64` and its
+`.provenance.json` / `.base-sbom.spdx.json` / `.bundle` sidecars) are therefore
+the official runner image with the Preloop runner baked in — no extra
+provisioning needed.
 
 GitHub's hosted runner images are not published as OCI images, but the
 community [runner-image-blobs](https://github.com/ChristopherHX/runner-image-blobs)

--- a/docs/vm-images.md
+++ b/docs/vm-images.md
@@ -549,3 +549,72 @@ fetches `index.docker.io` means the running CLI has an older compiled pin or
   `mirror.gcr.io/library/ubuntu:24.04@sha256:...`, not a bare
   `ubuntu:24.04@sha256:...`.
 
+### Building the official-runner-image golden on Apple Silicon
+
+The official GitHub-hosted runner image (`ubuntu24-runner-large`, published
+per-arch to `ghcr.io/preloopdev/runner-images` by the runner-image-blobs
+fork) is tens of GiB and declares `USER=runner`. Building a golden from it
+locally exercises several smolvm/praeloop sharp edges that a stock Ubuntu
+base never hits. All were fixed in smolvm's `src/cli/internal_boot.rs`,
+`src/cli/machine.rs`, `src/pack_export.rs`, `crates/smolvm-agent/src/…`, and
+`crates/preloop-cli`/`preloop-vm`; the notes below describe the failure each
+one produced so a regression is recognizable.
+
+- **`krun_start_enter returned: -22 (EINVAL)` — `Building the microVM failed:
+  Internal(Vm(VmSetup(VmCreate)))`**: the `smolvm` binary was re-signed with
+  an ad-hoc identity that dropped the `com.apple.security.hypervisor`
+  entitlement, so `hv_vm_create` returns `HV_UNSUPPORTED`. Re-sign with the
+  entitlement:
+  ```sh
+  cat > /tmp/hv.entitlements <<'EOF'
+  <?xml version="1.0" encoding="UTF-8"?>
+  <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+  <plist version="1.0"><dict>
+    <key>com.apple.security.hypervisor</key><true/>
+  </dict></plist>
+  EOF
+  codesign --force --sign - --entitlements /tmp/hv.entitlements ~/.smolvm/smolvm-bin
+  ```
+  Sanity-check with a tiny C probe calling `hv_vm_create` (returns 0 only
+  when the entitlement is present).
+- **Disk stays 20 GiB while the record says 120 GiB**: smolvm's
+  `open_or_create_at` never resizes an existing raw disk, and a machine
+  recreated under the same name reuses the same hash dir. A large flatten
+  then fills the small disk, and the guest surfaces the failure as
+  `io operation failed: Resource temporarily unavailable (os error 35)`.
+  `internal_boot.rs::open_boot_disk` now grows the raw disk to the requested
+  size (`set_len`; the guest `resize2fs` expands the ext4 at boot).
+- **Machine created with default resources despite `--mem/--storage`**:
+  `machine create` treats everything after `--` as the workload, so any flag
+  appended after the keep-alive workload (`-- /bin/sh -c sleep infinity`) is
+  silently swallowed — the machine boots with 8192 MiB / 20 GiB and no
+  network. The workload must be the *last* positional: praeloop now emits
+  every flag before `--`.
+- **`unknown variant \`flatten_layers\`` during pack**: the pack binary and
+  the guest agent's protocol disagree. The agent in
+  `~/.smolvm/agent-rootfs/usr/local/bin/` must be rebuilt from the *same*
+  checkout as the CLI (`cargo zigbuild --profile release-small -p smolvm-agent
+  --target aarch64-unknown-linux-musl`) and copied into the rootfs.
+- **`read file: guest streamed N bytes, exceeding the 4294967296 byte cap`**:
+  pack export streams multi-GiB flattened layers, but the general 4 GiB
+  file-transfer cap applies unless raised. praeloop sets
+  `SMOLVM_FILE_TRANSFER_MAX_BYTES=64GiB` on the pack command.
+- **`mkdir: cannot create directory '/var/lib/preloop-runner': Permission
+  denied` during the bake**: the official image declares `USER=runner`, and
+  `machine exec` runs as the image's declared user. The exec path now
+  accepts `--user` (added to smolvm's `ExecCmd`) and praeloop passes
+  `--user root` for bake commands.
+- **Packed layer contains `archive.tar`, not a rootfs (no `/bin/sh`)**:
+  a `local:<hash>` machine's cache dir holds the *archive*, not the
+  flattened rootfs. The pack export must flatten from the machine's own
+  storage (`image-archives/packed_layers/0000_rootfs`), not the cache dir;
+  `pack_export.rs` now sources the base that way for archive machines.
+- **`crun create` hangs then fails with EAGAIN**: never pipe crun's stderr
+  in the agent (`crun.rs` keeps `Stdio::null()`); capturing it for debugging
+  makes the two-step `crun create` deadlock.
+- **Disk fills from stale machine dirs**: a failed create can leak
+  `~/Library/Caches/smolvm/vms/<hash>/storage.raw` sparse files that a later
+  `machine delete` does not reclaim. When the host reports "No space left on
+  device" or flaky EAGAINs appear, prune the vms cache and verify free space
+  with `df -h /System/Volumes/Data`.
+

--- a/plans/001-caching-performance-strategy.html
+++ b/plans/001-caching-performance-strategy.html
@@ -1,0 +1,1238 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Plan 001 — Caching Strategy for Local CI</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Source+Serif+4:ital,opsz,wght@0,8..60,300;0,8..60,400;0,8..60,600;0,8..60,700;1,8..60,400&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: oklch(96.5% 0.008 80);
+    --bg-sheet: oklch(99% 0.004 80);
+    --bg-raised: oklch(97.5% 0.006 80);
+    --bg-code: oklch(95% 0.008 80);
+    --bg-code-inline: oklch(93.5% 0.01 80);
+    --border: oklch(88% 0.01 80);
+    --border-strong: oklch(78% 0.012 80);
+    --text: oklch(22% 0.012 67);
+    --text-secondary: oklch(42% 0.01 67);
+    --text-muted: oklch(55% 0.008 67);
+    --accent: oklch(55% 0.16 55);
+    --accent-soft: oklch(93% 0.04 55);
+    --accent-hover: oklch(48% 0.18 55);
+    --green: oklch(52% 0.14 155);
+    --green-soft: oklch(94% 0.04 155);
+    --red: oklch(55% 0.18 25);
+    --red-soft: oklch(94% 0.04 25);
+    --blue: oklch(52% 0.14 255);
+    --blue-soft: oklch(94% 0.04 255);
+    --yellow: oklch(75% 0.14 85);
+    --yellow-soft: oklch(95% 0.04 85);
+    --toc-width: 240px;
+    --content-max: 72ch;
+    --font-display: 'Outfit', system-ui, sans-serif;
+    --font-body: 'Source Serif 4', Georgia, serif;
+    --font-mono: 'Fira Code', 'Menlo', monospace;
+  }
+
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  html { scroll-behavior: smooth; scroll-padding-top: 2rem; }
+
+  body {
+    font-family: var(--font-body);
+    font-size: 1.05rem;
+    line-height: 1.72;
+    color: var(--text);
+    background: var(--bg);
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* ── Layout ── */
+  .page-grid {
+    display: grid;
+    grid-template-columns: var(--toc-width) minmax(0, 1fr);
+    gap: 3rem;
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 3rem 2rem 6rem;
+  }
+
+  /* ── TOC Sidebar ── */
+  .toc {
+    position: sticky;
+    top: 2rem;
+    align-self: start;
+    max-height: calc(100vh - 4rem);
+    overflow-y: auto;
+    padding-right: 1rem;
+    scrollbar-width: thin;
+    scrollbar-color: var(--border-strong) transparent;
+  }
+
+  .toc-title {
+    font-family: var(--font-display);
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-muted);
+    margin-bottom: 1rem;
+  }
+
+  .toc ol {
+    list-style: none;
+    counter-reset: toc-counter;
+  }
+
+  .toc li {
+    counter-increment: toc-counter;
+    margin-bottom: 0.35rem;
+  }
+
+  .toc a {
+    font-family: var(--font-display);
+    font-size: 0.78rem;
+    font-weight: 400;
+    color: var(--text-secondary);
+    text-decoration: none;
+    line-height: 1.4;
+    display: block;
+    padding: 0.2rem 0.6rem;
+    border-radius: 4px;
+    transition: color 0.15s, background 0.15s;
+  }
+
+  .toc a:hover {
+    color: var(--accent);
+    background: var(--accent-soft);
+  }
+
+  .toc a.active {
+    color: var(--accent);
+    font-weight: 500;
+    background: var(--accent-soft);
+  }
+
+  .toc .toc-h3 { padding-left: 1.4rem; font-size: 0.73rem; }
+
+  /* ── Main Content ── */
+  .content {
+    min-width: 0;
+    max-width: var(--content-max);
+  }
+
+  /* ── Hero / Title Block ── */
+  .hero {
+    margin-bottom: 3rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .hero-eyebrow {
+    font-family: var(--font-display);
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--accent);
+    margin-bottom: 0.75rem;
+  }
+
+  .hero h1 {
+    font-family: var(--font-display);
+    font-size: clamp(2rem, 4vw, 2.8rem);
+    font-weight: 800;
+    line-height: 1.1;
+    color: var(--text);
+    letter-spacing: -0.02em;
+    margin-bottom: 1rem;
+  }
+
+  .hero-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1.5rem;
+    font-family: var(--font-display);
+    font-size: 0.78rem;
+    color: var(--text-muted);
+  }
+
+  .hero-meta .meta-item {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  .hero-meta .meta-label {
+    font-weight: 500;
+    color: var(--text-secondary);
+  }
+
+  .status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.15rem 0.55rem;
+    border-radius: 100px;
+    font-family: var(--font-display);
+    font-size: 0.7rem;
+    font-weight: 600;
+    background: var(--yellow-soft);
+    color: oklch(45% 0.12 85);
+  }
+
+  .status-badge::before {
+    content: '';
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--yellow);
+  }
+
+  /* ── Sections ── */
+  .content > h2 {
+    font-family: var(--font-display);
+    font-size: clamp(1.3rem, 2.5vw, 1.65rem);
+    font-weight: 700;
+    line-height: 1.2;
+    color: var(--text);
+    margin-top: 3.5rem;
+    margin-bottom: 1rem;
+    letter-spacing: -0.015em;
+    scroll-margin-top: 1.5rem;
+  }
+
+  .content > h3 {
+    font-family: var(--font-display);
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text);
+    margin-top: 2rem;
+    margin-bottom: 0.6rem;
+    scroll-margin-top: 1.5rem;
+  }
+
+  .content > h4 {
+    font-family: var(--font-display);
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin-top: 1.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .content > p,
+  .content > ul,
+  .content > ol {
+    margin-bottom: 1rem;
+  }
+
+  .content > ul, .content > ol {
+    padding-left: 1.4rem;
+  }
+
+  .content > li {
+    margin-bottom: 0.35rem;
+  }
+
+  .content > li::marker {
+    color: var(--accent);
+  }
+
+  /* ── Blockquote (Executive Decision) ── */
+  blockquote.callout {
+    background: var(--bg-sheet);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.25rem 1.5rem;
+    margin: 1.5rem 0;
+    font-size: 0.95rem;
+  }
+
+  blockquote.callout p {
+    margin-bottom: 0.5rem;
+  }
+
+  blockquote.callout p:last-child {
+    margin-bottom: 0;
+  }
+
+  blockquote.callout strong {
+    color: var(--accent);
+  }
+
+  /* ── Numbered List (Executive Priorities) ── */
+  .priority-list {
+    list-style: none;
+    counter-reset: priority;
+    padding-left: 0;
+    margin: 1rem 0 1.5rem;
+  }
+
+  .priority-list li {
+    counter-increment: priority;
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
+    padding: 0.6rem 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .priority-list li:last-child { border-bottom: none; }
+
+  .priority-list li::before {
+    content: counter(priority);
+    font-family: var(--font-display);
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: var(--accent);
+    background: var(--accent-soft);
+    min-width: 1.6rem;
+    height: 1.6rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    flex-shrink: 0;
+    margin-top: 0.15rem;
+  }
+
+  /* ── Tables ── */
+  .table-wrap {
+    overflow-x: auto;
+    margin: 1.25rem 0 1.5rem;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg-sheet);
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.88rem;
+    line-height: 1.55;
+  }
+
+  thead {
+    background: var(--bg-raised);
+  }
+
+  th {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-secondary);
+    text-align: left;
+    padding: 0.65rem 1rem;
+    border-bottom: 1px solid var(--border-strong);
+    white-space: nowrap;
+  }
+
+  td {
+    padding: 0.55rem 1rem;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+  }
+
+  tr:last-child td { border-bottom: none; }
+
+  tbody tr:hover {
+    background: oklch(97% 0.006 80);
+  }
+
+  td code, th code {
+    font-family: var(--font-mono);
+    font-size: 0.82em;
+    background: var(--bg-code-inline);
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+    white-space: nowrap;
+  }
+
+  /* ── Code Blocks ── */
+  pre {
+    background: var(--bg-code);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 1rem 1.25rem;
+    overflow-x: auto;
+    margin: 1rem 0 1.5rem;
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    line-height: 1.65;
+    color: var(--text);
+    scrollbar-width: thin;
+  }
+
+  pre code {
+    background: none;
+    padding: 0;
+    border-radius: 0;
+    font-size: inherit;
+  }
+
+  /* inline code */
+  .content > p code,
+  .content > li code,
+  .content > td code {
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    background: var(--bg-code-inline);
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+    white-space: nowrap;
+  }
+
+  /* ── Callout Boxes ── */
+  .callout {
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+    margin: 1.25rem 0;
+    font-size: 0.92rem;
+    line-height: 1.6;
+  }
+
+  .callout-title {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 0.4rem;
+  }
+
+  .callout-evidence {
+    background: var(--blue-soft);
+    border: 1px solid oklch(82% 0.04 255);
+  }
+  .callout-evidence .callout-title { color: var(--blue); }
+
+  .callout-stop {
+    background: var(--red-soft);
+    border: 1px solid oklch(82% 0.04 25);
+  }
+  .callout-stop .callout-title { color: var(--red); }
+
+  .callout-decision {
+    background: var(--green-soft);
+    border: 1px solid oklch(82% 0.04 155);
+  }
+  .callout-decision .callout-title { color: var(--green); }
+
+  /* ── Metric Cards ── */
+  .metric-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 0.75rem;
+    margin: 1.25rem 0 1.5rem;
+  }
+
+  .metric-card {
+    background: var(--bg-sheet);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1rem 1.1rem;
+  }
+
+  .metric-value {
+    font-family: var(--font-display);
+    font-size: 1.6rem;
+    font-weight: 700;
+    line-height: 1.1;
+    color: var(--text);
+    letter-spacing: -0.02em;
+  }
+
+  .metric-value.preloop { color: var(--red); }
+  .metric-value.agent-ci { color: var(--green); }
+
+  .metric-label {
+    font-family: var(--font-display);
+    font-size: 0.72rem;
+    font-weight: 500;
+    color: var(--text-muted);
+    margin-top: 0.25rem;
+    line-height: 1.3;
+  }
+
+  /* ── Phase Indicator ── */
+  .phase-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    font-family: var(--font-display);
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 0.2rem 0.6rem;
+    border-radius: 4px;
+    margin-bottom: 0.5rem;
+  }
+
+  .phase-tag.current {
+    background: var(--accent-soft);
+    color: var(--accent);
+  }
+
+  .phase-tag.future {
+    background: var(--bg-raised);
+    color: var(--text-muted);
+  }
+
+  /* ── Section Divider ── */
+  .section-divider {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 2.5rem 0 0;
+  }
+
+  /* ── Responsive ── */
+  @media (max-width: 860px) {
+    .page-grid {
+      grid-template-columns: 1fr;
+      padding: 1.5rem 1.25rem 4rem;
+      gap: 0;
+    }
+    .toc {
+      position: static;
+      max-height: none;
+      overflow: visible;
+      padding-right: 0;
+      margin-bottom: 2rem;
+      padding-bottom: 1.5rem;
+      border-bottom: 1px solid var(--border);
+    }
+    .hero h1 { font-size: 1.8rem; }
+    .metric-row { grid-template-columns: 1fr 1fr; }
+  }
+
+  /* ── Print ── */
+  @media print {
+    .toc { display: none; }
+    .page-grid { grid-template-columns: 1fr; max-width: 100%; }
+    body { background: white; }
+    pre { border: 1px solid #ccc; }
+  }
+</style>
+</head>
+<body>
+
+<div class="page-grid">
+
+<!-- ════════════════════ TOC ════════════════════ -->
+<nav class="toc" aria-label="Table of contents">
+  <div class="toc-title">Contents</div>
+  <ol>
+    <li><a href="#executive-decision">Executive Decision</a></li>
+    <li><a href="#goals">Goals</a></li>
+    <li><a href="#non-goals">Non-Goals</a></li>
+    <li><a href="#current-state">Current State &amp; Evidence</a></li>
+    <li><a href="#cache-taxonomy">Cache Taxonomy</a></li>
+    <li><a href="#storage-model">The Storage Model</a></li>
+    <li><a href="#cache-key-design">Cache Key Design</a></li>
+    <li><a href="#placement">Placement &amp; Data Flow</a></li>
+    <li><a href="#deployment-profile">Deployment Profile</a></li>
+    <li><a href="#security">Security Design</a></li>
+    <li><a href="#correctness">Correctness Rules</a></li>
+    <li><a href="#admission">Admission, Retention &amp; Eviction</a></li>
+    <li><a href="#performance">Performance Techniques</a></li>
+    <li><a href="#observability">Observability</a></li>
+    <li><a href="#verification">Verification &amp; Benchmarks</a></li>
+    <li><a href="#roadmap">Phased Roadmap</a></li>
+    <li><a href="#boundaries">Implementation Boundaries</a></li>
+    <li><a href="#rejected">Rejected Approaches</a></li>
+    <li><a href="#stop-conditions">Stop Conditions</a></li>
+    <li><a href="#checklist">Review Checklist</a></li>
+  </ol>
+</nav>
+
+<!-- ════════════════════ CONTENT ════════════════════ -->
+<main class="content">
+
+<!-- Hero -->
+<header class="hero">
+  <div class="hero-eyebrow">Plan 001 · Architecture</div>
+  <h1>Caching Strategy for Local CI</h1>
+  <div class="hero-meta">
+    <span class="meta-item"><span class="status-badge">Proposed</span></span>
+    <span class="meta-item"><span class="meta-label">Priority</span> P1</span>
+    <span class="meta-item"><span class="meta-label">Category</span> Performance · Correctness · Architecture</span>
+    <span class="meta-item"><span class="meta-label">Planned</span> commit <code>1342346a</code></span>
+  </div>
+</header>
+
+<!-- Executive Decision -->
+<h2 id="executive-decision">Executive Decision</h2>
+
+<p>Preloop should not build one undifferentiated cache. It should build a layered cache system with three properties:</p>
+
+<ol class="priority-list">
+  <li><strong>Immutable content-addressed blobs</strong> hold bytes once and are addressed by a verified digest.</li>
+  <li><strong>Scoped metadata</strong> maps workflow-visible keys to those blobs.</li>
+  <li><strong>Guest-local materialization</strong> makes hot content available to a runner without making a shared writable filesystem part of job correctness.</li>
+</ol>
+
+<div class="table-wrap">
+<table>
+  <thead><tr><th>Layer</th><th>Storage</th></tr></thead>
+  <tbody>
+    <tr><td>Durable metadata</td><td>SQLite under <code>~/.preloop/cache/v1</code></td></tr>
+    <tr><td>Durable blobs</td><td>Local content-addressed files under <code>~/.preloop/cache/v1/blobs/</code></td></tr>
+    <tr><td>Hot tier</td><td>Golden/COW disk and host page cache</td></tr>
+  </tbody>
+</table>
+</div>
+
+<p>The same logical model extends to self-hosted (Postgres + S3) and managed (Postgres + object store + KMS) deployments in future phases. The local profile uses one developer machine, one implicit tenant, loopback control plane, and disposable SmolVM runners.</p>
+
+<div class="callout callout-evidence">
+  <div class="callout-title">Measured Losses — Evidence, Not Speculation</div>
+  <p>The first performance work targets measured losses, not speculative caching.</p>
+</div>
+
+<div class="metric-row">
+  <div class="metric-card">
+    <div class="metric-value preloop">92.45s</div>
+    <div class="metric-label">Vite warm<br>Preloop</div>
+  </div>
+  <div class="metric-card">
+    <div class="metric-value agent-ci">38.71s</div>
+    <div class="metric-label">Vite warm<br>Agent CI</div>
+  </div>
+  <div class="metric-card">
+    <div class="metric-value">34.24s</div>
+    <div class="metric-label">setup-node / cache<br>handling</div>
+  </div>
+  <div class="metric-card">
+    <div class="metric-value">16.50s</div>
+    <div class="metric-label">pnpm install</div>
+  </div>
+  <div class="metric-card">
+    <div class="metric-value">28.31s</div>
+    <div class="metric-label">Post-job<br>cache save</div>
+  </div>
+</div>
+
+<p>The cache restore emitted <code>File name too long</code>, so dependency installation ran on a cache miss. Cold time before the first guest step was 48.54s for ripgrep, 545.84s for Vite, and 18.59s for testcontainers-go — VM/image preparation, not workload execution.</p>
+
+<p>This evidence establishes the priority order:</p>
+
+<ol class="priority-list">
+  <li>Make declared toolchains discoverable in the official toolcache layout.</li>
+  <li>Make Actions cache restore/save correct, indexed, and streaming.</li>
+  <li>Persist package download stores across disposable runners.</li>
+  <li>Resolve and cache immutable action/image/tool artifacts by digest.</li>
+  <li>Move VM preparation out of the run critical path.</li>
+</ol>
+
+<hr class="section-divider">
+
+<!-- Goals -->
+<h2 id="goals">Goals</h2>
+<ul>
+  <li>Preserve official-runner and unmodified-workflow compatibility.</li>
+  <li>Make a cache miss equivalent to normal uncached execution, except when a workflow explicitly requests <code>fail-on-cache-miss</code>.</li>
+  <li>Eliminate repeated downloads and archive work that dominates warm jobs.</li>
+  <li>Keep process memory usage proportional to a transfer chunk, not cache size.</li>
+  <li>Bound disk growth with quotas, expiration, admission, and eviction.</li>
+  <li>Give operators enough telemetry to explain every hit, miss, restore, save, and eviction.</li>
+  <li>Design metadata/blob interfaces that extend to self-hosted and managed deployments later.</li>
+</ul>
+
+<!-- Non-Goals -->
+<h2 id="non-goals">Non-Goals</h2>
+<ul>
+  <li>Making local CI pass because an undeclared tool happens to exist. Workflows must remain portable to GitHub Actions.</li>
+  <li>Treating artifacts or logs as disposable caches. They are user-visible outputs with separate retention semantics.</li>
+  <li>Reusing complete workspaces across jobs. Workspaces remain disposable unless a workflow explicitly saves paths through the cache protocol.</li>
+  <li>Sharing mutable build caches across security boundaries.</li>
+  <li>Replacing package-manager integrity checks or OCI digest verification.</li>
+  <li>Guaranteeing that a cache survives eviction. A job must remain correct on a miss.</li>
+</ul>
+
+<hr class="section-divider">
+
+<!-- Current State -->
+<h2 id="current-state">Current State &amp; Evidence</h2>
+
+<h3>Actions cache store</h3>
+<p><code>crates/aksh-cache/src/lib.rs</code> implements a local file-backed <code>CacheStore</code>:</p>
+<ul>
+  <li>Cache identity is a SHA-256-derived directory.</li>
+  <li>Original key, version, and creation time are stored as metadata.</li>
+  <li>Entries are immutable.</li>
+  <li>Restore order supports exact key and prefix matching.</li>
+  <li>Prefix lookup scans every cache directory.</li>
+  <li>Complete archives are read into <code>Vec&lt;u8&gt;</code> on restore.</li>
+  <li>There is no quota, expiration, eviction policy, or indexed lookup.</li>
+</ul>
+
+<p><code>crates/aksh-runner-server/src/blob_store.rs</code> stages v2 blocks on disk, then assembles all blocks in a single <code>Vec&lt;u8&gt;</code>, writes a second complete copy, and reads complete blobs to return downloads.</p>
+
+<h3>Cache scoping and authorization</h3>
+<p><code>results_twirp::scoped_cache_key</code> currently combines workflow-requested <code>repository</code> and <code>scope</code> fields. Managed isolation cannot trust these values. The server must derive tenant, repository, ref/trust class, plan, and job identity from authenticated server state.</p>
+
+<h3>Toolcache mismatch</h3>
+<p>The runner exports <code>RUNNER_TOOL_CACHE=/var/lib/preloop-runner/_work/_tool</code>, but the JavaScript action runtime is installed separately at <code>/var/lib/preloop-runner/externals/node24/bin/node</code>. <code>actions/setup-node</code> therefore downloads Node even though the runner has a Node executable.</p>
+
+<p>A declared Node installation must be materialized in the official toolcache shape:</p>
+
+<pre><code>$RUNNER_TOOL_CACHE/node/&lt;exact-version&gt;/&lt;arch&gt;/bin/node
+$RUNNER_TOOL_CACHE/node/&lt;exact-version&gt;/&lt;arch&gt;.complete</code></pre>
+
+<p>Do not merely put <code>/externals/node24/bin</code> on <code>PATH</code> and call the setup step satisfied. The setup action owns version selection and must observe the version it requested.</p>
+
+<h3>Golden VMs and images</h3>
+<p><code>crates/preloop-orchestrator/src/environment.rs</code> computes an environment fingerprint from a base-image string and declared toolchain layers. A mutable tag is not a durable compatibility identity; the fingerprint must ultimately include the resolved base-image digest.</p>
+
+<p>An additional virtiofs cache mount caused 20–50 second fork stalls and instability. The cache design must not add one mount per ecosystem or per cache.</p>
+
+<h3>Other useful caches</h3>
+<ul>
+  <li><strong>Actions:</strong> streams action tarballs into an atomic on-disk cache keyed by owner/repository/ref. Mutable tags are cached indefinitely — resolve tags to commit SHA.</li>
+  <li><strong>Git snapshots:</strong> lock-protected Git object cache improves <code>git add</code> from 156ms to 16ms for a 6,000-file workspace.</li>
+  <li><strong>Keys:</strong> deliberately gives every runner a unique RSA key. Runner private keys must never enter a shared cache or golden image.</li>
+</ul>
+
+<hr class="section-divider">
+
+<!-- Cache Taxonomy -->
+<h2 id="cache-taxonomy">Cache Taxonomy</h2>
+
+<div class="table-wrap">
+<table>
+  <thead>
+    <tr><th>Class</th><th>Examples</th><th>Cache?</th><th>Scope</th><th>Placement</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Runner internals</td><td>Node 20/24 for JS actions</td><td>Yes, immutable</td><td>Release + OS + arch</td><td>Base/golden <code>externals/</code></td></tr>
+    <tr><td>Declared toolchains</td><td>Node, Python, Go, Rust, .NET</td><td>Yes</td><td>Version + platform + format</td><td>Host tool CAS → <code>$RUNNER_TOOL_CACHE</code></td></tr>
+    <tr><td>Action source</td><td><code>actions/checkout</code>, <code>setup-node</code></td><td>Yes, immutable</td><td>Owner/repo/SHA</td><td>Shared verified action CAS</td></tr>
+    <tr><td>OCI images/layers</td><td>Base VM, containers, services</td><td>Yes, immutable</td><td>Registry/digest/platform</td><td>Registry mirror + node cache + golden</td></tr>
+    <tr><td>Package download stores</td><td>pnpm, npm, Cargo, Go, uv</td><td>Yes</td><td>Integrity + platform</td><td>Persistent host/node store</td></tr>
+    <tr><td>Compiler/build cache</td><td>sccache, Go build, Vite</td><td>Cautiously</td><td>Source/config/toolchain</td><td>Repository/trust-scoped</td></tr>
+    <tr><td>Actions cache archives</td><td><code>actions/cache</code> paths</td><td>Yes</td><td>Namespace + key/version</td><td>Indexed metadata + blob CAS</td></tr>
+    <tr><td>Git snapshot objects</td><td>Immutable objects, stat index</td><td>Yes</td><td>Git identity</td><td>Host-local persistent store</td></tr>
+    <tr><td>Workspace</td><td>Source, generated files</td><td style="color:var(--red)">No reuse</td><td>One job/run</td><td>Disposable guest disk</td></tr>
+    <tr><td>Artifacts &amp; logs</td><td>Builds, reports, logs</td><td>Store, not cache</td><td>Retention policy</td><td>Artifact/log store</td></tr>
+    <tr><td>Secrets &amp; identity</td><td>Tokens, keys, <code>.credentials</code></td><td style="color:var(--red)">Never</td><td>One job or runner</td><td>Ephemeral only</td></tr>
+  </tbody>
+</table>
+</div>
+
+<hr class="section-divider">
+
+<!-- Storage Model -->
+<h2 id="storage-model">The Storage Model</h2>
+
+<h3>Separate logical identity from physical bytes</h3>
+
+<p>A logical cache entry is metadata:</p>
+
+<pre><code>CacheEntry {
+  namespace,
+  cache_class,
+  user_key,
+  version,
+  blob_digest,
+  compressed_size,
+  uncompressed_size,
+  compression,
+  created_at,
+  last_accessed_at,
+  expires_at,
+  producer_identity,
+  trust_domain,
+  state
+}</code></pre>
+
+<p>The physical blob is immutable:</p>
+
+<pre><code>blobs/sha256/ab/cd/&lt;digest&gt;</code></pre>
+
+<p>Benefits: user-controlled keys never become filesystem paths; identical bytes may be deduplicated without weakening logical isolation; atomic publication is simple; metadata lookup does not scan directories; eviction can remove logical references before garbage-collecting unreferenced blobs; blob integrity is verified independently from cache-key correctness.</p>
+
+<h3>Required operations</h3>
+<ol>
+  <li><strong>Reserve</strong> a logical key/version under an authenticated namespace.</li>
+  <li><strong>Upload</strong> chunks or multipart blocks to a staging identity.</li>
+  <li><strong>Finalize</strong> only after size and digest verification; atomically publish metadata.</li>
+  <li><strong>Lookup</strong> exact key, then restore prefixes in official order.</li>
+  <li><strong>Download</strong> by an expiring, read-only capability.</li>
+  <li><strong>Touch</strong> access metadata asynchronously.</li>
+  <li><strong>Expire/evict</strong> metadata, then garbage-collect unreferenced blobs after a grace period.</li>
+</ol>
+
+<p>Readers must never observe pending uploads. Concurrent writers for the same immutable key/version produce one winner; the loser gets "already exists."</p>
+
+<h3>Streaming requirements</h3>
+<ul>
+  <li>Upload memory use: <code>O(chunk_size)</code>.</li>
+  <li>Block assembly: concatenate using streaming file/object-store operations, never a complete <code>Vec&lt;u8&gt;</code>.</li>
+  <li>Finalization: compute digest and size while streaming; avoid staging-to-store-to-memory copies.</li>
+  <li>Download: stream with backpressure and range support where the client uses it.</li>
+  <li>Managed CI: issue short-lived direct object-store URLs after authorization.</li>
+  <li>Self-hosted: <code>sendfile</code>/streamed file responses are sufficient.</li>
+</ul>
+
+<hr class="section-divider">
+
+<!-- Cache Key Design -->
+<h2 id="cache-key-design">Cache Key Design</h2>
+
+<h3>General rule</h3>
+<p>A key must include every input that can change the cached output. If that set cannot be identified, do not cache the output.</p>
+
+<p>Use canonical serialization followed by a hash for storage identity. Keep human-readable components in metadata and telemetry.</p>
+
+<pre><code>schema_version
++ tenant_id
++ repository_id
++ trust_domain
++ cache_class
++ workflow-visible key/version</code></pre>
+
+<h3>Key Recipes</h3>
+
+<h4>Toolchains</h4>
+<pre><code>tool/v1/&lt;tool&gt;/&lt;exact-version&gt;/&lt;os&gt;/&lt;arch&gt;/&lt;libc&gt;/&lt;toolcache-format&gt;/&lt;upstream-sha256&gt;</code></pre>
+<p>Include exact version, not only major. A workflow may request <code>24</code>, but the resolved cache entry should identify <code>24.18.0</code> with a separately expiring major-to-exact resolution record.</p>
+
+<h4>Action source</h4>
+<pre><code>action/v1/&lt;owner&gt;/&lt;repo&gt;/&lt;resolved-commit-sha&gt;/&lt;archive-sha256&gt;</code></pre>
+<p>Mutable refs such as <code>v4</code>, branches, and tags are resolution records with a short TTL pointing to immutable commit/archive entries.</p>
+
+<h4>OCI images</h4>
+<pre><code>oci/v1/&lt;registry&gt;/&lt;repository&gt;/&lt;manifest-digest&gt;/&lt;platform-os&gt;/&lt;platform-arch&gt;</code></pre>
+<p>Cache layers by OCI digest. Golden compatibility must use the resolved base manifest/config digest, never <code>ubuntu:24.04</code> alone.</p>
+
+<h4>Package download stores</h4>
+<pre><code>package/v1/&lt;ecosystem&gt;/&lt;content-integrity&gt;/&lt;platform-if-native&gt;</code></pre>
+<p>Prefer the ecosystem's verified content store over archiving an installed dependency tree.</p>
+
+<h4>Actions cache archive</h4>
+<pre><code>&lt;os&gt;-&lt;arch&gt;-&lt;package-manager-major&gt;-&lt;runtime-abi&gt;-&lt;lockfile-hash&gt;</code></pre>
+<p>Do not silently rewrite the workflow's visible key. Namespace it server-side.</p>
+
+<h4>Build outputs</h4>
+<pre><code>build/v1/&lt;repo&gt;/&lt;tool&gt;/&lt;tool-version&gt;/&lt;target&gt;/&lt;profile&gt;/
+         &lt;feature-hash&gt;/&lt;relevant-env-hash&gt;/&lt;source-and-config-hash&gt;</code></pre>
+
+<h4>Golden VM</h4>
+<pre><code>golden/v1/&lt;base-image-digest&gt;/&lt;guest-arch&gt;/&lt;kernel-and-smolvm-version&gt;/
+          &lt;runner-bundle-sha&gt;/&lt;provisioner-sha&gt;/
+          &lt;declared-toolchain-set-hash&gt;/&lt;baseline-packages-hash&gt;</code></pre>
+<p>Preload OCI digest set and action digest set are optimization metadata, not compatibility identity.</p>
+
+<hr class="section-divider">
+
+<!-- Placement -->
+<h2 id="placement">Placement &amp; Data Flow</h2>
+
+<h3>L0: process-local coordination</h3>
+<p>Cache only small metadata: in-flight reservation deduplication, short negative cache for failed mutable-ref resolutions, recently resolved metadata entries. Do not retain archive bytes in process memory.</p>
+
+<h3>L1: guest-local ephemeral state</h3>
+<p>Use for active job extraction, package-manager working state, and compiler scratch data. Disappears with the runner.</p>
+
+<h3>L2: node-local persistent CAS</h3>
+<p>Use for hot tools, actions, package objects, OCI layers, and recently restored cache archives. A node-local entry is an optimization. Its loss must fall back to L3 or origin.</p>
+
+<h3>L3: durable blob and metadata store</h3>
+<ul>
+  <li><strong>Local:</strong> host filesystem plus SQLite.</li>
+  <li><strong>Self-hosted:</strong> persistent disk or S3-compatible object store; SQLite for one node, Postgres for multiple.</li>
+  <li><strong>Managed:</strong> object storage plus Postgres, with regional placement and KMS encryption.</li>
+</ul>
+
+<hr class="section-divider">
+
+<!-- Deployment Profile -->
+<h2 id="deployment-profile">Deployment Profile: Local CI</h2>
+
+<p>One developer machine, one implicit tenant, loopback control plane, disposable SmolVM runners, latency matters more than cross-host durability.</p>
+
+<pre><code>~/.preloop/cache/v1/
+├── index.sqlite
+├── blobs/sha256/
+├── staging/
+├── locks/
+├── tools/
+├── actions/
+├── packages/
+└── metrics/</code></pre>
+
+<p>Write-through to local disk; one cache root, not one virtiofs mount per cache class; seed declared toolchains into an environment-specific golden/toolcache; keep runner internals in <code>externals/</code>, separate from declared workflow tools; default starting quota: 20 GiB soft target and configurable hard limit.</p>
+
+<h3>Performance targets</h3>
+<div class="metric-row">
+  <div class="metric-card">
+    <div class="metric-value">&lt;10ms</div>
+    <div class="metric-label">Metadata lookup p95</div>
+  </div>
+  <div class="metric-card">
+    <div class="metric-value">&lt;1s</div>
+    <div class="metric-label">Node/tool cache hit materialization</div>
+  </div>
+  <div class="metric-card">
+    <div class="metric-value">&lt;2s</div>
+    <div class="metric-label">Vite setup-node / cache phase</div>
+  </div>
+  <div class="metric-card">
+    <div class="metric-value">&lt;45s</div>
+    <div class="metric-label">Vite warm total</div>
+  </div>
+</div>
+
+<hr class="section-divider">
+
+<!-- Security -->
+<h2 id="security">Security Design (Local CI)</h2>
+
+<p>In local CI, the trust boundary is the developer's OS account. No adversarial tenants, no untrusted fork PRs, no remote runners.</p>
+
+<h3>Never cache (even locally)</h3>
+<ul>
+  <li>Runner RSA private keys or shared runner credentials</li>
+  <li>OAuth, GitHub, cloud, package-registry, or signing tokens</li>
+  <li><code>.runner</code>, <code>.credentials</code>, <code>.credentials_rsaparams</code></li>
+  <li><code>.npmrc</code>, <code>.pypirc</code>, <code>.netrc</code>, Docker auth config, cloud CLI credential directories</li>
+  <li>Secret-bearing <code>$GITHUB_ENV</code>, <code>$GITHUB_OUTPUT</code>, process environments, or debug state</li>
+  <li>Decrypted job messages; arbitrary home directories</li>
+</ul>
+
+<p>Path deny-lists are defense in depth. The primary controls are narrow cache paths and no implicit whole-workspace caching.</p>
+
+<h3>Deduplication</h3>
+<p>Physical byte reuse is safe locally because the OS account is the sole trust boundary. Dedup across repos is a win, not a risk.</p>
+
+<hr class="section-divider">
+
+<!-- Correctness -->
+<h2 id="correctness">Correctness Rules</h2>
+
+<ol>
+  <li><strong>Misses are normal.</strong> Backend failure should degrade to a miss/warning when official cache semantics allow it.</li>
+  <li><strong>Explicit failure remains explicit.</strong> Preserve <code>fail-on-cache-miss</code> and action-defined failure behavior.</li>
+  <li><strong>Immutable publication.</strong> Write staging, verify, atomically publish; never mutate a finalized key/version.</li>
+  <li><strong>No partial reads.</strong> Readers see pending or complete, never both.</li>
+  <li><strong>Version archive semantics.</strong> Compression method and cached path set contribute to cache version.</li>
+  <li><strong>Safe restore keys.</strong> Prefix matches follow official order within the authenticated namespace.</li>
+  <li><strong>Reproducibility first.</strong> Preload only declared toolchains/containers. A faster local pass that would fail on GitHub is incorrect.</li>
+  <li><strong>Resolved identities.</strong> Mutable labels are lookup hints, not immutable storage identities.</li>
+  <li><strong>Crash recovery.</strong> Finalization and metadata/blob reference updates are transactional or restart-reconcilable.</li>
+  <li><strong>Clock independence.</strong> Ordering uses server timestamps or monotonic sequence IDs.</li>
+  <li><strong>Bounded retries.</strong> Cache outages cannot add minutes of exponential backoff to a job.</li>
+  <li><strong>Isolation before deduplication.</strong> Physical byte reuse must not change logical authorization.</li>
+</ol>
+
+<hr class="section-divider">
+
+<!-- Admission -->
+<h2 id="admission">Admission, Retention &amp; Eviction</h2>
+
+<p>Track for each entry: compressed/uncompressed size, restore count, last access, save/restore/origin-download cost, producer and trust scope, expiration and pin state.</p>
+
+<h3>Eviction policy</h3>
+<ol>
+  <li>Never evict active uploads or blobs with active readers.</li>
+  <li>Expire logical entries first.</li>
+  <li>Prefer evicting unreferenced, old, low-hit, cheap-to-recreate bytes.</li>
+  <li>Bias toward retaining high-download-cost tools/images and frequently restored dependency caches.</li>
+  <li>GC a physical blob only after no metadata references it and a grace period has elapsed.</li>
+  <li>Keep soft and hard quotas separate so background eviction runs before writes must be rejected.</li>
+</ol>
+
+<h3>Starting retention classes</h3>
+<div class="table-wrap">
+<table>
+  <thead><tr><th>Class</th><th>Policy</th><th>Reason</th></tr></thead>
+  <tbody>
+    <tr><td>Mutable tag/ref resolution</td><td>Minutes to hours</td><td>Must observe upstream movement</td></tr>
+    <tr><td>Immutable action/tool/image blob</td><td>LRU under capacity; long TTL</td><td>Verified and expensive to redownload</td></tr>
+    <tr><td>Package content store</td><td>LRU under capacity</td><td>Content-addressed and broadly reusable</td></tr>
+    <tr><td>Branch dependency cache</td><td>7–30 days since last access</td><td>Useful during active development</td></tr>
+    <tr><td>PR/fork writable cache</td><td>PR lifetime + short grace</td><td>Limits untrusted accumulation</td></tr>
+    <tr><td>Build output cache</td><td>Shorter TTL, cost-aware admission</td><td>Large and sensitive to weak keys</td></tr>
+    <tr><td>Staging upload</td><td>Hours, never days</td><td>Incomplete and not restorable</td></tr>
+    <tr><td>Negative lookup</td><td>Seconds to minutes</td><td>Avoids hiding newly published content</td></tr>
+  </tbody>
+</table>
+</div>
+
+<hr class="section-divider">
+
+<!-- Performance -->
+<h2 id="performance">Performance Techniques by Layer</h2>
+
+<h3>Toolchains</h3>
+<ul>
+  <li>Maintain a host-side immutable tool distribution CAS.</li>
+  <li>During golden preparation, materialize only toolchains explicitly declared by parsed setup actions/version files.</li>
+  <li>Write official toolcache completion markers only after verification.</li>
+  <li>Prefer reflink/hardlink/COW materialization where filesystem rules permit.</li>
+  <li>Keep the internal JavaScript action runtime separate from workflow-selected Node.</li>
+</ul>
+
+<h3>Package managers</h3>
+<ul>
+  <li>Set stable package-store locations, not action-installation-relative paths.</li>
+  <li>Cache package content, not arbitrary home directories.</li>
+  <li>Let pnpm/npm/Cargo/Go/uv perform their integrity checks.</li>
+  <li>Avoid archiving huge stores on every job when a node-local read-through store can serve immutable objects directly.</li>
+</ul>
+
+<h3>Actions cache protocol</h3>
+<ul>
+  <li>Replace directory scans with indexed exact/prefix lookup.</li>
+  <li>Stream archive bytes end to end.</li>
+  <li>Avoid recompressing an already compressed cache archive.</li>
+  <li>Keep post-job cache work visible in step telemetry.</li>
+</ul>
+
+<h3>VM and OCI preparation</h3>
+<ul>
+  <li>Resolve base images to digests before fingerprinting.</li>
+  <li>Use a prepared, digest-pinned Ubuntu image to avoid base pulls.</li>
+  <li>Mirror Docker Hub dependencies to avoid anonymous pull-rate limits.</li>
+  <li>Build/refresh goldens in the background and maintain warm capacity.</li>
+  <li>Do not add per-cache virtiofs mounts to forked goldens.</li>
+</ul>
+
+<h3>Metadata and control plane</h3>
+<ul>
+  <li>Keep cache metadata out of the global <code>Arc&lt;Mutex&lt;InnerState&gt;&gt;</code>.</li>
+  <li>Use database uniqueness for reservation and idempotent finalize.</li>
+  <li>Update <code>last_accessed_at</code> asynchronously/batched.</li>
+  <li>Separate cache data transfer from scheduling/control-plane request pools.</li>
+</ul>
+
+<hr class="section-divider">
+
+<!-- Observability -->
+<h2 id="observability">Observability</h2>
+
+<p>Every cache operation emits structured metrics and trace fields:</p>
+
+<pre><code>cache.class
+cache.namespace_hash
+cache.visible_key_hash
+cache.version_hash
+cache.outcome = exact_hit | prefix_hit | miss | rejected | corrupt | error
+cache.tier = guest | node | durable | origin
+cache.bytes_compressed / cache.bytes_uncompressed
+cache.lookup_ms / cache.first_byte_ms / cache.transfer_ms
+cache.archive_ms / cache.extract_ms / cache.verify_ms / cache.save_ms
+cache.eviction_reason
+cache.trust_domain</code></pre>
+
+<p>Job UI/logs should make the critical path obvious:</p>
+
+<pre><code>setup-node: toolcache exact hit, Node 24.18.0, 180 ms
+pnpm cache: prefix miss, reason=not_found, lookup 12 ms
+pnpm install: 16.5 s
+cache save: 1.2 GiB, archive 8.1 s, upload 3.4 s</code></pre>
+
+<p>A hit ratio alone is not enough. A 95% hit ratio can still lose time if archive/extraction costs exceed origin installation.</p>
+
+<hr class="section-divider">
+
+<!-- Verification -->
+<h2 id="verification">Verification &amp; Benchmark Plan</h2>
+
+<h3>Correctness matrix</h3>
+<p>Test with the official runner and <code>actions/cache@v4</code>:</p>
+<ul>
+  <li>exact-key hit; ordered restore-prefix hit; version mismatch</li>
+  <li>immutable duplicate save; concurrent save of one key</li>
+  <li>interrupted multipart upload; restart between upload and finalize</li>
+  <li>corrupt block/digest; quota exhaustion</li>
+  <li>eviction while another entry downloads</li>
+  <li>untrusted PR cannot write/read trusted-only entries</li>
+  <li>tenant/repository scope cannot be forged through request fields</li>
+  <li>expired/replayed signed URL</li>
+  <li>multi-gigabyte transfer with bounded process RSS</li>
+  <li>backend outage degrades according to action semantics</li>
+</ul>
+
+<h3>Performance matrix</h3>
+<p>For each representative repository, record cold, warm, and forced-miss runs. Keep existing five-repository slices and add synthetic cases: 10 MiB / 1 GiB / 10 GiB archives; many small vs. few large files; concurrent readers/writers; cold node-local tier with warm object storage.</p>
+
+<h3>Success criteria</h3>
+<div class="callout callout-decision">
+  <div class="callout-title">First Campaign Targets</div>
+  <ul style="margin-bottom:0">
+    <li>Vite build/lint within 10% of existing 9.91s</li>
+    <li>Vite warm total below 45s</li>
+    <li>Setup-node exact toolcache hit below 2s</li>
+    <li>Cache restore/save no longer reports <code>File name too long</code></li>
+    <li>Server RSS does not scale with archive size</li>
+    <li>Cold first-step latency returns to prepared-image target range</li>
+  </ul>
+</div>
+
+<hr class="section-divider">
+
+<!-- Roadmap -->
+<h2 id="roadmap">Phased Roadmap</h2>
+
+<div class="phase-tag current">Phase 0 — Current Scope</div>
+<h3>Instrument before changing policy</h3>
+<p>Structured phase metrics, cache hit/miss reasons, byte and latency accounting, benchmark command that produces a comparable JSON record.</p>
+
+<div class="phase-tag current">Phase 1 — Current Scope</div>
+<h3>Fix local correctness and measured Vite losses</h3>
+<ol>
+  <li>Reproduce and fix the cache backend <code>File name too long</code> failure.</li>
+  <li>Add indexed metadata for exact and prefix lookup.</li>
+  <li>Stream v1/v2 upload, finalize, and download without complete in-memory buffers.</li>
+  <li>Materialize workflow-declared Node into <code>$RUNNER_TOOL_CACHE</code> in the official layout.</li>
+  <li>Configure a stable pnpm store and verify a real warm restore.</li>
+  <li>Add quota/status/prune controls before automatic eviction.</li>
+</ol>
+
+<div class="phase-tag future">Phase 2 — Future</div>
+<h3>Immutable supply and VM caches</h3>
+<p>Action digest resolution, OCI digest pinning, prepared base artifacts.</p>
+
+<div class="phase-tag future">Phase 3 — Future</div>
+<h3>Self-hosted durable backend</h3>
+<p>Postgres metadata, S3 blobs, node-local read-through CAS.</p>
+
+<div class="phase-tag future">Phase 4 — Future</div>
+<h3>Managed multi-tenancy</h3>
+<p>KMS encryption, tenant isolation, regional object storage.</p>
+
+<hr class="section-divider">
+
+<!-- Boundaries -->
+<h2 id="boundaries">Implementation Boundaries</h2>
+
+<p>The architecture introduces narrow interfaces, not a generic cache framework:</p>
+
+<pre><code>CacheMetadataStore
+  reserve(namespace, key, version)
+  lookup(namespace, key, version, restore_keys)
+  finalize(reservation, blob, metadata)
+  expire(entry)
+
+BlobStore
+  begin_upload(limits)
+  put_part(upload, part, stream)
+  finalize_upload(upload, expected_digest)
+  open(digest, range)
+  delete(digest)
+
+HotCache
+  get(digest)
+  populate(digest, stream)
+  evict(policy)</code></pre>
+
+<p>Toolchains, actions, OCI layers, and Git objects may use the same underlying blob CAS, but retain class-specific resolvers and policy. Do not force Git object semantics through the user-facing Actions cache API.</p>
+
+<hr class="section-divider">
+
+<!-- Rejected -->
+<h2 id="rejected">Rejected Approaches</h2>
+
+<div class="table-wrap">
+<table>
+  <thead><tr><th>Approach</th><th>Why Rejected</th></tr></thead>
+  <tbody>
+    <tr><td>One shared writable tool/package directory mounted into every VM</td><td>Concurrent jobs can corrupt it; extra virtiofs mounts caused measurable fork stalls</td></tr>
+    <tr><td>Bake every common tool into one universal golden</td><td>Undeclared tools make workflows pass locally and fail on GitHub</td></tr>
+    <tr><td>Cache complete workspaces</td><td>Stale files create false passes, cross-branch contamination, and secret leakage</td></tr>
+    <tr><td>Branch-only build keys</td><td>Toolchain, flags, lockfiles, source, and architecture can change without the branch name changing</td></tr>
+    <tr><td>Share mutable caches across tenants</td><td>Cache poisoning can turn a trusted build into code execution from another tenant</td></tr>
+    <tr><td>Keep uploads/downloads in <code>Vec&lt;u8&gt;</code></td><td>Server memory becomes proportional to cache size; concurrent transfers multiply the problem</td></tr>
+    <tr><td>Cache mutable action tags forever</td><td><code>v4</code> and branches may move; cache immutable bytes, refresh resolution records</td></tr>
+    <tr><td>Add one virtiofs mount per ecosystem cache</td><td>Every golden mount is inherited and paid by every clone</td></tr>
+    <tr><td>Cache secrets with encryption</td><td>Encryption reduces disclosure risk but does not make cross-job replay of credentials correct</td></tr>
+  </tbody>
+</table>
+</div>
+
+<hr class="section-divider">
+
+<!-- Stop Conditions -->
+<h2 id="stop-conditions">Stop Conditions</h2>
+
+<div class="callout callout-stop">
+  <div class="callout-title">Stop and Revisit</div>
+  <p>Do not improvise if any of these arise:</p>
+  <ul style="margin-bottom:0">
+    <li>Official <code>actions/cache@v4</code> behavior requires a different exact/prefix/version order than <code>CacheStore</code> currently models</li>
+    <li>A proposed shared cache cannot prove its trust boundary and producer identity</li>
+    <li>A cache hit changes job output compared with a clean miss</li>
+    <li>Implementing persistence requires exposing host paths directly to untrusted jobs</li>
+    <li>A performance improvement depends on undeclared tools or stale workspace files</li>
+    <li>Storage deduplication exposes cross-tenant existence or timing information</li>
+    <li>Cache save/restore costs more than the origin operation for the target workload</li>
+    <li>The SmolVM transport requires another inherited mount and the fork regression has not been re-benchmarked</li>
+  </ul>
+</div>
+
+<hr class="section-divider">
+
+<!-- Checklist -->
+<h2 id="checklist">Maintenance &amp; Review Checklist</h2>
+
+<p>For every new cache class or key revision:</p>
+
+<ol>
+  <li>What exact computation/download is avoided?</li>
+  <li>What are all correctness inputs and where are they represented in the key?</li>
+  <li>Who may write it? Who may read it?</li>
+  <li>Can an untrusted producer affect a trusted consumer?</li>
+  <li>What verifies content integrity?</li>
+  <li>Where does it live in local, self-hosted, and managed profiles?</li>
+  <li>What happens on miss, corruption, backend outage, and partial upload?</li>
+  <li>How is it bounded, expired, evicted, and deleted?</li>
+  <li>What telemetry proves it saves time and bytes?</li>
+  <li>Does it preserve behavior against the official runner and GitHub-compatible workflow semantics?</li>
+</ol>
+
+<hr class="section-divider">
+
+<p style="text-align:center; color:var(--text-muted); font-family:var(--font-display); font-size:0.78rem; margin-top:2rem;">
+  Drift check before implementation: <code>git diff --stat 1342346a..HEAD -- crates/aksh-cache crates/aksh-runner-server crates/aksh-runner crates/preloop-orchestrator docs</code>
+</p>
+
+</main>
+</div>
+
+<script>
+// ── Active TOC highlighting ──
+(function() {
+  const tocLinks = document.querySelectorAll('.toc a');
+  const headings = [];
+  tocLinks.forEach(link => {
+    const id = link.getAttribute('href').slice(1);
+    const el = document.getElementById(id);
+    if (el) headings.push({ el, link });
+  });
+
+  if (!headings.length) return;
+
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        tocLinks.forEach(l => l.classList.remove('active'));
+        const match = headings.find(h => h.el === entry.target);
+        if (match) match.link.classList.add('active');
+      }
+    });
+  }, { rootMargin: '-10% 0px -80% 0px', threshold: 0 });
+
+  headings.forEach(h => observer.observe(h.el));
+})();
+</script>
+
+</body>
+</html>

--- a/plans/001-caching-performance-strategy.md
+++ b/plans/001-caching-performance-strategy.md
@@ -1,0 +1,941 @@
+# Plan 001: Caching strategy for local and self-hosted CI
+
+> **Status**: Proposed architecture and implementation roadmap
+>
+> **Scope**: Local CI and self-hosted CI, production grade. Managed multi-tenant is deferred.
+> The architecture is designed to extend to managed deployments, but implementation targets
+> `~/.preloop/cache/v1` (local) and `/var/lib/preloop/cache/v1` (self-hosted systemd deployment).
+>
+> **Priority**: P1
+> **Category**: performance, correctness, architecture
+> **Planned at**: commit `1342346a`, 2026-07-27
+> **Revised at**: commit `d7f495d5`, 2026-08-02 — scope widened from local-only to
+> local + self-hosted production grade; ecosystem download payload cache added as the
+> primary toolchain acceleration mechanism (replacing resolver-gated golden baking).
+> **Drift check before implementation**: `git diff --stat d7f495d5..HEAD -- crates/aksh-cache crates/aksh-runner-server crates/aksh-runner crates/preloop-orchestrator crates/preloop-vm docs`
+
+## Executive decision
+
+Preloop should not build one undifferentiated cache. It should build a layered cache system with four properties:
+
+1. **Immutable content-addressed blobs** hold bytes once and are addressed by a verified digest.
+2. **Scoped metadata** maps workflow-visible keys to those blobs.
+3. **Guest-local materialization** makes hot content available to a runner without making a shared writable filesystem part of job correctness.
+4. **A shared ecosystem download payload cache** caches the bytes the *tools themselves* fetch — registry metadata and version-stamped tarballs — keyed by origin URL, shared globally across all workspaces, jobs, and virtual machine images.
+
+Property 4 is the deliberate alternative to GitHub's everything-image and to per-environment golden baking. Images cache inputs at the wrong granularity (you pay for all inputs for all users). Per-workspace goldens cache inputs in per-repo VM snapshots and depend on a resolver that can only see a narrow slice of workflows. Caching payloads by URL is universal (any workflow, unmodified — the drop-in compatibility promise) and amortizes one origin fetch across every job on the host.
+
+**Storage layout:**
+
+| Layer | Local profile | Self-hosted profile |
+|---|---|---|
+| Durable metadata | SQLite under `~/.preloop/cache/v1` | SQLite (WAL) under `/var/lib/preloop/cache/v1`; Postgres optional for multi-node |
+| Durable blobs | Content-addressed files under `~/.preloop/cache/v1/blobs/` | Content-addressed files under `/var/lib/preloop/cache/v1/blobs/` |
+| Payload cache | Same blob store, URL-keyed | Same blob store, URL-keyed; LAN-facing HTTPS listener with deployment-pinned CA |
+| Hot tier | Golden/COW disk and host page cache | Golden/COW disk and host page cache; optional node-local read-through tier in multi-node |
+
+The same logical model extends to managed deployments (object store + Postgres + KMS) in a future phase. Design interfaces for it; do not build it now.
+
+### Evidence
+
+Measured before this plan (2026-07-27, five-repository benchmark):
+
+- Corrected Vite warm: Preloop `92.45 s`, Agent CI `38.71 s`.
+- Actual build plus lint: Preloop `9.91 s`, Agent CI `10.40 s`.
+- Preloop spent `34.24 s` in `setup-node`/cache handling, `16.50 s` in `pnpm install`, and `28.31 s` in the post-job cache save.
+- The cache restore emitted `File name too long`, so dependency installation ran on a cache miss.
+- Cold time before the first guest step was `48.54 s` for ripgrep, `545.84 s` for Vite, and `18.59 s` for testcontainers-go. That is VM/image preparation, not workload execution.
+
+Measured after 2026-08-02 production changes (self-hosted host `main`):
+
+- Packed golden fork pool is live: one 716 MB zstd-compressed artifact serves a forkable golden; two runners provision end-to-end in under a minute including configure, and the fork step itself is near-instant (CoW). No per-runner `apt`+`rustup` wait.
+- Guest→host TCP now works (smolvm `1.7.2`, virtio-net fix) and is already the control-plane transport (`PRELOOP_CONTROL_UPSTREAM=http://10.0.0.161:9090`). **This is the payload cache's transport prerequisite**: guests can now reach LAN-addressed cache endpoints on the host.
+- Toolchain baking (rustup into the golden) works — verified `cargo 1.97.1`/`rustc 1.97.1` on PATH in a CI run on 2026-08-02 — but only because `rust-toolchain.toml` was statically resolvable. It remains an opt-in accelerator, not the general mechanism.
+
+Revised priority order:
+
+1. Make Actions cache restore/save correct, indexed, and streaming (still the largest measured loss: 62 s of the 92 s Vite warm run).
+2. Make declared toolchains discoverable in the official toolcache layout.
+3. Build the shared download payload cache with config injection into the base image (Phase 2).
+4. Resolve and cache immutable action/image/tool artifacts by digest.
+5. Move VM preparation out of the run critical path (packed fork pool already shipped; keep refining).
+
+## Goals
+
+- Preserve official-runner and unmodified-workflow compatibility.
+- Cover **all** workflows — not only statically resolvable ones — by caching tool payloads, not declaring environments.
+- Make a cache miss equivalent to normal uncached execution, except when a workflow explicitly requests `fail-on-cache-miss`.
+- Eliminate repeated downloads and archive work that dominates warm jobs.
+- Keep process memory usage proportional to a transfer chunk, not cache size.
+- Bound disk growth with quotas, expiration, admission, and eviction.
+- Give operators enough telemetry to explain every hit, miss, restore, save, and eviction.
+- Self-hosted production grade: authenticated cache access on non-loopback listeners, TLS for guest→cache traffic, durable-on-restart state, explicit ops controls (status/prune/purge), and documented backup posture.
+- Design metadata/blob interfaces that extend to multi-node and managed deployments later.
+
+## Non-goals
+
+- Making local CI pass because an undeclared tool happens to exist. Workflows must remain portable to GitHub Actions. Toolchain baking into goldens is an opt-in accelerator, never a substitute for `setup-*` declarations.
+- Treating the environment resolver as a correctness mechanism. It accelerates statically detectable declarations only; dynamic versions, matrices, forks, and `curl`-installed toolchains must all work without it.
+- Treating artifacts or logs as disposable caches. They are user-visible outputs with separate retention semantics.
+- Reusing complete workspaces across jobs. Workspaces remain disposable unless a workflow explicitly saves paths through the cache protocol.
+- Sharing mutable build caches across security boundaries.
+- Replacing package-manager integrity checks or OCI digest verification.
+- Guaranteeing that a cache survives eviction. A job must remain correct on a miss.
+- Running a transparent HTTPS-intercept (MITM) egress cache by default. Mirror insertion is per-tool configuration against an allowlisted origin set; there is no transparent interception of arbitrary guest egress.
+
+## Current state and evidence
+
+### Actions cache store
+
+`crates/aksh-cache/src/lib.rs` implements a local file-backed `CacheStore`:
+
+- cache identity is a SHA-256-derived directory;
+- original key, version, and creation time are stored as metadata;
+- entries are immutable;
+- restore order supports exact key and prefix matching;
+- prefix lookup scans every cache directory;
+- complete archives are read into `Vec<u8>` on restore;
+- there is no quota, expiration, eviction policy, or indexed lookup.
+
+`crates/aksh-runner-server/src/models.rs` stores v1 uploads in `PendingCache.bytes`.
+
+`crates/aksh-runner-server/src/blob_store.rs` stages v2 blocks on disk, then:
+
+- assembles all blocks in a single `Vec<u8>`;
+- writes a second complete copy;
+- reads complete blobs to return downloads.
+
+`crates/aksh-runner-server/src/results_twirp.rs` reads the complete staged blob during finalize and passes complete bytes to `CacheStore::put`. This is acceptable for small local caches but cannot be the self-hosted data path under multi-gigabyte transfers.
+
+### Cache scoping and authorization
+
+`results_twirp::scoped_cache_key` currently combines workflow-requested `repository` and `scope` fields. Self-hosted isolation cannot trust these values: forked-PR jobs could poison or read base-branch caches by forging request fields. The server must derive repository scope and ref trust class from authenticated server state (job record), not from client payloads. The runtime token proves an `Actions.Results:<plan>:<job>` scope; the cache API needs that resolved authorization context enforced in Phase 3. Download tokens are stored in memory and should become expiring, operation-specific capabilities.
+
+### Toolcache mismatch
+
+The runner exports:
+
+```text
+RUNNER_TOOL_CACHE=/var/lib/preloop-runner/_work/_tool
+```
+
+The JavaScript action runtime is installed separately:
+
+```text
+/var/lib/preloop-runner/externals/node24/bin/node
+```
+
+The first path is where setup actions look for workflow-declared tools. The second is an internal runtime used to execute JavaScript actions. `actions/setup-node` therefore downloads Node even though the runner has a Node executable.
+
+A declared Node installation must be materialized in the official toolcache shape:
+
+```text
+$RUNNER_TOOL_CACHE/node/<exact-version>/<arch>/bin/node
+$RUNNER_TOOL_CACHE/node/<exact-version>/<arch>.complete
+```
+
+Do not merely put `/externals/node24/bin` on `PATH` and call the setup step satisfied. The setup action owns version selection and must observe the version it requested.
+
+PATH in guests: step shells run `bash --noprofile --norc`, so `/etc/profile.d/*` is never sourced. Guest PATH comes from `GITHUB_PATH` (which setup actions write) or from absolute install locations (`/usr/local/bin`). Bake-time PATH exports in shell profiles are silently inert — this already bit the rustup bake (symlinks to `/usr/local/bin` were the fix). Toolcache materialization is the correct mechanism for declared tools, because setup actions consume it directly.
+
+### Golden VMs and images
+
+`crates/preloop-orchestrator/src/environment.rs` computes an environment fingerprint from a base-image string and declared toolchain layers. A mutable tag is not a durable compatibility identity; the fingerprint must ultimately include the resolved base-image digest.
+
+Declared service/container images are preloaded into a golden and inherited by COW forks. Keeping preload images outside the environment compatibility fingerprint is reasonable because they are an optimization, not semantic environment state. Record them as a **coverage set** on the golden and select an existing compatible golden whose coverage is a superset; do not rebuild a golden solely because an optional preload set differs.
+
+`docs/preloop-performance-engineering.md` records that an additional virtiofs cache mount caused 20–50 second fork stalls and instability. The cache design must not add one mount per ecosystem or per cache. Prefer COW image contents, one stable existing transport, or HTTP/cache-service transfer.
+
+Toolchain baking status (2026-08-02): `prepare_artifact` installs workspace-resolved toolchains into the packed artifact. This stays as an opt-in accelerator (`PRELOOP_BAKE_TOOLCHAINS`, to be added, default off once Phase 2 lands) because it only accelerates statically resolvable declarations. The payload cache is the default-on mechanism.
+
+### Other useful caches
+
+- `crates/aksh-runner-server/src/actions.rs` streams action tarballs into an atomic on-disk cache keyed by owner/repository/ref. Mutable tags are cached indefinitely; resolve tags to commit SHA and store immutable content by digest.
+- `crates/aksh-runner-server/src/snapshots.rs` maintains a lock-protected Git object cache per local Git common-directory identity and persists stat data. Its documented `git add` result improves from `156 ms` to `16 ms` for a 6,000-file workspace. This is the right pattern: immutable objects, narrow identity, atomic refresh, and no workspace reuse.
+- `crates/preloop-orchestrator/src/keys.rs` deliberately gives every runner a unique RSA key. Runner private keys, credentials, and secret-bearing state must never enter a shared cache or golden image.
+
+### No payload cache today
+
+There is currently no cache for the bytes `setup-*` actions and package managers download. Every ephemeral runner re-downloads rustup dists, npm tarballs, Go modules, and pip wheels from the internet. On a forked-runner pool this dominates job time and burns egress. The transport prerequisite (guest→host TCP) is now in place (smolvm `1.7.2`); the cache itself does not exist yet.
+
+## Cache taxonomy
+
+Each class has different identity, mutability, trust, and placement rules.
+
+| Class | Examples | Cache? | Scope | Preferred placement |
+|---|---|---|---|---|
+| Runner internals | Node 20/24 used to execute JS actions | Yes, immutable | Preloop release + OS + arch | Base/golden image under `externals/` |
+| Declared toolchains | Node, Python, Go, Java, Rust, .NET selected by `setup-*` | Yes, declared-only | Exact version + platform + toolcache format | Host tool CAS; materialize into `$RUNNER_TOOL_CACHE` (opt-in: golden bake) |
+| Ecosystem download payloads | rustup dists, npm metadata/tarballs, cargo index/.crate, Go module zips, pip wheels, apt debs, Node runtime, GitHub release assets | Yes | Exact URL (immutable class); registry metadata (mutable class, TTL) | Host payload cache; guests fetch through it |
+| Action source | `actions/checkout`, `setup-node`, third-party actions | Yes, immutable after resolution | Owner/repo/commit SHA | Shared verified action CAS |
+| OCI images/layers | base VM input, job containers, services | Yes, immutable | Registry/repository/digest/platform | Golden preload (already shipped); registry mirror optional later |
+| Package download stores | pnpm store, npm cache, Cargo registry/db, Go module cache, uv wheels | Yes | Ecosystem integrity identity + platform where needed | Persistent host store; served to guests through the payload cache |
+| Compiler/build cache | sccache objects, Go build cache, Vite transform cache | Yes, cautiously | Source/config/toolchain/target/features | Repository/trust-scoped cache |
+| Actions cache archives | User paths saved through `actions/cache` or setup actions | Yes | Server-derived namespace + workflow key/version | Indexed metadata + blob CAS |
+| Git snapshot objects | Immutable Git objects and stat index | Yes | Local Git common-dir identity or repository identity | Host-local persistent store |
+| Workspace | Checked-out source and arbitrary generated files | No implicit reuse | One job/run | Disposable guest disk |
+| Artifacts and logs | Build deliverables, test reports, logs | Store, but not as cache | Run/job retention policy | Artifact/log store |
+| Secrets and identity | tokens, runner keys, `.credentials`, `.npmrc`, cloud config | Never shared-cache | One job or runner | Secret channel and ephemeral memory/disk only |
+
+## Ecosystem download payload cache
+
+This is the mechanism that replaces per-environment toolchain baking as the default acceleration path. It is a read-only reverse proxy over a fixed allowlist of upstream origins, fronted by the shared blob CAS, serving every guest on the host — regardless of workspace, workflow shape, or how a toolchain was requested.
+
+### Why URL-keyed bytes, not resolved environments
+
+- Setup actions, matrices, expression inputs, forked or custom actions, and `curl`-installed toolchains all compute download URLs at runtime with full context. The resolver can never see many of these; the URL fetch is always correct.
+- Version-stamped URLs (`/dist/v22.14.0/node-v22.14.0-linux-x64.tar.xz`, rustup dists, Go module zips, versioned wheels) are effectively immutable and content-verify independently, so they are ideal cache citizens.
+- One origin fetch amortizes across every VM on the host: 100 rustup builds download Rust from `static.rust-lang.org` exactly once.
+- Nothing in job correctness depends on the cache. Every miss is a normal download; every hit is the same bytes the origin would have sent.
+
+### Architecture
+
+```text
+guest tool (rustup, npm, cargo, go, pip, apt, setup-* actions)
+  │  GET https://<cache-host>:<cache-port>/<row-id>/<origin path>
+  ▼
+preloop-server payload cache listener (HTTPS, allowlisted rows only, read-only)
+  ├─ blob present?  → stream from CAS (hit)
+  └─ miss → singleflight coalesce → fetch origin once →
+            tee stream(a) to guest, (b) to staging file →
+            verify rules → atomic publish into CAS (tmp + rename)
+```
+
+The cache is a **dumb byte store**: it relays responses verbatim and never re-serializes payloads. All integrity stays where ecosystems already put it — npm/Cargo registry checksums and lockfile integrity fields, Go checksum database, rustup SHA256 manifests, pip hashes, apt `InRelease` signatures. A corrupt cache entry produces exactly the failure a corrupt origin would, and can be purged and refetched.
+
+### Upstream policy table
+
+One row per origin class, in one config file. Adding an ecosystem is one row + tests.
+
+| Row | Origin | Allowlisted path classes | Mutability/TTL | Injected guest config |
+|---|---|---|---|---|
+| rustup | `static.rust-lang.org` | `/dist/**`, `/rustup/**` | immutable ∞ (versioned); channel manifests TTL 10 min | `RUSTUP_DIST_SERVER`, `RUSTUP_UPDATE_ROOT` |
+| cargo | `index.crates.io`, `static.crates.io` | sparse index files; `/crates/**` | index TTL 5 min; `.crate` ∞ | `[source.crates-io]` replacement in `$CARGO_HOME/config.toml` |
+| npm | `registry.npmjs.org` | `/{pkg}` metadata; `/{pkg}/-/*.tgz` | metadata TTL 5 min + ETag revalidate; tarballs ∞ | global `registry=` npmrc |
+| Go modules | `proxy.golang.org` | `/{mod}/@v/{ver}.*` (immutable); `@v/list`, `@latest` (TTL 15 min) | `GOPROXY` (keep `,direct` fallback) | |
+| pip | `files.pythonhosted.org`, `pypi.org/simple` | wheel/sdist URLs are hash-laden ∞; simple index TTL 5 min + revalidate | `/etc/pip.conf` / `PIP_INDEX_URL` | |
+| apt | distro mirrors | `pool/**.deb` immutable; `dists/**` TTL 1 h | optional row; guests use golden-baked baselines first |
+| Node runtime | `nodejs.org` | `/dist/v*/**` immutable | only when using payload downloads directly; `$RUNNER_TOOL_CACHE` materialization preferred |
+| GitHub release assets | `github.com`, `objects.githubusercontent.com` | release download URLs | tag resolution records TTL 1 h; versioned archives ∞ | optional |
+
+Rules for all rows:
+
+- GET/HEAD only. No POST/PUT. No cookies forwarded. No client-controlled URL paths off the allowlist (hard anti-SSRF boundary).
+- Response byte cap per class (default 1 GiB; apt/deb 4 GiB) to avoid disk bombs.
+- HTTP error responses are cached negatively for 60 s, never positively.
+- Range requests supported where the client sends them; cached under the object's own integrity only after a complete body is present.
+
+### Transport and TLS
+
+Guests reach the cache over the same NAT TCP path as the control plane (smolvm ≥ 1.7.2 required; virtio-net guest→host fix). Two listener rules:
+
+- **Same daemon as the control plane.** Cache liveness must equal control-plane liveness, because some tools cannot fall back (npm, cargo, rustup hard-fail if their configured endpoint is down; Go falls back only via `GOPROXY=…,direct`).
+- **Self-hosted profile: dedicated interface + TLS.** Bind `PRELOOP_CACHE_LISTEN` (default: control-upstream interface, port `9091`) and serve TLS with a per-deployment CA generated at first start under `$PRELOOP_HOME/cache/ca/`. The CA is injected into the golden's system trust store and per-tool stores (`NODE_EXTRA_CA_CERTS`, `SSL_CERT_FILE`, `CARGO_HTTP_CAINFO`). This is a *pinned, single-endpoint* CA — not general egress MITM. Plain-HTTP would require per-tool insecure flags (`GOINSECURE`, cargo registry HTTP rules) and gives no integrity for metadata rows, so it is rejected.
+- **Local profile: loopback HTTP is acceptable** (`http://127.0.0.1:9091`); the same CA path is recommended to keep guest images identical across profiles.
+- CA rotation requires golden rebuild; the fingerprint includes the deployment CA digest so goldens invalidate deliberately.
+- **Auth**: on a non-loopback listener, `/cache/*` requires the runtime/job capability (Phase 3); loopback local profile requires none. The public tunnel address must never expose cache routes.
+
+### Failure behavior by tool
+
+| Tool | If cache is down | Design response |
+|---|---|---|
+| go | `GOPROXY=cache,direct` falls through automatically | keep `,direct`; log fallback |
+| rustup / cargo / npm / pip | hard failure of the configured endpoint | cache runs **in the control-plane process** (same liveness); provision-time health gate refuses to start runners with an unhealthy cache; ops runbook entry |
+| apt | hard failure of configured mirror | keep in-guest default sources as fallback or rely on golden-baked baseline |
+
+Per-operation latency budget: origin fetch timeout 300 s; on timeout the guest sees the same failure an origin timeout would. No minutes-long backoff loops on the job path (correctness rule 11).
+
+### Performance requirements
+
+- **Singleflight**: concurrent cold fetches of one URL (8-runner pool, cold cache) trigger exactly one origin fetch; others attach to the stream.
+- **Tee streaming**: response body streams to guest *while* written to a staging file; no full-file memory ever.
+- **Atomic publication**: staging tmp file, size/length verification, `rename` into CAS; readers never observe partial files.
+- **LRU eviction by bytes** with a soft (20 GiB default) and hard quota; in-flight or read-active entries are never evicted.
+- **Reuse the seam**: payload blobs live in the same `BlobStore` CAS as cache archives; TTL/mutability classes live in `CacheMetadataStore`. Don't fork storage.
+- Expected results: warm rustup toolchain install drops to LAN disk speed; `npm ci` on a warm registry mirror bounded by lockfile work, not origin bandwidth.
+
+## Cache key design
+
+### General rule
+
+A key must include every input that can change the cached output. If that set cannot be identified, do not cache the output.
+
+Use canonical serialization followed by a hash for storage identity. Keep human-readable components in metadata and telemetry.
+
+Logical namespace:
+
+```text
+schema_version
++ tenant_id            (fixed local identity in local profile; deployment identity
+                        + repository scope in self-hosted profile)
++ repository_id
++ trust_domain
++ cache_class
++ workflow-visible key/version
+```
+
+Compatibility inputs then vary by class.
+
+### Trust domain
+
+**Local profile**: one trust domain — the developer's OS account. Field default is a fixed local value.
+
+**Self-hosted profile**: trust domains exist. Base branches/tags and fork pull requests are not mutually writable: fork-PR jobs may read base-ref caches (official GitHub behavior) but must never write into base-ref namespaces. Trust class is derived server-side from the job record (event type, ref, base ref), never from client-supplied request fields.
+
+### Key recipes
+
+#### Toolchains
+
+```text
+tool/v1/<tool>/<exact-version>/<os>/<arch>/<libc>/<toolcache-format>/<upstream-sha256>
+```
+
+Include exact version, not only major version. A workflow may request `24`, but the resolved cache entry should identify `24.18.0` and maintain a separately expiring major-to-exact resolution record.
+
+#### Download payloads
+
+```text
+payload/v1/<origin-host>/<normalized-path>/<query-hash>
+```
+
+Two mutability classes ride on the same storage identity:
+
+- **immutable** (version-stamped URLs): near-infinite TTL, LRU under capacity. Purge on caveat: operator `preloop cache purge <url>` after a verified-corrupt fetch.
+- **mutable** (registry metadata, channel manifests, `@latest`/`@v/list`): short TTL (5–15 min) with ETag/`If-Modified-Since` revalidation; stale-while-revalidate for no more than one TTL period under origin outage, then fail-fresh.
+
+#### Action source
+
+```text
+action/v1/<owner>/<repo>/<resolved-commit-sha>/<archive-sha256>
+```
+
+Mutable refs such as `v4`, branches, and tags are resolution records with a short TTL. They point to immutable commit/archive entries. Pinning by commit should bypass mutable-ref TTL concerns.
+
+#### OCI images
+
+```text
+oci/v1/<registry>/<repository>/<manifest-digest>/<platform-os>/<platform-arch>
+```
+
+Cache layers by their OCI digest. Golden compatibility must use the resolved base manifest/config digest, never `ubuntu:24.04` or another mutable tag alone.
+
+#### Package download stores
+
+Prefer the ecosystem's verified content store over archiving an installed dependency tree:
+
+```text
+package/v1/<ecosystem>/<content-integrity>/<platform-if-native>
+```
+
+Examples:
+
+- pnpm/npm: package integrity digest; share verified tarballs/store objects, not arbitrary `node_modules`.
+- Cargo registry: crate checksum; Cargo Git DB by repository and commit.
+- Go modules: module path/version/checksum; build cache remains platform/toolchain-specific.
+- uv/pip: wheel/sdist hash, Python ABI, platform tag for native wheels.
+
+A package store can safely benefit many lockfiles because the package manager verifies content. A hydrated dependency tree is more fragile and requires a stricter repository-specific key. **When the payload cache covers the same registries, prefer the payload cache and set stable in-guest store paths; don't build a second store-hydration layer.**
+
+#### Actions cache archive for dependencies
+
+The workflow supplies the primary key, restore keys, and cache version. The server prepends its private namespace. Recommended workflow key ingredients:
+
+```text
+<os>-<arch>-<package-manager-major>-<runtime-abi>-<lockfile-hash>
+```
+
+Do not silently rewrite the workflow's visible key because restore behavior is user-facing. Namespace it server-side and expose diagnostics showing both the visible key digest and the server scope.
+
+#### Build outputs
+
+```text
+build/v1/<repo>/<tool>/<tool-version>/<target>/<profile>/<feature-hash>/
+         <relevant-env-hash>/<source-and-config-hash>
+```
+
+Examples of relevant inputs:
+
+- Rust: rustc version, target triple, features, profile, `RUSTFLAGS`, build-script inputs, source hash.
+- Go: Go version, `GOOS`, `GOARCH`, CGO/toolchain inputs, module graph, source hash.
+- JavaScript transforms: Node version, package-manager version, lockfile, bundler version/config, source hash.
+
+Prefer compiler-native remote caches such as sccache when they correctly encode compiler inputs. Avoid caching a whole `target/` or `node_modules/` directory under a weak branch-only key.
+
+#### Golden VM
+
+Compatibility identity:
+
+```text
+golden/v1/<base-image-digest>/<guest-arch>/<kernel-and-smolvm-version>/
+          <runner-bundle-sha>/<provisioner-sha>/<declared-toolchain-set-hash>/
+          <baseline-packages-hash>/<deployment-ca-digest>
+```
+
+Optimization metadata, not compatibility identity:
+
+```text
+preloaded OCI digest set
+action digest set
+last used
+build cost
+```
+
+Select a compatible golden with a useful preload superset. Do not create a new 249-second golden merely to save a 4–9-second optional image pull. Golden chain depth: at most base → optional workspace-baked toolchains. Do not build a general N-deep fork-and-extend layering tree; the payload cache makes combinatorial environment layering unnecessary, and fork trees multiply golden build/maintenance cost.
+
+#### Git snapshot objects
+
+Local CI may continue keying by canonical Git common-directory identity because it identifies the developer’s repository object store. Self-hosted systems use repository identity plus immutable commit/object IDs and keep working-tree stat indexes node-local. Never share a mutable working-tree index across repositories.
+
+## Placement and data flow
+
+### L0: process-local coordination
+
+Cache only small metadata:
+
+- in-flight reservation deduplication;
+- singleflight deduplication for payload origin fetches;
+- short negative cache for failed mutable-ref resolutions;
+- recently resolved metadata entries.
+
+Do not retain archive bytes in process memory. Every L0 entry needs a short TTL and bounded size.
+
+### L1: guest-local ephemeral state
+
+Use for active job extraction, package-manager working state, and compiler scratch data. It disappears with the runner. The guest may read immutable content inherited from a golden, but arbitrary job writes must stay in its COW layer. In-the-guest package-manager stores (`~/.npm`, `~/.cargo/registry`) stay ephemeral — persistence comes from the payload cache the package managers fetch through, not from preserved guest disks.
+
+### L2: node-local persistent CAS
+
+Use for hot tools, actions, package objects, OCI layers, payload bodies, and recently restored cache archives. It provides high throughput without adding one VM mount per cache. Population is atomic and lock-protected.
+
+A node-local entry is an optimization. Its loss must fall back to L3 or origin.
+
+### L3: durable blob and metadata store
+
+- Local: host filesystem plus SQLite.
+- Self-hosted single-node: persistent disk under `/var/lib/preloop`, SQLite WAL. Postgres + S3-compatible store optional for multi-node.
+- Managed (future): object storage plus Postgres, with regional placement and KMS encryption.
+
+The runner accesses user `actions/cache` entries through the protocol, not a shared writable filesystem. BYO self-hosted runners cannot be assumed to share a mount with the control plane; remote runners use `actions/cache` archives or ecosystem-native remote caches.
+
+## Deployment profiles
+
+### Local CI
+
+Assumptions:
+
+- one developer machine;
+- one implicit tenant;
+- loopback control plane;
+- disposable SmolVM runners;
+- latency matters more than cross-host durability.
+
+Recommended layout:
+
+```text
+~/.preloop/cache/v1/
+├── index.sqlite
+├── blobs/sha256/
+├── staging/
+├── locks/
+├── tools/
+├── actions/
+├── packages/
+├── payload/
+└── metrics/
+```
+
+Policy:
+
+- write-through to local disk;
+- one cache root, not one virtiofs mount per cache class;
+- payload cache listener on loopback only;
+- seed declared toolchains into `$RUNNER_TOOL_CACHE` where resolvable;
+- keep runner internals in `externals/`, separate from declared workflow tools;
+- retain the Git snapshot object cache;
+- preload declared service/container images by digest;
+- resolve action tags but store archives by commit and digest;
+- default starting quota: 20 GiB soft target and configurable hard limit; expose `preloop cache status`, `preloop cache prune`, and `preloop cache purge` before enabling automatic destructive pruning;
+- encryption at rest optional (OS account is the trust boundary); permissions must be user-only; secrets remain forbidden.
+
+### Self-hosted CI (production)
+
+Assumptions:
+
+- systemd deployment (e.g., `/var/lib/preloop`, `/opt/preloop/current`);
+- control plane reachable by guests over LAN (`PRELOOP_CONTROL_UPSTREAM`);
+- multiple repositories; fork-PR jobs may be untrusted;
+- availability of `preloop` service == availability of cache (single daemon);
+- operators need quota enforcement, audit logs, and a rebuildable-not-backed-up cache.
+
+Layout: `/var/lib/preloop/cache/v1/` with the same substructure as the local profile.
+
+Production requirements:
+
+1. **Same-process cache** — the listener runs inside `preloop serve`; no separate service to drift out of sync with runner provisioning.
+2. **TLS with deployment CA** for guest→cache traffic; CA persisted under `$PRELOOP_HOME/cache/ca/`; rotation rebuilds goldens via fingerprint.
+3. **Auth boundary** — cache and payload routes require the job capability on non-loopback listeners. Public ingress (Cloudflare tunnel) routes *never* include the cache.
+4. **Namespaces derived server-side** — repository scope and ref trust class come from the job record; fork PRs read base-ref caches and write only PR-scoped ones.
+5. **Durability** — SQLite WAL mode; finalize is atomic (blob CAS publish + metadata commit); crash-reconcilable orphans (staging older than 24 h is reclaimed).
+6. **Quota enforcement** — background eviction loop maintains soft quota; writes never fail for quota without an eviction attempt first.
+7. **Ops surface** — `preloop cache status|prune|purge`, structured access logs per row, and a health endpoint consumed by the runner provision gate.
+8. **Backup posture** — the cache is *rebuildable*: excluded from backup. Artifacts and logs are not caches and retain separate retention/backup policy.
+9. **Ingress sizing** — cache listener serves LAN only; no per-request Cloudflare roundtrips (matches the existing `PRELOOP_CONTROL_UPSTREAM` LAN decision).
+
+### Managed CI (future)
+
+Regional Postgres with row-level authorization. Object storage with KMS envelope encryption. Short-lived signed URLs (5–15 minutes) with direct object-store transfers so archive bytes stay off control-plane instances. Regional NVMe hot tiers. Immutable global cache only for public tools/actions/OCI layers/payloads. Per-tenant rate limits, quotas, cost attribution, and complete audit logs.
+
+## Security design
+
+### Trust boundaries by profile
+
+- **Local**: the developer's OS account. One trust domain. Deduplication across repos on one machine is a win, not a risk.
+- **Self-hosted**: the host OS account is trusted; *jobs are semi-trusted* (workflow code is arbitrary, fork PRs are adversarial inputs). Physical byte deduplication of **public immutable content** (payloads, actions, OCI layers, tools) is cross-repository-safe *only because* consumers verify integrity (npm integrity fields, cargo checksums, Go sumdb, rustup manifests, OCI digests). Logical authorization stays scoped per repository/trust domain.
+
+### Never cache (any profile)
+
+- Runner RSA private keys or shared runner credentials;
+- OAuth, GitHub, cloud, package-registry, or signing tokens;
+- `.runner`, `.credentials`, `.credentials_rsaparams`;
+- `.npmrc`, `.pypirc`, `.netrc`, Docker auth config, cloud CLI credential directories;
+- secret-bearing `$GITHUB_ENV`, `$GITHUB_OUTPUT`, process environments, or debug state;
+- decrypted job messages;
+- arbitrary home directories.
+
+Path deny-lists are defense in depth. The primary controls are narrow cache paths and no implicit whole-workspace caching.
+
+### Payload cache threat controls
+
+- **SSRF / egress abuse**: guests cannot make the server fetch arbitrary URLs. The origin allowlist is hardcoded (policy table), path prefixes are validated, and there is no client-supplied upstream.
+- **Open-proxy abuse on public interfaces**: cache routes require the job capability on non-loopback; public tunnel ingress never mounts them.
+- **Cache poisoning**: mitigated by design — the cache never interprets payloads; bytes are relayed verbatim; ecosystems verify integrity client-side. Known-digest verification for rows where the origin publishes digests is done at finalize when cheap (e.g., rustup SHA256 manifest), not as a general requirement.
+- **Denial via cache**: response size caps, per-row quota, LRU bound; a guest cannot balloon the store past hard quota.
+- **Trust model**: the deployment CA cert is pinned to cache endpoints in guest config, not an egress-intercepting root. Document that clearly: jobs running in guests trust the same deployment they already trust for the control plane.
+- **Mutable-tag squatting**: short TTLs + revalidation; immutable content stored by resolved identity.
+
+### Deduplication
+
+Per profile: local — full physical dedup. Self-hosted — dedup only for the public immutable classes (payloads, actions, layers, tools); user `actions/cache` archives dedup within a repository scope only.
+
+### Capability URLs
+
+- **Local**: not needed, loopback.
+- **Self-hosted**: short-lived, operation-specific capabilities (expiring, read-only for downloads) issued after server-side authorization (Phase 3). Signed URLs on object stores are a managed-phase concern.
+
+## Correctness rules
+
+1. **Misses are normal.** Backend failure should degrade to a miss/warning when official cache semantics allow it, not fail unrelated job work.
+2. **Explicit failure remains explicit.** Preserve `fail-on-cache-miss` and action-defined failure behavior.
+3. **Immutable publication.** Write staging, verify, atomically publish; never mutate a finalized key/version.
+4. **No partial reads.** Readers see pending or complete, never both.
+5. **Version archive semantics.** Compression method and cached path set contribute to the cache version so incompatible archives do not match.
+6. **Safe restore keys.** Prefix matches follow official order and remain within the authenticated namespace.
+7. **Reproducibility first.** Preload only declared toolchains/containers. A faster local pass that would fail on GitHub is incorrect; baking is opt-in, never a substitute for declarations.
+8. **Resolved identities.** Mutable labels are lookup hints, not immutable storage identities.
+9. **Crash recovery.** Finalization and metadata/blob reference updates are transactional or restart-reconcilable.
+10. **Clock independence.** Ordering uses server timestamps or monotonic sequence IDs; clients do not choose creation time.
+11. **Bounded retries.** Cache outages cannot add minutes of exponential backoff to a job. Set per-operation latency budgets and fall back where allowed.
+12. **Isolation before deduplication.** Physical byte reuse must not change logical authorization.
+13. **PATH is `GITHUB_PATH`.** Step shells run `bash --noprofile --norc`; shell profile hooks never execute. Tools for steps come from `GITHUB_PATH` or absolute locations (`/usr/local/bin`). Profile-file PATH exports in goldens are silently inert bugs.
+14. **Byte-relay equivalence.** A payload cache hit returns byte-identical content to the origin response for immutable classes; metadata classes obey TTL/revalidation, not invisibility. If it cannot be made byte-equivalent, it is not cached.
+15. **Corruption is recoverable.** A verified-corrupt entry is purgeable (`preloop cache purge`), and the next fetch repopulates from origin. Corruption must never require reinstalling the deployment.
+
+## Admission, retention, and eviction
+
+Caching everything is not optimal. Large one-hit entries consume bandwidth twice and evict useful hot data.
+
+Track for each entry:
+
+- compressed and uncompressed size;
+- restore count;
+- last access;
+- save, restore, and origin-download cost;
+- producer and trust scope;
+- expiration and pin state.
+
+Admission policy:
+
+- always admit small verified tools/actions with high expected reuse;
+- always admit immutable payload bodies under size cap (their origin URL is versioned; re-fetch cost is high and value is proven by being requested);
+- admit package content objects after integrity verification;
+- reject or short-retain oversized one-off workflow caches unless explicitly allowed;
+- coalesce concurrent uploads and origin fetches for the same immutable identity (singleflight);
+- use historical workflow manifests to prefetch only repeatedly used declared content.
+
+Eviction policy:
+
+1. Never evict active uploads, in-flight payload fetches, or blobs with active readers.
+2. Expire logical entries first.
+3. Prefer evicting unreferenced, old, low-hit, cheap-to-recreate bytes.
+4. Bias toward retaining high-download-cost tools/images/payloads and frequently restored dependency caches.
+5. Garbage-collect a physical blob only after no metadata references it and a grace period has elapsed.
+6. Keep soft and hard quotas separate so background eviction runs before writes must be rejected.
+
+Starting retention classes:
+
+| Class | Starting policy | Reason |
+|---|---|---|
+| Mutable tag/ref resolution | minutes to hours | Must observe upstream movement |
+| Mutable payload metadata | 5–15 min + revalidation; stale-while-revalidate one TTL | Registry correctness under movement |
+| Immutable payload body | LRU under capacity; long TTL | Versioned URL; expensive to re-fetch |
+| Immutable action/tool/image blob | LRU under capacity; long TTL | Verified and expensive to redownload |
+| Package content store | LRU under capacity | Content-addressed and broadly reusable |
+| Branch dependency cache | 7–30 days since last access | Useful during active development |
+| PR/fork writable cache | PR lifetime plus short grace | Limits untrusted accumulation |
+| Build output cache | shorter TTL, cost-aware admission | Large and sensitive to weak keys |
+| Staging upload / orphaned payload staging | hours, never days | Incomplete and not restorable |
+| Negative lookup | seconds to minutes | Avoids hiding newly published content |
+
+These are policy starting points. Ship telemetry and operator controls before fixing service-wide constants.
+
+## Performance techniques by layer
+
+### Toolchains
+
+- Maintain a host-side immutable tool distribution CAS.
+- Materialize only toolchains explicitly declared by parsed setup actions/version files, in the official `$RUNNER_TOOL_CACHE` layout, with completion markers written after verification.
+- Bake toolchains into goldens only behind `PRELOOP_BAKE_TOOLCHAINS` (default off once the payload cache ships); never bake undeclared environments.
+- Let everything not resolvable fall through setup actions to the payload cache. This is stronger than resolver breadth: matrices, expression inputs, forks, and `curl` installs all work uniformly.
+- Prefer reflink/hardlink/COW materialization where filesystem and ownership rules permit; otherwise copy from local CAS, never redownload.
+- Keep the internal JavaScript action runtime separate from workflow-selected Node.
+
+### Package managers
+
+- Set stable package-store locations, not action-installation-relative paths.
+- Cache package content, not arbitrary home directories.
+- Let pnpm/npm/Cargo/Go/uv perform their integrity checks.
+- Fetch through the payload cache (config injection in the golden, per policy table) instead of archiving huge stores on every job.
+- For remote/BYO runners, use `actions/cache` archives or ecosystem-native remote caches; do not assume host mounts.
+
+### Download payload cache
+
+- Singleflight origin fetch per URL; stream to guest and disk concurrently (tee).
+- Atomic publish from staging; no partial observations.
+- Per-listener backpressure; Range passthrough.
+- Coalesce identical concurrent requests across *all* guests, not per-VM.
+- Instrument hit/miss/bytes/RPS per origin row in metrics.
+
+### Actions cache protocol
+
+- Replace directory scans with indexed exact/prefix lookup.
+- Stream archive bytes end to end.
+- Allow local durable spool plus asynchronous remote replication only after documenting the durability tradeoff. A successful finalize must mean “durable enough for this profile.”
+- Avoid recompressing an already compressed cache archive.
+- Keep post-job cache work visible in step telemetry.
+
+### VM and OCI preparation
+
+- Packed-golden fork pool is the VM fast path (shipped 2026-08-02): one artifact → forkable golden → CoW forks. Keep toolchains out of the default golden; preload stays image/`-cache`-oriented.
+- Resolve base images to digests before fingerprinting.
+- Requires smolvm ≥ 1.7.2 (virtio-net guest→host connectivity) for both control and payload traffic; gate on version at startup.
+- Mirror Docker Hub dependencies to avoid anonymous pull-rate limits.
+- Build/refresh goldens in the background and maintain warm capacity.
+- Store preload coverage separately from compatibility identity.
+- Do not add per-cache virtiofs mounts to forked goldens.
+
+### Metadata and control plane
+
+- Keep cache metadata out of the global `Arc<Mutex<InnerState>>` in server profiles.
+- Use database uniqueness for reservation and idempotent finalize.
+- Update `last_accessed_at` asynchronously/batched.
+- Paginate administration/list APIs.
+- Separate cache data transfer from scheduling/control-plane request pools.
+
+## Observability
+
+Every cache operation should emit structured metrics and trace fields:
+
+```text
+cache.class
+cache.namespace_hash
+cache.visible_key_hash
+cache.version_hash
+cache.outcome = exact_hit | prefix_hit | miss | rejected | corrupt | error
+cache.tier = guest | node | durable | origin
+cache.origin_host        # payload rows
+cache.bytes_compressed
+cache.bytes_uncompressed
+cache.lookup_ms
+cache.first_byte_ms
+cache.transfer_ms
+cache.archive_ms
+cache.extract_ms
+cache.verify_ms
+cache.save_ms
+cache.eviction_reason
+cache.trust_domain
+```
+
+Do not log secret-bearing raw keys or signed URLs. Hash keys for correlation and expose raw workflow keys only in appropriately authorized diagnostics.
+
+Job UI/logs should make the critical path obvious:
+
+```text
+setup-node: toolcache exact hit, Node 24.18.0, 180 ms
+pnpm cache: prefix miss, reason=not_found, lookup 12 ms
+pypi: payload hit, numpy-2.2.2-cp312-manylinux_2_17_x86_64.whl, 41 ms (origin 900 ms saved)
+pnpm install: 16.5 s
+cache save: 1.2 GiB, archive 8.1 s, upload 3.4 s
+```
+
+Dashboards:
+
+- hit ratio and byte-hit ratio by class/profile/repository/origin row;
+- time saved versus save/restore cost;
+- p50/p95 lookup, first-byte, transfer, archive, and extract latency;
+- cache-service errors and fallback-to-miss rate;
+- payload singleflight coalescing ratio (requests ÷ origin fetches);
+- logical versus physical bytes and deduplication ratio;
+- eviction churn and rejected writes;
+- fork-trust access denials;
+- cold VM phase breakdown before first guest step.
+
+A hit ratio alone is not enough. A 95% hit ratio can still lose time if archive/extraction costs exceed origin installation.
+
+## Verification and benchmark plan
+
+### Correctness matrix
+
+Test with the official runner and `actions/cache@v4`:
+
+- exact-key hit;
+- ordered restore-prefix hit;
+- version mismatch;
+- immutable duplicate save;
+- concurrent save of one key;
+- interrupted multipart upload;
+- restart between upload and finalize;
+- corrupt block/digest;
+- quota exhaustion;
+- eviction while another entry downloads;
+- untrusted PR cannot write/read trusted-only entries;
+- repository scope cannot be forged through request fields (server-derived namespace);
+- expired/replayed capability URL (self-hosted profile);
+- multi-gigabyte transfer with bounded process RSS;
+- backend outage degrades according to action semantics.
+
+Payload-specific:
+
+- two concurrent cold guests fetch the same URL → exactly one origin fetch, both receive identical bytes;
+- byte-identity: cached body is byte-for-byte the origin response (immutable rows);
+- purge-then-refetch recovers from a planted corrupt entry;
+- origin outage on mutable row: stale within one TTL, error after, no unbounded stale;
+- authorization: non-loopback payload request without capability is rejected; loopback/local profile requires none;
+- CA pinning: guest tools reject anything not presenting the deployment CA;
+- size-cap enforcement does not leave a partial blob.
+
+Run protocol changes against the official runner, not only unit tests. Final implementation gates remain:
+
+```text
+just test-ci
+just dogfood
+```
+
+### Performance matrix
+
+For each representative repository, record cold, warm, and forced-miss runs:
+
+- command-to-run-created;
+- run-created-to-runner-first-log;
+- setup action durations;
+- exact/prefix/miss status;
+- archive, upload, download, and extraction time;
+- origin bytes and cache bytes;
+- host and guest CPU/RSS where observable;
+- cache size before and after;
+- second and fifth repetition.
+
+Keep the existing five-repository slices and add controlled synthetic cases:
+
+- 10 MiB, 1 GiB, and 10 GiB cache archives;
+- many small files versus a few large files;
+- concurrent readers of one blob;
+- concurrent writers of one key;
+- 8 simultaneous forks cold-fetching the same rustup dist;
+- cold node-local tier with warm object storage;
+- warm node-local tier;
+- upstream-error and upstream-slowmoon cases with latency budgeting.
+
+Success criteria for the first campaign:
+
+- Vite build/lint remains within 10% of the existing measured `9.91 s`;
+- Vite warm total falls below `45 s` on the same host;
+- setup-node exact toolcache hit is below `2 s`;
+- cache restore/save no longer reports `File name too long`;
+- server RSS does not scale with archive size;
+- warm `cargo build --locked` on this repository restores crates without internet;
+- rustup channel update on a warm mirror is LAN-speed;
+- cold first-step latency remains in the fork-pool target range observed on `main` (sub-minute end-to-end including configure), without Docker Hub rate-limit dependence.
+
+## Phased roadmap
+
+### Phase 0: Instrument before changing policy
+
+Target areas:
+
+- cache handlers in `aksh-runner-server`;
+- `CacheStore` operations;
+- orchestrator golden/tool/image phases;
+- runner setup/post action timing.
+
+Deliverables:
+
+- structured phase metrics;
+- cache hit/miss reasons;
+- byte and latency accounting;
+- benchmark command that produces a comparable JSON record.
+
+Do not optimize a phase that cannot be separately measured.
+
+### Phase 1: Fix Actions cache correctness and measured Vite losses
+
+1. Reproduce and fix the cache backend `File name too long` failure at its source.
+2. Add indexed metadata for exact and prefix lookup.
+3. Stream v1/v2 upload, finalize, and download without complete in-memory buffers.
+4. Materialize workflow-declared Node into `$RUNNER_TOOL_CACHE` in the official layout.
+5. Configure a stable pnpm store and verify a real warm restore.
+6. Add quota/status/prune controls before automatic eviction.
+
+Acceptance: corrected Vite passes twice, the second run restores a cache, and warm total meets the first-campaign target.
+
+### Phase 2: Ecosystem download payload cache
+
+1. `preloop-cache` crate: `PayloadCache` seam (`get(url)` streaming), policy table (allowlist rows, mutability classes), singleflight, tee-to-staging, atomic publish, LRU-by-bytes with soft/hard quotas.
+2. Deployment CA generation + TLS listener (`PRELOOP_CACHE_LISTEN`); self-hosted default TLS, local loopback permitted.
+3. Config injection into guest provisioning for: rustup, cargo, npm/npmrc, Go `GOPROXY`, pip. Each row one table entry + integration test.
+4. Provision-time health gate: runners only start when payload cache is healthy.
+5. Operator controls: `preloop cache status|prune|purge`.
+6. Flip `PRELOOP_BAKE_TOOLCHAINS` default to off; keep baking as opt-in.
+7. Metrics: hit/miss/bytes/RPS per origin row; singleflight coalescing ratio.
+
+Acceptance: on `main`, two consecutive `cargo fetch` runs on fresh forks — the second completes without touching the internet; the conformance suite stays green.
+
+### Phase 3: Self-hosted production hardening
+
+1. Server-derived namespaces and trust-class enforcement for all cache classes (fork-PR read/write split).
+2. Capability URLs for downloads on non-loopback listeners; remove plaintext token rows.
+3. SQLite WAL + crash reconciliation; optional Postgres + S3-compatible store for multi-node.
+4. Background quota enforcement loop; quota pressure metrics.
+5. Runbook: purge, rotate CA, cache-drain, restore-from-scratch.
+6. Optional Docker Hub pull-through row (registry `registry-mirrors` config) — only if measured Docker rate limits still bite after preloading.
+
+Acceptance: forked-PR simulation cannot read/write trusted entries; restart preserves cache; eviction maintains quota under adversarial writes; docs updated.
+
+### Future phases (not in scope now)
+
+- **Phase 4**: Managed multi-tenancy (KMS, tenant isolation, regional object storage, direct signed URLs)
+- **Phase 5**: Ecosystem remote-cache integrations (sccache/Bazel/gocache server support)
+- Consider when earned: full container-registry pull-through cache, deeper action-graph prefetching.
+
+## Implementation boundaries
+
+The architecture should introduce narrow interfaces, not a generic cache framework that every crate must adopt.
+
+Suggested seams:
+
+```text
+CacheMetadataStore
+  reserve(namespace, key, version)
+  lookup(namespace, key, version, restore_keys)
+  finalize(reservation, blob, metadata)
+  expire(entry)
+
+BlobStore
+  begin_upload(limits)
+  put_part(upload, part, stream)
+  finalize_upload(upload, expected_digest)
+  open(digest, range)
+  delete(digest)
+
+PayloadCache
+  get(url)                          → streaming body + fetch metadata
+  policy(row): allowlist / TTL / size-cap
+  eviction: LRU by bytes
+
+HotCache
+  get(digest)
+  populate(digest, stream)
+  evict(policy)
+```
+
+Toolchains, actions, OCI layers, payloads, and Git objects may use the same underlying blob CAS where useful, but retain class-specific resolvers and policy. Do not force Git object semantics or package-manager stores through the user-facing Actions cache API.
+
+## Rejected approaches
+
+### One shared writable tool/package directory mounted into every VM
+
+Rejected because concurrent jobs can corrupt it, trust boundaries become unclear, and prior extra virtiofs mounts caused measurable fork stalls and instability. Use immutable host/node CAS plus guest-local materialization.
+
+### Bake every common tool into one universal golden
+
+Rejected because undeclared tools make workflows pass locally and fail on GitHub, images grow without bound, and any update invalidates a large artifact. Bake runner internals and baseline packages; layer only workflow-declared toolchains, behind an opt-in flag.
+
+### Resolver-gated toolchain environments
+
+Rejected as a correctness mechanism. The resolver only sees the five action names it knows; it cannot expand matrices, evaluate expressions, or observe custom/`curl` installs. Keep it as a hinting accelerator for toolcache materialization and *optional* baking; let the payload cache carry correctness for every other shape.
+
+### Fork-and-extend golden trees per environment combination
+
+Rejected as the default. Fan-out of `(base × toolchain-set)` goldens is combinatorial (matrix × versions × repos), each golden is a long build and multi-hundred-MB artifact, and layering depth grows without bound. The payload cache provides the same speed property at byte granularity without image complexity. Allow at most base → single opt-in bake layer.
+
+### Transparent HTTPS MITM egress cache
+
+Rejected by default. It changes the trust model for all guest HTTPS, breaks cert-pinning clients, and is indistinguishable from surveillance tooling. Scope mirror insertion to allowlisted origins via per-tool config with a deployment-pinned CA.
+
+### Cache complete workspaces
+
+Rejected because stale files create false passes, cross-branch contamination, and secret leakage. Cache immutable Git objects and explicit workflow-selected paths instead.
+
+### Branch-only build keys
+
+Rejected because toolchain, flags, lockfiles, source, and architecture can change without the branch name changing.
+
+### Share mutable caches across tenants or trust domains
+
+Rejected because cache poisoning can turn a normal trusted build into code execution supplied by another tenant or an untrusted pull request.
+
+### Keep uploads/downloads in `Vec<u8>`
+
+Rejected because server memory becomes proportional to cache size and concurrent transfers multiply the problem. Stream every data path.
+
+### Cache mutable action tags forever
+
+Rejected because `v4` and branches may move. Cache immutable commit/archive bytes indefinitely under capacity, but refresh the mutable resolution record.
+
+### Add one virtiofs mount per ecosystem cache
+
+Rejected by measured fork behavior. Every golden mount is inherited and paid by every clone.
+
+### Cache secrets with encryption and call it safe
+
+Rejected. Encryption reduces storage disclosure risk but does not make cross-job replay of credentials correct. Secret-bearing state remains job-scoped and ephemeral.
+
+## STOP conditions for implementation
+
+Stop and revisit this strategy rather than improvising if:
+
+- official `actions/cache@v4` behavior requires a different exact/prefix/version order than `CacheStore` currently models;
+- a proposed shared cache cannot prove its trust boundary and producer identity;
+- a cache hit changes job output compared with a clean miss;
+- implementing persistence requires exposing host paths directly to untrusted jobs;
+- a performance improvement depends on undeclared tools or stale workspace files;
+- storage deduplication exposes cross-repo existence or timing information for private content;
+- cache save/restore costs more than the origin operation for the target workload;
+- the payload cache cannot guarantee byte-equivalence for an immutable class;
+- the SmolVM transport requires another inherited mount and the fork regression has not been re-benchmarked.
+
+## Maintenance and review checklist
+
+For every new cache class or key revision, reviewers must answer:
+
+1. What exact computation/download is avoided?
+2. What are all correctness inputs and where are they represented in the key?
+3. Who may write it? Who may read it?
+4. Can an untrusted producer affect a trusted consumer?
+5. What verifies content integrity?
+6. Where does it live in local, self-hosted, and managed profiles?
+7. What happens on miss, corruption, backend outage, and partial upload?
+8. How is it bounded, expired, evicted, and deleted?
+9. What telemetry proves it saves time and bytes?
+10. Does it preserve behavior against the official runner and GitHub-compatible workflow semantics?
+11. For payload rows: which origin is allowlisted, what path prefixes, what mutability/TTL class, what guest config injection does it need, and what is the documented tool behavior when the cache is down?

--- a/scripts/capture-base-provenance.py
+++ b/scripts/capture-base-provenance.py
@@ -11,8 +11,10 @@ SBOM blob is copied locally as well.
 from __future__ import annotations
 
 import argparse
+import base64
 import hashlib
 import json
+import os
 import subprocess
 from pathlib import Path
 from typing import NoReturn
@@ -87,7 +89,40 @@ def referrers_url(registry: str, repository: str, subject_digest: str) -> str:
     )
 
 
-def fetch(url: str, accept: str) -> bytes:
+def fetch(url: str, accept: str, allow_404: bool = False) -> bytes:
+    auth_args: list[str] = []
+    token = os.environ.get("GHCR_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if token:
+        # GHCR requires a registry-scoped token, not the raw credential:
+        # exchange it against the token endpoint first (anonymous for
+        # public packages; Basic auth for private ones).
+        try:
+            registry = url.split("/")[2]
+            repo = url.split("/v2/", 1)[1].rsplit("/", 1)[0]
+            exchange = subprocess.run(
+                [
+                    "curl",
+                    "--fail",
+                    "--silent",
+                    "--show-error",
+                    "--location",
+                    "--user",
+                    f"x-access-token:{token}",
+                    (
+                        f"https://{registry}/token?service={registry}"
+                        f"&scope=repository:{repo}:pull"
+                    ),
+                ],
+                check=True,
+                capture_output=True,
+            )
+            registry_token = json.loads(exchange.stdout).get("token")
+            if registry_token:
+                auth_args = ["--header", f"Authorization: Bearer {registry_token}"]
+        except (subprocess.CalledProcessError, json.JSONDecodeError):
+            # Fall through to anonymous; the manifest fetch will report the
+            # registry's real answer.
+            pass
     try:
         result = subprocess.run(
             [
@@ -105,6 +140,7 @@ def fetch(url: str, accept: str) -> bytes:
                 "120",
                 "--header",
                 f"Accept: {accept}",
+                *auth_args,
                 "--user-agent",
                 USER_AGENT,
                 url,
@@ -115,6 +151,8 @@ def fetch(url: str, accept: str) -> bytes:
     except FileNotFoundError:
         fail("curl is required to capture OCI base provenance")
     except subprocess.CalledProcessError as error:
+        if allow_404 and b"404" in error.stderr:
+            return b""
         detail = error.stderr.decode("utf-8", "replace").strip()
         fail(f"registry request failed for {url}: {detail}")
     return result.stdout
@@ -183,8 +221,14 @@ def fetch_referrers(
     registry: str, repository: str, subject_digest: str
 ) -> list[dict]:
     body = fetch(
-        referrers_url(registry, repository, subject_digest), ACCEPT_MANIFEST
+        referrers_url(registry, repository, subject_digest),
+        ACCEPT_MANIFEST,
+        allow_404=True,
     )
+    if not body:
+        # Registries return 404 for subjects without referrers (or without
+        # referrers support); that means "none", not an error.
+        return []
     try:
         payload = json.loads(body)
     except json.JSONDecodeError as error:
@@ -197,6 +241,24 @@ def fetch_referrers(
         for descriptor in manifests
         if is_attestation_descriptor(descriptor, subject_digest)
     ]
+
+
+def fetch_cosign_attestation(
+    registry: str, repository: str, subject_digest: str
+) -> list[dict]:
+    # cosign stores attestations in the tag schema (`sha256-<digest>.att`)
+    # rather than the OCI referrers API; GHCR does not index those as
+    # referrers, so discover the tag directly.
+    tag = "sha256-" + subject_digest.removeprefix("sha256:") + ".att"
+    body = fetch(
+        manifest_url(registry, repository, tag), ACCEPT_MANIFEST, allow_404=True
+    )
+    if not body:
+        return []
+    try:
+        return [json.loads(body)]
+    except json.JSONDecodeError:
+        return []
 
 
 def copy_spdx_blob(
@@ -216,6 +278,17 @@ def copy_spdx_blob(
         parsed = json.loads(body)
     except json.JSONDecodeError as error:
         fail(f"SPDX blob {digest} is not valid JSON: {error}")
+    # cosign wraps the statement in a DSSE envelope: the payload is the
+    # base64-encoded in-toto statement.
+    if isinstance(parsed, dict) and isinstance(parsed.get("payload"), str):
+        try:
+            payload = base64.b64decode(parsed["payload"])
+        except (ValueError, TypeError) as error:
+            fail(f"SPDX blob {digest} has an undecodable DSSE payload: {error}")
+        try:
+            parsed = json.loads(payload)
+        except json.JSONDecodeError as error:
+            fail(f"SPDX blob {digest} has a non-JSON DSSE payload: {error}")
     # BuildKit attaches the SPDX document as the predicate of an in-toto
     # statement; consumers of the sidecar expect a bare SPDX JSON document,
     # so unwrap the predicate before publishing it.
@@ -229,6 +302,12 @@ def copy_spdx_blob(
                 "statement; refusing to guess its structure"
             )
         parsed = parsed["predicate"]
+    elif isinstance(parsed, dict) and isinstance(parsed.get("predicate"), str):
+        # cosign embeds the SPDX document as a JSON string predicate.
+        try:
+            parsed = json.loads(parsed["predicate"])
+        except json.JSONDecodeError as error:
+            fail(f"SPDX blob {digest} has a non-JSON string predicate: {error}")
     body = json.dumps(parsed, indent=2, sort_keys=True).encode("utf-8")
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_bytes(body)
@@ -242,7 +321,8 @@ def copy_spdx_blob(
         "media_type": layer.get("mediaType"),
         "predicate_type": (layer.get("annotations") or {}).get(
             "in-toto.io/predicate-type"
-        ),
+        )
+        or (layer.get("annotations") or {}).get("predicateType"),
     }
 
 
@@ -274,6 +354,10 @@ def main() -> None:
     )
 
     source_annotations = platform_descriptor.get("annotations") or {}
+    # Composite descriptors often drop annotations; the platform manifest
+    # itself carries them (org.opencontainers.image.source/revision/...).
+    if not source_annotations:
+        source_annotations = platform_manifest.get("annotations") or {}
     source = source_annotations.get("org.opencontainers.image.source")
     if args.require_source_prefix:
         prefix = args.require_source_prefix
@@ -288,29 +372,43 @@ def main() -> None:
                 f"{source!r} (expected {prefix!r})"
             )
 
-    # Prefer the OCI referrers API: cosign-attached attestations (SBOMs,
-    # signatures) are registered as referrers of the platform manifest and
-    # are not necessarily listed in the (unmodified) index. Fall back to
-    # index-listed attestation descriptors for registries without referrers
-    # support.
-    attestation_descriptors = fetch_referrers(registry, repository, platform_digest)
-    if not attestation_descriptors:
-        attestation_descriptors = [
+    # Collect attestation manifests from every discovery mechanism: the OCI
+    # referrers API, attestation descriptors listed in the index, and
+    # cosign's tag-schema attestation (sha256-<digest>.att).
+    attestation_manifests: list[tuple[dict, str | None]] = []
+    seen: set[str] = set()
+    for descriptor in [
+        *fetch_referrers(registry, repository, platform_digest),
+        *[
             descriptor
             for descriptor in index.get("manifests", [])
             if is_attestation_descriptor(descriptor, platform_digest)
-        ]
+        ],
+    ]:
+        digest = descriptor.get("digest")
+        if not isinstance(digest, str) or digest in seen:
+            continue
+        seen.add(digest)
+        manifest, manifest_hash = fetch_attestation(registry, repository, descriptor)
+        attestation_manifests.append((manifest, manifest_hash))
+    for manifest in fetch_cosign_attestation(registry, repository, platform_digest):
+        key = digest_bytes(json.dumps(manifest, sort_keys=True).encode("utf-8"))
+        if key in seen:
+            continue
+        seen.add(key)
+        attestation_manifests.append((manifest, None))
 
     attestations = []
     sbom = None
-    for descriptor in attestation_descriptors:
-        manifest, manifest_hash = fetch_attestation(
-            registry, repository, descriptor
-        )
+    for manifest, manifest_hash in attestation_manifests:
         layers = []
         for layer in manifest.get("layers", []):
             annotations = layer.get("annotations") or {}
-            predicate_type = annotations.get("in-toto.io/predicate-type")
+            # cosign uses a bare `predicateType` annotation; BuildKit and
+            # GitHub's attestation API use the in-toto namespaced key.
+            predicate_type = annotations.get("in-toto.io/predicate-type") or (
+                annotations.get("predicateType")
+            )
             summary = {
                 key: value
                 for key, value in {
@@ -335,8 +433,16 @@ def main() -> None:
                 )
         attestations.append(
             {
-                "descriptor": descriptor_summary(descriptor),
-                "manifest_digest": descriptor.get("digest"),
+                "descriptor": descriptor_summary(
+                    {
+                        "mediaType": manifest.get("mediaType"),
+                        "size": None,
+                        "digest": manifest_hash,
+                        "platform": None,
+                        "annotations": manifest.get("annotations"),
+                    }
+                ),
+                "manifest_digest": manifest_hash,
                 "manifest_sha256": manifest_hash,
                 "layers": layers,
             }

--- a/scripts/capture-base-provenance.py
+++ b/scripts/capture-base-provenance.py
@@ -91,38 +91,48 @@ def referrers_url(registry: str, repository: str, subject_digest: str) -> str:
 
 def fetch(url: str, accept: str, allow_404: bool = False) -> bytes:
     auth_args: list[str] = []
+    # GHCR requires a registry-scoped token (not the raw credential): exchange
+    # it against the token endpoint. Try the configured credential first, then
+    # the anonymous exchange — public packages serve anonymous tokens, and a
+    # workflow token may legitimately lack access to a package linked to a
+    # different repository.
+    registry = url.split("/")[2]
+    path = url.split("/v2/", 1)[1]
+    for marker in ("/manifests/", "/blobs/", "/referrers/"):
+        if marker in path:
+            path = path.split(marker, 1)[0]
+            break
+    repo = path
+    exchange_url = (
+        f"https://{registry}/token?service={registry}"
+        f"&scope=repository:{repo}:pull"
+    )
     token = os.environ.get("GHCR_TOKEN") or os.environ.get("GITHUB_TOKEN")
-    if token:
-        # GHCR requires a registry-scoped token, not the raw credential:
-        # exchange it against the token endpoint first (anonymous for
-        # public packages; Basic auth for private ones).
+    credentials = ([("x-access-token", token)] if token else []) + [None]
+    registry_token = None
+    for credential in credentials:
+        cmd = [
+            "curl",
+            "--fail",
+            "--silent",
+            "--show-error",
+            "--location",
+        ]
+        if credential:
+            cmd += ["--user", f"{credential[0]}:{credential[1]}"]
+        cmd += [exchange_url]
         try:
-            registry = url.split("/")[2]
-            repo = url.split("/v2/", 1)[1].rsplit("/", 1)[0]
-            exchange = subprocess.run(
-                [
-                    "curl",
-                    "--fail",
-                    "--silent",
-                    "--show-error",
-                    "--location",
-                    "--user",
-                    f"x-access-token:{token}",
-                    (
-                        f"https://{registry}/token?service={registry}"
-                        f"&scope=repository:{repo}:pull"
-                    ),
-                ],
-                check=True,
-                capture_output=True,
-            )
+            exchange = subprocess.run(cmd, check=True, capture_output=True)
             registry_token = json.loads(exchange.stdout).get("token")
-            if registry_token:
-                auth_args = ["--header", f"Authorization: Bearer {registry_token}"]
         except (subprocess.CalledProcessError, json.JSONDecodeError):
-            # Fall through to anonymous; the manifest fetch will report the
-            # registry's real answer.
-            pass
+            registry_token = None
+        if registry_token:
+            break
+    auth_args = (
+        ["--header", f"Authorization: Bearer {registry_token}"]
+        if registry_token
+        else []
+    )
     try:
         result = subprocess.run(
             [

--- a/versions.toml
+++ b/versions.toml
@@ -13,7 +13,7 @@ smolvm_min_version = "1.7.7"
 # .github/workflows/smolvm-release-verify.yml gates the merge with the real-VM
 # E2E on the smolvm-host. Deliberately separate from smolvm_min_version:
 # goldens track the last *verified* release, the runtime floor rarely moves.
-smolvm_golden_version = "1.7.7"
+smolvm_golden_version = "1.8.2"
 
 # Image inputs for the runner golden. The OCI bases are immutable filesystem
 # inputs. `github_runner_image_version` is the actions/runner-images snapshot

--- a/versions.toml
+++ b/versions.toml
@@ -28,6 +28,15 @@ github_runner_image_version = "20260720.247.2"
 ubuntu_24_04_base = "mirror.gcr.io/library/ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90"
 ubuntu_22_04_base = "mirror.gcr.io/library/ubuntu:22.04@sha256:0e0a0fc6d18feda9db1590da249ac93e8d5abfea8f4c3c0c849ce512b5ef8982"
 
+# The official GitHub-hosted runner image snapshot, republished as OCI by the
+# preloopdev/runner-image-blobs dump pipeline and vetted (scanned, signed, and
+# SLSA-attested) before the floating tag advances. Release goldens are baked
+# from this instead of the plain Ubuntu base. The dump pipeline publishes
+# per-architecture tags (ubuntu24-* for amd64, ubuntu24-arm64-* for arm64);
+# each is digest-pinned at its own platform index.
+official_runner_image_base_amd64 = "ghcr.io/preloopdev/runner-images:ubuntu24-runner-large-latest@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+official_runner_image_base_arm64 = "ghcr.io/preloopdev/runner-images:ubuntu24-arm64-runner-large-latest@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+
 # Provisioning version pins baked into the runner golden.
 node_version = "22.23.1"
 rustup_version = "1.29.0"

--- a/versions.toml
+++ b/versions.toml
@@ -34,8 +34,8 @@ ubuntu_22_04_base = "mirror.gcr.io/library/ubuntu:22.04@sha256:0e0a0fc6d18feda9d
 # from this instead of the plain Ubuntu base. The dump pipeline publishes
 # per-architecture tags (ubuntu24-* for amd64, ubuntu24-arm64-* for arm64);
 # each is digest-pinned at its own platform index.
-official_runner_image_base_amd64 = "ghcr.io/preloopdev/runner-images:ubuntu24-runner-large-latest@sha256:0000000000000000000000000000000000000000000000000000000000000000"
-official_runner_image_base_arm64 = "ghcr.io/preloopdev/runner-images:ubuntu24-arm64-runner-large-latest@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+official_runner_image_base_amd64 = "ghcr.io/preloopdev/runner-images:ubuntu24-runner-large-latest@sha256:4f7e4be438e4eb9c0f23bebdec12cf1d25520876ad2052412ba18580919b7795"
+official_runner_image_base_arm64 = "ghcr.io/preloopdev/runner-images:ubuntu24-arm64-runner-large-latest@sha256:3884ef2266edee7ae2da8f70f54faba5340238e68ede5274d0e90fdec80faf9e"
 
 # Provisioning version pins baked into the runner golden.
 node_version = "22.23.1"


### PR DESCRIPTION
## What's in this release

- **Version 0.30.3** — CHANGELOG promoted.
- **Official GitHub-hosted runner image goldens.** `versions.toml` gains per-arch pins for the republished official image (`runner-image-blobs` fork): `official_runner_image_base_amd64` / `_arm64`, pinned by attested digest.
- **`release-golden.yml`**: resolves the per-arch key, sources the base from the runner-image-blobs repo, bakes in a 120 GiB VM, uploads the golden + provenance sidecars (`.base-provenance.json`, `.base-sbom.spdx.json`, `.provenance.json`, `.sha256`, cosign `.bundle`), and retains the artifact for non-release builds.
- **Capture/writer hardening** (`capture-base-provenance.py`, `write-golden-provenance.py`): anonymous token-exchange fallback, referrers API + cosign `.att` discovery, DSSE/SPDX unwrap, SBOM-digest binding, source-prefix enforcement.
- **Golden build/use fixes** found while building the arm64 golden locally and running real jobs through the pool:
  - pool creates the golden from the `.smolmachine` sidecar, not the launcher stub (`invalid magic: expected SMOLPACK`)
  - sidecar extension appending (dotted artifact names)
  - `--cpus/--mem/--storage/--overlay` emitted for `--from` machines too (the golden previously booted with a 20 GiB disk and the ~30 GB rootfs unpack ENOSPC'd)
  - `machine exec --user root` for bakes against images declaring `USER=runner`
  - keep-alive workload is the last positional (flags no longer swallowed)
  - `SMOLVM_FILE_TRANSFER_MAX_BYTES=64GiB` on pack
- **Docs**: `docs/vm-images.md` (official-image golden + troubleshooting), `docs/internal/smolvm-issues-golden-build.md` (10 smolvm issues with repro steps for upstream filing).

## Verification
- `just test-ci` passes.
- aarch64 golden built locally from the attested official image; boots, forks, and executes real jobs (node build, python, go, docker, git) inside the golden's CoW clones; cosign signature + in-toto attestation verified; base SBOM/provenance bound.
- Digest pins verified: arm64 pin resolves to the same platform manifest as the golden's base; amd64 pin resolves.
- x86_64 golden bakes on the pool in the release-golden job (after merge + tag).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release 0.30.3 switches the runner golden to the official GitHub‑hosted runner image and verifies the base with `cosign` signatures plus SPDX attestations. This restores runner parity; the golden is larger, so bakes run as root and the bake VM is bigger.

- Pins per‑arch bases in `versions.toml` (`official_runner_image_base_{amd64,arm64}`) and captures provenance via OCI referrers with GHCR token exchange (`packages: read`, anonymous fallback); replaces `gh attestation verify` with `cosign` and allows key‑signed mirrors via `PRELOOP_BASE_IMAGE_PUBKEY`.
- Pins `smolvm` 1.8.2; creates from the `.smolmachine` sidecar; applies `--cpus/--mem/--storage/--overlay` to `--from`; runs bakes as `root` by default (override with `PRELOOP_RUNNER_USER`); sets `SMOLVM_FILE_TRANSFER_MAX_BYTES=64GiB`; gates on MemAvailable and retries; bake VM storage is 120 GiB; always retains the golden artifact.
- Curated toolchains bake Rust 1.88.0 with `rustfmt`/`clippy` and Go 1.26; `preloop-cli` v0.30.3; docs updated for `cosign`‑only verification; adds a caching strategy plan.

**Rollout**
- Builders need ≥120 GiB free; the golden exceeds GitHub’s 2 GiB release‑asset limit—download from workflow artifacts or host it and set `PRELOOP_GOLDEN_URL`.
- Ensure `cosign` is available on the golden builder; for mirrored bases publish OIDC keyless signatures or set `PRELOOP_BASE_IMAGE_PUBKEY`.

<sup>Written for commit c34d8df1408303f28b864ed009594b714db524fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved golden image creation for x86_64 and ARM64 platforms.
  * Increased image transfer capacity and execution reliability.
  * Curated development environments now include Rust formatting and linting tools.
  * Added stronger base-image signature and SBOM verification.

* **Bug Fixes**
  * Fixed artifact naming and sidecar handling for names containing dots.
  * Improved provenance capture across supported registry formats.

* **Documentation**
  * Updated image provenance, Apple Silicon troubleshooting, and caching architecture guidance.

* **Release**
  * Version 0.30.3 is now documented and available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->