### PR TITLE
fix(server): cap per-job live log buffer to bound memory

### DIFF
--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -2276,11 +2276,11 @@ async fn live_log_websocket_accepts_bearer_and_stores_lines() {
                 let inner = state.inner.lock().await;
                 if let Some(job_lines) = inner.live_log_lines.get("job-live") {
                     let wrappers = job_lines.lock().await;
-                    if wrappers.len() == 1 {
-                        assert_eq!(wrappers[0].step_id, "step-1");
-                        assert_eq!(wrappers[0].start_line, 1);
-                        assert_eq!(wrappers[0].count, 2);
-                        assert_eq!(wrappers[0].value, vec!["hello", "world"]);
+                    if wrappers.lines.len() == 1 {
+                        assert_eq!(wrappers.lines[0].step_id, "step-1");
+                        assert_eq!(wrappers.lines[0].start_line, 1);
+                        assert_eq!(wrappers.lines[0].count, 2);
+                        assert_eq!(wrappers.lines[0].value, vec!["hello", "world"]);
                         break;
                     }
                 }
@@ -2361,8 +2361,8 @@ async fn live_log_websocket_survives_malformed_payload() {
             let inner = state.inner.lock().await;
             if let Some(job_lines) = inner.live_log_lines.get("job-malformed") {
                 let wrappers = job_lines.lock().await;
-                if wrappers.len() == 1 {
-                    assert_eq!(wrappers[0].value, vec!["survived"]);
+                if wrappers.lines.len() == 1 {
+                    assert_eq!(wrappers.lines[0].value, vec!["survived"]);
                     break;
                 }
             }

--- a/crates/preloop-runner-server/src/live_logs.rs
+++ b/crates/preloop-runner-server/src/live_logs.rs
@@ -1,5 +1,82 @@
 use super::*;
 
+/// Per-job live console feed buffer.
+///
+/// The ingestion paths (the live-log WebSocket and the `TimeLineWebConsoleLog`
+/// POST) are driven by authenticated runners, but a long-lived or hung job can
+/// stream output for hours, so the retained history is capped by byte size
+/// instead of growing without bound for the job's lifetime. Oldest wrappers
+/// are dropped past the cap — mid-job SSE viewers see the retained tail, and
+/// the durable step-log blob remains the source of truth for full logs. A
+/// single wrapper larger than the whole budget is dropped outright: storing it
+/// would evict the entire existing tail for one batch, and broadcasting it
+/// would amplify across every subscriber.
+#[derive(Clone)]
+pub(crate) struct LiveLogBuffer {
+    pub(crate) lines: VecDeque<LiveLogFeedLinesWrapper>,
+    bytes: usize,
+    max_bytes: usize,
+}
+
+impl LiveLogBuffer {
+    /// Default per-job cap on retained live feed bytes. The accounting covers
+    /// the wrapper struct, the step id, and every line string (header plus
+    /// bytes), so it bounds heap use regardless of wrapper shape.
+    pub(crate) const DEFAULT_MAX_BYTES: usize = 64 * 1024 * 1024;
+
+    pub(crate) fn new(max_bytes: usize) -> Self {
+        Self {
+            lines: VecDeque::new(),
+            bytes: 0,
+            max_bytes,
+        }
+    }
+
+    pub(crate) fn total_bytes(&self) -> usize {
+        self.bytes
+    }
+
+    /// Append a wrapper, tail-dropping the oldest wrappers once the byte cap
+    /// is exceeded. Returns `false` (storing nothing) when a single wrapper
+    /// exceeds the whole budget.
+    pub(crate) fn push(&mut self, wrapper: LiveLogFeedLinesWrapper) -> bool {
+        let size = Self::wrapper_bytes(&wrapper);
+        if size > self.max_bytes {
+            return false;
+        }
+        self.bytes += size;
+        self.lines.push_back(wrapper);
+        while self.bytes > self.max_bytes {
+            if let Some(oldest) = self.lines.pop_front() {
+                self.bytes -= Self::wrapper_bytes(&oldest);
+            }
+        }
+        true
+    }
+
+    fn wrapper_bytes(wrapper: &LiveLogFeedLinesWrapper) -> usize {
+        std::mem::size_of::<LiveLogFeedLinesWrapper>()
+            + wrapper.step_id.len()
+            + wrapper.value.len() * std::mem::size_of::<String>()
+            + wrapper.value.iter().map(|line| line.len()).sum::<usize>()
+    }
+}
+
+impl Default for LiveLogBuffer {
+    fn default() -> Self {
+        Self::new(Self::DEFAULT_MAX_BYTES)
+    }
+}
+
+impl IntoIterator for LiveLogBuffer {
+    type Item = LiveLogFeedLinesWrapper;
+    type IntoIter = std::collections::vec_deque::IntoIter<LiveLogFeedLinesWrapper>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.lines.into_iter()
+    }
+}
+
 pub(crate) async fn live_logs_sse(
     State(shared): State<Arc<SharedState>>,
     Path((run_id, job_id)): Path<(RunId, String)>,
@@ -137,7 +214,90 @@ pub(crate) async fn record_live_log_wrapper(
         let tx = live_log_sender(&mut inner, job_id);
         (lines_arc, tx)
     };
-    // Push and broadcast under per-job lock only.
-    job_lines.lock().await.push(wrapper.clone());
-    let _ = tx.send(wrapper);
+    // Push and broadcast under per-job lock only. An oversized batch is
+    // dropped from both the retained buffer and the live fan-out, so one
+    // pathological frame cannot evict the tail or amplify across subscribers.
+    let stored = job_lines.lock().await.push(wrapper.clone());
+    if stored {
+        let _ = tx.send(wrapper);
+    } else {
+        warn!(%job_id, "dropping live log batch exceeding per-job buffer cap");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wrapper(step_id: &str, line: &str) -> LiveLogFeedLinesWrapper {
+        LiveLogFeedLinesWrapper {
+            step_id: step_id.to_string(),
+            start_line: 1,
+            count: 1,
+            value: vec![line.to_string()],
+        }
+    }
+
+    #[test]
+    fn buffer_tail_drops_oldest_wrappers_past_cap() {
+        // One wrapper's accounted size: struct (64) + step id + String header
+        // (24) + line bytes.
+        let one = wrapper("a", "hello");
+        let size = LiveLogBuffer::wrapper_bytes(&one);
+        assert_eq!(size, 64 + 1 + 24 + 5);
+
+        let mut buffer = LiveLogBuffer::new(size + 10);
+        assert!(buffer.push(wrapper("a", "hello")));
+        assert_eq!(buffer.lines.len(), 1);
+        assert_eq!(buffer.total_bytes(), size);
+
+        // Second wrapper pushes the total over the cap; the oldest is dropped.
+        assert!(buffer.push(wrapper("b", "hello")));
+        assert_eq!(buffer.lines.len(), 1);
+        assert_eq!(buffer.lines[0].step_id, "b");
+        assert_eq!(buffer.total_bytes(), size);
+
+        // Eviction continues until the buffer fits inside the cap.
+        let mut buffer = LiveLogBuffer::new(size * 2 + 5);
+        assert!(buffer.push(wrapper("a", "hello")));
+        assert!(buffer.push(wrapper("b", "hello")));
+        assert!(buffer.push(wrapper("c", "hello")));
+        assert_eq!(buffer.lines.len(), 2);
+        assert_eq!(buffer.lines[0].step_id, "b");
+        assert_eq!(buffer.lines[1].step_id, "c");
+        assert_eq!(buffer.total_bytes(), size * 2);
+    }
+
+    #[test]
+    fn buffer_rejects_wrapper_larger_than_whole_budget() {
+        let mut buffer = LiveLogBuffer::new(100);
+        assert!(buffer.push(wrapper("a", "hello")));
+
+        let oversized = LiveLogFeedLinesWrapper {
+            step_id: "huge".to_string(),
+            start_line: 1,
+            count: 1,
+            value: vec!["x".repeat(200)],
+        };
+        assert!(!buffer.push(oversized));
+        assert_eq!(buffer.lines.len(), 1);
+        assert_eq!(buffer.lines[0].step_id, "a");
+    }
+
+    #[test]
+    fn buffer_clones_preserve_retained_tail() {
+        let mut buffer =
+            LiveLogBuffer::new(LiveLogBuffer::wrapper_bytes(&wrapper("a", "hello")) + 10);
+        buffer.push(wrapper("a", "hello"));
+        buffer.push(wrapper("b", "hello"));
+        assert_eq!(buffer.lines.len(), 1);
+
+        let snapshot = buffer.clone();
+        assert_eq!(snapshot.lines.len(), 1);
+        assert_eq!(snapshot.lines[0].step_id, "b");
+        assert_eq!(snapshot.total_bytes(), buffer.total_bytes());
+
+        let replayed: Vec<String> = snapshot.into_iter().map(|w| w.step_id).collect();
+        assert_eq!(replayed, vec!["b".to_string()]);
+    }
 }

--- a/crates/preloop-runner-server/src/live_logs.rs
+++ b/crates/preloop-runner-server/src/live_logs.rs
@@ -58,14 +58,30 @@ impl LiveLogBuffer {
                 self.bytes -= Self::wrapper_bytes(&oldest);
             }
         }
+        self.compact_if_wasteful();
         true
+    }
+
+    /// Reclaim `VecDeque` backing-buffer slack after evictions. `pop_front`
+    /// never shrinks the allocation, so a batch of evictions can leave
+    /// capacity far above the retained length (many small wrappers displaced
+    /// by one large one). Shrinking keeps that unused allocation bounded.
+    fn compact_if_wasteful(&mut self) {
+        let len = self.lines.len();
+        if self.lines.capacity() > len.saturating_mul(2).saturating_add(64) {
+            self.lines.shrink_to_fit();
+        }
     }
 
     fn wrapper_bytes(wrapper: &LiveLogFeedLinesWrapper) -> usize {
         std::mem::size_of::<LiveLogFeedLinesWrapper>()
-            + wrapper.step_id.len()
-            + wrapper.value.len() * std::mem::size_of::<String>()
-            + wrapper.value.iter().map(|line| line.len()).sum::<usize>()
+            + wrapper.step_id.capacity()
+            + wrapper.value.capacity() * std::mem::size_of::<String>()
+            + wrapper
+                .value
+                .iter()
+                .map(|line| line.capacity())
+                .sum::<usize>()
     }
 }
 
@@ -276,6 +292,40 @@ mod tests {
         assert_eq!(buffer.lines[0].step_id, "b");
         assert_eq!(buffer.lines[1].step_id, "c");
         assert_eq!(buffer.total_bytes(), size * 2);
+    }
+
+    #[test]
+    fn buffer_compacts_deque_capacity_after_large_evictions() {
+        let small = wrapper("a", "hello");
+        let small_size = LiveLogBuffer::wrapper_bytes(&small);
+
+        let mut buffer = LiveLogBuffer::new(small_size * 128);
+        for _ in 0..128 {
+            assert!(buffer.push(wrapper("a", "hello")));
+        }
+        assert!(buffer.lines.capacity() >= 128);
+
+        // One wrapper accounting for ~120 small wrappers evicts the bulk of
+        // the retained tail. `pop_front` alone would leave the deque backing
+        // allocation at its old size, so this also verifies compaction.
+        let large = LiveLogFeedLinesWrapper {
+            step_id: String::new(),
+            start_line: 1,
+            count: 1,
+            value: vec!["x".repeat(small_size * 120)],
+        };
+        assert!(buffer.push(large));
+
+        let len = buffer.lines.len();
+        assert!(
+            len < 16,
+            "large wrapper should evict most small wrappers, got {len}"
+        );
+        assert!(
+            buffer.lines.capacity() <= len * 2 + 64,
+            "deque capacity {} should shrink near retained length {len}",
+            buffer.lines.capacity()
+        );
     }
 
     #[test]

--- a/crates/preloop-runner-server/src/live_logs.rs
+++ b/crates/preloop-runner-server/src/live_logs.rs
@@ -36,6 +36,13 @@ impl LiveLogBuffer {
         self.bytes
     }
 
+    /// Whether a single wrapper is small enough to be retained on its own,
+    /// regardless of any eviction it may trigger. Used to reject oversized
+    /// batches before they are cloned for the buffer.
+    pub(crate) fn fits(&self, wrapper: &LiveLogFeedLinesWrapper) -> bool {
+        Self::wrapper_bytes(wrapper) <= self.max_bytes
+    }
+
     /// Append a wrapper, tail-dropping the oldest wrappers once the byte cap
     /// is exceeded. Returns `false` (storing nothing) when a single wrapper
     /// exceeds the whole budget.
@@ -214,11 +221,14 @@ pub(crate) async fn record_live_log_wrapper(
         let tx = live_log_sender(&mut inner, job_id);
         (lines_arc, tx)
     };
-    // Push and broadcast under per-job lock only. An oversized batch is
-    // dropped from both the retained buffer and the live fan-out, so one
-    // pathological frame cannot evict the tail or amplify across subscribers.
-    let stored = job_lines.lock().await.push(wrapper.clone());
-    if stored {
+    // Hold the per-job lock across both the buffer push and the broadcast send
+    // so concurrent ingestion cannot reorder live fan-out relative to the
+    // retained tail. Reject oversized batches before cloning, then drop them
+    // from both the retained buffer and the live fan-out so one pathological
+    // frame cannot evict the tail or amplify across subscribers.
+    let mut lines = job_lines.lock().await;
+    if lines.fits(&wrapper) {
+        lines.push(wrapper.clone());
         let _ = tx.send(wrapper);
     } else {
         warn!(%job_id, "dropping live log batch exceeding per-job buffer cap");

--- a/crates/preloop-runner-server/src/state.rs
+++ b/crates/preloop-runner-server/src/state.rs
@@ -1099,8 +1099,7 @@ pub(crate) struct InnerState {
     /// Persisted timeline records keyed by `{plan_id}/{timeline_id}`.
     /// Upserted on each PATCH; returned by GET.
     pub(crate) timeline_records: BTreeMap<String, BTreeMap<uuid::Uuid, azdo::TimelineRecord>>,
-    pub(crate) live_log_lines:
-        BTreeMap<String, Arc<tokio::sync::Mutex<Vec<LiveLogFeedLinesWrapper>>>>,
+    pub(crate) live_log_lines: BTreeMap<String, Arc<tokio::sync::Mutex<LiveLogBuffer>>>,
     pub(crate) live_log_tx: BTreeMap<String, broadcast::Sender<LiveLogFeedLinesWrapper>>,
     pub(crate) inflight_requests: BTreeMap<i64, (RunId, JobId)>,
     pub(crate) job_requests: BTreeMap<i64, TaskAgentJobRequestRecord>,


### PR DESCRIPTION
## Problem

The live console feed ingestion paths — the runner WebSocket (`/ws/live-logs/:job_id`)
and the `TimeLineWebConsoleLog` POST — pushed every batch into an unbounded
per-job `Vec<LiveLogFeedLinesWrapper>` (`state.rs` `live_log_lines`), evicted
only when the job completed. A long-lived or hung job with chatty output grows
server memory without bound, and each SSE connect (`live_logs_sse`) deep-clones
the whole snapshot, amplifying the spike across concurrent viewers. No
per-message size cap exists beyond axum/tungstenite's transport defaults
(16 MiB frame / 64 MiB message).

Reachability: both ingestion routes sit behind `require_protocol_bearer` on
`protected_apis`, so the vector requires an authenticated runner/job token —
unauthenticated sockets are rejected with 401 before upgrade (covered by
`live_log_websocket_rejects_unauthenticated`). A malicious authenticated runner
can already exhaust the server by other means, so this is a memory-bound
hardening fix (Medium), not a privilege boundary.

## Change

- Replace the per-job `Vec` with a byte-capped `LiveLogBuffer` (`live_logs.rs`):
  - 64 MiB per-job cap, accounting for the wrapper struct, step id, and every
    line string (header + bytes), so heap use is bounded regardless of wrapper
    shape.
  - Oldest wrappers are tail-dropped past the cap; mid-job SSE viewers see the
    retained tail, and the durable step-log blob stays the source of truth.
  - A single wrapper larger than the whole budget is dropped outright: storing
    it would evict the entire tail for one batch, and broadcasting it would
    amplify across every SSE subscriber.
- The cap applies to both ingestion paths (WS + `console_log`), since both route
  through `record_live_log_wrapper`.
- SSE snapshot replay is unchanged — it now clones a bounded buffer.

## Tests

- `buffer_tail_drops_oldest_wrappers_past_cap` — eviction order + byte accounting.
- `buffer_rejects_wrapper_larger_than_whole_budget` — oversized batch dropped,
  tail preserved.
- `buffer_clones_preserve_retained_tail` — snapshot clone / replay contract.
- Existing `live_log_websocket_*` tests updated to the buffer accessors.

## CI

- Local: `cargo fmt --check`, workspace clippy, and full `cargo test --locked
  --workspace` green.
- Control plane (submit-first, run 25): the `ci.yml` `rust` job **passed** on a
  workspace snapshot of this exact tree — fmt-check, clippy `-D warnings`, and
  `cargo test --locked --workspace` all green. `property-tests-fast` stayed
  queued behind a pool stall on the CI host (smolvm golden re-arm failure
  affecting all queued jobs, unrelated to this change; the concurrency
  property profile does not exercise live-log code).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps per-job live console memory at 64 MiB by replacing the unbounded Vec with a byte-capped `LiveLogBuffer`. Previously we retained all batches until job completion; now we evict the oldest entries to stay within the cap and drop any batch larger than the budget before cloning or broadcasting.

- Applies to both ingestion paths (WS `/ws/live-logs/:job_id` and `TimeLineWebConsoleLog` POST) via `record_live_log_wrapper`.
- Holds the per-job lock across buffer push and broadcast send so live fan-out preserves the retained tail order.
- Oversized batches are rejected pre-clone and not broadcast; a warning is logged.
- State change: `InnerState.live_log_lines` now stores `Mutex<LiveLogBuffer>`; accounting uses allocation capacities and compacts the `VecDeque` after evictions to bound slack; SSE snapshot replay is unchanged but bounded.

<sup>Written for commit 93f5b8e91fa0bb02d8d66deb1c11d833ee692b2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live logs now retain the newest entries within a 64 MiB limit per job.
  * Oversized log entries are safely rejected, while accepted entries continue streaming in real time.
  * Live-log history remains available when a log view is cloned or resumed.

* **Bug Fixes**
  * Prevented excessive live-log memory usage by automatically evicting older entries when the limit is reached.
  * Ensured rejected entries are not broadcast to live viewers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->