### PR TITLE
feat(orchestrator): default to the official-runner OCI golden on arm64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,6 +2022,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "uuid",
+ "zstd",
 ]
 
 [[package]]
@@ -4238,4 +4239,32 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/benchmarks/real-world/conformance-5repos.sh
+++ b/benchmarks/real-world/conformance-5repos.sh
@@ -190,7 +190,7 @@ start_server() {
   "$SERVER_BIN" serve --listen "127.0.0.1:$PORT" >"$log" 2>&1 &
   SERVER_PID=$!
   for _ in $(seq 1 120); do
-    if curl -fsS "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1; then
+    if curl -fsS --max-time 5 "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1; then
       echo "=== preloop server ready on :$PORT using $OFFICIAL_GOLDEN_ARTIFACT ==="
       return 0
     fi
@@ -210,10 +210,16 @@ cleanup() {
     wait "$SERVER_PID" 2>/dev/null || true
   fi
 }
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+# Signal-specific handlers: the shared cleanup would otherwise resume the
+# script after the interrupt. Exit with the conventional statuses (130/143).
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 run_status() {
-  curl -fsS -H "Authorization: Bearer ${PRELOOP_SYSTEM_TOKEN:-preloop-system-token}" \
+  # --max-time keeps a stalled status request from masking the deadline; a
+  # dead server then surfaces as `unknown` and wait_run fails fast instead.
+  curl -fsS --max-time 15 -H "Authorization: Bearer ${PRELOOP_SYSTEM_TOKEN:-preloop-system-token}" \
     "http://127.0.0.1:$PORT/api/v1/runs/$1" 2>/dev/null \
     | python3 -c 'import json,sys; r=json.load(sys.stdin); print(r.get("status", "unknown"))' \
     || echo unknown
@@ -221,7 +227,7 @@ run_status() {
 
 run_snapshot() {
   local run_id="$1" output="$2"
-  curl -fsS -H "Authorization: Bearer ${PRELOOP_SYSTEM_TOKEN:-preloop-system-token}" \
+  curl -fsS --max-time 15 -H "Authorization: Bearer ${PRELOOP_SYSTEM_TOKEN:-preloop-system-token}" \
     "http://127.0.0.1:$PORT/api/v1/runs/$run_id" >"$output" 2>/dev/null || printf '%s\n' '{}' >"$output"
 }
 
@@ -271,6 +277,13 @@ wait_run() {
   local target="$1" run_id="$2" deadline status
   deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
   while [ "$(date +%s)" -lt "$deadline" ]; do
+    # A crashed server would otherwise be retried as `unknown` until the
+    # campaign deadline; fail immediately instead.
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+      echo "[$target] preloop server exited; cannot poll run $run_id" >&2
+      printf '%s\n' server-crashed
+      return 0
+    fi
     status="$(run_status "$run_id")"
     echo "[$target] status=$status" >&2
     case "$status" in

--- a/benchmarks/real-world/conformance-5repos.sh
+++ b/benchmarks/real-world/conformance-5repos.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+# Run the five-repository conformance campaign against the pinned official
+# GitHub-hosted runner golden.
+#
+# The golden is the 9GB packed artifact produced from the official
+# ubuntu24-arm64 runner image.  It is selected by its immutable base-image
+# reference and exposed to Preloop through a temporary PRELOOP_HOME symlink;
+# no second 9GB copy is made.
+#
+# Usage:
+#   benchmarks/real-world/conformance-5repos.sh [all|grafana|deno|pydantic|valkey|cli]
+#   benchmarks/real-world/conformance-5repos.sh cli --workflow test.yml
+#
+# The default run is sequential.  A single server and a small fork pool keep
+# the 9GB golden usable on a laptop while preserving real matrix/job behavior.
+set -Eeuo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+WORKSPACE_ROOT="${CONFORMANCE_WORKSPACE_ROOT:-/tmp/preloop-conformance-5repos/workspaces}"
+OUTPUT_ROOT="${CONFORMANCE_OUTPUT_ROOT:-$ROOT/benchmarks/real-world/results/conformance-5repos}"
+# The control socket is Unix-domain based; keep this path short enough for
+# macOS SUN_LEN even when the checkout lives in a deep worktree.
+CAMPAIGN_HOME="${CONFORMANCE_HOME:-/tmp/preloop-5repos-home}"
+PORT="${CONFORMANCE_PORT:-9197}"
+POLL_SECONDS="${CONFORMANCE_POLL_SECONDS:-10}"
+TIMEOUT_SECONDS="${CONFORMANCE_TIMEOUT_SECONDS:-7200}"
+POOL_SIZE="${PRELOOP_RUNNER_POOL_SIZE:-2}"
+HOST_HOME="${HOME:-}"
+SMOLVM_PROCESS_HOME="${CONFORMANCE_SMOLVM_HOME:-$CAMPAIGN_HOME/smolvm-home}"
+export PRELOOP_SYSTEM_TOKEN="${PRELOOP_SYSTEM_TOKEN:-preloop-system-token}"
+export PRELOOP_CLIENT_TIMEOUT_SECONDS="${PRELOOP_CLIENT_TIMEOUT_SECONDS:-600}"
+
+SERVER_BIN="${PRELOOP_BIN:-$ROOT/target/debug/preloop}"
+CLIENT_BIN="${PRELOOP_CLIENT_BIN:-$ROOT/target/debug/preloop-runner-client}"
+GUEST_RUNNER_BUNDLE="${PRELOOP_RUNNER_BUNDLE:-$ROOT/target/aarch64-unknown-linux-gnu/debug}"
+
+# This is the official ubuntu24 arm64 hosted-image snapshot whose local packed
+# artifact is approximately 9GB.  Keep the digest and artifact name together:
+# changing either silently selects a different image and invalidates results.
+OFFICIAL_GOLDEN_BASE="ghcr.io/preloopdev/runner-images:ubuntu24-arm64-runner-large-latest@sha256:a58990d6b6f8ca5861f33d77e1d3f0732d7d14261caacd6fba8c8f707c05b40e"
+OFFICIAL_GOLDEN_NAME="preloop-ghcr.io-preloopdev-runner-images-ubuntu24-arm64-runner-large-latest-sha256-a58990d6b6f8ca5861f33d77e1d3f0732d7d14261caacd6fba8c8f707c05b40e-aarch64"
+OFFICIAL_GOLDEN_ARTIFACT="${PRELOOP_GOLDEN_ARTIFACT:-$HOME/.config/preloop/vms/${OFFICIAL_GOLDEN_NAME}.smolmachine}"
+
+SERVER_PID=""
+FAILED_TARGETS=""
+
+# The macOS SmolVM release keeps libkrunfw beside the wrapper binary but does
+# not encode that directory in the child bootstrap's loader path.  Without
+# this export, every VM fails after creation with "Couldn't find or load
+# libkrunfw.5.dylib".  Keep an operator-provided loader path intact.
+if [ "$(uname -s)" = Darwin ]; then
+  SMOLVM_LIB_DIR="${SMOLVM_LIB_DIR:-$HOME/.smolvm/lib}"
+  if [ -d "$SMOLVM_LIB_DIR" ]; then
+    export DYLD_LIBRARY_PATH="$SMOLVM_LIB_DIR${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+  fi
+fi
+
+usage() {
+  cat <<'EOF'
+Usage: conformance-5repos.sh [all|grafana|deno|pydantic|valkey|cli] [--workflow NAME]
+
+Environment:
+  PRELOOP_GOLDEN_ARTIFACT       9GB official .smolmachine artifact
+  CONFORMANCE_WORKSPACE_ROOT    clone root (default /tmp/preloop-conformance-5repos/workspaces)
+  CONFORMANCE_OUTPUT_ROOT       result root under benchmarks/real-world/results
+  CONFORMANCE_TIMEOUT_SECONDS   per-workflow timeout (default 7200)
+  PRELOOP_RUNNER_POOL_SIZE      concurrent fork slots (default 2)
+  CONFORMANCE_TARGETS           space-separated target IDs (overrides positional repo)
+EOF
+}
+
+fail() {
+  echo "conformance-5repos: $*" >&2
+  exit 1
+}
+
+# target_cfg returns: repo-slug git-url branch workflow event git-ref.
+target_cfg() {
+  case "$1" in
+    grafana/ci)
+      # Grafana replaced ci.yml with the split backend-unit-tests workflow.
+      echo "grafana https://github.com/grafana/grafana.git main .github/workflows/backend-unit-tests.yml push refs/heads/main" ;;
+    grafana/frontend-metrics)
+      # frontend-metrics.yml was renamed to frontend-lint.yml upstream.
+      echo "grafana https://github.com/grafana/grafana.git main .github/workflows/frontend-lint.yml push refs/heads/main" ;;
+    deno/ci)
+      echo "deno https://github.com/denoland/deno.git main .github/workflows/ci.yml push refs/heads/main" ;;
+    pydantic/ci)
+      echo "pydantic https://github.com/pydantic/pydantic.git main .github/workflows/ci.yml push refs/heads/main" ;;
+    pydantic/test)
+      echo "pydantic https://github.com/pydantic/pydantic.git main .github/workflows/test.yml push refs/heads/main" ;;
+    valkey/ci)
+      echo "valkey https://github.com/valkey-io/valkey.git unstable .github/workflows/ci.yml push refs/heads/unstable" ;;
+    cli/test)
+      echo "cli https://github.com/cli/cli.git trunk .github/workflows/test.yml push refs/heads/trunk" ;;
+    cli/lint)
+      echo "cli https://github.com/cli/cli.git trunk .github/workflows/lint.yml push refs/heads/trunk" ;;
+    *) return 1 ;;
+  esac
+}
+
+all_targets() {
+  echo "grafana/ci grafana/frontend-metrics deno/ci pydantic/ci pydantic/test valkey/ci cli/test cli/lint"
+}
+
+repo_targets() {
+  case "$1" in
+    grafana) echo "grafana/ci grafana/frontend-metrics" ;;
+    deno) echo "deno/ci" ;;
+    pydantic) echo "pydantic/ci pydantic/test" ;;
+    valkey) echo "valkey/ci" ;;
+    cli) echo "cli/test cli/lint" ;;
+    *) return 1 ;;
+  esac
+}
+
+file_size() {
+  stat -f %z "$1" 2>/dev/null || stat -c %s "$1"
+}
+
+prepare_golden_home() {
+  [ -f "$OFFICIAL_GOLDEN_ARTIFACT" ] || fail "missing 9GB official golden: $OFFICIAL_GOLDEN_ARTIFACT"
+  local bytes expected
+  bytes="$(file_size "$OFFICIAL_GOLDEN_ARTIFACT")"
+  # Reject the small launcher stub or a partial download.  The packed payload
+  # used by this campaign is the ~9GB .smolmachine sidecar.
+  [ "$bytes" -ge 8589934592 ] || fail "golden is ${bytes} bytes, not the required ~9GB .smolmachine payload"
+  expected="$CAMPAIGN_HOME/vms/$OFFICIAL_GOLDEN_NAME"
+  mkdir -p "$(dirname "$expected")"
+  ln -sfn "$OFFICIAL_GOLDEN_ARTIFACT" "$expected"
+  [ -f "$expected" ] || fail "failed to expose official golden at $expected"
+}
+
+ensure_binaries() {
+  if [ ! -x "$SERVER_BIN" ] || [ ! -x "$CLIENT_BIN" ] || [ ! -x "$GUEST_RUNNER_BUNDLE/preloop-runner" ]; then
+    echo "=== building Preloop CLI, client, and Linux guest runner ==="
+    cargo build --locked -p preloop-cli -p preloop-runner-client
+    cargo zigbuild --locked -p preloop-runner --target aarch64-unknown-linux-gnu
+  fi
+  [ -x "$SERVER_BIN" ] || fail "missing server binary: $SERVER_BIN"
+  [ -x "$CLIENT_BIN" ] || fail "missing client binary: $CLIENT_BIN"
+  [ -x "$GUEST_RUNNER_BUNDLE/preloop-runner" ] || fail "missing Linux guest runner: $GUEST_RUNNER_BUNDLE/preloop-runner"
+}
+
+clone_repo() {
+  local slug="$1" url="$2" branch="$3" dir="$WORKSPACE_ROOT/$1"
+  mkdir -p "$WORKSPACE_ROOT"
+  if [ ! -d "$dir/.git" ]; then
+    echo "=== cloning $slug ($branch) ==="
+    git clone "$url" "$dir"
+  else
+    echo "=== refreshing $slug ($branch) ==="
+    git -C "$dir" remote set-url origin "$url"
+    git -C "$dir" fetch --prune --tags origin
+  fi
+  git -C "$dir" fetch --prune --tags origin "$branch"
+  git -C "$dir" checkout -B "$branch" "origin/$branch"
+  git -C "$dir" reset --hard "origin/$branch"
+  git -C "$dir" clean -fdx
+}
+
+start_server() {
+  local log="$OUTPUT_ROOT/server.log"
+  mkdir -p "$OUTPUT_ROOT" "$CAMPAIGN_HOME" "$SMOLVM_PROCESS_HOME"
+  rm -f "$log"
+  # The base reference is intentionally the same string encoded in the local
+  # cache filename.  The CLI then consumes the symlinked 9GB artifact instead
+  # of downloading or rebuilding a different golden.
+  if [ -z "${PRELOOP_GITHUB_TOKEN:-}" ] && command -v gh >/dev/null 2>&1; then
+    PRELOOP_GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
+    export PRELOOP_GITHUB_TOKEN
+  fi
+  PRELOOP_HOME="$CAMPAIGN_HOME" \
+  HOME="$SMOLVM_PROCESS_HOME" \
+  SMOLVM_DATA_DIR="${SMOLVM_DATA_DIR:-$CAMPAIGN_HOME/smolvm}" \
+  SMOLVM_AGENT_ROOTFS="${SMOLVM_AGENT_ROOTFS:-$HOST_HOME/.smolvm/agent-rootfs}" \
+  SMOLVM_LIB_DIR="${SMOLVM_LIB_DIR:-$HOST_HOME/.smolvm/lib}" \
+  PRELOOP_RUNNER_BASE_IMAGE="$OFFICIAL_GOLDEN_BASE" \
+  PRELOOP_RUNNER_BUNDLE="$GUEST_RUNNER_BUNDLE" \
+  PRELOOP_RUNNER_NAME_PREFIX="conformance-5repos" \
+  PRELOOP_USE_PACKED_GOLDEN=1 \
+  PRELOOP_RUNNER_POOL_ENABLED=1 \
+  PRELOOP_RUNNER_POOL_SIZE="$POOL_SIZE" \
+  PRELOOP_USE_FORK=1 \
+  PRELOOP_RUNNER_MEMORY_MIB="${PRELOOP_RUNNER_MEMORY_MIB:-8192}" \
+  PRELOOP_RUNNER_STORAGE_GB="${PRELOOP_RUNNER_STORAGE_GB:-80}" \
+  PRELOOP_RUNNER_LABELS="${PRELOOP_RUNNER_LABELS:-X64,ubuntu-arm64-small,ubuntu-x64-small,ubuntu-x64}" \
+  PRELOOP_PUBLIC_URL="http://127.0.0.1:$PORT" \
+  RUST_LOG="${RUST_LOG:-info,preloop=info}" \
+  "$SERVER_BIN" serve --listen "127.0.0.1:$PORT" >"$log" 2>&1 &
+  SERVER_PID=$!
+  for _ in $(seq 1 120); do
+    if curl -fsS "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1; then
+      echo "=== preloop server ready on :$PORT using $OFFICIAL_GOLDEN_ARTIFACT ==="
+      return 0
+    fi
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+      tail -50 "$log" >&2 || true
+      fail "preloop server exited during startup"
+    fi
+    sleep 1
+  done
+  tail -100 "$log" >&2 || true
+  fail "preloop server did not become ready"
+}
+
+cleanup() {
+  if [ -n "$SERVER_PID" ]; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+run_status() {
+  curl -fsS -H "Authorization: Bearer ${PRELOOP_SYSTEM_TOKEN:-preloop-system-token}" \
+    "http://127.0.0.1:$PORT/api/v1/runs/$1" 2>/dev/null \
+    | python3 -c 'import json,sys; r=json.load(sys.stdin); print(r.get("status", "unknown"))' \
+    || echo unknown
+}
+
+run_snapshot() {
+  local run_id="$1" output="$2"
+  curl -fsS -H "Authorization: Bearer ${PRELOOP_SYSTEM_TOKEN:-preloop-system-token}" \
+    "http://127.0.0.1:$PORT/api/v1/runs/$run_id" >"$output" 2>/dev/null || printf '%s\n' '{}' >"$output"
+}
+
+write_push_payload() {
+  local workspace="$1" branch="$2" output="$3"
+  python3 - "$workspace" "$branch" >"$output" <<'PY'
+import json
+import subprocess
+import sys
+
+workspace, branch = sys.argv[1:]
+
+def git(*args):
+    return subprocess.check_output(
+        ["git", "-C", workspace, *args], text=True
+    ).splitlines()
+
+head = git("rev-parse", "HEAD")[0]
+try:
+    before = git("rev-parse", "HEAD^")[0]
+except subprocess.CalledProcessError:
+    before = "0" * 40
+# A campaign run is intentionally a synthetic "changed everything" event:
+# it must exercise the selected workflow even when the current upstream commit
+# touched an unrelated path.  The list is complete, so the server can still
+# evaluate path filters without guessing.
+paths = git("ls-files")
+
+print(json.dumps({
+    "before": before,
+    "after": head,
+    "ref": f"refs/heads/{branch}",
+    # Preloop requires an explicit complete list for path-filter evaluation.
+    "paths": paths,
+    "commits": [{"modified": paths, "added": [], "removed": []}],
+    "repository": {"default_branch": branch},
+    "pull_request": {
+        "number": 1,
+        "base": {"ref": branch, "sha": before},
+        "head": {"ref": branch, "sha": head},
+    },
+}, separators=(",", ":")))
+PY
+}
+
+wait_run() {
+  local target="$1" run_id="$2" deadline status
+  deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    status="$(run_status "$run_id")"
+    echo "[$target] status=$status" >&2
+    case "$status" in
+      success|failure|cancelled|skipped) printf '%s\n' "$status"; return 0 ;;
+    esac
+    sleep "$POLL_SECONDS"
+  done
+  printf '%s\n' timeout
+}
+
+run_target() {
+  local target="$1" workflow_filter="${2:-}"
+  local cfg slug url branch workflow event git_ref ws_dir target_dir submit run_id final_status
+  cfg="$(target_cfg "$target")" || fail "unknown target: $target"
+  read -r slug url branch workflow event git_ref <<EOF
+$cfg
+EOF
+  if [ -n "$workflow_filter" ] \
+    && [ "$workflow" != "$workflow_filter" ] \
+    && [ "${workflow##*/}" != "$workflow_filter" ]; then
+    return 0
+  fi
+  clone_repo "$slug" "$url" "$branch"
+  ws_dir="$WORKSPACE_ROOT/$slug"
+  [ -f "$ws_dir/$workflow" ] || fail "$target workflow is missing after checkout: $ws_dir/$workflow"
+  target_dir="$OUTPUT_ROOT/$target"
+  rm -rf "$target_dir"
+  mkdir -p "$target_dir"
+  write_push_payload "$ws_dir" "$branch" "$target_dir/event.json"
+  echo "=== [$target] submitting $workflow ($event $git_ref) ==="
+  if ! submit="$("$CLIENT_BIN" --server "http://127.0.0.1:$PORT" submit \
+    -W "$ws_dir/$workflow" --workspace-root "$ws_dir" \
+    --git-ref "$git_ref" --event "$event" --payload "$target_dir/event.json" 2>&1)"; then
+    # Some upstream workflows intentionally omit push and only accept
+    # pull_request.  The same complete changed-file payload is valid for the
+    # fallback event, and rejected submissions do not create a run.
+    if [ "$event" = "push" ] && [[ "$submit" == *"does not match event"* ]]; then
+      event="pull_request"
+      echo "[$target] retrying with pull_request trigger"
+      submit="$("$CLIENT_BIN" --server "http://127.0.0.1:$PORT" submit \
+        -W "$ws_dir/$workflow" --workspace-root "$ws_dir" \
+        --git-ref "$git_ref" --event "$event" --payload "$target_dir/event.json" 2>&1)" || {
+          printf '%s\n' "$submit" | tee "$target_dir/submit.txt"
+          fail "[$target] workflow submission failed"
+        }
+    else
+      printf '%s\n' "$submit" | tee "$target_dir/submit.txt"
+      fail "[$target] workflow submission failed"
+    fi
+  fi
+  printf '%s\n' "$submit" | tee "$target_dir/submit.txt"
+  run_id="$(printf '%s\n' "$submit" | python3 -c 'import json,sys; print(json.load(sys.stdin)["run_id"])')"
+  printf '%s\n' "$run_id" >"$target_dir/run-id.txt"
+  final_status="$(wait_run "$target" "$run_id")"
+  run_snapshot "$run_id" "$target_dir/run.json"
+  printf '%s\n' "$final_status" >"$target_dir/status.txt"
+  echo "=== [$target] final status: $final_status ==="
+  case "$final_status" in
+    success|skipped) ;;
+    *) FAILED_TARGETS="${FAILED_TARGETS}${target}=${final_status}\n" ;;
+  esac
+}
+
+main() {
+  local repo="${1:-all}" workflow_filter="" target target_list
+  if [ "$repo" = "--help" ] || [ "$repo" = "-h" ]; then usage; return 0; fi
+  shift || true
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --workflow) [ "$#" -ge 2 ] || fail "--workflow needs a path"; workflow_filter="$2"; shift 2 ;;
+      --help|-h) usage; return 0 ;;
+      *) fail "unknown argument: $1" ;;
+    esac
+  done
+  if [ -n "${CONFORMANCE_TARGETS:-}" ]; then
+    target_list="$CONFORMANCE_TARGETS"
+  elif [ "$repo" = "all" ]; then
+    target_list="$(all_targets)"
+  else
+    target_list="$(repo_targets "$repo")" || fail "unknown repository: $repo"
+  fi
+
+  prepare_golden_home
+  ensure_binaries
+  mkdir -p "$WORKSPACE_ROOT" "$OUTPUT_ROOT"
+  start_server
+  for target in $target_list; do
+    run_target "$target" "$workflow_filter"
+  done
+  if [ -n "$FAILED_TARGETS" ]; then
+    printf 'Campaign failures:\n%b' "$FAILED_TARGETS" >&2
+    return 1
+  fi
+  echo "Campaign complete. Results: $OUTPUT_ROOT"
+}
+
+main "$@"

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -102,14 +102,10 @@ pub(crate) fn smolvm_command() -> anyhow::Result<std::process::Command> {
     // (see crates/preloop-cli/src/server_install.rs), so the engine records
     // its machines in that registry. A separately invoked `preloop shell` /
     // `preloop debug` must consult the SAME registry or it cannot find the
-    // paused, service-owned machine — the caller's default data dir would
-    // resolve a different one. An operator value wins, so this only fills
-    // the gap, never overrides.
-    if std::env::var_os("SMOLVM_DATA_DIR").is_none() {
-        let data_dir = preloop_home().join("smolvm");
-        command.env("SMOLVM_DATA_DIR", data_dir);
-    }
-    preloop_vm::apply_smolvm_runtime_env(&mut command, None);
+    // paused, service-owned machine. `apply_smolvm_runtime_env` fills the
+    // same gap from the effective Preloop home (and isolates `HOME` on macOS,
+    // where SmolVM ignores `SMOLVM_DATA_DIR`); an operator value still wins.
+    preloop_vm::apply_smolvm_runtime_env(&mut command, None)?;
     preloop_vm::apply_smolvm_sandbox_env(&mut command)?;
     Ok(command)
 }

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -109,6 +109,7 @@ pub(crate) fn smolvm_command() -> anyhow::Result<std::process::Command> {
         let data_dir = preloop_home().join("smolvm");
         command.env("SMOLVM_DATA_DIR", data_dir);
     }
