### PR TITLE
fix(security): cap expression parser nesting depth

### DIFF
--- a/crates/preloop-gha-expressions/src/expr_parser.rs
+++ b/crates/preloop-gha-expressions/src/expr_parser.rs
@@ -6,18 +6,44 @@ use super::{
     ExpressionError,
 };
 
+/// Maximum expression nesting depth.
+///
+/// The parser is recursive descent and the evaluator recurses over the same
+/// AST, so unbounded nesting (e.g. megabytes of `(((…` or `!!!…`) overflows
+/// the thread stack, which aborts the process instead of unwinding. Real
+/// workflow expressions are shallow; nothing legitimate nests near this.
+pub(crate) const MAX_EXPRESSION_DEPTH: usize = 256;
+
 pub(crate) struct Parser {
     tokens: Vec<Token>,
     index: usize,
+    depth: usize,
 }
 
 impl Parser {
     pub(crate) fn new(tokens: Vec<Token>) -> Self {
-        Self { tokens, index: 0 }
+        Self {
+            tokens,
+            index: 0,
+            depth: 0,
+        }
+    }
+
+    /// Enter one nesting level, refusing input past the depth ceiling. An
+    /// over-deep error aborts the whole parse, so the counter is not unwound.
+    fn enter(&mut self) -> Result<(), ExpressionError> {
+        self.depth += 1;
+        if self.depth > MAX_EXPRESSION_DEPTH {
+            return Err(ExpressionError::TooDeep(MAX_EXPRESSION_DEPTH));
+        }
+        Ok(())
     }
 
     pub(crate) fn parse_expr(&mut self) -> Result<Expr, ExpressionError> {
-        self.parse_or()
+        self.enter()?;
+        let expr = self.parse_or();
+        self.depth -= 1;
+        expr
     }
 
     pub(crate) fn expect_end(&self) -> Result<(), ExpressionError> {
@@ -81,7 +107,10 @@ impl Parser {
     fn parse_unary(&mut self) -> Result<Expr, ExpressionError> {
         if matches!(self.current(), Token::Bang) {
             self.advance();
-            Ok(Expr::UnaryNot(Box::new(self.parse_unary()?)))
+            self.enter()?;
+            let inner = self.parse_unary();
+            self.depth -= 1;
+            Ok(Expr::UnaryNot(Box::new(inner?)))
         } else {
             self.parse_primary()
         }

--- a/crates/preloop-gha-expressions/src/expr_parser.rs
+++ b/crates/preloop-gha-expressions/src/expr_parser.rs
@@ -55,8 +55,11 @@ impl Parser {
 
     fn parse_or(&mut self) -> Result<Expr, ExpressionError> {
         let mut expr = self.parse_and()?;
+        let mut chain_depth = 0;
         while matches!(self.current(), Token::Or) {
             self.advance();
+            self.enter()?;
+            chain_depth += 1;
             let right = self.parse_and()?;
             expr = Expr::Binary {
                 op: BinaryOp::Or,
@@ -64,13 +67,17 @@ impl Parser {
                 right: Box::new(right),
             };
         }
+        self.depth -= chain_depth;
         Ok(expr)
     }
 
     fn parse_and(&mut self) -> Result<Expr, ExpressionError> {
         let mut expr = self.parse_eq()?;
+        let mut chain_depth = 0;
         while matches!(self.current(), Token::And) {
             self.advance();
+            self.enter()?;
+            chain_depth += 1;
             let right = self.parse_eq()?;
             expr = Expr::Binary {
                 op: BinaryOp::And,
@@ -78,11 +85,13 @@ impl Parser {
                 right: Box::new(right),
             };
         }
+        self.depth -= chain_depth;
         Ok(expr)
     }
 
     fn parse_eq(&mut self) -> Result<Expr, ExpressionError> {
         let mut expr = self.parse_unary()?;
+        let mut chain_depth = 0;
         loop {
             let op = match self.current() {
                 Token::Eq => BinaryOp::Eq,
@@ -94,6 +103,8 @@ impl Parser {
                 _ => break,
             };
             self.advance();
+            self.enter()?;
+            chain_depth += 1;
             let right = self.parse_unary()?;
             expr = Expr::Binary {
                 op,
@@ -101,6 +112,7 @@ impl Parser {
                 right: Box::new(right),
             };
         }
+        self.depth -= chain_depth;
         Ok(expr)
     }
 

--- a/crates/preloop-gha-expressions/src/lib.rs
+++ b/crates/preloop-gha-expressions/src/lib.rs
@@ -95,6 +95,9 @@ pub enum ExpressionError {
     /// Invalid leading option passed to `hashFiles()`.
     #[error("invalid hashFiles option `{0}`")]
     InvalidHashFilesOption(String),
+    /// Expression nesting exceeded the parser's depth ceiling.
+    #[error("expression nesting exceeds the maximum depth of {0}")]
+    TooDeep(usize),
 }
 
 /// Parse an expression without evaluating it.

--- a/crates/preloop-gha-expressions/src/lib_tests.rs
+++ b/crates/preloop-gha-expressions/src/lib_tests.rs
@@ -616,12 +616,33 @@ mod official_semantics {
     /// Expressions within the ceiling must keep working unchanged.
     #[test]
     fn expressions_within_depth_limit_still_parse() {
-        let n = 200;
+        use super::expr_parser::MAX_EXPRESSION_DEPTH;
+
+        // `parse_expr` consumes one level for the root, so this is the
+        // largest accepted parenthesized/unary nesting.
+        let n = MAX_EXPRESSION_DEPTH - 1;
         let expr = format!("{}true{}", "(".repeat(n), ")".repeat(n));
         assert!(eval_bool(&expr, &Context::default()).unwrap());
 
-        let negated = format!("{}true", "!".repeat(200));
+        let unary_n = n - (n % 2);
+        let negated = format!("{}true", "!".repeat(unary_n));
         assert!(eval_bool(&negated, &Context::default()).unwrap());
+
+        let too_deep = format!(
+            "{}true{}",
+            "(".repeat(MAX_EXPRESSION_DEPTH),
+            ")".repeat(MAX_EXPRESSION_DEPTH)
+        );
+        assert!(matches!(
+            validate_expression(&too_deep),
+            Err(ExpressionError::TooDeep(_))
+        ));
+
+        let too_deep_negated = format!("{}true", "!".repeat(MAX_EXPRESSION_DEPTH));
+        assert!(matches!(
+            validate_expression(&too_deep_negated),
+            Err(ExpressionError::TooDeep(_))
+        ));
     }
 
     #[test]

--- a/crates/preloop-gha-expressions/src/lib_tests.rs
+++ b/crates/preloop-gha-expressions/src/lib_tests.rs
@@ -623,4 +623,19 @@ mod official_semantics {
         let negated = format!("{}true", "!".repeat(200));
         assert!(eval_bool(&negated, &Context::default()).unwrap());
     }
+
+    #[test]
+    fn deeply_nested_binary_chains_error_instead_of_overflowing() {
+        for operator in ["||", "&&", "=="] {
+            let mut expr = "true".to_owned();
+            for _ in 0..1_000 {
+                expr.push_str(operator);
+                expr.push_str("true");
+            }
+            assert!(
+                matches!(validate_expression(&expr), Err(ExpressionError::TooDeep(_))),
+                "operator chain should be depth-limited: {operator}"
+            );
+        }
+    }
 }

--- a/crates/preloop-gha-expressions/src/lib_tests.rs
+++ b/crates/preloop-gha-expressions/src/lib_tests.rs
@@ -588,4 +588,39 @@ mod official_semantics {
         let _ = std::fs::remove_dir_all(&workspace);
         assert!(result.is_err(), "unknown hashFiles flags must fail");
     }
+
+    /// Deeply nested parens overflow the parser's stack instead of returning
+    /// an error: 100k `(` from a 200 KB expression aborted the process before
+    /// the depth guard existed. The guard must reject, not crash.
+    #[test]
+    fn deeply_nested_parens_error_instead_of_overflowing() {
+        let n = 100_000;
+        let expr = format!("{}1{}", "(".repeat(n), ")".repeat(n));
+        assert!(matches!(
+            validate_expression(&expr),
+            Err(ExpressionError::TooDeep(_))
+        ));
+    }
+
+    /// `!` recurses through a different parse function than parens; it needs
+    /// the same ceiling.
+    #[test]
+    fn deeply_nested_negations_error_instead_of_overflowing() {
+        let expr = format!("{}true", "!".repeat(100_000));
+        assert!(matches!(
+            validate_expression(&expr),
+            Err(ExpressionError::TooDeep(_))
+        ));
+    }
+
+    /// Expressions within the ceiling must keep working unchanged.
+    #[test]
+    fn expressions_within_depth_limit_still_parse() {
+        let n = 200;
+        let expr = format!("{}true{}", "(".repeat(n), ")".repeat(n));
+        assert!(eval_bool(&expr, &Context::default()).unwrap());
+
+        let negated = format!("{}true", "!".repeat(200));
+        assert!(eval_bool(&negated, &Context::default()).unwrap());
+    }
 }


### PR DESCRIPTION
## Summary

The recursive-descent parser (and the evaluator that walks the same AST) had no depth ceiling. An expression of 100k nested parens — a 200 KB payload, far under the 64 MiB run-submission body limit — overflowed the thread stack, which **aborts the process** rather than unwinding. Reachable from any authenticated workflow submitter via `${{ }}` interpolation in run creation (`runs.rs` `eval_expression`), and from repo-controlled YAML via the webhook path.

**Reproduced** (release build, pre-fix): `thread 'main' has overflowed its stack — fatal runtime error: stack overflow, aborting`, exit 134. Post-fix the same payload is rejected cleanly:

```
REJECTED CLEANLY: expression nesting exceeds the maximum depth of 256
```

## Changes

- Depth counter in the two recursive parse functions: paren/argument nesting through `parse_expr`, negation chains through `parse_unary` (`!!!…x` recurses through a different function than parens and needs its own guard).
- New `ExpressionError::TooDeep` past 256 levels. Dotted access chains (`a.b.c…`) and the lexer are iterative and need no guard.

## Tests

- 100k nested parens → `TooDeep` instead of stack overflow
- 100k chained `!` → `TooDeep`
- 200 levels of parens / negations → still evaluate correctly

`just test-ci`: green except the pre-existing `test_golden_acquirejob_payloads_parsing` failure, which also fails on `main` (missing `06-multi-step` golden locally).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps expression nesting at 256 to prevent stack overflows that aborted the process. Previously, unbounded nesting in `${{ }}` or repo YAML could crash the runner; now inputs over the limit return `ExpressionError::TooDeep` and are rejected cleanly.

- Enforces depth in `parse_expr` (paren/argument nesting), `parse_unary` (negation chains), and binary chains in `parse_or`, `parse_and`, and `parse_eq`; dotted access and the lexer remain iterative.
- Adds `ExpressionError::TooDeep(usize)` with “expression nesting exceeds the maximum depth of 256”.
- Adds boundary tests: accepts max-depth-1 expressions; rejects over-limit parens, long negation chains, and long `||`/`&&`/`==` chains.

<sup>Written for commit d431f86c5c1c8519d1b137bda6ff9efa59f3bc3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added protection against excessively deeply nested expressions.
  * The parser now reports a clear error instead of risking a stack overflow.
  * Valid expressions within the supported nesting limit continue to parse and evaluate normally.

* **Tests**
  * Added coverage for deeply nested parentheses, negations, and operators.
  * Added regression tests confirming supported-depth expressions remain functional.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->