### PR TITLE
fix(orchestrator): create /dev/fuse for dockerd; runner parity refinements

### DIFF
--- a/crates/preloop-orchestrator/src/lib.rs
+++ b/crates/preloop-orchestrator/src/lib.rs
@@ -1304,15 +1304,30 @@ fn docker_start_command() -> Vec<String> {
              mkdir -p {DOCKER_DATA_ROOT}; \
              modprobe overlay >/dev/null 2>&1 || true; \
              modprobe fuse >/dev/null 2>&1 || true; \
+             # The krunfw guest kernel has fuse built in, but the VM boots
+             # /dev as a plain tmpfs with only the image's baked nodes, so
+             # /dev/fuse is missing and fuse-overlayfs (dockerd's fallback
+             # when its overlay probe fails) dies with 'fuse: device not
+             # found'). Create the node when the kernel supports fuse; dockerd
+             # then auto-picks fuse-overlayfs (CoW) on kernels whose overlay
+             # probe fails, and overlay2 on stock kernels where it succeeds.
+             if grep -q fuse /proc/filesystems; then \
+               [ -e /dev/fuse ] || mknod /dev/fuse c 10 229; \
+             fi; \
              mkdir -p /tmp/.preloop-ovprobe; \
              if mount -t overlay overlay -o lowerdir=/tmp:/usr /tmp/.preloop-ovprobe 2>/dev/null; then \
                umount /tmp/.preloop-ovprobe 2>/dev/null || true; \
-               DRIVER=overlay2; \
+               DRIVER=; \
              else \
-               DRIVER=vfs; \
+               # Overlay unusable (the krunfw kernel rejects the probe mount
+               # with EINVAL). Only force vfs when fuse is unavailable too —
+               # otherwise fuse-overlayfs auto-detects and works.
+               [ -e /dev/fuse ] || DRIVER=vfs; \
              fi; \
              rmdir /tmp/.preloop-ovprobe 2>/dev/null || true; \
-             printf '{{\"data-root\":\"{DOCKER_DATA_ROOT}\",\"storage-driver\":\"%s\"}}\\n' \"$DRIVER\" > /etc/docker/daemon.json; \
+             if [ -n \"$DRIVER\" ]; then \
+               printf '{{\"data-root\":\"{DOCKER_DATA_ROOT}\",\"storage-driver\":\"%s\"}}\\n' \"$DRIVER\" > /etc/docker/daemon.json; \
+             fi; \
              start_dockerd() {{ \
                rm -f /var/run/docker.pid; \
                dockerd >/var/log/dockerd.log 2>&1 & \


### PR DESCRIPTION
Follow-up to #151 (the conformance campaign fixes).

- **docker**: the krunfw guest kernel has fuse built in, but `/dev` boots as a plain tmpfs with no device nodes, so fuse-overlayfs (dockerd's fallback when its overlay probe fails) dies with `fuse: device not found`. The hook now creates `/dev/fuse` when the kernel lists fuse, letting dockerd auto-pick fuse-overlayfs (CoW) — on this kernel dockerd's overlay2 probe mount gets EINVAL and overlay2 is never viable, so the earlier approach fell back to vfs. vfs is now forced only when overlay fails AND fuse is absent. Combined with #151's `start_dockerd()` reap + `exit 1` retry.
- Verified live on the golden VM: hook creates `/dev/fuse`, dockerd 28.0.4 reports `Storage Driver: fuse-overlayfs`, and `hello-world` runs. Orchestrator tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable CoW storage for `dockerd` on krunfw guests by creating `/dev/fuse` and refining driver selection. Previously the overlay probe failed and we forced `vfs`; now we create `/dev/fuse` when the kernel supports fuse, let Docker auto-select `fuse-overlayfs`, and only force `vfs` when overlay fails and fuse is absent.

- Create `/dev/fuse` when `/proc/filesystems` lists fuse; this lets `dockerd` fall back to `fuse-overlayfs`.
- Do not force `"overlay2"` when the probe succeeds; leave the driver unset and only write `/etc/docker/daemon.json` when overriding. When the probe fails, set `vfs` only if `/dev/fuse` is missing.
- Runner parity: set `RLIMIT_NOFILE=524288`, use the runner user’s `~/.cargo/bin` in `PATH`, and add `libsystemd0:amd64` for x86_64 Valkey binaries.

<sup>Written for commit 24a742665082a056d08ba0091de2843281c63d1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Create `/dev/fuse` in `docker_start_command` and let dockerd auto-select storage driver
> - After `modprobe fuse`, the startup script now creates `/dev/fuse` via `mknod` when the kernel lists `fuse` in `/proc/filesystems` and the device is missing
> - On a successful overlay probe, `DRIVER` is cleared instead of forcing `overlay2`; on a failed probe, `vfs` is only forced when `/dev/fuse` is absent, otherwise `DRIVER` is left unset so dockerd can auto-select `fuse-overlayfs`
> - `/etc/docker/daemon.json` is now written only when a storage driver is explicitly chosen, instead of always
> - Risk: environments that relied on the always-present `daemon.json` with a forced driver may now see dockerd auto-select a different storage driver when `/dev/fuse` exists and overlay fails
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 24a7426.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker startup compatibility across environments with different kernel and storage capabilities.
  * Enabled FUSE support when available and preserved Docker’s automatic storage-driver selection.
  * Falls back to the `vfs` storage driver only when other supported options are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->