+    preloop_vm::apply_smolvm_runtime_env(&mut command, None);
     preloop_vm::apply_smolvm_sandbox_env(&mut command)?;
     Ok(command)
 }

--- a/crates/preloop-orchestrator/Cargo.toml
+++ b/crates/preloop-orchestrator/Cargo.toml
@@ -25,6 +25,7 @@ serde_yaml = { workspace = true }
 sha2 = "0.10"
 uuid = { workspace = true }
 reqwest = { workspace = true }
+zstd = "0.13"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/preloop-orchestrator/src/lib.rs
+++ b/crates/preloop-orchestrator/src/lib.rs
@@ -20,6 +20,7 @@ use preloop_vm::{
     MachineName, MachineSpec, MachineState, NetworkPolicy, OutputChunk, SecretSource,
     SmolVmProvider, SocketMount, VmError, VmProvider, VolumeMount,
 };
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -270,11 +271,33 @@ fn default_golden_url(release_version: &str) -> String {
     )
 }
 
+/// Public OCI artifact carrying the official arm64 packed VM golden.
+///
+/// This is deliberately separate from the `runner-images` base-image package:
+/// the latter is an OCI rootfs image, while this package contains a
+/// `.smolmachine` payload ready for `machine create --from`.
+const DEFAULT_GOLDEN_OCI_REF: &str =
+    "ghcr.io/preloopdev/preloop-golden:ubuntu24-arm64-runner-large-latest";
+
 fn should_download_prebaked_golden(base_image: &str, custom_golden_url: bool) -> bool {
     is_stock_base_image(base_image) || custom_golden_url
 }
 
 async fn download_prebaked_golden(payload: &Path, release_version: &str) -> bool {
+    if std::env::consts::ARCH == "aarch64" && std::env::var("PRELOOP_GOLDEN_URL").is_err() {
+        let reference = std::env::var("PRELOOP_GOLDEN_OCI_REF")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_GOLDEN_OCI_REF.to_owned());
+        if download_oci_golden(payload, &reference).await {
+            return true;
+        }
+        warn!(
+            reference,
+            "default OCI golden unavailable; trying release asset"
+        );
+    }
+
     let default_url = default_golden_url(release_version);
     let url = std::env::var("PRELOOP_GOLDEN_URL")
         .ok()
