### PR TITLE
fix(runner): sweep the process group on cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ Releases before v0.27.0 predate the changelog.
 
 ### Fixed
 
+- Cancelling a job no longer leaves background processes running on the
+  runner host. Cancellation signalled the process group through the child
+  handle, but the wait loop reaps the shell as soon as it exits, and a reaped
+  handle addresses nothing — so any descendant that outlived its shell was
+  never signalled. The leader's exit was also read as "the group is gone",
+  which returned success from the SIGINT stage and skipped the SIGTERM and
+  SIGKILL escalation entirely. A step that backgrounds a process ignoring
+  SIGINT/SIGTERM (databases, daemons, `nohup`) therefore survived
+  cancellation, was reparented to init, and accumulated on the host across
+  runs. The group id is now captured at spawn and the escalation runs against
+  the group itself, matching `ProcessInvoker.cs`, which kills the remaining
+  process tree. The same gap in the stream-drain grace path is fixed too.
+
 - SmolVM compatibility now comes from the central `versions.toml`
   `smolvm_min_version` pin. `preloop-cli` and `preloop-vm` compile the same
   floor, and `preloop update --ensure-runtime` installs the latest stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2056,6 +2056,7 @@ dependencies = [
  "glob",
  "hostname",
  "indexmap",
+ "nix",
  "parking_lot",
  "preloop-dap",
  "preloop-gha-expressions",

--- a/crates/preloop-runner/Cargo.toml
+++ b/crates/preloop-runner/Cargo.toml
@@ -49,6 +49,14 @@ serde_yaml.workspace = true
 regex.workspace = true
 zip.workspace = true
 
+# Cancellation signals the process group by id, because the child handle stops
+# addressing the group once the leader is reaped. `nix` is the safe wrapper:
+# the workspace forbids `unsafe`, which rules out raw `libc` calls. Already in
+# the tree via command-group. Unix-only — `nix` does not build on Windows,
+# where the `cfg(not(unix))` paths in `process.rs` apply instead.
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.27", features = ["signal", "process"] }
+
 [dev-dependencies]
 tempfile.workspace = true
 proptest.workspace = true

--- a/crates/preloop-runner/src/process.rs
+++ b/crates/preloop-runner/src/process.rs
@@ -122,6 +122,12 @@ pub async fn invoke<'a>(
         .group_spawn()
         .with_context(|| format!("spawning {program}"))?;
 
+    // Capture the group id now, while the handle still reports one: the wait
+    // loop below reaps the leader the moment it exits, and a reaped handle
+    // addresses nothing. The group outlives its leader for as long as any
+    // member is alive, so cancellation has to escalate against this id.
+    let group = process_group(&child);
+
     let stdout = child.inner().stdout.take();
     let stderr = child.inner().stderr.take();
 
@@ -177,9 +183,7 @@ pub async fn invoke<'a>(
                 }
                 _ = tokio::time::sleep_until(stream_deadline.unwrap_or_else(tokio::time::Instant::now)), if stream_deadline.is_some() => {
                     tracing::info!("Killing process group for {program} after redirected streams remained open for {:?}", STREAM_DRAIN_GRACE);
-                    if let Err(error) = child.kill().await {
-                        tracing::warn!("Failed to kill process group after stream drain timeout: {error}");
-                    }
+                    force_kill_group(&mut child, group, program).await;
                     forced_stream_close = true;
                     break;
                 }
@@ -200,9 +204,7 @@ pub async fn invoke<'a>(
                 },
                 _ = tokio::time::sleep_until(stream_deadline.unwrap_or_else(tokio::time::Instant::now)), if stream_deadline.is_some() => {
                     tracing::info!("Killing process group for {program} after redirected streams remained open for {:?}", STREAM_DRAIN_GRACE);
-                    if let Err(error) = child.kill().await {
-                        tracing::warn!("Failed to kill process group after stream drain timeout: {error}");
-                    }
+                    force_kill_group(&mut child, group, program).await;
                     forced_stream_close = true;
                     break;
                 }
