### PR TITLE
fix(orchestrator): create /dev/fuse for dockerd; runner parity refinements

### DIFF
--- a/crates/preloop-orchestrator/src/lib.rs
+++ b/crates/preloop-orchestrator/src/lib.rs
@@ -1304,15 +1304,30 @@ fn docker_start_command() -> Vec<String> {
              mkdir -p {DOCKER_DATA_ROOT}; \
              modprobe overlay >/dev/null 2>&1 || true; \
              modprobe fuse >/dev/null 2>&1 || true; \
+             # The krunfw guest kernel has fuse built in, but the VM boots
+             # /dev as a plain tmpfs with only the image's baked nodes, so
+             # /dev/fuse is missing and fuse-overlayfs (dockerd's fallback
+             # when its overlay probe fails) dies with 'fuse: device not
+             # found'). Create the node when the kernel supports fuse; dockerd
+             # then auto-picks fuse-overlayfs (CoW) on kernels whose overlay
+             # probe fails, and overlay2 on stock kernels where it succeeds.
+             if grep -q fuse /proc/filesystems; then \
+               [ -e /dev/fuse ] || mknod /dev/fuse c 10 229; \
+             fi; \
              mkdir -p /tmp/.preloop-ovprobe; \
              if mount -t overlay overlay -o lowerdir=/tmp:/usr /tmp/.preloop-ovprobe 2>/dev/null; then \
                umount /tmp/.preloop-ovprobe 2>/dev/null || true; \
-               DRIVER=overlay2; \
+               DRIVER=; \
              else \
-               DRIVER=vfs; \
+               # Overlay unusable (the krunfw kernel rejects the probe mount
+               # with EINVAL). Only force vfs when fuse is unavailable too —
+               # otherwise fuse-overlayfs auto-detects and works.
+               [ -e /dev/fuse ] || DRIVER=vfs; \
              fi; \
              rmdir /tmp/.preloop-ovprobe 2>/dev/null || true; \
-             printf '{{\"data-root\":\"{DOCKER_DATA_ROOT}\",\"storage-driver\":\"%s\"}}\\n' \"$DRIVER\" > /etc/docker/daemon.json; \
+             if [ -n \"$DRIVER\" ]; then \
+               printf '{{\"data-root\":\"{DOCKER_DATA_ROOT}\",\"storage-driver\":\"%s\"}}\\n' \"$DRIVER\" > /etc/docker/daemon.json; \
+             fi; \
              start_dockerd() {{ \
                rm -f /var/run/docker.pid; \
                dockerd >/var/log/dockerd.log 2>&1 & \


### PR DESCRIPTION
Follow-ups to the conformance campaign fixes (PR #151).

- **docker**: the krunfw guest kernel has fuse built in, but `/dev` boots as a plain tmpfs with no device nodes, so fuse-overlayfs (dockerd's fallback when its overlay probe fails) dies with `fuse: device not found`. The hook now creates `/dev/fuse` when the kernel lists fuse, letting dockerd auto-pick fuse-overlayfs (CoW) — on this kernel dockerd's overlay2 probe mount gets EINVAL and overlay2 is never viable, so the earlier fix was falling back to vfs. vfs is now forced only when overlay fails AND fuse is absent.
- **RLIMIT_NOFILE**: 524288 instead of 1048576 — systemd's built-in hard default, which is what GitHub's runner service inherits (exact parity).
- **guest PATH**: cargo bin dir matches the runner user (`/home/<user>/.cargo`) instead of hardcoded `/root/.cargo/bin`, which the unprivileged runner cannot stat (nodejs/ci EACCES).
- **multiarch shim**: add `libsystemd0:amd64` (valkey's x86_64 tarballs link `libsystemd.so.0`).

Verified live on the golden VM: hook creates `/dev/fuse`, dockerd 28.0.4 reports `Storage Driver: fuse-overlayfs`, and `hello-world` runs. 61 orchestrator tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Creates `/dev/fuse` in krun guests so `dockerd` can auto-select `fuse-overlayfs` and keep copy-on-write. Previously we forced `vfs` when the `overlay2` probe failed; now we only force `vfs` if overlay is unusable and `/dev/fuse` is missing, and we write `daemon.json` only when a driver is forced.

- Create `/dev/fuse` when the kernel supports fuse; leave `DRIVER` unset when the `overlay2` probe succeeds or fails but fuse exists; force `DRIVER=vfs` only when the probe fails and fuse is absent.
- Migration: if you rely on a custom Docker `data-root` without forcing a driver, it will no longer be written; configure it elsewhere.
- Runner parity: set `RLIMIT_NOFILE=524288`, add `/home/<user>/.cargo` to PATH, and install `libsystemd0:amd64` for the multiarch shim.

<sup>Written for commit 64d00559a8ad00c70e986716e8a1c0e6d27e1ac2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Create `/dev/fuse` for `dockerd` and stop forcing `overlay2`/`vfs` storage drivers
> - Creates `/dev/fuse` (via `mknod c 10 229`) when `/proc/filesystems` reports fuse support and the node is missing, in `docker_start_command` in [lib.rs](https://github.com/preloopdev/preloop/pull/152/files#diff-2d8f260146e957e725ce81cc61c0dd0be728bdb14854ddce65993faab9a7015c)
> - On successful overlay probe, no longer forces `overlay2`; leaves `DRIVER` empty so dockerd selects its own driver
> - On failed overlay probe, only forces `vfs` when `/dev/fuse` is absent; otherwise leaves `DRIVER` empty to allow dockerd's fallback
> - Writes `/etc/docker/daemon.json` (including `data-root` and `storage-driver`) only when `DRIVER` is non-empty
> - Risk: `data-root` is no longer written to `daemon.json` when no explicit driver is selected; any setup relying on a custom data-root without a forced driver will lose that configuration
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 64d0055. 1 file reviewed, 2 issues evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->