@@ -401,6 +424,196 @@ async fn download_prebaked_golden(payload: &Path, release_version: &str) -> bool
     }
 
     info!(target = %payload.display(), "Downloaded pre-baked golden microVM image successfully");
+    true
+}
+
+#[derive(Debug, Deserialize)]
+struct OciManifest {
+    #[serde(default)]
+    layers: Vec<OciLayer>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OciLayer {
+    digest: String,
+    media_type: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct OciToken {
+    token: String,
+}
+
+/// Download the packed VM layer from a public OCI artifact without requiring
+/// `oras`, Docker, or any other host-side registry client.
+async fn download_oci_golden(payload: &Path, reference: &str) -> bool {
+    let Some((registry, repository, version)) = split_oci_reference(reference) else {
+        warn!(reference, "invalid OCI golden reference");
+        return false;
+    };
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(600))
+        .build()
+    {
+        Ok(client) => client,
+        Err(_) => return false,
+    };
+    let manifest_url = format!("https://{registry}/v2/{repository}/manifests/{version}");
+    let accept = "application/vnd.oci.image.manifest.v1+json, \
+                  application/vnd.docker.distribution.manifest.v2+json";
+    let Some(response) = registry_get(&client, &manifest_url, accept).await else {
+        info!(reference, "OCI golden manifest unavailable");
+        return false;
+    };
+    let Ok(manifest) = response.json::<OciManifest>().await else {
+        return false;
+    };
+    let Some(layer) = manifest
+        .layers
+        .into_iter()
+        .find(|layer| layer.media_type == "application/vnd.preloop.smolmachine.v1+zstd")
+    else {
+        warn!(reference, "OCI golden has no packed VM layer");
+        return false;
+    };
+    let blob_url = format!("https://{registry}/v2/{repository}/blobs/{}", layer.digest);
+    let Some(response) = registry_get(&client, &blob_url, "*/*").await else {
+        return false;
+    };
+    let Some(parent) = payload.parent() else {
+        return false;
+    };
+    let tmp_payload = parent.join(format!(".tmp-golden-{}", uuid::Uuid::new_v4()));
+    if stream_golden_response(response, &tmp_payload, Some(layer.digest)).await
+        && tokio::fs::rename(&tmp_payload, payload).await.is_ok()
+    {
+        info!(
+            reference,
+            target = %payload.display(),
+            "Downloaded OCI pre-baked golden microVM image successfully"
+        );
+        return true;
+    }
+    let _ = tokio::fs::remove_file(&tmp_payload).await;
+    false
+}
+
+async fn registry_get(
+    client: &reqwest::Client,
+    url: &str,
+    accept: &str,
+) -> Option<reqwest::Response> {
+    let response = client
+        .get(url)
+        .header(reqwest::header::ACCEPT, accept)
+        .send()
+        .await
+        .ok()?;
+    if response.status().is_success() {
+        return Some(response);
+    }
+    if response.status() != reqwest::StatusCode::UNAUTHORIZED {
+        return None;
+    }
+    let challenge = response
+        .headers()
+        .get(reqwest::header::WWW_AUTHENTICATE)?
+        .to_str()
+        .ok()?;
+    let realm = auth_parameter(challenge, "realm")?;
+    let service = auth_parameter(challenge, "service")?;
+    let scope = auth_parameter(challenge, "scope")?;
+    let token = client
+        .get(realm)
+        .query(&[("service", service), ("scope", scope)])
+        .send()
+        .await
+        .ok()?
+        .json::<OciToken>()
+        .await
+        .ok()?;
+    client
+        .get(url)
+        .header(reqwest::header::ACCEPT, accept)
+        .bearer_auth(token.token)
+        .send()
+        .await
+        .ok()
+        .filter(|response| response.status().is_success())
+}
+
+fn auth_parameter(challenge: &str, name: &str) -> Option<String> {
+    challenge.split(',').find_map(|part| {
+        let (key, value) = part.trim().split_once('=')?;
+        (key.trim()
+            .trim_start_matches("Bearer ")
+            .eq_ignore_ascii_case(name))
+        .then(|| value.trim_matches('"').to_owned())
+    })
+}
+
+fn split_oci_reference(reference: &str) -> Option<(String, String, String)> {
+    let (registry, remainder) = reference.split_once('/')?;
+    let (repository, version) = remainder
+        .rsplit_once('@')
+        .or_else(|| remainder.rsplit_once(':'))?;
+    if registry.is_empty() || repository.is_empty() || version.is_empty() {
+        return None;
+    }
+    Some((
+        registry.to_owned(),
+        repository.to_owned(),
+        version.to_owned(),
+    ))
+}
+
+async fn stream_golden_response(
+    response: reqwest::Response,
+    tmp_payload: &Path,
+    expected_sha256: Option<String>,
+) -> bool {
+    let mut file = match tokio::fs::File::create(tmp_payload).await {
+        Ok(file) => file,
+        Err(_) => return false,
+    };
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let Ok(chunk) = chunk else {
+            let _ = tokio::fs::remove_file(tmp_payload).await;
+            return false;
+        };
+        if file.write_all(&chunk).await.is_err() {
+            let _ = tokio::fs::remove_file(tmp_payload).await;
+            return false;
+        }
+    }
+    if file.flush().await.is_err() {
+        let _ = tokio::fs::remove_file(tmp_payload).await;
+        return false;
+    }
+    drop(file);
+    if let Some(expected) = expected_sha256 {
+        let digest = match tokio::task::spawn_blocking({
+            let path = tmp_payload.to_owned();
+            move || {
+                use sha2::{Digest, Sha256};
+                let mut hasher = Sha256::new();
+                let mut file = std::fs::File::open(path)?;
+                std::io::copy(&mut file, &mut hasher)?;
+                Ok::<String, std::io::Error>(format!("{:x}", hasher.finalize()))
+            }
+        })
+        .await
+        {
+            Ok(Ok(digest)) => digest,
+            _ => return false,
+        };
+        let expected = expected.strip_prefix("sha256:").unwrap_or(&expected);
+        if digest != expected {
+            warn!(expected, %digest, "OCI golden layer digest mismatch");
+            return false;
+        }
+    }
     true
 }
 
