### PR TITLE
fix(store): drop undecodable workspace snapshots instead of bricking startup

### DIFF
--- a/crates/preloop-runner-server/src/store.rs
+++ b/crates/preloop-runner-server/src/store.rs
@@ -555,9 +555,18 @@ pub(crate) fn restore_run_record(cipher: &Envelope, blob: &[u8]) -> anyhow::Resu
             .unwrap_or_default()
             .to_owned();
         // `run_record_value` always writes the key (null when absent), so a
-        // JSON null must restore as `None` rather than fail to parse.
+        // JSON null must restore as `None` rather than fail to parse. A
+        // snapshot whose shape this binary no longer understands is dropped
+        // with a warning: the store is best-effort and one stale record must
+        // not brick startup (see `load_into`).
         run.workspace_snapshot = match object.get("workspace_snapshot") {
-            Some(value) if !value.is_null() => Some(serde_json::from_value(value.clone())?),
+            Some(value) if !value.is_null() => match serde_json::from_value(value.clone()) {
+                Ok(snapshot) => Some(snapshot),
+                Err(error) => {
+                    tracing::warn!(run_id = %run.run_id, %error, "dropping undecodable workspace snapshot on load");
+                    None
+                }
+            },
             _ => None,
         };
     }


### PR DESCRIPTION
## What

`restore_run_record` propagated a snapshot deserialize error, so `load_into` aborted and the server refused to start when the persisted store contained a `workspace_snapshot` written by an older binary (pre-#143, before `WorkspaceSnapshot` gained `tree_sha`).

## Evidence

Deploying current main (post-#143) onto the production store bricked every boot:

```
Error: missing field `tree_sha`
```

Store contract is best-effort: the session-key and broker-message restore paths already log-and-drop. This makes the snapshot path do the same.

## Change

- `restore_run_record`: `workspace_snapshot` deserialize failure → `tracing::warn!` + `None`, matching `restore_session_key` / broker-message handling.

Verified live: the patched binary boots against the affected store, logs 5 drop warnings, and serves.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents startup from failing when the store contains a workspace snapshot written by an older binary. Old behavior: a deserialize error in the workspace snapshot aborted load and bricked startup. New behavior: log a warning and drop the undecodable snapshot; the server starts and continues.

- Localized change in restore_run_record: wrap snapshot deserialization, warn with run_id on error, set the snapshot to None.
- Aligns the snapshot path with existing best-effort restore for session keys and broker messages.
- No migration required; expect warning logs like “dropping undecodable workspace snapshot on load” on first boot against stores with stale snapshots (e.g., missing tree_sha).

<sup>Written for commit b8f64a5f3ecd9d054e1137d2f5bef82695ca5c90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Runs now load successfully when their workspace snapshot cannot be decoded.
  * A warning is recorded, and the unavailable snapshot is treated as absent instead of blocking the run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->