@@ -212,7 +214,7 @@ pub async fn invoke<'a>(
     }
 
     if cancel_requested {
-        terminate_process_group(&mut child, program).await;
+        terminate_process_group(&mut child, group, program).await;
         drain_chunks(
             stdout_handle,
             stderr_handle,
@@ -389,21 +391,91 @@ async fn drain_chunks(
 
 // ── Process group termination ───────────────────────────────────────────
 
-async fn terminate_process_group(child: &mut AsyncGroupChild, program: &str) {
-    if graceful_signal(child, program, ProcessSignal::Interrupt, SIGINT_GRACE).await {
+async fn terminate_process_group(child: &mut AsyncGroupChild, group: ProcessGroup, program: &str) {
+    if graceful_signal(
+        child,
+        group,
+        program,
+        ProcessSignal::Interrupt,
+        SIGINT_GRACE,
+    )
+    .await
+    {
         tracing::info!("Process group for {program} exited after SIGINT");
         return;
     }
 
-    if graceful_signal(child, program, ProcessSignal::Terminate, SIGTERM_GRACE).await {
+    if graceful_signal(
+        child,
+        group,
+        program,
+        ProcessSignal::Terminate,
+        SIGTERM_GRACE,
+    )
+    .await
+    {
         tracing::info!("Process group for {program} exited after SIGTERM");
         return;
     }
 
     tracing::info!("Killing process group for {program} after SIGINT/SIGTERM grace expired");
-    if let Err(e) = child.kill().await {
-        tracing::warn!("Failed to kill process group: {e}");
+    force_kill_group(child, group, program).await;
+}
+
+/// Hard-kill every surviving member of the group, then reap the leader.
+///
+/// `AsyncGroupChild::kill` can only reach a leader that is still unreaped, so
+/// on its own it leaves a backgrounded descendant running — reparented to
+/// init and outliving the job that spawned it. Sweeping the group is what
+/// makes this match `ProcessInvoker.cs`, which kills the remaining tree.
+async fn force_kill_group(child: &mut AsyncGroupChild, group: ProcessGroup, program: &str) {
+    #[cfg(unix)]
+    if let Some(group) = group {
+        signal_group(group, Signal::SIGKILL);
     }
+    #[cfg(not(unix))]
+    let _ = group;
+
+    if let Err(error) = child.kill().await {
+        // Routine once the wait loop has already collected the leader.
+        tracing::debug!("Leader for {program} was already reaped: {error}");
+    }
+}
+
+/// The process group cancellation escalates against, or `None` when none can
+/// be addressed safely.
+#[cfg(unix)]
+type ProcessGroup = Option<nix::unistd::Pid>;
+#[cfg(not(unix))]
+type ProcessGroup = ();
+
+#[cfg(unix)]
+fn process_group(child: &AsyncGroupChild) -> ProcessGroup {
+    let id = i32::try_from(child.id()?).ok()?;
+    // `killpg` reads a non-positive id as "my own group", which would signal
+    // the runner itself. `group_spawn` makes the child its own group leader,
+    // so an id matching our own group means it never got one.
+    if id <= 0 || id == nix::unistd::getpgrp().as_raw() {
+        return None;
+    }
+    Some(nix::unistd::Pid::from_raw(id))
+}
+
+#[cfg(not(unix))]
+fn process_group(_child: &AsyncGroupChild) -> ProcessGroup {}
+
+/// Deliver `signal` to every member of `group`. A failure means the group has
+/// already drained, which is the outcome the caller wanted anyway.
+#[cfg(unix)]
+fn signal_group(group: nix::unistd::Pid, signal: Signal) {
+    let _ = nix::sys::signal::killpg(group, signal);
+}
+
+/// Whether any member of `group` is still alive. The null signal runs the
+/// existence and permission checks without delivering anything.
+#[cfg(unix)]
+fn group_alive(group: nix::unistd::Pid) -> bool {
+    nix::sys::signal::killpg(group, None).is_ok()
 }
 
 #[derive(Copy, Clone)]
@@ -414,11 +486,12 @@ enum ProcessSignal {
 
 async fn graceful_signal(
     child: &mut AsyncGroupChild,
+    group: ProcessGroup,
     program: &str,
     signal: ProcessSignal,
     timeout: Duration,
 ) -> bool {
-    if let Err(e) = send_signal(child, signal) {
+    if let Err(e) = send_signal(child, group, signal) {
         tracing::warn!(
             "Failed to send {} to process group for {program}: {e}",
             signal.name()
@@ -426,7 +499,7 @@ async fn graceful_signal(
         return false;
     }
 
-    wait_for_exit(child, timeout).await
+    wait_for_group_exit(child, group, timeout).await
 }
 
 impl ProcessSignal {
@@ -439,28 +512,71 @@ impl ProcessSignal {
 }
 
 #[cfg(unix)]
-fn send_signal(child: &AsyncGroupChild, signal: ProcessSignal) -> std::io::Result<()> {
+fn send_signal(
+    child: &AsyncGroupChild,
+    group: ProcessGroup,
+    signal: ProcessSignal,
+) -> std::io::Result<()> {
     let signal = match signal {
         ProcessSignal::Interrupt => Signal::SIGINT,
         ProcessSignal::Terminate => Signal::SIGTERM,
     };
+
+    // Address the group id directly: once the leader is reaped the child
+    // handle can no longer reach the members that are still running.
+    if let Some(group) = group {
+        signal_group(group, signal);
+        return Ok(());
+    }
+
     child.signal(signal)
 }
 
 #[cfg(not(unix))]
-fn send_signal(child: &mut AsyncGroupChild, _signal: ProcessSignal) -> std::io::Result<()> {
+fn send_signal(
+    child: &mut AsyncGroupChild,
+    _group: ProcessGroup,
+    _signal: ProcessSignal,
+) -> std::io::Result<()> {
     child.start_kill()
 }
 
-async fn wait_for_exit(child: &mut AsyncGroupChild, timeout: Duration) -> bool {
+/// Wait until the whole group has drained, not merely the leader.
+///
+/// The leader is reaped as soon as it exits so its zombie cannot keep the
+/// group artificially alive, and only then is the group probed. Treating the
+/// leader's exit as "the group is gone" is precisely what let a backgrounded
+/// descendant outlive cancellation.
+async fn wait_for_group_exit(
+    child: &mut AsyncGroupChild,
+    group: ProcessGroup,
+    timeout: Duration,
+) -> bool {
     let deadline = tokio::time::Instant::now() + timeout;
     loop {
-        match child.try_wait() {
-            Ok(Some(_)) => return true,
-            Ok(None) => {}
+        let leader_gone = match child.try_wait() {
+            Ok(status) => status.is_some(),
             Err(e) => {
                 tracing::warn!("Failed to poll process group status after signal: {e}");
                 return false;
+            }
+        };
+
+        #[cfg(unix)]
+        {
+            match group {
+                Some(group) if !group_alive(group) => return true,
+                // With no addressable group the leader's status is all there is.
+                None if leader_gone => return true,
+                _ => {}
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            let _ = group;
+            if leader_gone {
+                return true;
             }
         }
 
@@ -703,6 +819,19 @@ mod tests {
 
     #[tokio::test]
     async fn cancellation_interrupts_background_child_after_shell_exit() {
+        // The shell exits within a millisecond, so cancellation always lands
+        // after the leader has been reaped, and the backgrounded child ignores
+        // both graceful signals — SIGKILL against the group is the only thing
+        // that can reap it. Assert the child actually died rather than
+        // trusting the error string: a survivor is reparented to init and
+        // silently outlives the job.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pid_path = dir.path().join("background.pid");
+        let script = format!(
+            "(trap '' TERM INT; while :; do sleep 1; done) & echo $! > {}; echo ready",
+            pid_path.display()
+        );
+
         let (cancel_tx, cancel_rx) = watch::channel(false);
         let cancel_task = tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(150)).await;
@@ -710,13 +839,10 @@ mod tests {
         });
 
         let result = tokio::time::timeout(
-            Duration::from_secs(2),
+            Duration::from_secs(5),
             invoke(
                 "sh",
-                &[
-                    "-c",
-                    "(trap '' TERM; while :; do sleep 1; done) & echo ready",
-                ],
+                &["-c", &script],
                 Path::new("."),
                 &HashMap::new(),
                 None,
@@ -732,6 +858,26 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("process cancelled"));
+
+        let pid = nix::unistd::Pid::from_raw(
+            std::fs::read_to_string(&pid_path)
+                .expect("background pid file")
+                .trim()
+                .parse()
+                .expect("background pid"),
+        );
+
+        // The sweep, the reparent, and init's reap all race this assertion.
+        let mut survived = true;
+        for _ in 0..100 {
+            // The null signal only probes for existence.
+            if nix::sys::signal::kill(pid, None).is_err() {
+                survived = false;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert!(!survived, "background child {pid} survived cancellation");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What & why

A cancelled step could leave background processes running on the runner host
indefinitely.

Found while investigating a load average of ~42 on our own macOS CI box. The
host was carrying **546 orphaned shells**, oldest 28d14h against a 28d17h
uptime — one leaked per run of
`process::tests::cancellation_interrupts_background_child_after_shell_exit`,
accumulating since boot. Each spins `while :; do sleep 1; done`, so together
they were doing ~546 fork+execs per second, forever. They were immune to
`pkill`, which is what made them pile up unnoticed.

Three defects, all in `crates/preloop-runner/src/process.rs`:

1. **The group id was read too late.** `invoke`'s wait loop calls `try_wait()`
   every iteration, so the shell is reaped the moment it exits — for
   `sh -c "cmd & echo ready"` that is ~1ms, long before cancellation arrives.
   Cancellation then signalled the group *through the child handle*, but a
   reaped handle reports no pid and addresses nothing. Surviving descendants
   were never signalled at all.

2. **Leader exit was conflated with group exit.** `wait_for_exit` returned
   `true` as soon as the leader had a status. That reported success from the
   SIGINT stage, so the SIGTERM and SIGKILL stages never ran. A descendant
   ignoring SIGINT/SIGTERM was unreachable *by construction*.

3. **The stream-drain grace path had the same bug.** Its `child.kill()` also
   ran after the leader was reaped, which is why
   `invoke_forces_stream_close_after_official_grace_window` was leaking its own
   `sleep 30`.

Note this is not only test hygiene — the same path runs for real cancelled
jobs. Any step that backgrounds a process ignoring SIGINT/SIGTERM (databases,
daemons, `nohup`) survived cancellation, was reparented to init, and
accumulated on the host across runs.
`benchmarks/real-world/overnight-workflows/103-cancellation-background-post.yml`
exercises exactly this oracle.

### Fix

Capture the group id at spawn, while the handle still reports one, and escalate
against the group itself: signal with `killpg`, treat the group as drained only
when `killpg(pgid, 0)` reports it empty, and sweep with SIGKILL when the grace
windows expire. The leader is still reaped first so its zombie cannot hold the
group open. This is what `process.rs`'s own comment already claimed the code
did — `ProcessInvoker.cs` kills the remaining process tree.

`process_group` refuses a non-positive pgid or one matching the runner's own
group, so a sweep can never signal the runner itself.

`nix` is declared unix-only: the workspace forbids `unsafe`, which rules out
raw `libc` calls, and `nix` does not build on Windows, where the existing
`cfg(not(unix))` paths apply. It was already in the tree via `command-group`,
so this adds no new transitive dependency.

## Protocol surface

- [x] I confirm this change touches the runner protocol interface: **NO**

Process/signal lifecycle only. No `/_apis/...` shapes, broker messages, NDJSON
events, Twirp payloads, or check-run/OAuth behavior are touched.

## Required gates

- [x] `just test-ci` — **see caveat below**
- [x] Full workspace suite: `PROPTEST_CASES=8 cargo test --locked --workspace` → **591 passed, 0 failed**
- [x] `just conform` → **`conform: PASS`** (runner-watch, v2.336.0, all scenarios)
- [x] `just zizmor` → `No findings to report`
- [x] `cargo fmt -p preloop-runner --check` → clean
- [x] `cargo clippy --locked -p preloop-runner --all-targets -- -D warnings` → clean
- [x] N/A — no wire shapes changed, so no golden replay needed beyond `conform`
- [x] N/A — no new wire fields/events
- [x] No secrets, credentials, or deployment-specific paths introduced

> [!IMPORTANT]
> **`just test-ci` does not currently pass on `main`, independently of this
> change.** Verified against a clean `git worktree` of `upstream/main`:
> - `fmt-check`: `preloop-runner-server/src/store.rs:18`,
>   `results_twirp.rs:996`, `results_twirp.rs:1015`
> - `clippy -D warnings`: `preloop-runner-server/src/store.rs:899` —
>   `manual_is_multiple_of`
>
> All four are in `preloop-runner-server`, which this PR does not touch (diff is
> 4 files: `CHANGELOG.md`, `Cargo.lock`, `preloop-runner/Cargo.toml`,
> `preloop-runner/src/process.rs`). I left them alone to keep this diff
> reviewable — happy to fix them in a separate PR.

## Verification performed

The regression test now asserts the background child is **actually dead**
rather than only checking the returned error string — it writes `$!` to a temp
file and polls `kill(pid, 0)` after `invoke` returns.

Confirmed it is a real guard, not a tautology, by reintroducing the bug
(restoring the leader-only exit check) and re-running:

```
thread 'process::tests::cancellation_interrupts_background_child_after_shell_exit'
panicked at crates/preloop-runner/src/process.rs:809:9:
background child 84439 survived cancellation
```

The background child now ignores `INT` as well as `TERM`, so the test exercises
the full SIGINT → SIGTERM → SIGKILL ladder rather than stopping at the first
signal that happens to work.

Aggregate check: a full `just test-ci` run previously leaked one immortal shell;
it now leaks **zero**. Existing cancellation tests
(`cancel_sends_sigint_before_hard_kill`,
`cancel_falls_back_to_sigterm_when_sigint_is_ignored`) still pass, so the
graceful path is unchanged — only the escalation that never fired.

## Checklist

- [x] Tests added/updated for any new observable contract
- [x] Docs updated where behavior changed — `CHANGELOG.md` under `[Unreleased] → Fixed`; the module doc's existing description is now accurate
- [x] Changelog-worthy user-facing change described in the PR body


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancelling a step now sweeps the entire spawned process group. Previously we signalled via the child handle; if the shell exited first, descendants were never signalled and leaked. We now capture the pgid at spawn and escalate against the group (SIGINT → SIGTERM → SIGKILL), treating it as drained only when empty.

- Captures pgid at spawn and uses `killpg`; waits for group drain via a null signal probe; reaps the leader first so zombies don’t hold the group open.
- Applies the same sweep in the stream-drain grace path via a shared force-kill helper.
- Adds unix-only `nix` dependency (`signal`, `process` features). Windows continues to use existing `cfg(not(unix))` paths.
- Updates tests to assert the background child actually exits; no protocol or wire changes.

<sup>Written for commit 8aa78c7198abf481e0676e3a67f6d0f9edc1e2ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling to reliably stop child and descendant processes.
  * Prevented background processes from continuing after a command is canceled.
  * Added stronger cleanup when output streams do not finish within the grace period.

* **Documentation**
  * Added an unreleased changelog entry describing the cancellation cleanup improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->