@@ -4009,6 +4222,28 @@ chmod +x "$destination/bin/node"
         let url = default_golden_url("9.8.7");
         assert!(url.contains("/releases/download/v9.8.7/"), "{url}");
         assert!(!url.contains(env!("CARGO_PKG_VERSION")), "{url}");
+    }
+
+    #[test]
+    fn default_oci_golden_reference_targets_arm64_pack() {
+        let (registry, repository, version) =
+            split_oci_reference(DEFAULT_GOLDEN_OCI_REF).expect("valid OCI reference");
+        assert_eq!(registry, "ghcr.io");
+        assert_eq!(repository, "preloopdev/preloop-golden");
+        assert_eq!(version, "ubuntu24-arm64-runner-large-latest");
+    }
+
+    #[test]
+    fn oci_auth_challenge_parameters_parse() {
+        let challenge = r#"Bearer realm="https://ghcr.io/token",service="ghcr.io",scope="repository:preloopdev/preloop-golden:pull""#;
+        assert_eq!(
+            auth_parameter(challenge, "realm").as_deref(),
+            Some("https://ghcr.io/token")
+        );
+        assert_eq!(
+            auth_parameter(challenge, "scope").as_deref(),
+            Some("repository:preloopdev/preloop-golden:pull")
+        );
     }
 
     #[test]

--- a/crates/preloop-orchestrator/src/lib.rs
+++ b/crates/preloop-orchestrator/src/lib.rs
@@ -276,15 +276,31 @@ fn default_golden_url(release_version: &str) -> String {
 /// This is deliberately separate from the `runner-images` base-image package:
 /// the latter is an OCI rootfs image, while this package contains a
 /// `.smolmachine` payload ready for `machine create --from`.
+///
+/// Pinned to the immutable manifest digest of the mutable
+/// `ubuntu24-arm64-runner-large-latest` tag (verified reachable 2026-08-17):
+/// a mutable tag could be silently replaced between the manifest fetch and
+/// the blob pull, and moving the default stays a reviewed code change
+/// instead of a registry retag. The artifact is produced by the CI golden
+/// pipeline (pool-side bake of the official ubuntu24-arm64 runner image);
+/// the repo release flow additionally publishes the packed golden as a
+/// GitHub Release asset, which `PRELOOP_GOLDEN_URL` selects over this
+/// default.
 const DEFAULT_GOLDEN_OCI_REF: &str =
-    "ghcr.io/preloopdev/preloop-golden:ubuntu24-arm64-runner-large-latest";
+    "ghcr.io/preloopdev/preloop-golden@sha256:a2f7caf367e19efa4cb2d6f32a7093db8fae79e1b1525b65ac1190c1d2b44361";
 
 fn should_download_prebaked_golden(base_image: &str, custom_golden_url: bool) -> bool {
     is_stock_base_image(base_image) || custom_golden_url
 }
 
 async fn download_prebaked_golden(payload: &Path, release_version: &str) -> bool {
-    if std::env::consts::ARCH == "aarch64" && std::env::var("PRELOOP_GOLDEN_URL").is_err() {
+    // An exported-but-blank `PRELOOP_GOLDEN_URL` must behave like an unset
+    // one in both places below: the operator otherwise gets neither the OCI
+    // default nor their (empty) override.
+    let forced_url = std::env::var("PRELOOP_GOLDEN_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty());
+    if std::env::consts::ARCH == "aarch64" && forced_url.is_none() {
         let reference = std::env::var("PRELOOP_GOLDEN_OCI_REF")
             .ok()
             .filter(|value| !value.trim().is_empty())
@@ -299,10 +315,7 @@ async fn download_prebaked_golden(payload: &Path, release_version: &str) -> bool
     }
 
     let default_url = default_golden_url(release_version);
-    let url = std::env::var("PRELOOP_GOLDEN_URL")
-        .ok()
-        .filter(|value| !value.trim().is_empty())
-        .unwrap_or(default_url);
+    let url = forced_url.unwrap_or(default_url);
 
     info!(url = %url, target = %payload.display(), "Attempting to download pre-baked golden microVM image");
 
@@ -436,6 +449,10 @@ struct OciManifest {
 #[derive(Debug, Deserialize)]
 struct OciLayer {
     digest: String,
+    /// OCI descriptors name this field `mediaType`; without the rename every
+    /// standard manifest fails to parse and the OCI path silently falls back
+    /// to the release asset.
+    #[serde(rename = "mediaType")]
     media_type: String,
 }
 
@@ -465,8 +482,12 @@ async fn download_oci_golden(payload: &Path, reference: &str) -> bool {
         info!(reference, "OCI golden manifest unavailable");
         return false;
     };
-    let Ok(manifest) = response.json::<OciManifest>().await else {
-        return false;
+    let manifest = match response.json::<OciManifest>().await {
+        Ok(manifest) => manifest,
+        Err(error) => {
+            warn!(reference, %error, "OCI golden manifest parse failed");
+            return false;
+        }
     };
     let Some(layer) = manifest
         .layers
@@ -484,9 +505,7 @@ async fn download_oci_golden(payload: &Path, reference: &str) -> bool {
         return false;
     };
     let tmp_payload = parent.join(format!(".tmp-golden-{}", uuid::Uuid::new_v4()));
-    if stream_golden_response(response, &tmp_payload, Some(layer.digest)).await
-        && tokio::fs::rename(&tmp_payload, payload).await.is_ok()
-    {
+    if stream_golden_response(response, &tmp_payload, payload, Some(layer.digest)).await {
         info!(
             reference,
             target = %payload.display(),
@@ -567,34 +586,51 @@ fn split_oci_reference(reference: &str) -> Option<(String, String, String)> {
     ))
 }
 
+/// zstd-decode the bare `+zstd` layer frame `compressed` into `payload`.
+///
+/// The published `application/vnd.preloop.smolmachine.v1+zstd` layer is a
+/// zstd frame wrapping the `.smolmachine` sidecar; `machine create --from`
+/// reads the sidecar container (stub + compressed assets + manifest +
+/// footer) directly, so the layer must be decoded before it is installed.
+fn decompress_golden_layer(compressed: &Path, payload: &Path) -> std::io::Result<()> {
+    let input = std::fs::File::open(compressed)?;
+    let mut output = std::fs::File::create(payload)?;
+    zstd::stream::copy_decode(input, &mut output)
+}
+
+/// Stream the OCI layer to a temporary file, verify its digest against the
+/// manifest descriptor, then zstd-decode it into the final payload. The
+/// digest check runs against the compressed bytes the layer was published
+/// under; only a digest-verified layer is ever decompressed.
 async fn stream_golden_response(
     response: reqwest::Response,
-    tmp_payload: &Path,
+    compressed_tmp: &Path,
+    payload: &Path,
     expected_sha256: Option<String>,
 ) -> bool {
-    let mut file = match tokio::fs::File::create(tmp_payload).await {
+    let mut file = match tokio::fs::File::create(compressed_tmp).await {
         Ok(file) => file,
         Err(_) => return false,
     };
     let mut stream = response.bytes_stream();
     while let Some(chunk) = stream.next().await {
         let Ok(chunk) = chunk else {
-            let _ = tokio::fs::remove_file(tmp_payload).await;
+            let _ = tokio::fs::remove_file(compressed_tmp).await;
             return false;
         };
         if file.write_all(&chunk).await.is_err() {
-            let _ = tokio::fs::remove_file(tmp_payload).await;
+            let _ = tokio::fs::remove_file(compressed_tmp).await;
             return false;
         }
     }
     if file.flush().await.is_err() {
-        let _ = tokio::fs::remove_file(tmp_payload).await;
+        let _ = tokio::fs::remove_file(compressed_tmp).await;
         return false;
     }
     drop(file);
     if let Some(expected) = expected_sha256 {
         let digest = match tokio::task::spawn_blocking({
-            let path = tmp_payload.to_owned();
+            let path = compressed_tmp.to_owned();
             move || {
                 use sha2::{Digest, Sha256};
                 let mut hasher = Sha256::new();
@@ -614,7 +650,25 @@ async fn stream_golden_response(
             return false;
         }
     }
-    true
+    let decoded = tokio::task::spawn_blocking({
+        let compressed = compressed_tmp.to_owned();
+        let target = payload.to_owned();
+        move || decompress_golden_layer(&compressed, &target)
+    })
+    .await;
+    let _ = tokio::fs::remove_file(compressed_tmp).await;
+    match decoded {
+        Ok(Ok(())) => true,
+        Ok(Err(error)) => {
+            warn!(%error, target = %payload.display(), "OCI golden layer decompression failed");
+            let _ = tokio::fs::remove_file(payload).await;
+            false
+        }
+        Err(_) => {
+            let _ = tokio::fs::remove_file(payload).await;
+            false
+        }
+    }
 }
 
 /// First whitespace-separated token of a `sha256sum`-style checksum file
@@ -4230,7 +4284,41 @@ chmod +x "$destination/bin/node"
             split_oci_reference(DEFAULT_GOLDEN_OCI_REF).expect("valid OCI reference");
         assert_eq!(registry, "ghcr.io");
         assert_eq!(repository, "preloopdev/preloop-golden");
-        assert_eq!(version, "ubuntu24-arm64-runner-large-latest");
+        // Immutable digest pin: changing the default must be a reviewed code
+        // change, not a registry retag.
+        assert!(
+            version.len() == "sha256:".len() + 64 && version.starts_with("sha256:"),
+            "expected a digest-pinned default, got `{version}`"
+        );
+    }
+
+    #[test]
+    fn oci_layer_deserializes_camel_case_media_type() {
+        let manifest: OciManifest = serde_json::from_str(
+            r#"{"layers":[{"digest":"sha256:00","mediaType":"application/vnd.preloop.smolmachine.v1+zstd"}]}"#,
+        )
+        .expect("standard OCI manifest must parse");
+        let layer = manifest
+            .layers
+            .into_iter()
+            .find(|layer| layer.media_type == "application/vnd.preloop.smolmachine.v1+zstd")
+            .expect("packed VM layer present");
+        assert_eq!(layer.digest, "sha256:00");
+    }
+
+    #[test]
+    fn golden_layer_decompression_roundtrip() {
+        let bytes: &[u8] = b"smolpack payload";
+        let compressed = zstd::stream::encode_all(bytes, 3).expect("compress");
+        let dir = std::env::temp_dir().join(format!("golden-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let compressed_path = dir.join("layer.zst");
+        let payload_path = dir.join("payload.smolmachine");
+        std::fs::write(&compressed_path, compressed).expect("write");
+        decompress_golden_layer(&compressed_path, &payload_path).expect("decode");
+        let decoded = std::fs::read(&payload_path).expect("read");
+        assert_eq!(decoded, bytes);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/crates/preloop-runner-client/src/main.rs
+++ b/crates/preloop-runner-client/src/main.rs
@@ -91,8 +91,13 @@ async fn main() -> anyhow::Result<()> {
     let native_api_token =
         env::var("PRELOOP_SYSTEM_TOKEN").unwrap_or_else(|_| "preloop-system-token".to_owned());
     let cli = Cli::parse();
+    let timeout_seconds = env::var("PRELOOP_CLIENT_TIMEOUT_SECONDS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(30);
     let http = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
+        .timeout(std::time::Duration::from_secs(timeout_seconds))
         .user_agent("preloop-runner-client")
         .build()?;
 
@@ -166,13 +171,13 @@ async fn main() -> anyhow::Result<()> {
                     .encode(canonical.as_os_str().to_string_lossy().as_bytes());
                 request = request.header("x-preloop-local-workspace", encoded);
             }
-            let response = request
-                .json(&submission)
-                .send()
-                .await?
-                .error_for_status()?
-                .text()
-                .await?;
+            let response = request.json(&submission).send().await?;
+            let status = response.status();
+            let body = response.text().await?;
+            if !status.is_success() {
+                anyhow::bail!("server rejected workflow submission ({status}): {body}");
+            }
+            let response = body;
             println!("{response}");
         }
         Command::Run { run_id } => {

--- a/crates/preloop-runner-client/src/main.rs
+++ b/crates/preloop-runner-client/src/main.rs
@@ -231,7 +231,7 @@ async fn main() -> anyhow::Result<()> {
             let reusable_workflows =
                 collect_reusable_workflows(workspace_root.as_deref(), &workflow).await?;
             let reusable_workflows =
-                resolve_remote_workflows(reusable_workflows, &workflow_yaml).await?;
+                resolve_remote_workflows(reusable_workflows, &workflow_yaml, &http).await?;
             let expanded =
                 preloop_gha_parser::expand_jobs_with_reusables(&parsed, &reusable_workflows)
                     .with_context(|| format!("expand workflow {}", workflow.display()))?;
@@ -328,10 +328,8 @@ fn same_file_path(left: &std::path::Path, right: &std::path::Path) -> bool {
 async fn resolve_remote_workflows(
     mut workflows: BTreeMap<String, String>,
     root_yaml: &str,
+    client: &reqwest::Client,
 ) -> anyhow::Result<BTreeMap<String, String>> {
-    let client = reqwest::Client::builder()
-        .user_agent("preloop-runner-client")
-        .build()?;
     let token = std::env::var("PRELOOP_GITHUB_TOKEN").ok();
     let mut queue = vec![(root_yaml.to_owned(), 0usize)];
     let mut visited = std::collections::BTreeSet::new();

--- a/crates/preloop-vm/src/lib.rs
+++ b/crates/preloop-vm/src/lib.rs
@@ -238,6 +238,12 @@ pub enum VmError {
         /// Operating-system error.
         source: std::io::Error,
     },
+    /// Failed to prepare the SmolVM runtime directories.
+    #[error("failed to prepare SmolVM runtime directories: {source}")]
+    RuntimeIo {
+        /// Operating-system error.
+        source: std::io::Error,
+    },
     /// SmolVM rejected an operation.
     #[error("smolvm {operation} failed with exit code {exit_code}: {message}")]
     Command {
@@ -490,7 +496,7 @@ impl SmolVmProvider {
     /// pack — not just machine creation.
     fn sandboxed_command(&self) -> Result<Command, VmError> {
         let mut command = self.command();
-        apply_smolvm_runtime_env_async(&mut command, Some(&self.binary));
+        apply_smolvm_runtime_env_async(&mut command, Some(&self.binary))?;
         apply_sandbox_env(&mut command, self.env_lookup)?;
         Ok(command)
     }
@@ -507,8 +513,9 @@ impl SmolVmProvider {
     /// forwarded unvalidated: on an invalid override they are removed, so a
     /// recovery command runs without sandbox variables (no VMM is spawned
     /// here, so nothing boots unconfined) rather than with garbage.
-    fn recovery_command(&self) -> Command {
+    fn recovery_command(&self) -> Result<Command, VmError> {
         let mut command = self.command();
+        apply_smolvm_runtime_env_async(&mut command, Some(&self.binary))?;
         match sandbox_env_with(self.env_lookup) {
             Ok(sandbox) => {
                 for key in sandbox.remove {
@@ -524,7 +531,7 @@ impl SmolVmProvider {
                 command.env_remove("SMOLVM_CGROUP_ROOT");
             }
         }
-        command
+        Ok(command)
     }
 
     /// Run an operation that can never boot or restart a VMM, using
@@ -535,7 +542,7 @@ impl SmolVmProvider {
         operation: &'static str,
         args: &[String],
     ) -> Result<ExecOutput, VmError> {
-        let mut command = self.recovery_command();
+        let mut command = self.recovery_command()?;
         command
             .args(args)
             .stdin(Stdio::null())
@@ -1525,35 +1532,54 @@ pub fn apply_smolvm_sandbox_env(command: &mut std::process::Command) -> Result<(
     Ok(())
 }
 
+/// Preloop home the helper isolates SmolVM into: the explicit `PRELOOP_HOME`,
+/// else `<HOME>/.preloop` (the CLI's `preloop_home()` default), else the
+/// bare `.preloop` relative directory.
+fn effective_preloop_home() -> Option<PathBuf> {
+    std::env::var_os("PRELOOP_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".preloop")))
+}
+
 fn smolvm_runtime_env(binary: Option<&Path>) -> Vec<(String, std::ffi::OsString)> {
     let host_home = std::env::var_os("HOME").map(PathBuf::from);
     let mut env = Vec::new();
-    if std::env::var_os("SMOLVM_DATA_DIR").is_none() {
-        if let Some(preloop_home) = std::env::var_os("PRELOOP_HOME") {
-            let preloop_home = PathBuf::from(preloop_home);
+    let explicit_data_dir = std::env::var_os("SMOLVM_DATA_DIR").map(PathBuf::from);
+    let data_dir = explicit_data_dir
+        .clone()
+        .or_else(|| effective_preloop_home().map(|home| home.join("smolvm")));
+    if explicit_data_dir.is_none() {
+        if let Some(data_dir) = &data_dir {
             // SmolVM 1.8.x ignores SMOLVM_DATA_DIR on macOS and derives its
             // registry from HOME. Keep each Preloop home isolated while still
             // leaving an explicit operator registry untouched.
             #[cfg(target_os = "macos")]
-            env.push((
-                "HOME".to_owned(),
-                preloop_home.join("smolvm-home").into_os_string(),
-            ));
+            if let Some(preloop_home) = effective_preloop_home() {
+                env.push((
+                    "HOME".to_owned(),
+                    preloop_home.join("smolvm-home").into_os_string(),
+                ));
+            }
             env.push((
                 "SMOLVM_DATA_DIR".to_owned(),
-                preloop_home.join("smolvm").into_os_string(),
+                data_dir.clone().into_os_string(),
             ));
         }
     }
 
     // HOME may be isolated above, so preserve the host installation assets
-    // explicitly for the child SmolVM process.
+    // explicitly for the child SmolVM process. Official installs keep the
+    // agent rootfs inside the SmolVM data directory, so probe that first,
+    // then the historical `~/.smolvm` location.
     if std::env::var_os("SMOLVM_AGENT_ROOTFS").is_none() {
-        if let Some(path) = host_home
-            .as_ref()
-            .map(|home| home.join(".smolvm/agent-rootfs"))
-            .filter(|path| path.is_dir())
-        {
+        let mut candidates = Vec::new();
+        if let Some(data_dir) = &data_dir {
+            candidates.push(data_dir.join("agent-rootfs"));
+        }
+        if let Some(home) = host_home.as_ref() {
+            candidates.push(home.join(".smolvm/agent-rootfs"));
+        }
+        if let Some(path) = candidates.into_iter().find(|path| path.is_dir()) {
             env.push(("SMOLVM_AGENT_ROOTFS".to_owned(), path.into_os_string()));
         }
     }
@@ -1606,16 +1632,53 @@ fn smolvm_runtime_env(binary: Option<&Path>) -> Vec<(String, std::ffi::OsString)
 /// fails at the Hypervisor.framework boundary. An explicit `SMOLVM_LIB_DIR`
 /// wins; otherwise use the resolved binary's sibling directory or the
 /// standard per-user install location.
-pub fn apply_smolvm_runtime_env(command: &mut std::process::Command, binary: Option<&Path>) {
-    for (key, value) in smolvm_runtime_env(binary) {
-        command.env(key, value);
+/// Directories derived from the effective Preloop home that must exist before
+/// SmolVM starts (it does not create a missing data dir itself).
+fn runtime_dirs_to_create() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if std::env::var_os("SMOLVM_DATA_DIR").is_none() {
+        if let Some(home) = effective_preloop_home() {
+            dirs.push(home.join("smolvm"));
+            #[cfg(target_os = "macos")]
+            dirs.push(home.join("smolvm-home"));
+        }
     }
+    dirs
 }
 
-fn apply_smolvm_runtime_env_async(command: &mut Command, binary: Option<&Path>) {
+/// Add the bundled SmolVM libraries to boot-capable child commands on macOS.
+///
+/// The macOS release binary dynamically loads `libkrunfw.5.dylib` from the
+/// adjacent `.smolvm/lib` directory, but the binary has no rpath and the
+/// bootstrap process does not inherit a loader path from the installer.
+/// Without this, `machine create` succeeds and every subsequent VM start
+/// fails at the Hypervisor.framework boundary. An explicit `SMOLVM_LIB_DIR`
+/// wins; otherwise use the resolved binary's sibling directory or the
+/// standard per-user install location.
+pub fn apply_smolvm_runtime_env(
+    command: &mut std::process::Command,
+    binary: Option<&Path>,
+) -> Result<(), VmError> {
+    for dir in runtime_dirs_to_create() {
+        std::fs::create_dir_all(&dir).map_err(|source| VmError::RuntimeIo { source })?;
+    }
     for (key, value) in smolvm_runtime_env(binary) {
         command.env(key, value);
     }
+    Ok(())
+}
+
+fn apply_smolvm_runtime_env_async(
+    command: &mut Command,
+    binary: Option<&Path>,
+) -> Result<(), VmError> {
+    for dir in runtime_dirs_to_create() {
+        std::fs::create_dir_all(&dir).map_err(|source| VmError::RuntimeIo { source })?;
+    }
+    for (key, value) in smolvm_runtime_env(binary) {
+        command.env(key, value);
+    }
+    Ok(())
 }
 
 /// Apply the sandbox policy to a provider command.

--- a/crates/preloop-vm/src/lib.rs
+++ b/crates/preloop-vm/src/lib.rs
@@ -490,6 +490,7 @@ impl SmolVmProvider {
     /// pack — not just machine creation.
     fn sandboxed_command(&self) -> Result<Command, VmError> {
         let mut command = self.command();
+        apply_smolvm_runtime_env_async(&mut command, Some(&self.binary));
         apply_sandbox_env(&mut command, self.env_lookup)?;
         Ok(command)
     }
@@ -1522,6 +1523,99 @@ pub fn apply_smolvm_sandbox_env(command: &mut std::process::Command) -> Result<(
         command.env(key, value);
     }
     Ok(())
+}
+
+fn smolvm_runtime_env(binary: Option<&Path>) -> Vec<(String, std::ffi::OsString)> {
+    let host_home = std::env::var_os("HOME").map(PathBuf::from);
+    let mut env = Vec::new();
+    if std::env::var_os("SMOLVM_DATA_DIR").is_none() {
+        if let Some(preloop_home) = std::env::var_os("PRELOOP_HOME") {
+            let preloop_home = PathBuf::from(preloop_home);
+            // SmolVM 1.8.x ignores SMOLVM_DATA_DIR on macOS and derives its
+            // registry from HOME. Keep each Preloop home isolated while still
+            // leaving an explicit operator registry untouched.
+            #[cfg(target_os = "macos")]
+            env.push((
+                "HOME".to_owned(),
+                preloop_home.join("smolvm-home").into_os_string(),
+            ));
+            env.push((
+                "SMOLVM_DATA_DIR".to_owned(),
+                preloop_home.join("smolvm").into_os_string(),
+            ));
+        }
+    }
+
+    // HOME may be isolated above, so preserve the host installation assets
+    // explicitly for the child SmolVM process.
+    if std::env::var_os("SMOLVM_AGENT_ROOTFS").is_none() {
+        if let Some(path) = host_home
+            .as_ref()
+            .map(|home| home.join(".smolvm/agent-rootfs"))
+            .filter(|path| path.is_dir())
+        {
+            env.push(("SMOLVM_AGENT_ROOTFS".to_owned(), path.into_os_string()));
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let mut candidates = Vec::new();
+        if let Some(path) = std::env::var_os("SMOLVM_LIB_DIR") {
+            candidates.push(PathBuf::from(path));
+        }
+        if let Some(binary) = binary {
+            let resolved = binary
+                .canonicalize()
+                .ok()
+                .or_else(|| binary.is_absolute().then(|| binary.to_path_buf()));
+            if let Some(parent) = resolved.and_then(|path| path.parent().map(Path::to_path_buf)) {
+                candidates.push(parent.join("lib"));
+            }
+        }
+        if let Some(home) = host_home {
+            candidates.push(home.join(".smolvm/lib"));
+        }
+        let Some(lib_dir) = candidates
+            .into_iter()
+            .find(|path| path.join("libkrunfw.5.dylib").is_file())
+        else {
+            return env;
+        };
+        let mut paths = vec![lib_dir];
+        if let Some(existing) = std::env::var_os("DYLD_LIBRARY_PATH") {
+            paths.extend(std::env::split_paths(&existing));
+        }
+        if let Ok(loader_path) = std::env::join_paths(paths) {
+            env.push(("DYLD_LIBRARY_PATH".to_owned(), loader_path));
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = binary;
+    }
+    env
+}
+
+/// Add the bundled SmolVM libraries to boot-capable child commands on macOS.
+///
+/// The macOS release binary dynamically loads `libkrunfw.5.dylib` from the
+/// adjacent `.smolvm/lib` directory, but the binary has no rpath and the
+/// bootstrap process does not inherit a loader path from the installer.
+/// Without this, `machine create` succeeds and every subsequent VM start
+/// fails at the Hypervisor.framework boundary. An explicit `SMOLVM_LIB_DIR`
+/// wins; otherwise use the resolved binary's sibling directory or the
+/// standard per-user install location.
+pub fn apply_smolvm_runtime_env(command: &mut std::process::Command, binary: Option<&Path>) {
+    for (key, value) in smolvm_runtime_env(binary) {
+        command.env(key, value);
+    }
+}
+
+fn apply_smolvm_runtime_env_async(command: &mut Command, binary: Option<&Path>) {
+    for (key, value) in smolvm_runtime_env(binary) {
+        command.env(key, value);
+    }
 }
 
 /// Apply the sandbox policy to a provider command.

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -260,7 +260,7 @@ steps.
 | `PRELOOP_USE_FORK` | Run the pool as forked microVMs (default true with a packed golden) |
 | `PRELOOP_USE_PACKED_GOLDEN` | Use a release or locally cached packed golden (default on; set `false` for cold OCI provisioning) |
 | `PRELOOP_GOLDEN_URL` | Override the packed golden URL; checksum URL is this value plus `.sha256` |
-| `PRELOOP_GOLDEN_OCI_REF` | Override the default public OCI packed golden reference (arm64 default: `ghcr.io/preloopdev/preloop-golden:ubuntu24-arm64-runner-large-latest`) |
+| `PRELOOP_GOLDEN_OCI_REF` | Override the default public OCI packed golden reference (arm64 default: `ghcr.io/preloopdev/preloop-golden@sha256:a2f7caf367e19efa4cb2d6f32a7093db8fae79e1b1525b65ac1190c1d2b44361`) |
 | `PRELOOP_RUNNER_BASE_IMAGE` | Override the digest-pinned Ubuntu base identity at serve time; set it with `PRELOOP_GOLDEN_URL` for a custom packed golden |
 | `PRELOOP_VERIFY_BASE_IMAGE` / `PRELOOP_VERIFY_BASE_IMAGE_REPO` | Require a digest-pinned OCI base's GitHub attestation and Cosign signature before `build-golden` |
 | `PRELOOP_REQUIRE_BASE_DIGEST` | Reject mutable registry tags during `build-golden` (used by release provenance builds) |

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -260,6 +260,7 @@ steps.
 | `PRELOOP_USE_FORK` | Run the pool as forked microVMs (default true with a packed golden) |
 | `PRELOOP_USE_PACKED_GOLDEN` | Use a release or locally cached packed golden (default on; set `false` for cold OCI provisioning) |
 | `PRELOOP_GOLDEN_URL` | Override the packed golden URL; checksum URL is this value plus `.sha256` |
+| `PRELOOP_GOLDEN_OCI_REF` | Override the default public OCI packed golden reference (arm64 default: `ghcr.io/preloopdev/preloop-golden:ubuntu24-arm64-runner-large-latest`) |
 | `PRELOOP_RUNNER_BASE_IMAGE` | Override the digest-pinned Ubuntu base identity at serve time; set it with `PRELOOP_GOLDEN_URL` for a custom packed golden |
 | `PRELOOP_VERIFY_BASE_IMAGE` / `PRELOOP_VERIFY_BASE_IMAGE_REPO` | Require a digest-pinned OCI base's GitHub attestation and Cosign signature before `build-golden` |
 | `PRELOOP_REQUIRE_BASE_DIGEST` | Reject mutable registry tags during `build-golden` (used by release provenance builds) |

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -136,6 +136,7 @@ Client-side (`preloop` CLI): `PRELOOP_URL` (default `http://127.0.0.1:9090`) and
 | `PRELOOP_USE_FORK` | — | Fork machines from a prepared golden instead of building each |
 | `PRELOOP_USE_PACKED_GOLDEN` | `true` | Use a release or locally cached packed golden for on-demand and pooled runners |
 | `PRELOOP_GOLDEN_URL` | release asset | Packed golden URL; the optional checksum is fetched from the same URL plus `.sha256` |
+| `PRELOOP_GOLDEN_OCI_REF` | official arm64 GHCR artifact | OCI packed golden reference downloaded automatically on arm64 hosts |
 | `PRELOOP_RUNNER_BUNDLE` | — | Directory of runner binaries mounted into guests |
 | `PRELOOP_RUNNER_EXTERNALS` | temp dir | Host-side Node externals directory |
 | `PRELOOP_RUNNER_BASE_IMAGE` | digest-pinned Ubuntu 24.04 | OCI base identity for `runs-on` resolution; set it with `PRELOOP_GOLDEN_URL` for a custom packed golden |

--- a/justfile
+++ b/justfile
@@ -127,6 +127,11 @@ conform-server-deep:
     cargo zigbuild -p preloop-runner-server --release --target aarch64-unknown-linux-musl
     bash ./scripts/conform-server-deep.sh
 
+# Run the five-repository campaign against the pinned 9GB official runner
+# golden. Override PRELOOP_GOLDEN_ARTIFACT when the cache lives elsewhere.
+conform-5repos:
+    bash ./benchmarks/real-world/conformance-5repos.sh
+
 # Compare workflow/job status responses from the official and preloop runners.
 conform-runner-light:
     python3 benchmarks/real-world/runner-conformance.py --mode light


### PR DESCRIPTION
## What

Makes the packed microVM golden built from the official GitHub-hosted
runner image the default provisioning source on arm64 hosts.

- **OCI artifact default**: on aarch64, `download_prebaked_golden` now pulls
  `ghcr.io/preloopdev/preloop-golden:ubuntu24-arm64-runner-large-latest`
  (a `.smolmachine` payload of the official ubuntu24-arm64 runner image)
  before falling back to the release asset. Bearer-token registry auth,
  layer-digest verification, `PRELOOP_GOLDEN_OCI_REF` override.
- **preloop-vm / preloop-cli**: apply the SmolVM runtime env (isolated
  `HOME`/`SMOLVM_DATA_DIR` per preloop home, `SMOLVM_AGENT_ROOTFS`
  preservation, macOS `DYLD_LIBRARY_PATH` for `libkrunfw.5.dylib`) to
  sandboxed provider commands and the CLI bootstrap path so packed-golden
  VMs boot with the bundled libraries.
- **preloop-runner-client**: `PRELOOP_CLIENT_TIMEOUT_SECONDS` override;
  non-2xx submission responses surface the server body instead of dropping it.
- **benchmarks**: `conformance-5repos.sh` campaign runner against the
  official runner golden plus a `just conform-5repos` target.
- **docs**: `PRELOOP_GOLDEN_OCI_REF` in cli_reference and self-hosting.

## Verification

- `just test-ci` (fmt + clippy + workspace tests + runner-watch conformance):
  all green.
- `cargo check` of the touched crates against main: clean.
- CI submitted to the preloop control plane: run 18
  (`022e5b86-64ca-4b36-8554-f2c1c5227df8`) — rust + property-tests-fast
  in progress.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default arm64 golden source to the public OCI packed VM artifact. Previously, arm64 hosts only downloaded the packed golden from a release URL; now `preloop-orchestrator` first pulls `ghcr.io/preloopdev/preloop-golden@sha256:a2f7caf367e19efa4cb2d6f32a7093db8fae79e1b1525b65ac1190c1d2b44361`, verifies and decompresses the layer, and falls back to the release asset. This aligns with the official GitHub-hosted runner image and improves reliability.

- `preloop-orchestrator`: adds OCI fetch with Bearer-token auth negotiation, fixes manifest `mediaType` parsing, verifies the layer’s sha256 against the descriptor, zstd-decompresses the `application/vnd.preloop.smolmachine.v1+zstd` payload, writes atomically, and uses a digest-pinned default. Override with `PRELOOP_GOLDEN_OCI_REF`; `PRELOOP_GOLDEN_URL` (non-empty) forces a URL and disables the OCI default. Adds `zstd` dependency.
- `preloop-vm` and `preloop-cli`: apply the SmolVM runtime env to sandboxed and recovery commands and CLI bootstrap so packed-golden VMs boot with bundled libs. Isolates `HOME`/`SMOLVM_DATA_DIR` per `PRELOOP_HOME`, creates required dirs, preserves `SMOLVM_AGENT_ROOTFS`, and on macOS adds `DYLD_LIBRARY_PATH` for `libkrunfw.5.dylib`.
- `preloop-runner-client`: `PRELOOP_CLIENT_TIMEOUT_SECONDS` configures HTTP timeouts; non-2xx submission responses include the server body; remote workflow fetches reuse the client to avoid hangs.
- Benchmarks: add five-repo conformance script against the official runner golden and `just conform-5repos`.
- Docs: document `PRELOOP_GOLDEN_OCI_REF`.

**Rollout**
- No migration required. On arm64, ensure egress to `ghcr.io`. Set `PRELOOP_GOLDEN_URL` to keep using a release asset, or adjust the OCI source via `PRELOOP_GOLDEN_OCI_REF`.

<sup>Written for commit 1e9fbcbb577a6c9896783d1b57c176735b7350db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic arm64 packed-VM image downloads from a configurable OCI registry, with verification and release-asset fallback.
  * Added configurable client request timeouts through `PRELOOP_CLIENT_TIMEOUT_SECONDS`.
  * Added a command for running real-world conformance checks across five repositories.
* **Bug Fixes**
  * Improved runtime setup reliability across supported environments, including macOS.
  * Workflow submission errors now include HTTP status and response details.
* **Documentation**
  * Documented OCI image configuration and arm64 runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->