### PR TITLE
oobservability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,6 +2190,7 @@ version = "0.21.0"
 dependencies = [
  "async-trait",
  "parking_lot",
+ "preloop-observability",
  "serde",
  "serde_json",
  "tar",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1875,6 +1875,7 @@ dependencies = [
  "libc",
  "preloop-gha-parser",
  "preloop-gha-protocol",
+ "preloop-observability",
  "preloop-orchestrator",
  "preloop-runner-server",
  "preloop-vm",
@@ -2016,6 +2017,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "preloop-observability"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "parking_lot",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "preloop-orchestrator"
 version = "0.21.0"
 dependencies = [
@@ -2061,6 +2074,7 @@ dependencies = [
  "preloop-gha-expressions",
  "preloop-gha-parser",
  "preloop-gha-protocol",
+ "preloop-observability",
  "proptest",
  "rand 0.8.6",
  "regex",
@@ -2124,6 +2138,7 @@ dependencies = [
  "preloop-gha-expressions",
  "preloop-gha-parser",
  "preloop-gha-protocol",
+ "preloop-observability",
  "preloop-runner",
  "preloop-socket-activation",
  "proptest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,7 +2021,10 @@ name = "preloop-observability"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "parking_lot",
+ "serde",
+ "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2038,6 +2041,7 @@ dependencies = [
  "futures",
  "preloop-gha-parser",
  "preloop-gha-protocol",
+ "preloop-observability",
  "preloop-runner-server",
  "preloop-vm",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/preloop-orchestrator",
     "crates/preloop-socket-activation",
     "crates/preloop-cli",
+    "crates/preloop-observability",
     "benchmarks/preloop-perf",
 ]
 resolver = "2"

--- a/contrib/openobserve/compose.yml
+++ b/contrib/openobserve/compose.yml
@@ -1,0 +1,43 @@
+# Optional reference telemetry backend. Preloop never starts this — it is
+# opt-in, loopback-bound, and pinned by digest. Credentials come from the
+# environment (systemd LoadCredential / .env outside version control),
+# never from this file.
+#
+# Upstream: https://github.com/openobserve/openobserve (AGPL-3.0).
+# Run the stock image as a separate process; do not vendor or modify it.
+services:
+  openobserve:
+    # Digest-pinned: a floating tag is not an immutable input.
+    image: public.ecr.aws/zinclabs/openobserve@sha256:88fb692ac791d3eaff69653a4a4686f1c7eceb9e105491d58d29ac2739560b3b
+    container_name: preloop-openobserve
+    restart: unless-stopped
+    # Loopback only. The OSS build has no SSO/RBAC — never put the UI on the
+    # public webhook origin. Front it with operator auth if shared.
+    ports:
+      - "127.0.0.1:5080:5080"
+    environment:
+      ZO_ROOT_USER_EMAIL: ${ZO_ROOT_USER_EMAIL:-admin@preloop.local}
+      ZO_ROOT_USER_PASSWORD: ${ZO_ROOT_USER_PASSWORD:-ChangeMe.Preloop1}
+      ZO_DATA_DIR: /data
+      # Short retention: this is operational telemetry (hours/days), not a
+      # data lake. Losing SQLite metadata makes the install inoperable, so
+      # back up the volume if you rely on it.
+      ZO_COMPACT_DATA_RETENTION_DAYS: "7"
+      ZO_TELEMETRY: "false"
+    volumes:
+      - openobserve-data:/data
+    # Measured caps: do not starve the VM pool. Re-measure on your host.
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 2G
+    healthcheck:
+      test: ["CMD", "sh", "-c", "wget -qO- http://127.0.0.1:5080/healthz || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 20s
+
+volumes:
+  openobserve-data:

--- a/crates/preloop-cli/Cargo.toml
+++ b/crates/preloop-cli/Cargo.toml
@@ -15,6 +15,7 @@ name = "preloop"
 path = "src/main.rs"
 
 [dependencies]
+preloop-observability = { path = "../preloop-observability" }
 preloop-orchestrator = { path = "../preloop-orchestrator" }
 preloop-vm = { path = "../preloop-vm" }
 preloop-runner-server = { path = "../preloop-runner-server" }

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -749,7 +749,8 @@ async fn main() -> anyhow::Result<()> {
     // `RUST_LOG` defaults to `info` (the old `fmt::init()` default of ERROR hid
     // pool provisioning faults). The runtime is held for the life of `main`
     // and flushed with a bounded 2s shutdown on exit.
-    let obs_config = preloop_observability::ObservabilityConfig::from_env();
+    let obs_config = preloop_observability::ObservabilityConfig::from_env()
+        .with_service_version(env!("CARGO_PKG_VERSION"));
     let (observability, observability_runtime) =
         preloop_observability::Observability::from_config(obs_config);
     preloop_observability::ObservabilityRuntime::install_fmt_subscriber(observability.config());

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -736,17 +736,20 @@ struct ShellArgs {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // `fmt::init()` alone filters to ERROR when `RUST_LOG` is unset, which hid
-    // a runner pool that failed to provision 77 times in a row: every
-    // provisioning fault logs at `warn` or `info`, so the operator saw a server
-    // that accepted webhooks and silently never ran anything. Default to `info`
-    // and let `RUST_LOG` override as usual.
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
-        )
-        .init();
+    // Unified observability init (Step 2): one handle for the process, shared
+    // with `AppState` and `RunnerPoolConfig` later. `PRELOOP_LOG_FORMAT` now
+    // controls pretty/json/auto (auto = pretty on TTY, JSON when piped), and
+    // `RUST_LOG` defaults to `info` (the old `fmt::init()` default of ERROR hid
+    // pool provisioning faults). The runtime is held for the life of `main`
+    // and flushed with a bounded 2s shutdown on exit.
+    let obs_config = preloop_observability::ObservabilityConfig::from_env();
+    let (observability, observability_runtime) =
+        preloop_observability::Observability::from_config(obs_config);
+    preloop_observability::ObservabilityRuntime::install_fmt_subscriber(observability.config());
+    // Keep the handle alive; the pool/server will clone it later. Suppress
+    // unused warning until the wiring lands in Step 3.
+    let _observability = observability;
+    let _observability_runtime = observability_runtime;
 
     let cli = Cli::parse();
     // One config path for the whole process. `setup`/`doctor`/`secret` return

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -743,7 +743,7 @@ struct ShellArgs {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // Unified observability init (Step 2): one handle for the process, shared
+    // Unified observability init: one handle for the process, shared
     // with `AppState` and `RunnerPoolConfig` later. `PRELOOP_LOG_FORMAT` now
     // controls pretty/json/auto (auto = pretty on TTY, JSON when piped), and
     // `RUST_LOG` defaults to `info` (the old `fmt::init()` default of ERROR hid
@@ -754,7 +754,7 @@ async fn main() -> anyhow::Result<()> {
         preloop_observability::Observability::from_config(obs_config);
     preloop_observability::ObservabilityRuntime::install_fmt_subscriber(observability.config());
     // Keep the handle alive; the pool/server will clone it later. Suppress
-    // unused warning until the wiring lands in Step 3.
+    // unused warning until the wiring lands.
     let _observability = observability;
     let _observability_runtime = observability_runtime;
 

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -478,12 +478,8 @@ enum Command {
     /// Show the expanded job DAG without executing.
     Plan(PlanArgs),
 
-    /// Show active and recent runs, or the live status of one run (prints a
-    /// single machine-readable status word for scripting).
-    Status {
-        #[arg(value_name = "RUN_ID")]
-        run_id: Option<String>,
-    },
+    /// Show operational status, queue health, and recent runs.
+    Status(StatusArgs),
 
     Logs(LogsArgs),
 
@@ -709,6 +705,17 @@ struct PlanArgs {
 }
 
 #[derive(Debug, Parser)]
+struct StatusArgs {
+    /// Print the raw status JSON (no prose) for jq/scripting.
+    #[arg(long)]
+    json: bool,
+
+    /// Number of recent runs to show in the table.
+    #[arg(long, default_value = "20")]
+    limit: usize,
+}
+
+#[derive(Debug, Parser)]
 struct LogsArgs {
     /// Run ID. Defaults to the most recent run.
     run_id: Option<String>,
@@ -789,7 +796,7 @@ async fn main() -> anyhow::Result<()> {
     match cli.command {
         Command::Run(args) => cmd_run(args).await,
         Command::Plan(_) => unreachable!("plan is handled before engine bootstrap"),
-        Command::Status { run_id } => cmd_status(run_id).await,
+        Command::Status(args) => cmd_status(args).await,
         Command::Logs(args) => cmd_logs(args).await,
         Command::Cancel(args) => cmd_cancel(args).await,
         Command::Shell(args) => cmd_shell(args).await,
@@ -903,6 +910,7 @@ async fn cmd_build_golden(args: BuildGoldenArgs) -> anyhow::Result<()> {
         next_job_runs_on: None,
         pending_registrations: None,
         preparing_signal: None,
+        pool_status: None,
     };
     let payload = artifact_payload(&output, &config.base_image);
     RunnerPool::new(std::sync::Arc::new(SmolVmProvider::default()), config)?
@@ -1366,6 +1374,8 @@ async fn cmd_engine(args: ServeArgs) -> anyhow::Result<()> {
             next_job_runs_on: Some(next_job_runs_on.clone()),
             pool_preparing: Some(pool_preparing.clone()),
             pending_registrations: pool_available.then_some(pending_registrations),
+            pool_status: None,
+            observability: None,
             require_job_assignments: env_flag("PRELOOP_REQUIRE_JOB_ASSIGNMENTS", false),
             state_dir,
             store_url: args.store.clone(),
@@ -1459,24 +1469,85 @@ async fn engine_shutdown_signal() {
 }
 
 async fn wait_for_engine_socket(socket: &std::path::Path) -> anyhow::Result<()> {
+    // readyz probe: http://localhost/readyz (500ms timeout, 30s window)
     #[cfg(unix)]
     let client = reqwest::Client::builder().unix_socket(socket).build()?;
     #[cfg(not(unix))]
     let client = reqwest::Client::new();
     let start = std::time::Instant::now();
+    let mut last_reason: Option<String> = None;
     while start.elapsed() < Duration::from_secs(30) {
-        if client
-            .get("http://localhost/healthz")
+        match client
+            .get("http://localhost/readyz")
             .timeout(Duration::from_millis(500))
             .send()
             .await
-            .is_ok()
         {
-            return Ok(());
+            Ok(resp) => {
+                if resp.status().is_success() {
+                    return Ok(());
+                }
+                // Non-2xx readyz: capture reason for timeout reporting.
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                let reason = extract_readyz_reason(&body)
+                    .unwrap_or_else(|| format!("{status}: {}", truncate_reason(&body)));
+                last_reason = Some(reason);
+            }
+            Err(err) => {
+                last_reason = Some(err.to_string());
+            }
         }
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
+    if let Some(reason) = last_reason {
+        anyhow::bail!("local control plane did not become ready within 30 seconds: last readyz reason: {reason}")
+    }
     anyhow::bail!("local control plane did not become ready within 30 seconds")
+}
+
+fn extract_readyz_reason(body: &str) -> Option<String> {
+    if body.trim().is_empty() {
+        return None;
+    }
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(body) {
+        for key in ["reason", "code", "message", "error", "status"] {
+            if let Some(s) = v.get(key).and_then(|x| x.as_str()) {
+                if !s.trim().is_empty() {
+                    return Some(s.to_owned());
+                }
+            }
+        }
+        // Nested { "ready": { "reason": ... } } or similar
+        if let Some(obj) = v.as_object() {
+            for (_, val) in obj {
+                if let Some(s) = val.as_str() {
+                    if !s.trim().is_empty() && s.len() < 200 {
+                        return Some(s.to_owned());
+                    }
+                }
+                if let Some(inner) = val.as_object() {
+                    for k in ["reason", "code"] {
+                        if let Some(s) = inner.get(k).and_then(|x| x.as_str()) {
+                            return Some(s.to_owned());
+                        }
+                    }
+                }
+            }
+        }
+        // Return truncated JSON if no specific field
+        return Some(truncate_reason(body));
+    }
+    Some(truncate_reason(body))
+}
+
+fn truncate_reason(s: &str) -> String {
+    let t = s.trim();
+    if t.len() > 300 {
+        format!("{}…", &t[..300])
+    } else {
+        t.to_owned()
+    }
 }
 
 // Configuration assembly, not a public API: the parameter list mirrors the
@@ -1653,6 +1724,7 @@ fn local_runner_pool_config(
         next_job_runs_on: (!custom_base).then_some(next_job_runs_on),
         pending_registrations: Some(pending_registrations),
         preparing_signal: Some(preparing_signal),
+        pool_status: None,
     })
 }
 
@@ -2801,63 +2873,418 @@ fn plan_json(plan: &preloop_gha_protocol::JobPlan) -> serde_json::Value {
     })
 }
 
-async fn cmd_status(run_id: Option<String>) -> anyhow::Result<()> {
+async fn cmd_status(args: StatusArgs) -> anyhow::Result<()> {
     let client = build_client();
     let url = server_url();
-    if let Some(run_id) = run_id {
-        // Single-run mode: one machine-readable status word
-        // (success/failure/cancelled/skipped/in_progress/queued/pending) for
-        // scripts like the pre-push hook. Connection failures carry the
-        // engine-unreachable marker so the hook can fail open.
-        let mut request = client.get(format!("{url}/api/v1/runs/{run_id}"));
-        if let Some(token) = api_token() {
-            request = request.bearer_auth(token);
-        }
-        let response = request
-            .send()
-            .await
-            .with_context(engine_unreachable_context)?;
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("server returned {status}: {body}");
-        }
-        let run: serde_json::Value = response.json().await?;
-        println!(
-            "{}",
-            run.get("status")
-                .and_then(serde_json::Value::as_str)
-                .unwrap_or("unknown")
-        );
-        return Ok(());
-    }
-    let mut request = client.get(format!("{url}/api/v1/runs?limit=20"));
+    // Native bearer required for /api/v1/status (same as other native calls)
+    let mut status_req = client.get(format!("{url}/api/v1/status"));
     if let Some(token) = api_token() {
-        request = request.bearer_auth(token);
+        status_req = status_req.bearer_auth(token);
     }
-    let response = request.send().await?;
-    if !response.status().is_success() {
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
+    let status_resp = status_req
+        .send()
+        .await
+        .with_context(engine_unreachable_context)?;
+    if !status_resp.status().is_success() {
+        let status = status_resp.status();
+        let body = status_resp.text().await.unwrap_or_default();
         anyhow::bail!("server returned {status}: {body}");
     }
-    let runs: Vec<serde_json::Value> = response.json().await?;
+    let status_text = status_resp.text().await?;
+    if args.json {
+        // Byte-for-byte, no prose: so jq works
+        print!("{}", status_text);
+        if !status_text.ends_with('\n') {
+            println!();
+        }
+        return Ok(());
+    }
+    let status: serde_json::Value =
+        serde_json::from_str(&status_text).context("parse status json")?;
+
+    // Fetch recent runs for table (preserve existing behavior)
+    let mut runs_req = client.get(format!("{url}/api/v1/runs?limit={}", args.limit));
+    if let Some(token) = api_token() {
+        runs_req = runs_req.bearer_auth(token);
+    }
+    let runs: Vec<serde_json::Value> = match runs_req.send().await {
+        Ok(r) if r.status().is_success() => r.json().await.unwrap_or_default(),
+        Ok(r) => {
+            let st = r.status();
+            let body = r.text().await.unwrap_or_default();
+            eprintln!("[warn] runs table unavailable: {st}: {body}");
+            Vec::new()
+        }
+        Err(e) => {
+            eprintln!("[warn] runs table unavailable: {e}");
+            Vec::new()
+        }
+    };
+
+    // --- Human rendering: 10 sections in order ---
+    render_status_human(&status, &runs, args.limit);
+    Ok(())
+}
+
+fn render_status_human(status: &serde_json::Value, runs: &[serde_json::Value], limit: usize) {
+    // Helpers to extract safely
+    let get_str = |v: &serde_json::Value, k: &str| -> Option<String> {
+        v.get(k).and_then(|x| x.as_str()).map(|s| s.to_owned())
+    };
+    let get_f64 =
+        |v: &serde_json::Value, k: &str| -> Option<f64> { v.get(k).and_then(|x| x.as_f64()) };
+    let get_u64 =
+        |v: &serde_json::Value, k: &str| -> Option<u64> { v.get(k).and_then(|x| x.as_u64()) };
+    let get_bool =
+        |v: &serde_json::Value, k: &str| -> Option<bool> { v.get(k).and_then(|x| x.as_bool()) };
+
+    // 1. service + snapshot age
+    println!("== service ==");
+    let service = status.get("service").unwrap_or(&serde_json::Value::Null);
+    let version =
+        get_str(service, "version").unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_owned());
+    let instance = get_str(service, "instance_id")
+        .or_else(|| get_str(status, "instance_id"))
+        .unwrap_or_else(|| "-".to_owned());
+    let uptime = get_f64(service, "uptime_seconds")
+        .or_else(|| get_f64(status, "uptime_seconds"))
+        .unwrap_or(0.0);
+    let shutdown = get_bool(service, "shutdown_requested")
+        .or_else(|| get_bool(status, "shutdown_requested"))
+        .unwrap_or(false);
+    let snapshot_age = get_f64(status, "snapshot_age_seconds").unwrap_or(0.0);
+    let observed_at = get_str(status, "observed_at").unwrap_or_else(|| "-".to_owned());
+    let overall = get_str(status, "overall").unwrap_or_else(|| "unknown".to_owned());
+    println!(
+        "  version: {version}  instance: {instance}  uptime: {uptime:.0}s  overall: {overall}"
+    );
+    println!(
+        "  observed_at: {observed_at}  snapshot_age: {snapshot_age:.1}s  shutdown: {shutdown}"
+    );
+    if status.get("schema_version").is_some() {
+        println!("  schema_version: {}", status["schema_version"]);
+    }
+
+    // 2. queue (ready/blocked + oldest)
+    println!("\n== queue ==");
+    let jobs = status.get("jobs").unwrap_or(&serde_json::Value::Null);
+    let ready = get_u64(jobs, "ready").unwrap_or(0);
+    let dep_blocked = get_u64(jobs, "dependency_blocked").unwrap_or(0);
+    let conc_blocked = get_u64(jobs, "concurrency_blocked").unwrap_or(0);
+    let pending_exp = get_u64(jobs, "pending_expansion").unwrap_or(0);
+    let expanding = get_u64(jobs, "expanding").unwrap_or(0);
+    let claimable = get_u64(jobs, "claimable").unwrap_or(0);
+    let unclaimable = get_u64(jobs, "unclaimable").unwrap_or(0);
+    let oldest = get_f64(jobs, "oldest_ready_seconds");
+    println!("  ready: {ready}  claimable: {claimable}  unclaimable: {unclaimable}  dependency_blocked: {dep_blocked}  concurrency_blocked: {conc_blocked}  pending_expansion: {pending_exp}  expanding: {expanding}");
+    match oldest {
+        Some(v) => println!("  oldest_ready: {v:.1}s"),
+        None => println!("  oldest_ready: -"),
+    }
+    // Also show runs queued/in_progress if present
+    if let Some(runs_obj) = status.get("runs") {
+        let q = get_u64(runs_obj, "queued").unwrap_or(0);
+        let ip = get_u64(runs_obj, "in_progress").unwrap_or(0);
+        let completed = get_u64(runs_obj, "completed").unwrap_or(0);
+        println!("  runs queued: {q}  in_progress: {ip}  completed: {completed}");
+    }
+
+    // 3. concurrency + scheduler
+    println!("\n== concurrency & scheduler ==");
+    let conc = status
+        .get("concurrency")
+        .unwrap_or(&serde_json::Value::Null);
+    let groups_active = get_u64(conc, "groups_active").unwrap_or(0);
+    let groups_contended = get_u64(conc, "groups_contended").unwrap_or(0);
+    let pending_holders = get_u64(conc, "pending_holders").unwrap_or(0);
+    let deepest = get_u64(conc, "deepest_group_pending").unwrap_or(0);
+    let qmax = get_u64(conc, "queue_max_pending").unwrap_or(0);
+    let overflow = get_u64(conc, "overflow_cancellations").unwrap_or(0);
+    println!("  groups active: {groups_active}  contended: {groups_contended}  pending_holders: {pending_holders}  deepest_pending: {deepest}  queue_max: {qmax}  overflow_cancellations: {overflow}");
+    let sched = status.get("scheduler").unwrap_or(&serde_json::Value::Null);
+    let enabled = get_bool(sched, "enabled").unwrap_or(false);
+    let schedules = get_u64(sched, "schedules").unwrap_or(0);
+    let last_scan = get_str(sched, "last_scan_at").unwrap_or_else(|| "-".to_owned());
+    let next_fire = get_str(sched, "next_fire_at").unwrap_or_else(|| "-".to_owned());
+    let fired = get_u64(sched, "fired").unwrap_or(0);
+    let skipped = get_u64(sched, "skipped_overlapping").unwrap_or(0);
+    let late = get_u64(sched, "late_fires").unwrap_or(0);
+    let max_delay = get_f64(sched, "max_fire_delay_seconds");
+    println!("  scheduler enabled: {enabled}  schedules: {schedules}  fired: {fired}  skipped_overlapping: {skipped}  late_fires: {late}");
+    println!(
+        "  last_scan: {last_scan}  next_fire: {next_fire}  max_delay: {}",
+        max_delay
+            .map(|v| format!("{v:.1}s"))
+            .unwrap_or_else(|| "-".to_owned())
+    );
+
+    // 4. pool + runners
+    println!("\n== pool & runners ==");
+    let pool = status.get("pool").unwrap_or(&serde_json::Value::Null);
+    let mode = get_str(pool, "mode").unwrap_or_else(|| "-".to_owned());
+    let desired = get_u64(pool, "desired").unwrap_or(0);
+    let preparing = pool
+        .get("preparing")
+        .and_then(|x| x.as_bool())
+        .unwrap_or(false);
+    let building = get_u64(pool, "building").unwrap_or(0);
+    let provisioning = get_u64(pool, "provisioning").unwrap_or(0);
+    let pool_idle = get_u64(pool, "idle").unwrap_or(0);
+    let pool_busy = get_u64(pool, "busy").unwrap_or(0);
+    let paused = get_u64(pool, "paused").unwrap_or(0);
+    let failures = get_u64(pool, "consecutive_provision_failures").unwrap_or(0);
+    println!("  pool mode: {mode}  desired: {desired}  idle: {pool_idle}  busy: {pool_busy}  building: {building}  provisioning: {provisioning}  paused: {paused}  preparing: {preparing}  provision_failures: {failures}");
+    let runners = status.get("runners").unwrap_or(&serde_json::Value::Null);
+    let reg = get_u64(runners, "registered").unwrap_or(0);
+    let sessions = get_u64(runners, "sessions").unwrap_or(0);
+    let idle = get_u64(runners, "idle").unwrap_or(0);
+    let busy = get_u64(runners, "busy").unwrap_or(0);
+    let stale = get_u64(runners, "stale").unwrap_or(0);
+    let max_poll = get_f64(runners, "max_poll_age_seconds");
+    let max_lease = get_f64(runners, "max_lease_age_seconds");
+    println!("  runners registered: {reg}  sessions: {sessions}  idle: {idle}  busy: {busy}  stale: {stale}");
+    println!(
+        "  max_poll_age: {}  max_lease_age: {}",
+        max_poll
+            .map(|v| format!("{v:.1}s"))
+            .unwrap_or_else(|| "-".to_owned()),
+        max_lease
+            .map(|v| format!("{v:.1}s"))
+            .unwrap_or_else(|| "-".to_owned())
+    );
+
+    // 5. VM fleet stub
+    println!("\n== vm fleet ==");
+    let vms = status
+        .get("vms")
+        .unwrap_or(status.get("vm").unwrap_or(&serde_json::Value::Null));
+    if vms.is_null() || vms.as_object().map(|m| m.is_empty()).unwrap_or(false) {
+        println!("  source: unavailable  (host sampler not yet reporting)");
+        println!("  capabilities: cpu=false memory=false sparse_disk=false");
+        println!("  host_usage: -");
+    } else {
+        let source = get_str(vms, "source").unwrap_or_else(|| "unknown".to_owned());
+        let sample_age = get_f64(vms, "sample_age_seconds")
+            .map(|v| format!("{v:.1}s"))
+            .unwrap_or_else(|| "-".to_owned());
+        println!("  source: {source}  sample_age: {sample_age}");
+        if let Some(caps) = vms.get("capabilities") {
+            let cap_str = caps
+                .as_object()
+                .map(|m| {
+                    m.iter()
+                        .map(|(k, v)| format!("{k}={}", v.as_bool().unwrap_or(false)))
+                        .collect::<Vec<_>>()
+                        .join(" ")
+                })
+                .unwrap_or_else(|| "-".to_owned());
+            println!("  capabilities: {cap_str}");
+        }
+        if let Some(cnt) = vms.get("count") {
+            let runner = get_u64(cnt, "runner").unwrap_or(0);
+            let golden = get_u64(cnt, "golden").unwrap_or(0);
+            let unavailable = get_u64(cnt, "unavailable").unwrap_or(0);
+            println!("  count runner: {runner}  golden: {golden}  unavailable: {unavailable}");
+        }
+        if let Some(conf) = vms.get("configured") {
+            let vcpus = get_u64(conf, "vcpus")
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "-".to_owned());
+            let mem = get_u64(conf, "memory_bytes")
+                .map(|v| format!("{v}"))
+                .unwrap_or_else(|| "-".to_owned());
+            let storage = get_u64(conf, "storage_bytes")
+                .map(|v| format!("{v}"))
+                .unwrap_or_else(|| "-".to_owned());
+            println!("  configured vcpus: {vcpus}  memory: {mem}  storage: {storage}");
+        }
+        if let Some(usage) = vms.get("host_usage") {
+            let cores = get_f64(usage, "cpu_cores")
+                .map(|v| format!("{v:.1}"))
+                .unwrap_or_else(|| "-".to_owned());
+            let mem = get_u64(usage, "memory_bytes")
+                .map(|v| format!("{v}"))
+                .unwrap_or_else(|| "-".to_owned());
+            println!("  host_usage cpu_cores: {cores}  memory: {mem}");
+        }
+        if let Some(top) = vms.get("top_consumers").and_then(|x| x.as_array()) {
+            if !top.is_empty() {
+                println!("  top_consumers ({}):", top.len().min(5));
+                for c in top.iter().take(5) {
+                    let name = c
+                        .get("machine_name")
+                        .and_then(|x| x.as_str())
+                        .unwrap_or("?");
+                    let role = c.get("role").and_then(|x| x.as_str()).unwrap_or("?");
+                    let activity = c.get("activity").and_then(|x| x.as_str()).unwrap_or("?");
+                    println!("    - {name} ({role}/{activity})");
+                }
+            } else {
+                println!("  top_consumers: -");
+            }
+        }
+    }
+
+    // 6. store/storage/GitHub/debug/telemetry
+    println!("\n== store / storage / github / debug / telemetry ==");
+    let store = status.get("store").unwrap_or(&serde_json::Value::Null);
+    let backend = get_str(store, "backend").unwrap_or_else(|| "-".to_owned());
+    let cfail = get_u64(store, "consecutive_failures").unwrap_or(0);
+    println!("  store backend: {backend}  consecutive_failures: {cfail}");
+    let storage = status.get("storage").unwrap_or(&serde_json::Value::Null);
+    if !storage.is_null() {
+        let free = get_u64(storage, "state_fs_free_bytes")
+            .map(|v| format!("{v}"))
+            .unwrap_or_else(|| "-".to_owned());
+        let ratio = get_f64(storage, "state_fs_free_ratio")
+            .map(|v| format!("{v:.2}"))
+            .unwrap_or_else(|| "-".to_owned());
+        println!("  storage free: {free}  ratio: {ratio}");
+        if let Some(comps) = storage.get("components").and_then(|x| x.as_array()) {
+            for c in comps {
+                let store_name = c.get("store").and_then(|x| x.as_str()).unwrap_or("?");
+                let bytes = c.get("bytes").and_then(|x| x.as_u64()).unwrap_or(0);
+                println!("    {store_name}: {bytes} bytes");
+            }
+        }
+    } else {
+        println!("  storage: -");
+    }
+    let github = status.get("github").unwrap_or(&serde_json::Value::Null);
+    if !github.is_null() {
+        let configured = get_bool(github, "configured").unwrap_or(false);
+        let pending = get_u64(github, "pending_check_updates").unwrap_or(0);
+        println!("  github configured: {configured}  pending_check_updates: {pending}");
+        if let Some(rl) = github.get("rate_limit") {
+            let remaining = get_u64(rl, "remaining").unwrap_or(0);
+            let limit_rl = get_u64(rl, "limit").unwrap_or(0);
+            println!("  github rate_limit: {remaining}/{limit_rl} remaining");
+        }
+        if let Some(exp) = github
+            .get("installation_token_expires_in_seconds")
+            .and_then(|x| x.as_u64())
+        {
+            println!("  github token expires_in: {exp}s");
+        }
+    } else {
+        println!("  github: -");
+    }
+    let debug = status.get("debug").unwrap_or(&serde_json::Value::Null);
+    if !debug.is_null() {
+        let active = get_u64(debug, "active_sessions").unwrap_or(0);
+        let oldest = debug
+            .get("oldest_session_seconds")
+            .and_then(|x| x.as_f64())
+            .map(|v| format!("{v:.0}s"))
+            .unwrap_or_else(|| "-".to_owned());
+        println!("  debug active_sessions: {active}  oldest: {oldest}");
+    }
+    let tele = status.get("telemetry").unwrap_or(&serde_json::Value::Null);
+    if !tele.is_null() {
+        let enabled = get_bool(tele, "otlp_enabled").unwrap_or(false);
+        let dropped = get_u64(tele, "dropped_records").unwrap_or(0);
+        println!("  telemetry otlp_enabled: {enabled}  dropped_records: {dropped}");
+    }
+
+    // 7. non-zero limits
+    println!("\n== limits (non-zero) ==");
+    let limits = status.get("limits").and_then(|x| x.as_array());
+    let mut any_limit = false;
+    if let Some(arr) = limits {
+        for l in arr {
+            let dropped = l.get("dropped").and_then(|x| x.as_u64()).unwrap_or(0);
+            let rejected = l.get("rejected").and_then(|x| x.as_u64()).unwrap_or(0);
+            if dropped > 0 || rejected > 0 {
+                any_limit = true;
+                let name = l.get("limit").and_then(|x| x.as_str()).unwrap_or("?");
+                let value = l
+                    .get("value")
+                    .and_then(|x| x.as_u64())
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "-".to_owned());
+                println!("  {name}: value={value} dropped={dropped} rejected={rejected}");
+            }
+        }
+    }
+    if !any_limit {
+        println!("  (no limits with drops/rejects)");
+    }
+
+    // 8. stale tasks
+    println!("\n== tasks (stale/exited) ==");
+    let tasks = status.get("tasks").and_then(|x| x.as_array());
+    let mut any_task = false;
+    if let Some(arr) = tasks {
+        for t in arr {
+            let state = t.get("state").and_then(|x| x.as_str()).unwrap_or("running");
+            if state == "stale" || state == "exited" {
+                any_task = true;
+                let name = t.get("name").and_then(|x| x.as_str()).unwrap_or("?");
+                let critical = t.get("critical").and_then(|x| x.as_bool()).unwrap_or(false);
+                let age = t
+                    .get("heartbeat_age_seconds")
+                    .and_then(|x| x.as_f64())
+                    .map(|v| format!("{v:.1}s"))
+                    .unwrap_or_else(|| "-".to_owned());
+                println!("  {name}: state={state} critical={critical} age={age}");
+            }
+        }
+    }
+    if !any_task {
+        println!("  (all tasks healthy)");
+    }
+
+    // 9. conditions with one-line actions (≤5 exemplars)
+    println!("\n== conditions ==");
+    let conditions = status.get("conditions").and_then(|x| x.as_array());
+    if let Some(arr) = conditions {
+        if arr.is_empty() {
+            println!("  (no conditions)");
+        } else {
+            for c in arr {
+                let code = c.get("code").and_then(|x| x.as_str()).unwrap_or("?");
+                let severity = c.get("severity").and_then(|x| x.as_str()).unwrap_or("info");
+                let msg = c.get("message").and_then(|x| x.as_str()).unwrap_or("");
+                let action = condition_action(code);
+                println!("  [{severity}] {code}: {msg} -> {action}");
+                if let Some(exs) = c.get("exemplars").and_then(|x| x.as_array()) {
+                    for ex in exs.iter().take(5) {
+                        let ex_str = match ex {
+                            serde_json::Value::String(s) => s.clone(),
+                            other => other.to_string(),
+                        };
+                        println!("    - {ex_str}");
+                    }
+                    if exs.len() > 5 {
+                        println!("    ... and {} more", exs.len() - 5);
+                    }
+                } else if let Some(exs) = c.get("exemplar").and_then(|x| x.as_str()) {
+                    println!("    - {exs}");
+                }
+            }
+        }
+    } else {
+        println!("  (no conditions)");
+    }
+
+    // 10. recent runs table
+    println!("\n== recent runs (limit={}) ==", limit);
     if runs.is_empty() {
         println!("No runs found.");
-        return Ok(());
+        return;
     }
     println!(
         "{:<38}  {:<6}  {:<12}  {:<12}  {:<10}  WORKFLOW",
         "RUN ID", "#", "STATUS", "EVENT", "PUSH"
     );
     println!("{}", "-".repeat(104));
-    for run in &runs {
+    for run in runs {
         let run_id = run["run_id"].as_str().unwrap_or("?");
         let run_number = run
             .get("run_number")
             .and_then(serde_json::Value::as_u64)
             .unwrap_or(0);
-        let status = run["status"].as_str().unwrap_or("?");
+        let st = run["status"].as_str().unwrap_or("?");
         let event = run
             .get("event")
             .and_then(serde_json::Value::as_str)
@@ -2881,21 +3308,56 @@ async fn cmd_status(run_id: Option<String>) -> anyhow::Result<()> {
             })
             .unwrap_or("?");
         let push = match run.get("push_state").and_then(|state| state.get("status")) {
-            Some(status) => {
-                let status = status.as_str().unwrap_or("?");
+            Some(s) => {
+                let s = s.as_str().unwrap_or("?");
                 match run["push_state"]["pr_number"].as_u64() {
-                    Some(number) => format!("{status} #{number}"),
-                    None => status.to_owned(),
+                    Some(n) => format!("{s} #{n}"),
+                    None => s.to_owned(),
                 }
             }
             None => "-".to_owned(),
         };
         println!(
             "{:<38}  {:<6}  {:<12}  {:<12}  {:<10}  {}",
-            run_id, run_number, status, event, push, workflow
+            run_id, run_number, st, event, push, workflow
         );
     }
-    Ok(())
+}
+
+fn condition_action(code: &str) -> &'static str {
+    match code {
+        "queue_no_registered_runner" => "register a runner or enable the pool",
+        "queue_label_mismatch" => "add a runner with that label",
+        "concurrency_queue_overflow" => "raise concurrency queue max or reduce parallelism",
+        "concurrency_group_starved" => "check concurrency group that starves others",
+        "scheduler_scan_stale" => "check scheduler scan heartbeat (restart if stuck)",
+        "scheduler_fire_late" => "check scheduler clock / load",
+        "pool_preparing" => "wait for image preparation to finish",
+        "pool_provisioning_deficit" => "check pool capacity / provision failures",
+        "pool_repeated_provision_failure" => "inspect provision logs and VM host capacity",
+        "runner_poll_stale" => "check runner connectivity and heartbeat",
+        "runner_lease_stale" => "check runner lease renewal",
+        "vm_sampler_stale" | "vm_sample_unavailable" | "vm_unreachable" => {
+            "check VM host sampler and SmolVM health"
+        }
+        "vm_host_memory_pressure" => "free host memory or reduce pool size",
+        "vm_host_cpu_throttled" => "reduce host CPU load or raise CPU quota",
+        "vm_host_oom_kill" => "check host OOM kills and runner memory",
+        "vm_sparse_disk_pressure" => "free disk space on VM data volume",
+        "store_write_failure" | "store_connection_down" => "check store connectivity and disk",
+        "storage_capacity_pressure" => "free disk space or run GC/prune",
+        "limit_drop_active" => "raise that limit or reduce load",
+        "limit_reject_active" => "raise that limit or back off",
+        "github_check_update_failure" => "check GitHub App permissions and network",
+        "github_terminal_check_pending" => "retry check update or check GitHub status",
+        "github_rate_limit_low" => "back off GitHub API or wait for rate-limit reset",
+        "github_installation_token_expiring" => "refresh GitHub installation token",
+        "debug_session_stale" => "close stale debug session",
+        "debug_audit_evicted" => "increase audit retention or flush audits",
+        "telemetry_export_failure" => "check OTLP endpoint and credentials",
+        "state_sampler_stale" | "task_stale" | "task_exited" => "check background task health",
+        _ => "see runbook for this condition",
+    }
 }
 
 async fn cmd_logs(args: LogsArgs) -> anyhow::Result<()> {
@@ -3760,14 +4222,23 @@ mod tests {
     #[test]
     fn status_parses() {
         let cli = parse(&["status"]).unwrap();
-        assert!(matches!(cli.command, Command::Status { run_id: None }));
-        let cli = parse(&["status", "550e8400-e29b-41d4-a716-446655440000"]).unwrap();
-        assert!(matches!(
-            cli.command,
-            Command::Status {
-                run_id: Some(ref id)
-            } if id == "550e8400-e29b-41d4-a716-446655440000"
-        ));
+        let Command::Status(args) = cli.command else {
+            panic!("expected Status");
+        };
+        assert!(!args.json);
+        assert_eq!(args.limit, 20);
+        let cli = parse(&["status", "--json", "--limit", "5"]).unwrap();
+        let Command::Status(args) = cli.command else {
+            panic!("expected Status");
+        };
+        assert!(args.json);
+        assert_eq!(args.limit, 5);
+        // Default limit is 20 and --json defaults to false
+        let cli = parse(&["status", "--limit", "42"]).unwrap();
+        let Command::Status(args) = cli.command else {
+            panic!("expected Status");
+        };
+        assert_eq!(args.limit, 42);
     }
 
     #[test]

--- a/crates/preloop-observability/Cargo.toml
+++ b/crates/preloop-observability/Cargo.toml
@@ -8,13 +8,17 @@ repository = "https://github.com/preloopdev/preloop"
 
 [dependencies]
 anyhow = { workspace = true }
+chrono = { workspace = true }
 parking_lot = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
+serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/preloop-observability/Cargo.toml
+++ b/crates/preloop-observability/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "preloop-observability"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Observability handle for Preloop — metrics, logs, traces, status snapshot (Step 2)"
+repository = "https://github.com/preloopdev/preloop"
+
+[dependencies]
+anyhow = { workspace = true }
+parking_lot = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+uuid = { workspace = true }
+tokio = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/preloop-observability/Cargo.toml
+++ b/crates/preloop-observability/Cargo.toml
@@ -3,7 +3,7 @@ name = "preloop-observability"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
-description = "Observability handle for Preloop — metrics, logs, traces, status snapshot (Step 2)"
+description = "Observability handle for Preloop — metrics, logs, traces, status snapshot"
 repository = "https://github.com/preloopdev/preloop"
 
 [dependencies]

--- a/crates/preloop-observability/Cargo.toml
+++ b/crates/preloop-observability/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/preloopdev/preloop"
 anyhow = { workspace = true }
 chrono = { workspace = true }
 parking_lot = { workspace = true }
+rand = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/preloop-observability/Cargo.toml
+++ b/crates/preloop-observability/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/preloopdev/preloop"
 anyhow = { workspace = true }
 chrono = { workspace = true }
 parking_lot = { workspace = true }
+reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/crates/preloop-observability/src/export.rs
+++ b/crates/preloop-observability/src/export.rs
@@ -103,11 +103,13 @@ pub fn spawn(
     headers: Option<&str>,
     service_name: &str,
     instance_id: &str,
+    service_version: &str,
 ) -> Option<(Exporter, Arc<ExportHealth>)> {
     let endpoint = endpoint?.trim_end_matches('/').to_string();
     let header_pairs = parse_headers(headers);
     let service_name = service_name.to_string();
     let instance_id = instance_id.to_string();
+    let service_version = service_version.to_string();
     let health = Arc::new(ExportHealth::default());
     let (tx, mut rx) = mpsc::channel::<LogRecord>(QUEUE_CAPACITY);
 
@@ -138,17 +140,17 @@ pub fn spawn(
                         Some(record) => {
                             buffer.push(record);
                             if buffer.len() >= BATCH_MAX {
-                                flush(&client, &logs_url, &header_pairs, &service_name, &instance_id, &mut buffer, &worker_health).await;
+                                flush(&client, &logs_url, &header_pairs, &service_name, &instance_id, &service_version, &mut buffer, &worker_health).await;
                             }
                         }
                         None => {
-                            flush(&client, &logs_url, &header_pairs, &service_name, &instance_id, &mut buffer, &worker_health).await;
+                            flush(&client, &logs_url, &header_pairs, &service_name, &instance_id, &service_version, &mut buffer, &worker_health).await;
                             break;
                         }
                     }
                 }
                 _ = ticker.tick() => {
-                    flush(&client, &logs_url, &header_pairs, &service_name, &instance_id, &mut buffer, &worker_health).await;
+                    flush(&client, &logs_url, &header_pairs, &service_name, &instance_id, &service_version, &mut buffer, &worker_health).await;
                 }
             }
         }
@@ -169,6 +171,7 @@ async fn flush(
     headers: &[(String, String)],
     service_name: &str,
     instance_id: &str,
+    service_version: &str,
     buffer: &mut Vec<LogRecord>,
     health: &Arc<ExportHealth>,
 ) {
@@ -177,7 +180,7 @@ async fn flush(
     }
     let batch = std::mem::take(buffer);
     let count = batch.len() as u64;
-    let payload = encode_logs(&batch, service_name, instance_id);
+    let payload = encode_logs(&batch, service_name, instance_id, service_version);
     let mut req = client.post(url).json(&payload);
     for (name, value) in headers {
         req = req.header(name.as_str(), value.as_str());
@@ -218,7 +221,12 @@ fn severity_number(severity: &str) -> u8 {
 }
 
 /// Encode a batch into the OTLP/HTTP JSON `ExportLogsServiceRequest` shape.
-pub fn encode_logs(batch: &[LogRecord], service_name: &str, instance_id: &str) -> Value {
+pub fn encode_logs(
+    batch: &[LogRecord],
+    service_name: &str,
+    instance_id: &str,
+    service_version: &str,
+) -> Value {
     let ts = now_nanos().to_string();
     let records: Vec<Value> = batch
         .iter()
@@ -241,7 +249,7 @@ pub fn encode_logs(batch: &[LogRecord], service_name: &str, instance_id: &str) -
                 "attributes": [
                     attr("service.name", service_name),
                     attr("service.instance.id", instance_id),
-                    attr("service.version", env!("CARGO_PKG_VERSION")),
+                    attr("service.version", service_version),
                 ]
             },
             "scopeLogs": [{
@@ -277,7 +285,7 @@ mod tests {
 
     #[test]
     fn absent_endpoint_spawns_nothing() {
-        assert!(spawn(None, None, "preloop", "abc").is_none());
+        assert!(spawn(None, None, "preloop", "abc", "9.9.9").is_none());
     }
 
     #[test]
@@ -300,7 +308,7 @@ mod tests {
             body: "pool provisioning failed".to_string(),
             attributes: vec![("event.name".to_string(), "pool.provision".to_string())],
         }];
-        let payload = encode_logs(&batch, "preloop", "inst-1");
+        let payload = encode_logs(&batch, "preloop", "inst-1", "9.9.9");
         let record = &payload["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0];
         assert_eq!(record["severityText"], "WARN");
         assert_eq!(record["severityNumber"], 13);
@@ -308,5 +316,10 @@ mod tests {
         let resource = &payload["resourceLogs"][0]["resource"]["attributes"];
         assert_eq!(resource[0]["key"], "service.name");
         assert_eq!(resource[0]["value"]["stringValue"], "preloop");
+        assert_eq!(resource[2]["key"], "service.version");
+        assert_eq!(
+            resource[2]["value"]["stringValue"], "9.9.9",
+            "service.version must come from the host binary, not this crate"
+        );
     }
 }

--- a/crates/preloop-observability/src/export.rs
+++ b/crates/preloop-observability/src/export.rs
@@ -1,0 +1,312 @@
+//! Bounded OTLP/HTTP exporter using the existing reqwest+rustls stack.
+//!
+//! OTLP JSON encoding (`application/json`) per the OTLP/HTTP spec, so no
+//! protobuf or tonic dependency. Invariants:
+//! - Fail open: an export error is logged once per failure class and never
+//!   propagates to a caller.
+//! - No request-path export: callers push into a bounded channel; a single
+//!   background worker drains it. Overflow drops and counts.
+//! - No backend by default: constructed only when an endpoint is configured.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde_json::{json, Value};
+use tokio::sync::mpsc;
+
+/// Bounded queue depth. Overflow drops the newest record and increments
+/// `dropped`, which surfaces as `preloop.telemetry.export{outcome="dropped"}`.
+const QUEUE_CAPACITY: usize = 2048;
+const BATCH_MAX: usize = 256;
+const FLUSH_INTERVAL: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Default)]
+pub struct ExportHealth {
+    pub sent: AtomicU64,
+    pub failed: AtomicU64,
+    pub dropped: AtomicU64,
+    pub last_success_unix: AtomicU64,
+    pub last_failure_unix: AtomicU64,
+}
+
+impl ExportHealth {
+    fn record_success(&self, n: u64) {
+        self.sent.fetch_add(n, Ordering::Relaxed);
+        self.last_success_unix.store(now_secs(), Ordering::Relaxed);
+    }
+
+    fn record_failure(&self) {
+        self.failed.fetch_add(1, Ordering::Relaxed);
+        self.last_failure_unix.store(now_secs(), Ordering::Relaxed);
+    }
+
+    pub fn dropped(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
+    }
+
+    pub fn sent(&self) -> u64 {
+        self.sent.load(Ordering::Relaxed)
+    }
+
+    pub fn failed(&self) -> u64 {
+        self.failed.load(Ordering::Relaxed)
+    }
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn now_nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0)
+}
+
+/// One log record queued for export.
+#[derive(Debug, Clone)]
+pub struct LogRecord {
+    pub severity: &'static str,
+    pub body: String,
+    pub attributes: Vec<(String, String)>,
+}
+
+/// Handle used by the rest of the process to enqueue telemetry.
+#[derive(Debug, Clone)]
+pub struct Exporter {
+    tx: mpsc::Sender<LogRecord>,
+    health: Arc<ExportHealth>,
+}
+
+impl Exporter {
+    /// Enqueue a log record. Never blocks; drops on a full queue.
+    pub fn log(&self, record: LogRecord) {
+        if self.tx.try_send(record).is_err() {
+            self.health.dropped.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    pub fn health(&self) -> &Arc<ExportHealth> {
+        &self.health
+    }
+}
+
+/// Spawn the export worker. Returns `None` when no endpoint is configured,
+/// so the absent-endpoint path opens no socket at all.
+pub fn spawn(
+    endpoint: Option<&str>,
+    headers: Option<&str>,
+    service_name: &str,
+    instance_id: &str,
+) -> Option<(Exporter, Arc<ExportHealth>)> {
+    let endpoint = endpoint?.trim_end_matches('/').to_string();
+    let header_pairs = parse_headers(headers);
+    let service_name = service_name.to_string();
+    let instance_id = instance_id.to_string();
+    let health = Arc::new(ExportHealth::default());
+    let (tx, mut rx) = mpsc::channel::<LogRecord>(QUEUE_CAPACITY);
+
+    let worker_health = health.clone();
+    tokio::spawn(async move {
+        let client = match reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+        {
+            Ok(client) => client,
+            Err(error) => {
+                // Sanitized: never the endpoint or headers.
+                tracing::warn!(
+                    failure = "client_build",
+                    %error,
+                    "telemetry export disabled"
+                );
+                return;
+            }
+        };
+        let logs_url = format!("{endpoint}/v1/logs");
+        let mut buffer: Vec<LogRecord> = Vec::with_capacity(BATCH_MAX);
+        let mut ticker = tokio::time::interval(FLUSH_INTERVAL);
+        loop {
+            tokio::select! {
+                maybe = rx.recv() => {
+                    match maybe {
+                        Some(record) => {
+                            buffer.push(record);
+                            if buffer.len() >= BATCH_MAX {
+                                flush(&client, &logs_url, &header_pairs, &service_name, &instance_id, &mut buffer, &worker_health).await;
+                            }
+                        }
+                        None => {
+                            flush(&client, &logs_url, &header_pairs, &service_name, &instance_id, &mut buffer, &worker_health).await;
+                            break;
+                        }
+                    }
+                }
+                _ = ticker.tick() => {
+                    flush(&client, &logs_url, &header_pairs, &service_name, &instance_id, &mut buffer, &worker_health).await;
+                }
+            }
+        }
+    });
+
+    Some((
+        Exporter {
+            tx,
+            health: health.clone(),
+        },
+        health,
+    ))
+}
+
+async fn flush(
+    client: &reqwest::Client,
+    url: &str,
+    headers: &[(String, String)],
+    service_name: &str,
+    instance_id: &str,
+    buffer: &mut Vec<LogRecord>,
+    health: &Arc<ExportHealth>,
+) {
+    if buffer.is_empty() {
+        return;
+    }
+    let batch = std::mem::take(buffer);
+    let count = batch.len() as u64;
+    let payload = encode_logs(&batch, service_name, instance_id);
+    let mut req = client.post(url).json(&payload);
+    for (name, value) in headers {
+        req = req.header(name.as_str(), value.as_str());
+    }
+    match req.send().await {
+        Ok(response) if response.status().is_success() => health.record_success(count),
+        Ok(response) => {
+            // Status class only — never the body, which can echo credentials.
+            tracing::warn!(
+                failure = "http_status",
+                status = response.status().as_u16(),
+                "telemetry export failed"
+            );
+            health.record_failure();
+        }
+        Err(_) => {
+            // No error text: reqwest errors embed the URL, which may carry
+            // credentials in userinfo.
+            tracing::warn!(failure = "transport", "telemetry export failed");
+            health.record_failure();
+        }
+    }
+}
+
+fn attr(key: &str, value: &str) -> Value {
+    json!({"key": key, "value": {"stringValue": value}})
+}
+
+fn severity_number(severity: &str) -> u8 {
+    match severity {
+        "TRACE" => 1,
+        "DEBUG" => 5,
+        "INFO" => 9,
+        "WARN" => 13,
+        "ERROR" => 17,
+        _ => 9,
+    }
+}
+
+/// Encode a batch into the OTLP/HTTP JSON `ExportLogsServiceRequest` shape.
+pub fn encode_logs(batch: &[LogRecord], service_name: &str, instance_id: &str) -> Value {
+    let ts = now_nanos().to_string();
+    let records: Vec<Value> = batch
+        .iter()
+        .map(|record| {
+            let attributes: Vec<Value> =
+                record.attributes.iter().map(|(k, v)| attr(k, v)).collect();
+            json!({
+                "timeUnixNano": ts,
+                "observedTimeUnixNano": ts,
+                "severityNumber": severity_number(record.severity),
+                "severityText": record.severity,
+                "body": {"stringValue": record.body},
+                "attributes": attributes,
+            })
+        })
+        .collect();
+    json!({
+        "resourceLogs": [{
+            "resource": {
+                "attributes": [
+                    attr("service.name", service_name),
+                    attr("service.instance.id", instance_id),
+                    attr("service.version", env!("CARGO_PKG_VERSION")),
+                ]
+            },
+            "scopeLogs": [{
+                "scope": {"name": "preloop-observability"},
+                "logRecords": records,
+            }]
+        }]
+    })
+}
+
+/// Parse `OTEL_EXPORTER_OTLP_HEADERS` (`k1=v1,k2=v2`).
+fn parse_headers(raw: Option<&str>) -> Vec<(String, String)> {
+    let Some(raw) = raw else {
+        return Vec::new();
+    };
+    raw.split(',')
+        .filter_map(|pair| {
+            let (k, v) = pair.split_once('=')?;
+            let k = k.trim();
+            let v = v.trim();
+            if k.is_empty() || v.is_empty() {
+                None
+            } else {
+                Some((k.to_string(), v.to_string()))
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn absent_endpoint_spawns_nothing() {
+        assert!(spawn(None, None, "preloop", "abc").is_none());
+    }
+
+    #[test]
+    fn headers_parse_pairs() {
+        let parsed = parse_headers(Some("Authorization=Basic abc,stream-name=default"));
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].0, "Authorization");
+        assert_eq!(parsed[1].1, "default");
+    }
+
+    #[test]
+    fn headers_ignore_malformed() {
+        assert!(parse_headers(Some("novalue,=empty,k=")).is_empty());
+    }
+
+    #[test]
+    fn encodes_otlp_log_shape() {
+        let batch = vec![LogRecord {
+            severity: "WARN",
+            body: "pool provisioning failed".to_string(),
+            attributes: vec![("event.name".to_string(), "pool.provision".to_string())],
+        }];
+        let payload = encode_logs(&batch, "preloop", "inst-1");
+        let record = &payload["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0];
+        assert_eq!(record["severityText"], "WARN");
+        assert_eq!(record["severityNumber"], 13);
+        assert_eq!(record["body"]["stringValue"], "pool provisioning failed");
+        let resource = &payload["resourceLogs"][0]["resource"]["attributes"];
+        assert_eq!(resource[0]["key"], "service.name");
+        assert_eq!(resource[0]["value"]["stringValue"], "preloop");
+    }
+}

--- a/crates/preloop-observability/src/export.rs
+++ b/crates/preloop-observability/src/export.rs
@@ -61,11 +61,96 @@ fn now_secs() -> u64 {
         .unwrap_or(0)
 }
 
-fn now_nanos() -> u128 {
+/// Wall-clock nanoseconds since the epoch, for OTLP timestamps.
+pub fn now_nanos() -> u128 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0)
+}
+
+/// W3C Trace Context: 16-byte trace id / 8-byte span id, lowercase hex.
+///
+/// Generated locally when a request arrives without a `traceparent`, or
+/// adopted from the incoming header so a caller's trace continues through
+/// the control plane.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpanContext {
+    pub trace_id: String,
+    pub span_id: String,
+    pub parent_span_id: Option<String>,
+}
+
+impl SpanContext {
+    /// New root context with a random trace and span id.
+    pub fn root() -> Self {
+        Self {
+            trace_id: random_hex(16),
+            span_id: random_hex(8),
+            parent_span_id: None,
+        }
+    }
+
+    /// Child of an incoming `traceparent`, or a new root when absent/invalid.
+    ///
+    /// Format: `00-<32 hex trace>-<16 hex span>-<2 hex flags>`. A malformed
+    /// header starts a new trace rather than failing the request — telemetry
+    /// must never reject traffic.
+    pub fn from_traceparent(header: Option<&str>) -> Self {
+        let Some(raw) = header else {
+            return Self::root();
+        };
+        let parts: Vec<&str> = raw.trim().split('-').collect();
+        if parts.len() != 4 {
+            return Self::root();
+        }
+        let (version, trace_id, parent_span_id) = (parts[0], parts[1], parts[2]);
+        let valid = version.len() == 2
+            && trace_id.len() == 32
+            && parent_span_id.len() == 16
+            && trace_id.chars().all(|c| c.is_ascii_hexdigit())
+            && parent_span_id.chars().all(|c| c.is_ascii_hexdigit())
+            // All-zero ids are explicitly invalid per the spec.
+            && trace_id.chars().any(|c| c != '0')
+            && parent_span_id.chars().any(|c| c != '0');
+        if !valid {
+            return Self::root();
+        }
+        Self {
+            trace_id: trace_id.to_ascii_lowercase(),
+            span_id: random_hex(8),
+            parent_span_id: Some(parent_span_id.to_ascii_lowercase()),
+        }
+    }
+}
+
+fn random_hex(bytes: usize) -> String {
+    use std::fmt::Write;
+    let mut out = String::with_capacity(bytes * 2);
+    for _ in 0..bytes {
+        let byte: u8 = rand::random();
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+/// OTLP span status. `Unset` is the default for a successful server span;
+/// only an actual error sets `Error`, per the OTLP spec.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpanStatus {
+    Unset,
+    Error,
+}
+
+/// One completed span queued for export.
+#[derive(Debug, Clone)]
+pub struct SpanRecord {
+    pub context: SpanContext,
+    pub name: String,
+    pub start_nanos: u128,
+    pub end_nanos: u128,
+    pub status: SpanStatus,
+    pub attributes: Vec<(String, String)>,
 }
 
 /// One log record queued for export.
@@ -74,19 +159,38 @@ pub struct LogRecord {
     pub severity: &'static str,
     pub body: String,
     pub attributes: Vec<(String, String)>,
+    /// Correlates this record with a span. OTLP carries these as first-class
+    /// fields, not attributes, so a backend can pivot log <-> trace.
+    pub trace_id: Option<String>,
+    pub span_id: Option<String>,
+}
+
+/// Either signal, multiplexed over one bounded channel so a burst of one
+/// cannot starve the other beyond the shared capacity.
+#[derive(Debug, Clone)]
+pub enum Item {
+    Log(LogRecord),
+    Span(SpanRecord),
 }
 
 /// Handle used by the rest of the process to enqueue telemetry.
 #[derive(Debug, Clone)]
 pub struct Exporter {
-    tx: mpsc::Sender<LogRecord>,
+    tx: mpsc::Sender<Item>,
     health: Arc<ExportHealth>,
 }
 
 impl Exporter {
     /// Enqueue a log record. Never blocks; drops on a full queue.
     pub fn log(&self, record: LogRecord) {
-        if self.tx.try_send(record).is_err() {
+        if self.tx.try_send(Item::Log(record)).is_err() {
+            self.health.dropped.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Enqueue a completed span. Never blocks; drops on a full queue.
+    pub fn span(&self, record: SpanRecord) {
+        if self.tx.try_send(Item::Span(record)).is_err() {
             self.health.dropped.fetch_add(1, Ordering::Relaxed);
         }
     }
@@ -98,20 +202,27 @@ impl Exporter {
 
 /// Spawn the export worker. Returns `None` when no endpoint is configured,
 /// so the absent-endpoint path opens no socket at all.
+///
+/// One worker drains logs and spans from the shared queue and scrapes the
+/// metrics registry on each tick, so all three signals share one batching
+/// cadence and one client.
 pub fn spawn(
     endpoint: Option<&str>,
     headers: Option<&str>,
     service_name: &str,
     instance_id: &str,
     service_version: &str,
+    metrics: Option<Arc<crate::metrics::MetricsRegistry>>,
 ) -> Option<(Exporter, Arc<ExportHealth>)> {
     let endpoint = endpoint?.trim_end_matches('/').to_string();
     let header_pairs = parse_headers(headers);
-    let service_name = service_name.to_string();
-    let instance_id = instance_id.to_string();
-    let service_version = service_version.to_string();
+    let resource = Resource {
+        service_name: service_name.to_string(),
+        instance_id: instance_id.to_string(),
+        service_version: service_version.to_string(),
+    };
     let health = Arc::new(ExportHealth::default());
-    let (tx, mut rx) = mpsc::channel::<LogRecord>(QUEUE_CAPACITY);
+    let (tx, mut rx) = mpsc::channel::<Item>(QUEUE_CAPACITY);
 
     let worker_health = health.clone();
     tokio::spawn(async move {
@@ -122,35 +233,51 @@ pub fn spawn(
             Ok(client) => client,
             Err(error) => {
                 // Sanitized: never the endpoint or headers.
-                tracing::warn!(
-                    failure = "client_build",
-                    %error,
-                    "telemetry export disabled"
-                );
+                tracing::warn!(failure = "client_build", %error, "telemetry export disabled");
                 return;
             }
         };
-        let logs_url = format!("{endpoint}/v1/logs");
-        let mut buffer: Vec<LogRecord> = Vec::with_capacity(BATCH_MAX);
+        // Cumulative temporality needs a fixed start for every point, or a
+        // backend cannot tell a restart from a counter reset.
+        let start_nanos = now_nanos();
+        let urls = Urls {
+            logs: format!("{endpoint}/v1/logs"),
+            traces: format!("{endpoint}/v1/traces"),
+            metrics: format!("{endpoint}/v1/metrics"),
+        };
+        let mut logs: Vec<LogRecord> = Vec::with_capacity(BATCH_MAX);
+        let mut spans: Vec<SpanRecord> = Vec::with_capacity(BATCH_MAX);
         let mut ticker = tokio::time::interval(FLUSH_INTERVAL);
         loop {
             tokio::select! {
                 maybe = rx.recv() => {
                     match maybe {
-                        Some(record) => {
-                            buffer.push(record);
-                            if buffer.len() >= BATCH_MAX {
-                                flush(&client, &logs_url, &header_pairs, &service_name, &instance_id, &service_version, &mut buffer, &worker_health).await;
+                        Some(Item::Log(record)) => {
+                            logs.push(record);
+                            if logs.len() >= BATCH_MAX {
+                                flush_logs(&client, &urls, &header_pairs, &resource, &mut logs, &worker_health).await;
+                            }
+                        }
+                        Some(Item::Span(record)) => {
+                            spans.push(record);
+                            if spans.len() >= BATCH_MAX {
+                                flush_spans(&client, &urls, &header_pairs, &resource, &mut spans, &worker_health).await;
                             }
                         }
                         None => {
-                            flush(&client, &logs_url, &header_pairs, &service_name, &instance_id, &service_version, &mut buffer, &worker_health).await;
+                            // Channel closed: final drain, then exit.
+                            flush_logs(&client, &urls, &header_pairs, &resource, &mut logs, &worker_health).await;
+                            flush_spans(&client, &urls, &header_pairs, &resource, &mut spans, &worker_health).await;
                             break;
                         }
                     }
                 }
                 _ = ticker.tick() => {
-                    flush(&client, &logs_url, &header_pairs, &service_name, &instance_id, &service_version, &mut buffer, &worker_health).await;
+                    flush_logs(&client, &urls, &header_pairs, &resource, &mut logs, &worker_health).await;
+                    flush_spans(&client, &urls, &header_pairs, &resource, &mut spans, &worker_health).await;
+                    if let Some(registry) = &metrics {
+                        flush_metrics(&client, &urls, &header_pairs, &resource, registry, start_nanos, &worker_health).await;
+                    }
                 }
             }
         }
@@ -165,23 +292,31 @@ pub fn spawn(
     ))
 }
 
-async fn flush(
+#[derive(Debug, Clone)]
+struct Urls {
+    logs: String,
+    traces: String,
+    metrics: String,
+}
+
+#[derive(Debug, Clone)]
+struct Resource {
+    service_name: String,
+    instance_id: String,
+    service_version: String,
+}
+
+/// POST one payload, recording health. Never propagates an error.
+async fn post(
     client: &reqwest::Client,
     url: &str,
     headers: &[(String, String)],
-    service_name: &str,
-    instance_id: &str,
-    service_version: &str,
-    buffer: &mut Vec<LogRecord>,
+    payload: &Value,
+    signal: &'static str,
+    count: u64,
     health: &Arc<ExportHealth>,
 ) {
-    if buffer.is_empty() {
-        return;
-    }
-    let batch = std::mem::take(buffer);
-    let count = batch.len() as u64;
-    let payload = encode_logs(&batch, service_name, instance_id, service_version);
-    let mut req = client.post(url).json(&payload);
+    let mut req = client.post(url).json(payload);
     for (name, value) in headers {
         req = req.header(name.as_str(), value.as_str());
     }
@@ -191,6 +326,7 @@ async fn flush(
             // Status class only — never the body, which can echo credentials.
             tracing::warn!(
                 failure = "http_status",
+                signal,
                 status = response.status().as_u16(),
                 "telemetry export failed"
             );
@@ -199,14 +335,110 @@ async fn flush(
         Err(_) => {
             // No error text: reqwest errors embed the URL, which may carry
             // credentials in userinfo.
-            tracing::warn!(failure = "transport", "telemetry export failed");
+            tracing::warn!(failure = "transport", signal, "telemetry export failed");
             health.record_failure();
         }
     }
 }
 
+async fn flush_logs(
+    client: &reqwest::Client,
+    urls: &Urls,
+    headers: &[(String, String)],
+    resource: &Resource,
+    buffer: &mut Vec<LogRecord>,
+    health: &Arc<ExportHealth>,
+) {
+    if buffer.is_empty() {
+        return;
+    }
+    let batch = std::mem::take(buffer);
+    let count = batch.len() as u64;
+    let payload = encode_logs(
+        &batch,
+        &resource.service_name,
+        &resource.instance_id,
+        &resource.service_version,
+    );
+    post(client, &urls.logs, headers, &payload, "logs", count, health).await;
+}
+
+async fn flush_spans(
+    client: &reqwest::Client,
+    urls: &Urls,
+    headers: &[(String, String)],
+    resource: &Resource,
+    buffer: &mut Vec<SpanRecord>,
+    health: &Arc<ExportHealth>,
+) {
+    if buffer.is_empty() {
+        return;
+    }
+    let batch = std::mem::take(buffer);
+    let count = batch.len() as u64;
+    let payload = encode_spans(
+        &batch,
+        &resource.service_name,
+        &resource.instance_id,
+        &resource.service_version,
+    );
+    post(
+        client,
+        &urls.traces,
+        headers,
+        &payload,
+        "traces",
+        count,
+        health,
+    )
+    .await;
+}
+
+async fn flush_metrics(
+    client: &reqwest::Client,
+    urls: &Urls,
+    headers: &[(String, String)],
+    resource: &Resource,
+    registry: &Arc<crate::metrics::MetricsRegistry>,
+    start_nanos: u128,
+    health: &Arc<ExportHealth>,
+) {
+    let families = registry.collect();
+    if families.is_empty() {
+        return;
+    }
+    let count = families.len() as u64;
+    let payload = encode_metrics(
+        &families,
+        &resource.service_name,
+        &resource.instance_id,
+        &resource.service_version,
+        start_nanos,
+    );
+    post(
+        client,
+        &urls.metrics,
+        headers,
+        &payload,
+        "metrics",
+        count,
+        health,
+    )
+    .await;
+}
+
+const SCOPE_NAME: &str = "preloop-observability";
+
 fn attr(key: &str, value: &str) -> Value {
     json!({"key": key, "value": {"stringValue": value}})
+}
+
+fn resource_attributes(service_name: &str, instance_id: &str, service_version: &str) -> Vec<Value> {
+    vec![
+        attr("service.name", service_name),
+        attr("service.instance.id", instance_id),
+        attr("service.version", service_version),
+    ]
 }
 
 fn severity_number(severity: &str) -> u8 {
@@ -233,25 +465,25 @@ pub fn encode_logs(
         .map(|record| {
             let attributes: Vec<Value> =
                 record.attributes.iter().map(|(k, v)| attr(k, v)).collect();
-            json!({
+            let mut obj = json!({
                 "timeUnixNano": ts,
                 "observedTimeUnixNano": ts,
                 "severityNumber": severity_number(record.severity),
                 "severityText": record.severity,
                 "body": {"stringValue": record.body},
                 "attributes": attributes,
-            })
+            });
+            // OTLP carries correlation as first-class fields, not attributes.
+            if let (Some(trace_id), Some(span_id)) = (&record.trace_id, &record.span_id) {
+                obj["traceId"] = json!(trace_id);
+                obj["spanId"] = json!(span_id);
+            }
+            obj
         })
         .collect();
     json!({
         "resourceLogs": [{
-            "resource": {
-                "attributes": [
-                    attr("service.name", service_name),
-                    attr("service.instance.id", instance_id),
-                    attr("service.version", service_version),
-                ]
-            },
+            "resource": {"attributes": resource_attributes(service_name, instance_id, service_version)},
             "scopeLogs": [{
                 "scope": {"name": "preloop-observability"},
                 "logRecords": records,
@@ -279,13 +511,166 @@ fn parse_headers(raw: Option<&str>) -> Vec<(String, String)> {
         .collect()
 }
 
+/// Encode a batch into the OTLP/HTTP JSON `ExportTraceServiceRequest` shape.
+pub fn encode_spans(
+    batch: &[SpanRecord],
+    service_name: &str,
+    instance_id: &str,
+    service_version: &str,
+) -> Value {
+    let spans: Vec<Value> = batch
+        .iter()
+        .map(|record| {
+            let attributes: Vec<Value> =
+                record.attributes.iter().map(|(k, v)| attr(k, v)).collect();
+            let mut obj = json!({
+                "traceId": record.context.trace_id,
+                "spanId": record.context.span_id,
+                "name": record.name,
+                // 2 = SPAN_KIND_SERVER: every span we emit today is an
+                // inbound request handled by the control plane.
+                "kind": 2,
+                "startTimeUnixNano": record.start_nanos.to_string(),
+                "endTimeUnixNano": record.end_nanos.to_string(),
+                "attributes": attributes,
+                "status": {"code": match record.status {
+                    SpanStatus::Unset => 0,
+                    SpanStatus::Error => 2,
+                }},
+            });
+            if let Some(parent) = &record.context.parent_span_id {
+                obj["parentSpanId"] = json!(parent);
+            }
+            obj
+        })
+        .collect();
+    json!({
+        "resourceSpans": [{
+            "resource": {"attributes": resource_attributes(service_name, instance_id, service_version)},
+            "scopeSpans": [{
+                "scope": {"name": SCOPE_NAME},
+                "spans": spans,
+            }]
+        }]
+    })
+}
+
+/// Encode collected families into the OTLP/HTTP JSON `ExportMetricsServiceRequest`.
+///
+/// All points are cumulative (`aggregationTemporality: 2`) and share the
+/// process start as `startTimeUnixNano`, so a backend can distinguish a
+/// restart from a counter reset.
+pub fn encode_metrics(
+    families: &[crate::metrics::MetricFamily],
+    service_name: &str,
+    instance_id: &str,
+    service_version: &str,
+    start_nanos: u128,
+) -> Value {
+    use crate::metrics::MetricPoint;
+    const CUMULATIVE: u8 = 2;
+    let now = now_nanos().to_string();
+    let start = start_nanos.to_string();
+
+    let metrics: Vec<Value> = families
+        .iter()
+        .map(|family| {
+            let mut metric = json!({"name": family.name, "unit": family.unit});
+            match family.points.first() {
+                Some(MetricPoint::Sum { .. }) => {
+                    let points: Vec<Value> = family
+                        .points
+                        .iter()
+                        .filter_map(|point| match point {
+                            MetricPoint::Sum { value, attributes } => Some(json!({
+                                "asDouble": value,
+                                "startTimeUnixNano": start,
+                                "timeUnixNano": now,
+                                "attributes": encode_attrs(attributes),
+                            })),
+                            _ => None,
+                        })
+                        .collect();
+                    metric["sum"] = json!({
+                        "dataPoints": points,
+                        "aggregationTemporality": CUMULATIVE,
+                        "isMonotonic": true,
+                    });
+                }
+                Some(MetricPoint::Gauge { .. }) => {
+                    let points: Vec<Value> = family
+                        .points
+                        .iter()
+                        .filter_map(|point| match point {
+                            MetricPoint::Gauge { value, attributes } => Some(json!({
+                                "asDouble": value,
+                                "timeUnixNano": now,
+                                "attributes": encode_attrs(attributes),
+                            })),
+                            _ => None,
+                        })
+                        .collect();
+                    metric["gauge"] = json!({"dataPoints": points});
+                }
+                Some(MetricPoint::Histogram { .. }) => {
+                    let points: Vec<Value> = family
+                        .points
+                        .iter()
+                        .filter_map(|point| match point {
+                            MetricPoint::Histogram {
+                                count,
+                                sum,
+                                bounds,
+                                bucket_counts,
+                                attributes,
+                            } => Some(json!({
+                                "count": count.to_string(),
+                                "sum": sum,
+                                "explicitBounds": bounds,
+                                "bucketCounts": bucket_counts
+                                    .iter()
+                                    .map(|c| c.to_string())
+                                    .collect::<Vec<_>>(),
+                                "startTimeUnixNano": start,
+                                "timeUnixNano": now,
+                                "attributes": encode_attrs(attributes),
+                            })),
+                            _ => None,
+                        })
+                        .collect();
+                    metric["histogram"] = json!({
+                        "dataPoints": points,
+                        "aggregationTemporality": CUMULATIVE,
+                    });
+                }
+                None => {}
+            }
+            metric
+        })
+        .collect();
+
+    json!({
+        "resourceMetrics": [{
+            "resource": {"attributes": resource_attributes(service_name, instance_id, service_version)},
+            "scopeMetrics": [{
+                "scope": {"name": SCOPE_NAME},
+                "metrics": metrics,
+            }]
+        }]
+    })
+}
+
+fn encode_attrs(attributes: &[(String, String)]) -> Vec<Value> {
+    attributes.iter().map(|(k, v)| attr(k, v)).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn absent_endpoint_spawns_nothing() {
-        assert!(spawn(None, None, "preloop", "abc", "9.9.9").is_none());
+        assert!(spawn(None, None, "preloop", "abc", "9.9.9", None).is_none());
     }
 
     #[test]
@@ -307,6 +692,8 @@ mod tests {
             severity: "WARN",
             body: "pool provisioning failed".to_string(),
             attributes: vec![("event.name".to_string(), "pool.provision".to_string())],
+            trace_id: None,
+            span_id: None,
         }];
         let payload = encode_logs(&batch, "preloop", "inst-1", "9.9.9");
         let record = &payload["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0];
@@ -321,5 +708,155 @@ mod tests {
             resource[2]["value"]["stringValue"], "9.9.9",
             "service.version must come from the host binary, not this crate"
         );
+    }
+}
+
+#[cfg(test)]
+mod signal_tests {
+    use super::*;
+    use crate::metrics::{MetricFamily, MetricPoint};
+
+    #[test]
+    fn traceparent_is_adopted_as_parent() {
+        let ctx = SpanContext::from_traceparent(Some(
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+        ));
+        assert_eq!(ctx.trace_id, "4bf92f3577b34da6a3ce929d0e0e4736");
+        assert_eq!(ctx.parent_span_id.as_deref(), Some("00f067aa0ba902b7"));
+        // A child must get its own span id, never reuse the parent's.
+        assert_ne!(ctx.span_id, "00f067aa0ba902b7");
+        assert_eq!(ctx.span_id.len(), 16);
+    }
+
+    #[test]
+    fn malformed_traceparent_starts_a_new_root() {
+        for bad in [
+            "garbage",
+            "00-tooshort-00f067aa0ba902b7-01",
+            // All-zero ids are invalid per the spec.
+            "00-00000000000000000000000000000000-00f067aa0ba902b7-01",
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01",
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7",
+        ] {
+            let ctx = SpanContext::from_traceparent(Some(bad));
+            assert!(
+                ctx.parent_span_id.is_none(),
+                "{bad} must not adopt a parent"
+            );
+            assert_eq!(ctx.trace_id.len(), 32);
+        }
+    }
+
+    #[test]
+    fn generated_ids_are_unique_and_well_formed() {
+        let a = SpanContext::root();
+        let b = SpanContext::root();
+        assert_ne!(a.trace_id, b.trace_id);
+        assert_eq!(a.trace_id.len(), 32);
+        assert_eq!(a.span_id.len(), 8 * 2);
+        assert!(a.trace_id.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn spans_encode_to_otlp_shape() {
+        let ctx = SpanContext::from_traceparent(Some(
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+        ));
+        let batch = vec![SpanRecord {
+            context: ctx,
+            name: "GET /api/v1/runs/:run_id".to_string(),
+            start_nanos: 1_000,
+            end_nanos: 2_000,
+            status: SpanStatus::Error,
+            attributes: vec![("http.route".to_string(), "/api/v1/runs/:run_id".to_string())],
+        }];
+        let payload = encode_spans(&batch, "preloop", "inst", "0.2.0");
+        let span = &payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0];
+        assert_eq!(span["traceId"], "4bf92f3577b34da6a3ce929d0e0e4736");
+        assert_eq!(span["parentSpanId"], "00f067aa0ba902b7");
+        assert_eq!(span["kind"], 2, "server span");
+        assert_eq!(span["status"]["code"], 2, "error");
+        assert_eq!(span["startTimeUnixNano"], "1000");
+    }
+
+    #[test]
+    fn logs_carry_trace_correlation_as_fields() {
+        let batch = vec![LogRecord {
+            severity: "WARN",
+            body: "job.status.terminal".to_string(),
+            attributes: vec![],
+            trace_id: Some("4bf92f3577b34da6a3ce929d0e0e4736".to_string()),
+            span_id: Some("00f067aa0ba902b7".to_string()),
+        }];
+        let payload = encode_logs(&batch, "preloop", "inst", "0.2.0");
+        let record = &payload["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0];
+        // OTLP requires these as fields, not attributes, for log<->trace pivot.
+        assert_eq!(record["traceId"], "4bf92f3577b34da6a3ce929d0e0e4736");
+        assert_eq!(record["spanId"], "00f067aa0ba902b7");
+    }
+
+    #[test]
+    fn counters_encode_as_cumulative_monotonic_sums() {
+        let families = vec![MetricFamily {
+            name: "preloop.job.completed".to_string(),
+            unit: "{job}",
+            points: vec![MetricPoint::Sum {
+                value: 7.0,
+                attributes: vec![("preloop.conclusion".to_string(), "failure".to_string())],
+            }],
+        }];
+        let payload = encode_metrics(&families, "preloop", "inst", "0.2.0", 500);
+        let metric = &payload["resourceMetrics"][0]["scopeMetrics"][0]["metrics"][0];
+        assert_eq!(metric["name"], "preloop.job.completed");
+        assert_eq!(metric["sum"]["isMonotonic"], true);
+        assert_eq!(metric["sum"]["aggregationTemporality"], 2, "cumulative");
+        let point = &metric["sum"]["dataPoints"][0];
+        assert_eq!(point["asDouble"], 7.0);
+        assert_eq!(
+            point["startTimeUnixNano"], "500",
+            "cumulative points need a fixed start or a restart reads as a reset"
+        );
+    }
+
+    #[test]
+    fn histograms_encode_with_the_implicit_inf_bucket() {
+        let families = vec![MetricFamily {
+            name: "http.server.request.duration".to_string(),
+            unit: "s",
+            points: vec![MetricPoint::Histogram {
+                count: 5,
+                sum: 0.25,
+                bounds: vec![0.005, 0.01],
+                bucket_counts: vec![1, 3, 5],
+                attributes: vec![("http.route".to_string(), "/healthz".to_string())],
+            }],
+        }];
+        let payload = encode_metrics(&families, "preloop", "inst", "0.2.0", 0);
+        let point = &payload["resourceMetrics"][0]["scopeMetrics"][0]["metrics"][0]["histogram"]
+            ["dataPoints"][0];
+        let bounds = point["explicitBounds"].as_array().unwrap();
+        let counts = point["bucketCounts"].as_array().unwrap();
+        assert_eq!(
+            counts.len(),
+            bounds.len() + 1,
+            "OTLP requires one more bucket count than bounds (+Inf)"
+        );
+        assert_eq!(point["count"], "5");
+    }
+
+    #[test]
+    fn gauges_have_no_temporality_or_start_time() {
+        let families = vec![MetricFamily {
+            name: "http.server.active_requests".to_string(),
+            unit: "{request}",
+            points: vec![MetricPoint::Gauge {
+                value: 3.0,
+                attributes: vec![],
+            }],
+        }];
+        let payload = encode_metrics(&families, "preloop", "inst", "0.2.0", 0);
+        let metric = &payload["resourceMetrics"][0]["scopeMetrics"][0]["metrics"][0];
+        assert!(metric["gauge"]["dataPoints"][0]["asDouble"] == 3.0);
+        assert!(metric["gauge"]["aggregationTemporality"].is_null());
     }
 }

--- a/crates/preloop-observability/src/lib.rs
+++ b/crates/preloop-observability/src/lib.rs
@@ -11,6 +11,7 @@
 //! - Always retain `stderr`/`journald` even when OTLP is configured.
 //! - `Debug` on config never reveals headers or credential-bearing endpoint parts.
 
+pub mod metrics;
 pub mod status;
 
 use std::collections::HashMap;
@@ -381,6 +382,7 @@ struct Inner {
     config: Arc<ObservabilityConfig>,
     heartbeat: TaskHeartbeat,
     limits: LimitRegistry,
+    metrics: Arc<metrics::MetricsRegistry>,
     is_noop: bool,
 }
 
@@ -407,6 +409,7 @@ impl Observability {
                 config: Arc::new(config),
                 heartbeat: TaskHeartbeat::default(),
                 limits: LimitRegistry::default(),
+                metrics: Arc::new(metrics::MetricsRegistry::default()),
                 is_noop: true,
             }),
         }
@@ -420,6 +423,7 @@ impl Observability {
                 config: Arc::new(config),
                 heartbeat: TaskHeartbeat::default(),
                 limits: LimitRegistry::default(),
+                metrics: Arc::new(metrics::MetricsRegistry::default()),
                 is_noop,
             }),
         };
@@ -449,6 +453,10 @@ impl Observability {
 
     pub fn limits(&self) -> &LimitRegistry {
         &self.inner.limits
+    }
+
+    pub fn metrics(&self) -> &metrics::MetricsRegistry {
+        &self.inner.metrics
     }
 
     pub fn config(&self) -> &ObservabilityConfig {

--- a/crates/preloop-observability/src/lib.rs
+++ b/crates/preloop-observability/src/lib.rs
@@ -13,6 +13,7 @@
 
 pub mod metrics;
 pub mod status;
+pub mod vm_telemetry;
 
 use std::collections::HashMap;
 use std::fmt;
@@ -383,6 +384,7 @@ struct Inner {
     heartbeat: TaskHeartbeat,
     limits: LimitRegistry,
     metrics: Arc<metrics::MetricsRegistry>,
+    vm_registry: Arc<vm_telemetry::VmTelemetryRegistry>,
     is_noop: bool,
 }
 
@@ -410,6 +412,7 @@ impl Observability {
                 heartbeat: TaskHeartbeat::default(),
                 limits: LimitRegistry::default(),
                 metrics: Arc::new(metrics::MetricsRegistry::default()),
+                vm_registry: Arc::new(vm_telemetry::VmTelemetryRegistry::default()),
                 is_noop: true,
             }),
         }
@@ -424,6 +427,7 @@ impl Observability {
                 heartbeat: TaskHeartbeat::default(),
                 limits: LimitRegistry::default(),
                 metrics: Arc::new(metrics::MetricsRegistry::default()),
+                vm_registry: Arc::new(vm_telemetry::VmTelemetryRegistry::default()),
                 is_noop,
             }),
         };
@@ -457,6 +461,10 @@ impl Observability {
 
     pub fn metrics(&self) -> &metrics::MetricsRegistry {
         &self.inner.metrics
+    }
+
+    pub fn vm_registry(&self) -> &vm_telemetry::VmTelemetryRegistry {
+        &self.inner.vm_registry
     }
 
     pub fn config(&self) -> &ObservabilityConfig {

--- a/crates/preloop-observability/src/lib.rs
+++ b/crates/preloop-observability/src/lib.rs
@@ -443,12 +443,16 @@ impl Observability {
     pub fn from_config(config: ObservabilityConfig) -> (Self, ObservabilityRuntime) {
         let is_noop = !config.otlp_enabled;
         // Absent endpoint spawns nothing at all — no worker, no socket.
+        // The registry is shared with the worker so metric export scrapes the
+        // same instruments `/metrics` renders — one source, never two.
+        let metrics = Arc::new(metrics::MetricsRegistry::default());
         let exporter = export::spawn(
             config.otel_endpoint_raw(),
             config.otel_headers_raw(),
             &config.service_name,
             &config.instance_id,
             &config.service_version,
+            Some(metrics.clone()),
         )
         .map(|(exporter, _health)| exporter);
         let handle = Self {
@@ -456,7 +460,7 @@ impl Observability {
                 config: Arc::new(config),
                 heartbeat: TaskHeartbeat::default(),
                 limits: LimitRegistry::default(),
-                metrics: Arc::new(metrics::MetricsRegistry::default()),
+                metrics,
                 vm_registry: Arc::new(vm_telemetry::VmTelemetryRegistry::default()),
                 exporter,
                 is_noop,
@@ -505,13 +509,40 @@ impl Observability {
         body: impl Into<String>,
         attributes: Vec<(String, String)>,
     ) {
+        self.export_log_in_span(severity, body, attributes, None);
+    }
+
+    /// As [`Observability::export_log`], correlated with a span so a backend
+    /// can pivot from a log line to the request that produced it.
+    pub fn export_log_in_span(
+        &self,
+        severity: &'static str,
+        body: impl Into<String>,
+        attributes: Vec<(String, String)>,
+        context: Option<&export::SpanContext>,
+    ) {
         if let Some(exporter) = &self.inner.exporter {
             exporter.log(export::LogRecord {
                 severity,
                 body: body.into(),
                 attributes,
+                trace_id: context.map(|c| c.trace_id.clone()),
+                span_id: context.map(|c| c.span_id.clone()),
             });
         }
+    }
+
+    /// Enqueue a completed span. No-op when export is disabled.
+    pub fn export_span(&self, record: export::SpanRecord) {
+        if let Some(exporter) = &self.inner.exporter {
+            exporter.span(record);
+        }
+    }
+
+    /// Whether spans are worth building. Lets a caller skip id and timestamp
+    /// work entirely when nothing would consume the result.
+    pub fn tracing_enabled(&self) -> bool {
+        self.inner.exporter.is_some()
     }
 
     /// Export health for `/api/v1/status` and `preloop.telemetry.export`.

--- a/crates/preloop-observability/src/lib.rs
+++ b/crates/preloop-observability/src/lib.rs
@@ -1,0 +1,696 @@
+//! `preloop-observability` — Step 2 of Plan 002.
+//!
+//! Small, explicit API with no dependency on server/orchestrator internals. Both
+//! `preloop` and `preloop-server` construct one handle/runtime before building
+//! `ServerConfig`; the handle is cloned into `AppState` and `RunnerPoolConfig`.
+//! Tests use `Observability::noop()` which performs no network I/O.
+//!
+//! Invariants from the plan:
+//! - Fail open: export failure never rejects a workflow.
+//! - Bounded queues, 2s flush, no backend by default (absent `OTEL_EXPORTER_OTLP_*` = disabled, not `localhost:4318`).
+//! - Always retain `stderr`/`journald` even when OTLP is configured.
+//! - `Debug` on config never reveals headers or credential-bearing endpoint parts.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use parking_lot::RwLock;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Log format
+// ---------------------------------------------------------------------------
+
+/// How `tracing_subscriber::fmt` should render.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogFormat {
+    /// Pretty on TTY, JSON when piped / in journald.
+    Auto,
+    Pretty,
+    Json,
+}
+
+impl LogFormat {
+    fn parse(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "auto" => Some(Self::Auto),
+            "pretty" => Some(Self::Pretty),
+            "json" => Some(Self::Json),
+            _ => None,
+        }
+    }
+
+    /// Resolve `Auto` to a concrete format for the current stderr.
+    pub fn resolve(self) -> Self {
+        if self != Self::Auto {
+            return self;
+        }
+        if std::io::IsTerminal::is_terminal(&std::io::stderr()) {
+            Self::Pretty
+        } else {
+            Self::Json
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ObservabilityConfig
+// ---------------------------------------------------------------------------
+
+/// Parsed logging + OTel configuration. `Debug` is redacted.
+pub struct ObservabilityConfig {
+    /// `PRELOOP_LOG_FORMAT` resolved to concrete `LogFormat` (but `Auto` is kept for display).
+    pub log_format: LogFormat,
+    /// Effective `RUST_LOG` filter string (default `info` when unset, matching CLI behaviour).
+    pub rust_log: String,
+    /// `service.name` — `preloop` or `OTEL_SERVICE_NAME`.
+    pub service_name: String,
+    /// Per-process instance ID (UUID v4).
+    pub instance_id: String,
+    /// `OTEL_EXPORTER_OTLP_ENDPOINT` or signal-specific variant, if any. Kept as
+    /// given for transport, but `Debug` redacts userinfo/query.
+    otel_endpoint: Option<String>,
+    /// `OTEL_EXPORTER_OTLP_HEADERS` or signal-specific variant, if any. Never shown in `Debug` or errors.
+    otel_headers: Option<String>,
+    /// Whether any OTLP endpoint is present (i.e. export enabled).
+    pub otlp_enabled: bool,
+}
+
+impl ObservabilityConfig {
+    /// Read `PRELOOP_LOG_FORMAT`, `RUST_LOG`, and standard `OTEL_*` vars.
+    ///
+    /// `Debug` and error paths never expose `OTEL_EXPORTER_OTLP_HEADERS` values
+    /// or credential-bearing endpoint components (userinfo/query).
+    pub fn from_env() -> Self {
+        let log_format = std::env::var("PRELOOP_LOG_FORMAT")
+            .ok()
+            .and_then(|v| LogFormat::parse(&v))
+            .unwrap_or(LogFormat::Auto);
+
+        // CLI defaults to `info` when unset; the standalone server historically
+        // used `EnvFilter::from_default_env()` with no fallback (silent when
+        // unset). We unify on `info` per Step 2.
+        let rust_log = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string());
+
+        let service_name =
+            std::env::var("OTEL_SERVICE_NAME").unwrap_or_else(|_| "preloop".to_string());
+
+        // Endpoint: generic or signal-specific. Presence — not value — enables export.
+        // This is a deliberate deviation from the OTel spec default `http://localhost:4318`.
+        let otel_endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
+            .or_else(|_| std::env::var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"))
+            .or_else(|_| std::env::var("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT"))
+            .or_else(|_| std::env::var("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT"))
+            .ok()
+            .filter(|v| !v.trim().is_empty() && v.trim() != "none");
+
+        let otel_headers = std::env::var("OTEL_EXPORTER_OTLP_HEADERS")
+            .or_else(|_| std::env::var("OTEL_EXPORTER_OTLP_TRACES_HEADERS"))
+            .or_else(|_| std::env::var("OTEL_EXPORTER_OTLP_METRICS_HEADERS"))
+            .or_else(|_| std::env::var("OTEL_EXPORTER_OTLP_LOGS_HEADERS"))
+            .ok()
+            .filter(|v| !v.trim().is_empty());
+
+        let otlp_enabled = otel_endpoint.is_some();
+        let instance_id = Uuid::new_v4().to_string();
+
+        Self {
+            log_format,
+            rust_log,
+            service_name,
+            instance_id,
+            otel_endpoint,
+            otel_headers,
+            otlp_enabled,
+        }
+    }
+
+    /// Raw endpoint if export is enabled, for transport construction.
+    pub fn otel_endpoint_raw(&self) -> Option<&str> {
+        self.otel_endpoint.as_deref()
+    }
+
+    /// Whether any `OTEL_EXPORTER_OTLP_HEADERS` was supplied (for health reporting).
+    pub fn has_otel_headers(&self) -> bool {
+        self.otel_headers.is_some()
+    }
+
+    /// Sanitized endpoint for `Debug`/errors: strips userinfo and query.
+    fn sanitized_endpoint(&self) -> Option<String> {
+        self.otel_endpoint.as_ref().map(|raw| {
+            // Best-effort: hide `user:pass@` and `?...` without a URL parser dep.
+            let without_query = raw.split('?').next().unwrap_or(raw);
+            if let Some(at) = without_query.rfind('@') {
+                // Keep scheme + host/path, hide userinfo.
+                if let Some(scheme_end) = without_query.find("://") {
+                    let scheme = &without_query[..scheme_end + 3];
+                    return format!("{scheme}***@{}", &without_query[at + 1..]);
+                }
+                return format!("***@{}", &without_query[at + 1..]);
+            }
+            without_query.to_string()
+        })
+    }
+}
+
+impl fmt::Debug for ObservabilityConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ObservabilityConfig")
+            .field("log_format", &self.log_format)
+            .field("rust_log", &self.rust_log)
+            .field("service_name", &self.service_name)
+            .field("instance_id", &self.instance_id)
+            .field(
+                "otel_endpoint",
+                &self.sanitized_endpoint().map(|_| "<redacted-endpoint>"),
+            )
+            .field(
+                "otel_headers",
+                &self.otel_headers.as_ref().map(|_| "<redacted>"),
+            )
+            .field("otlp_enabled", &self.otlp_enabled)
+            .finish()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TaskHeartbeat registry
+// ---------------------------------------------------------------------------
+
+/// How a task gates `/readyz`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Criticality {
+    /// Staleness returns 503 from `/readyz`.
+    Critical,
+    /// Staleness surfaces only in `/api/v1/status` and metrics.
+    NonCritical,
+}
+
+/// Registry of long-lived background tasks. Generic replacement for per-task
+/// `AtomicU64` timestamps; every `tokio::spawn` that outlives a request
+/// registers here per invariant 15.
+#[derive(Debug, Clone, Default)]
+pub struct TaskHeartbeat {
+    inner: Arc<RwLock<HashMap<&'static str, HeartbeatEntry>>>,
+}
+
+#[derive(Debug, Clone)]
+struct HeartbeatEntry {
+    critical: Criticality,
+    last_beat: Instant,
+    /// Whether the task has exited cleanly (Drop without panic).
+    exited: bool,
+}
+
+impl TaskHeartbeat {
+    /// Register a task. Returns a guard — `Drop` deregisters.
+    pub fn register(&self, name: &'static str, critical: Criticality) -> HeartbeatHandle {
+        self.inner.write().insert(
+            name,
+            HeartbeatEntry {
+                critical,
+                last_beat: Instant::now(),
+                exited: false,
+            },
+        );
+        HeartbeatHandle {
+            registry: self.clone(),
+            name,
+        }
+    }
+
+    /// Record a beat for `name`. No-op if not registered (so tests can `noop()` without registering).
+    pub fn beat(&self, name: &'static str) {
+        if let Some(entry) = self.inner.write().get_mut(name) {
+            entry.last_beat = Instant::now();
+        }
+    }
+
+    pub(crate) fn deregister(&self, name: &'static str) {
+        self.inner.write().remove(name);
+    }
+
+    pub(crate) fn mark_exited(&self, name: &'static str) {
+        if let Some(entry) = self.inner.write().get_mut(name) {
+            entry.exited = true;
+        }
+    }
+
+    /// Snapshot for `/readyz` and `/api/v1/status`.
+    pub fn snapshot(&self) -> Vec<TaskSnapshot> {
+        self.inner
+            .read()
+            .iter()
+            .map(|(name, e)| TaskSnapshot {
+                name,
+                critical: e.critical,
+                heartbeat_age: e.last_beat.elapsed(),
+                exited: e.exited,
+            })
+            .collect()
+    }
+
+    /// Whether any critical task is stale beyond `threshold`.
+    pub fn any_critical_stale(&self, threshold: Duration) -> Option<&'static str> {
+        // Hold read lock across iteration to avoid TOCTOU.
+        let guard = self.inner.read();
+        for (name, e) in guard.iter() {
+            if e.critical == Criticality::Critical && !e.exited && e.last_beat.elapsed() > threshold
+            {
+                return Some(*name);
+            }
+        }
+        None
+    }
+
+    /// Number of registered tasks (for tests).
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.inner.read().len()
+    }
+}
+
+/// Guard — `beat()` updates, `Drop` deregisters.
+pub struct HeartbeatHandle {
+    registry: TaskHeartbeat,
+    name: &'static str,
+}
+
+impl HeartbeatHandle {
+    pub fn beat(&self) {
+        self.registry.beat(self.name);
+    }
+}
+
+impl Drop for HeartbeatHandle {
+    fn drop(&mut self) {
+        self.registry.deregister(self.name);
+    }
+}
+
+impl fmt::Debug for HeartbeatHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HeartbeatHandle")
+            .field("name", &self.name)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TaskSnapshot {
+    pub name: &'static str,
+    pub critical: Criticality,
+    pub heartbeat_age: Duration,
+    pub exited: bool,
+}
+
+// ---------------------------------------------------------------------------
+// LimitRegistry
+// ---------------------------------------------------------------------------
+
+/// Bounded-cap registry. `limit` is a `&'static str` constant name (finite set), never a value.
+#[derive(Debug, Clone, Default)]
+pub struct LimitRegistry {
+    inner: Arc<RwLock<HashMap<&'static str, LimitEntry>>>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct LimitEntry {
+    value: usize,
+    dropped: u64,
+    rejected: u64,
+}
+
+impl LimitRegistry {
+    /// Register a cap with its configured ceiling. Idempotent.
+    pub fn register(&self, limit: &'static str, value: usize) {
+        self.inner.write().entry(limit).or_insert(LimitEntry {
+            value,
+            ..Default::default()
+        });
+        // Update value if re-registered with different ceiling (for tests).
+        if let Some(entry) = self.inner.write().get_mut(limit) {
+            entry.value = value;
+        }
+    }
+
+    pub fn record_drop(&self, limit: &'static str, n: u64) {
+        if let Some(entry) = self.inner.write().get_mut(limit) {
+            entry.dropped = entry.dropped.saturating_add(n);
+        }
+    }
+
+    pub fn record_reject(&self, limit: &'static str) {
+        if let Some(entry) = self.inner.write().get_mut(limit) {
+            entry.rejected = entry.rejected.saturating_add(1);
+        }
+    }
+
+    pub fn snapshot(&self) -> Vec<LimitSnapshot> {
+        self.inner
+            .read()
+            .iter()
+            .map(|(limit, e)| LimitSnapshot {
+                limit,
+                value: e.value,
+                dropped: e.dropped,
+                rejected: e.rejected,
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LimitSnapshot {
+    pub limit: &'static str,
+    pub value: usize,
+    pub dropped: u64,
+    pub rejected: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Observability handle + Runtime
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct Inner {
+    config: Arc<ObservabilityConfig>,
+    heartbeat: TaskHeartbeat,
+    limits: LimitRegistry,
+    is_noop: bool,
+}
+
+/// Cloneable handle — cheap to clone into `AppState` and `RunnerPoolConfig`.
+#[derive(Debug, Clone)]
+pub struct Observability {
+    inner: Arc<Inner>,
+}
+
+impl Observability {
+    /// Allocation-light handle for tests and library-only consumers. Performs no I/O, no socket.
+    pub fn noop() -> Self {
+        let config = ObservabilityConfig {
+            log_format: LogFormat::Auto,
+            rust_log: "info".to_string(),
+            service_name: "preloop".to_string(),
+            instance_id: Uuid::new_v4().to_string(),
+            otel_endpoint: None,
+            otel_headers: None,
+            otlp_enabled: false,
+        };
+        Self {
+            inner: Arc::new(Inner {
+                config: Arc::new(config),
+                heartbeat: TaskHeartbeat::default(),
+                limits: LimitRegistry::default(),
+                is_noop: true,
+            }),
+        }
+    }
+
+    /// Real handle from `ObservabilityConfig`. Does not install the global subscriber — pair with `ObservabilityRuntime`.
+    pub fn from_config(config: ObservabilityConfig) -> (Self, ObservabilityRuntime) {
+        let is_noop = !config.otlp_enabled;
+        let handle = Self {
+            inner: Arc::new(Inner {
+                config: Arc::new(config),
+                heartbeat: TaskHeartbeat::default(),
+                limits: LimitRegistry::default(),
+                is_noop,
+            }),
+        };
+        let runtime = ObservabilityRuntime::new(handle.clone());
+        (handle, runtime)
+    }
+
+    pub fn is_noop(&self) -> bool {
+        self.inner.is_noop
+    }
+
+    pub fn otlp_enabled(&self) -> bool {
+        self.inner.config.otlp_enabled
+    }
+
+    pub fn instance_id(&self) -> &str {
+        &self.inner.config.instance_id
+    }
+
+    pub fn service_name(&self) -> &str {
+        &self.inner.config.service_name
+    }
+
+    pub fn heartbeat(&self) -> &TaskHeartbeat {
+        &self.inner.heartbeat
+    }
+
+    pub fn limits(&self) -> &LimitRegistry {
+        &self.inner.limits
+    }
+
+    pub fn config(&self) -> &ObservabilityConfig {
+        &self.inner.config
+    }
+}
+
+/// Owns subscriber/provider guards and performs bounded shutdown/flush.
+///
+/// On `Drop`, attempts to flush for at most 2s per invariant 3, then exits.
+/// Tests use scoped subscribers and never install the global one twice.
+pub struct ObservabilityRuntime {
+    _handle: Observability,
+    // Hold the tracing guard so it isn't dropped early when we use a
+    // non-global dispatcher in tests. For the global install, this is `None`
+    // and the global dispatcher owns the guard.
+    _guard: Option<
+        tracing_subscriber::reload::Handle<
+            tracing_subscriber::EnvFilter,
+            tracing_subscriber::Registry,
+        >,
+    >,
+}
+
+impl ObservabilityRuntime {
+    fn new(handle: Observability) -> Self {
+        // Step 2 does not install the global subscriber here — the binaries do
+        // that via `install_fmt_subscriber`. This runtime is the place for the
+        // future OTel provider guards and the 2s flush on `Drop`.
+        Self {
+            _handle: handle,
+            _guard: None,
+        }
+    }
+
+    /// Install the global `tracing_subscriber::fmt` layer once, respecting
+    /// `PRELOOP_LOG_FORMAT` and `RUST_LOG` from `config`. Safe to call at most
+    /// once per process; tests use `install_fmt_subscriber_for_test` instead.
+    pub fn install_fmt_subscriber(config: &ObservabilityConfig) {
+        let filter = tracing_subscriber::EnvFilter::try_new(&config.rust_log)
+            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+        let fmt = config.log_format.resolve();
+        match fmt {
+            LogFormat::Json => {
+                let subscriber = tracing_subscriber::fmt()
+                    .with_env_filter(filter)
+                    .json()
+                    .with_current_span(true)
+                    .with_span_list(true)
+                    .finish();
+                let _ = tracing::subscriber::set_global_default(subscriber);
+            }
+            LogFormat::Pretty | LogFormat::Auto => {
+                let subscriber = tracing_subscriber::fmt()
+                    .with_env_filter(filter)
+                    .with_ansi(std::io::IsTerminal::is_terminal(&std::io::stderr()))
+                    .finish();
+                let _ = tracing::subscriber::set_global_default(subscriber);
+            }
+        }
+    }
+
+    /// Attempt to flush exporters for at most 2s. Export failure is logged, never propagated.
+    pub async fn shutdown(self) {
+        // Step 2 has no exporter worker yet; this is the bounded-flush seam for
+        // the future OTel BatchSpanProcessor / metrics reader.
+        tokio::time::timeout(Duration::from_secs(2), async {
+            // No-op until OTel providers are wired in Step 3+.
+            tokio::task::yield_now().await;
+        })
+        .await
+        .ok();
+    }
+}
+
+impl fmt::Debug for ObservabilityRuntime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ObservabilityRuntime").finish()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests — Step 2 gates
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn noop_performs_no_network_io() {
+        let obs = Observability::noop();
+        assert!(obs.is_noop());
+        assert!(!obs.otlp_enabled());
+        assert!(!obs.instance_id().is_empty());
+    }
+
+    #[test]
+    fn absent_endpoint_means_disabled_not_localhost() {
+        // Ensure no ambient OTEL vars leak into the test.
+        for k in [
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+            "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+        ] {
+            std::env::remove_var(k);
+        }
+        // Also headers, so `has_otel_headers` is false.
+        for k in [
+            "OTEL_EXPORTER_OTLP_HEADERS",
+            "OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+            "OTEL_EXPORTER_OTLP_METRICS_HEADERS",
+            "OTEL_EXPORTER_OTLP_LOGS_HEADERS",
+        ] {
+            std::env::remove_var(k);
+        }
+        let cfg = ObservabilityConfig::from_env();
+        assert!(
+            !cfg.otlp_enabled,
+            "absent endpoint must be disabled, not localhost:4318"
+        );
+        assert!(cfg.otel_endpoint_raw().is_none());
+        let (obs, _rt) = Observability::from_config(cfg);
+        assert!(!obs.otlp_enabled());
+        assert!(obs.is_noop());
+    }
+
+    #[test]
+    fn none_disables_signal() {
+        std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", "none");
+        let cfg = ObservabilityConfig::from_env();
+        assert!(!cfg.otlp_enabled, "`none` must disable export");
+        std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
+    }
+
+    #[test]
+    fn heartbeat_register_beat_deregister() {
+        let obs = Observability::noop();
+        assert_eq!(obs.heartbeat().len(), 0);
+        {
+            let h = obs.heartbeat().register("reaper", Criticality::Critical);
+            assert_eq!(obs.heartbeat().len(), 1);
+            h.beat();
+            assert_eq!(obs.heartbeat().len(), 1);
+            // staleness: threshold 50ms, just-beat handle is fresh.
+            assert!(obs
+                .heartbeat()
+                .any_critical_stale(Duration::from_millis(50))
+                .is_none());
+        }
+        assert_eq!(obs.heartbeat().len(), 0, "Drop must deregister");
+    }
+
+    #[test]
+    fn critical_stale_detection() {
+        let obs = Observability::noop();
+        let _h = obs
+            .heartbeat()
+            .register("scheduler_scan", Criticality::Critical);
+        // Sleep past threshold — stale.
+        std::thread::sleep(Duration::from_millis(20));
+        assert_eq!(
+            obs.heartbeat().any_critical_stale(Duration::from_millis(5)),
+            Some("scheduler_scan")
+        );
+        // Non-critical with same age must not gate readiness.
+        let obs2 = Observability::noop();
+        let _h2 = obs2
+            .heartbeat()
+            .register("snapshot_gc", Criticality::NonCritical);
+        std::thread::sleep(Duration::from_millis(20));
+        assert_eq!(
+            obs2.heartbeat()
+                .any_critical_stale(Duration::from_millis(5)),
+            None
+        );
+    }
+
+    #[test]
+    fn limit_registry_counts() {
+        let obs = Observability::noop();
+        obs.limits().register("QUEUE_MAX_PENDING", 100);
+        obs.limits()
+            .register("LIVE_LOG_MAX_BYTES", 64 * 1024 * 1024);
+        obs.limits().record_reject("QUEUE_MAX_PENDING");
+        obs.limits().record_drop("LIVE_LOG_MAX_BYTES", 3);
+        let snap = obs.limits().snapshot();
+        let q = snap
+            .iter()
+            .find(|s| s.limit == "QUEUE_MAX_PENDING")
+            .unwrap();
+        assert_eq!(q.value, 100);
+        assert_eq!(q.rejected, 1);
+        let l = snap
+            .iter()
+            .find(|s| s.limit == "LIVE_LOG_MAX_BYTES")
+            .unwrap();
+        assert_eq!(l.dropped, 3);
+    }
+
+    #[test]
+    fn debug_redacts_headers_and_endpoint_userinfo() {
+        std::env::set_var(
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+            "https://user:secret@example.com:4318/v1/traces?token=abc",
+        );
+        std::env::set_var(
+            "OTEL_EXPORTER_OTLP_HEADERS",
+            "Authorization=Bearer secret123",
+        );
+        let cfg = ObservabilityConfig::from_env();
+        let dbg = format!("{cfg:?}");
+        assert!(
+            !dbg.contains("secret"),
+            "Debug must not contain secret material: {dbg}"
+        );
+        assert!(
+            !dbg.contains("Authorization"),
+            "Debug must not contain header values: {dbg}"
+        );
+        assert!(
+            !dbg.contains("user:"),
+            "Debug must not contain userinfo: {dbg}"
+        );
+        std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
+        std::env::remove_var("OTEL_EXPORTER_OTLP_HEADERS");
+    }
+
+    #[test]
+    fn log_format_auto_resolves() {
+        assert_eq!(LogFormat::parse("auto"), Some(LogFormat::Auto));
+        assert_eq!(LogFormat::parse("PRETTY"), Some(LogFormat::Pretty));
+        assert_eq!(LogFormat::parse("json"), Some(LogFormat::Json));
+        assert_eq!(LogFormat::parse("bogus"), None);
+    }
+
+    #[tokio::test]
+    async fn shutdown_is_bounded() {
+        let (obs, rt) = Observability::from_config(ObservabilityConfig::from_env());
+        // Must not hang even though there's no exporter.
+        tokio::time::timeout(Duration::from_secs(3), rt.shutdown())
+            .await
+            .expect("shutdown must be bounded to 2s");
+        drop(obs);
+    }
+}

--- a/crates/preloop-observability/src/lib.rs
+++ b/crates/preloop-observability/src/lib.rs
@@ -1,4 +1,4 @@
-//! `preloop-observability` — Step 2 of Plan 002.
+//! `preloop-observability` — observability handle for Preloop.
 //!
 //! Small, explicit API with no dependency on server/orchestrator internals. Both
 //! `preloop` and `preloop-server` construct one handle/runtime before building
@@ -93,7 +93,7 @@ impl ObservabilityConfig {
 
         // CLI defaults to `info` when unset; the standalone server historically
         // used `EnvFilter::from_default_env()` with no fallback (silent when
-        // unset). We unify on `info` per Step 2.
+        // unset). We unify on `info`.
         let rust_log = std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string());
 
         let service_name =
@@ -475,7 +475,7 @@ pub struct ObservabilityRuntime {
 
 impl ObservabilityRuntime {
     fn new(handle: Observability) -> Self {
-        // Step 2 does not install the global subscriber here — the binaries do
+        // Does not install the global subscriber here — the binaries do
         // that via `install_fmt_subscriber`. This runtime is the place for the
         // future OTel provider guards and the 2s flush on `Drop`.
         Self {
@@ -513,10 +513,10 @@ impl ObservabilityRuntime {
 
     /// Attempt to flush exporters for at most 2s. Export failure is logged, never propagated.
     pub async fn shutdown(self) {
-        // Step 2 has no exporter worker yet; this is the bounded-flush seam for
+        // No exporter worker yet; this is the bounded-flush seam for
         // the future OTel BatchSpanProcessor / metrics reader.
         tokio::time::timeout(Duration::from_secs(2), async {
-            // No-op until OTel providers are wired in Step 3+.
+            // No-op until OTLP providers are wired.
             tokio::task::yield_now().await;
         })
         .await
@@ -531,7 +531,7 @@ impl fmt::Debug for ObservabilityRuntime {
 }
 
 // ---------------------------------------------------------------------------
-// Tests — Step 2 gates
+// Tests
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]

--- a/crates/preloop-observability/src/lib.rs
+++ b/crates/preloop-observability/src/lib.rs
@@ -72,6 +72,9 @@ pub struct ObservabilityConfig {
     pub rust_log: String,
     /// `service.name` — `preloop` or `OTEL_SERVICE_NAME`.
     pub service_name: String,
+    /// `service.version` — set by the host binary via `with_service_version`.
+    /// Defaults to this crate's version only until the binary overrides it.
+    pub service_version: String,
     /// Per-process instance ID (UUID v4).
     pub instance_id: String,
     /// `OTEL_EXPORTER_OTLP_ENDPOINT` or signal-specific variant, if any. Kept as
@@ -125,6 +128,7 @@ impl ObservabilityConfig {
             log_format,
             rust_log,
             service_name,
+            service_version: env!("CARGO_PKG_VERSION").to_string(),
             instance_id,
             otel_endpoint,
             otel_headers,
@@ -140,6 +144,13 @@ impl ObservabilityConfig {
     /// Whether any `OTEL_EXPORTER_OTLP_HEADERS` was supplied (for health reporting).
     pub fn has_otel_headers(&self) -> bool {
         self.otel_headers.is_some()
+    }
+
+    /// Override `service.version` with the host binary's version. The crate's
+    /// own version is meaningless to an operator reading telemetry.
+    pub fn with_service_version(mut self, version: &str) -> Self {
+        self.service_version = version.to_string();
+        self
     }
 
     /// Raw headers for transport construction. Never logged or in `Debug`.
@@ -171,6 +182,7 @@ impl fmt::Debug for ObservabilityConfig {
             .field("log_format", &self.log_format)
             .field("rust_log", &self.rust_log)
             .field("service_name", &self.service_name)
+            .field("service_version", &self.service_version)
             .field("instance_id", &self.instance_id)
             .field(
                 "otel_endpoint",
@@ -408,6 +420,7 @@ impl Observability {
             log_format: LogFormat::Auto,
             rust_log: "info".to_string(),
             service_name: "preloop".to_string(),
+            service_version: env!("CARGO_PKG_VERSION").to_string(),
             instance_id: Uuid::new_v4().to_string(),
             otel_endpoint: None,
             otel_headers: None,
@@ -435,6 +448,7 @@ impl Observability {
             config.otel_headers_raw(),
             &config.service_name,
             &config.instance_id,
+            &config.service_version,
         )
         .map(|(exporter, _health)| exporter);
         let handle = Self {

--- a/crates/preloop-observability/src/lib.rs
+++ b/crates/preloop-observability/src/lib.rs
@@ -11,6 +11,8 @@
 //! - Always retain `stderr`/`journald` even when OTLP is configured.
 //! - `Debug` on config never reveals headers or credential-bearing endpoint parts.
 
+pub mod status;
+
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;

--- a/crates/preloop-observability/src/lib.rs
+++ b/crates/preloop-observability/src/lib.rs
@@ -11,6 +11,7 @@
 //! - Always retain `stderr`/`journald` even when OTLP is configured.
 //! - `Debug` on config never reveals headers or credential-bearing endpoint parts.
 
+pub mod export;
 pub mod metrics;
 pub mod status;
 pub mod vm_telemetry;
@@ -139,6 +140,11 @@ impl ObservabilityConfig {
     /// Whether any `OTEL_EXPORTER_OTLP_HEADERS` was supplied (for health reporting).
     pub fn has_otel_headers(&self) -> bool {
         self.otel_headers.is_some()
+    }
+
+    /// Raw headers for transport construction. Never logged or in `Debug`.
+    pub fn otel_headers_raw(&self) -> Option<&str> {
+        self.otel_headers.as_deref()
     }
 
     /// Sanitized endpoint for `Debug`/errors: strips userinfo and query.
@@ -385,6 +391,7 @@ struct Inner {
     limits: LimitRegistry,
     metrics: Arc<metrics::MetricsRegistry>,
     vm_registry: Arc<vm_telemetry::VmTelemetryRegistry>,
+    exporter: Option<export::Exporter>,
     is_noop: bool,
 }
 
@@ -413,6 +420,7 @@ impl Observability {
                 limits: LimitRegistry::default(),
                 metrics: Arc::new(metrics::MetricsRegistry::default()),
                 vm_registry: Arc::new(vm_telemetry::VmTelemetryRegistry::default()),
+                exporter: None,
                 is_noop: true,
             }),
         }
@@ -421,6 +429,14 @@ impl Observability {
     /// Real handle from `ObservabilityConfig`. Does not install the global subscriber — pair with `ObservabilityRuntime`.
     pub fn from_config(config: ObservabilityConfig) -> (Self, ObservabilityRuntime) {
         let is_noop = !config.otlp_enabled;
+        // Absent endpoint spawns nothing at all — no worker, no socket.
+        let exporter = export::spawn(
+            config.otel_endpoint_raw(),
+            config.otel_headers_raw(),
+            &config.service_name,
+            &config.instance_id,
+        )
+        .map(|(exporter, _health)| exporter);
         let handle = Self {
             inner: Arc::new(Inner {
                 config: Arc::new(config),
@@ -428,6 +444,7 @@ impl Observability {
                 limits: LimitRegistry::default(),
                 metrics: Arc::new(metrics::MetricsRegistry::default()),
                 vm_registry: Arc::new(vm_telemetry::VmTelemetryRegistry::default()),
+                exporter,
                 is_noop,
             }),
         };
@@ -465,6 +482,27 @@ impl Observability {
 
     pub fn vm_registry(&self) -> &vm_telemetry::VmTelemetryRegistry {
         &self.inner.vm_registry
+    }
+
+    /// Enqueue a log record for OTLP export. No-op when export is disabled.
+    pub fn export_log(
+        &self,
+        severity: &'static str,
+        body: impl Into<String>,
+        attributes: Vec<(String, String)>,
+    ) {
+        if let Some(exporter) = &self.inner.exporter {
+            exporter.log(export::LogRecord {
+                severity,
+                body: body.into(),
+                attributes,
+            });
+        }
+    }
+
+    /// Export health for `/api/v1/status` and `preloop.telemetry.export`.
+    pub fn export_health(&self) -> Option<&Arc<export::ExportHealth>> {
+        self.inner.exporter.as_ref().map(|e| e.health())
     }
 
     pub fn config(&self) -> &ObservabilityConfig {

--- a/crates/preloop-observability/src/metrics.rs
+++ b/crates/preloop-observability/src/metrics.rs
@@ -566,3 +566,242 @@ mod tests {
         assert_eq!(m.series_count(), 1, "1000 distinct IDs must be 1 series");
     }
 }
+
+// ---------------------------------------------------------------------------
+// Structured collection for OTLP export
+// ---------------------------------------------------------------------------
+
+/// One data point, already reduced to bounded attributes.
+#[derive(Debug, Clone)]
+pub enum MetricPoint {
+    /// Monotonic counter (OTLP `sum`, cumulative, `isMonotonic: true`).
+    Sum {
+        value: f64,
+        attributes: Vec<(String, String)>,
+    },
+    /// Instantaneous value (OTLP `gauge`).
+    Gauge {
+        value: f64,
+        attributes: Vec<(String, String)>,
+    },
+    /// Explicit-bucket histogram (OTLP `histogram`, cumulative).
+    ///
+    /// `bucket_counts` is one longer than `bounds`: OTLP requires the
+    /// implicit `+Inf` bucket to be present as the final entry.
+    Histogram {
+        count: u64,
+        sum: f64,
+        bounds: Vec<f64>,
+        bucket_counts: Vec<u64>,
+        attributes: Vec<(String, String)>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub struct MetricFamily {
+    pub name: String,
+    pub unit: &'static str,
+    pub points: Vec<MetricPoint>,
+}
+
+impl Histogram {
+    /// Cumulative bucket counts plus the implicit `+Inf` bucket OTLP requires.
+    fn otlp_bucket_counts(&self) -> Vec<u64> {
+        let mut counts: Vec<u64> = self.buckets.iter().map(|(_, c)| *c).collect();
+        counts.push(self.count);
+        counts
+    }
+
+    fn bounds(&self) -> Vec<f64> {
+        self.buckets.iter().map(|(le, _)| *le).collect()
+    }
+}
+
+impl HttpMetrics {
+    fn collect(&self, out: &mut Vec<MetricFamily>) {
+        let durations = self.durations.read();
+        if !durations.is_empty() {
+            out.push(MetricFamily {
+                name: "http.server.request.duration".to_string(),
+                unit: "s",
+                points: durations
+                    .iter()
+                    .map(|(labels, hist)| MetricPoint::Histogram {
+                        count: hist.count,
+                        sum: hist.sum,
+                        bounds: hist.bounds(),
+                        bucket_counts: hist.otlp_bucket_counts(),
+                        attributes: vec![
+                            ("http.request.method".to_string(), labels.method.clone()),
+                            ("http.route".to_string(), labels.route.clone()),
+                            ("preloop.surface".to_string(), labels.surface.clone()),
+                            (
+                                "http.response.status_class".to_string(),
+                                labels.status_class.clone(),
+                            ),
+                        ],
+                    })
+                    .collect(),
+            });
+        }
+        let active = self.active.read();
+        if !active.is_empty() {
+            out.push(MetricFamily {
+                name: "http.server.active_requests".to_string(),
+                unit: "{request}",
+                points: active
+                    .iter()
+                    .map(|(labels, value)| MetricPoint::Gauge {
+                        value: *value as f64,
+                        attributes: vec![
+                            ("http.request.method".to_string(), labels.method.clone()),
+                            ("http.route".to_string(), labels.route.clone()),
+                            ("preloop.surface".to_string(), labels.surface.clone()),
+                        ],
+                    })
+                    .collect(),
+            });
+        }
+    }
+}
+
+impl StoreMetrics {
+    fn collect(&self, out: &mut Vec<MetricFamily>) {
+        let durations = self.durations.read();
+        if !durations.is_empty() {
+            out.push(MetricFamily {
+                name: "preloop.store.operation.duration".to_string(),
+                unit: "s",
+                points: durations
+                    .iter()
+                    .map(|(labels, hist)| MetricPoint::Histogram {
+                        count: hist.count,
+                        sum: hist.sum,
+                        bounds: hist.bounds(),
+                        bucket_counts: hist.otlp_bucket_counts(),
+                        attributes: vec![
+                            ("db.system".to_string(), labels.backend.clone()),
+                            ("preloop.operation".to_string(), labels.operation.clone()),
+                            ("preloop.outcome".to_string(), labels.outcome.clone()),
+                        ],
+                    })
+                    .collect(),
+            });
+        }
+        let failures = self.consecutive_failures.read();
+        if !failures.is_empty() {
+            out.push(MetricFamily {
+                name: "preloop.store.consecutive_failures".to_string(),
+                unit: "{failure}",
+                points: failures
+                    .iter()
+                    .map(|(backend, value)| MetricPoint::Gauge {
+                        value: *value as f64,
+                        attributes: vec![("db.system".to_string(), backend.clone())],
+                    })
+                    .collect(),
+            });
+        }
+    }
+}
+
+impl LifecycleMetrics {
+    fn collect(&self, out: &mut Vec<MetricFamily>) {
+        let completed = self.job_completed.read();
+        if !completed.is_empty() {
+            out.push(MetricFamily {
+                name: "preloop.job.completed".to_string(),
+                unit: "{job}",
+                points: completed
+                    .iter()
+                    .map(|(labels, value)| MetricPoint::Sum {
+                        value: *value as f64,
+                        attributes: vec![
+                            ("preloop.conclusion".to_string(), labels.conclusion.clone()),
+                            ("preloop.reason".to_string(), labels.reason.clone()),
+                        ],
+                    })
+                    .collect(),
+            });
+        }
+        let wait = self.queue_wait.read();
+        if !wait.is_empty() {
+            out.push(MetricFamily {
+                name: "preloop.job.queue.wait".to_string(),
+                unit: "s",
+                points: wait
+                    .iter()
+                    .map(|(labels, hist)| MetricPoint::Histogram {
+                        count: hist.count,
+                        sum: hist.sum,
+                        bounds: hist.bounds(),
+                        bucket_counts: hist.otlp_bucket_counts(),
+                        attributes: vec![("preloop.outcome".to_string(), labels.outcome.clone())],
+                    })
+                    .collect(),
+            });
+        }
+        let poll = self.broker_poll.read();
+        if !poll.is_empty() {
+            out.push(MetricFamily {
+                name: "preloop.broker.poll".to_string(),
+                unit: "{poll}",
+                points: poll
+                    .iter()
+                    .map(|(labels, value)| MetricPoint::Sum {
+                        value: *value as f64,
+                        attributes: vec![("preloop.outcome".to_string(), labels.outcome.clone())],
+                    })
+                    .collect(),
+            });
+        }
+        let sessions = self.session_transition.read();
+        if !sessions.is_empty() {
+            out.push(MetricFamily {
+                name: "preloop.runner.session.transition".to_string(),
+                unit: "{transition}",
+                points: sessions
+                    .iter()
+                    .map(|(labels, value)| MetricPoint::Sum {
+                        value: *value as f64,
+                        attributes: vec![
+                            ("preloop.operation".to_string(), labels.operation.clone()),
+                            ("preloop.reason".to_string(), labels.reason.clone()),
+                        ],
+                    })
+                    .collect(),
+            });
+        }
+        let concurrency = self.concurrency_decision.read();
+        if !concurrency.is_empty() {
+            out.push(MetricFamily {
+                name: "preloop.concurrency.decision".to_string(),
+                unit: "{decision}",
+                points: concurrency
+                    .iter()
+                    .map(|(labels, value)| MetricPoint::Sum {
+                        value: *value as f64,
+                        attributes: vec![
+                            ("preloop.queue_mode".to_string(), labels.queue_mode.clone()),
+                            ("preloop.action".to_string(), labels.action.clone()),
+                        ],
+                    })
+                    .collect(),
+            });
+        }
+    }
+}
+
+impl MetricsRegistry {
+    /// Snapshot every instrument as OTLP-ready families.
+    ///
+    /// Read-only: takes each sub-registry's read lock in turn and never holds
+    /// two at once, so a scrape cannot deadlock against a recording caller.
+    pub fn collect(&self) -> Vec<MetricFamily> {
+        let mut families = Vec::new();
+        self.http.collect(&mut families);
+        self.store.collect(&mut families);
+        self.lifecycle.collect(&mut families);
+        families
+    }
+}

--- a/crates/preloop-observability/src/metrics.rs
+++ b/crates/preloop-observability/src/metrics.rs
@@ -1,0 +1,405 @@
+//! Metrics registry for HTTP and store — Step 4.
+//!
+//! In-memory, bounded, no network I/O. Instruments and attribute arrays are
+//! prebuilt where static; gauges are updated from the cached snapshot.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use parking_lot::RwLock;
+
+// ---------------------------------------------------------------------------
+// Histogram buckets
+// ---------------------------------------------------------------------------
+
+pub const HTTP_BUCKETS: &[f64] = &[
+    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+];
+pub const STORE_BUCKETS: &[f64] = &[
+    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+];
+pub const QUEUE_BUCKETS: &[f64] = &[
+    0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 900.0,
+];
+
+#[derive(Debug, Default, Clone)]
+struct Histogram {
+    buckets: Vec<(f64, u64)>, // (le, count)
+    count: u64,
+    sum: f64,
+}
+
+impl Histogram {
+    fn new(buckets: &[f64]) -> Self {
+        Self {
+            buckets: buckets.iter().map(|&le| (le, 0)).collect(),
+            count: 0,
+            sum: 0.0,
+        }
+    }
+
+    fn observe(&mut self, value: f64) {
+        self.count += 1;
+        self.sum += value;
+        for (le, cnt) in &mut self.buckets {
+            if value <= *le {
+                *cnt += 1;
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Http metrics
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct HttpLabels {
+    pub method: String,
+    pub route: String,
+    pub surface: String,
+    pub status_class: String,
+}
+
+#[derive(Debug, Default)]
+pub struct HttpMetrics {
+    active: RwLock<HashMap<HttpLabels, i64>>,
+    durations: RwLock<HashMap<HttpLabels, Histogram>>,
+}
+
+impl HttpMetrics {
+    pub fn inc_active(&self, labels: &HttpLabels) {
+        *self.active.write().entry(labels.clone()).or_insert(0) += 1;
+    }
+
+    pub fn dec_active(&self, labels: &HttpLabels) {
+        let mut g = self.active.write();
+        if let Some(v) = g.get_mut(labels) {
+            *v -= 1;
+            if *v <= 0 {
+                g.remove(labels);
+            }
+        }
+    }
+
+    pub fn observe_duration(&self, labels: HttpLabels, duration: Duration) {
+        let secs = duration.as_secs_f64();
+        let mut g = self.durations.write();
+        let hist = g
+            .entry(labels)
+            .or_insert_with(|| Histogram::new(HTTP_BUCKETS));
+        hist.observe(secs);
+    }
+
+    pub fn render(&self, out: &mut String) {
+        out.push_str("# HELP http_server_request_duration_seconds API latency — matched route, never raw URI\n");
+        out.push_str("# TYPE http_server_request_duration_seconds histogram\n");
+        let g = self.durations.read();
+        for (labels, hist) in g.iter() {
+            for (le, cnt) in &hist.buckets {
+                out.push_str(&format!(
+                    "http_server_request_duration_seconds_bucket{{method=\"{}\",route=\"{}\",surface=\"{}\",status_class=\"{}\",le=\"{}\"}} {}\n",
+                    labels.method, labels.route, labels.surface, labels.status_class, le, cnt
+                ));
+            }
+            out.push_str(&format!(
+                "http_server_request_duration_seconds_bucket{{method=\"{}\",route=\"{}\",surface=\"{}\",status_class=\"{}\",le=\"+Inf\"}} {}\n",
+                labels.method, labels.route, labels.surface, labels.status_class, hist.count
+            ));
+            out.push_str(&format!(
+                "http_server_request_duration_seconds_sum{{method=\"{}\",route=\"{}\",surface=\"{}\",status_class=\"{}\"}} {}\n",
+                labels.method, labels.route, labels.surface, labels.status_class, hist.sum
+            ));
+            out.push_str(&format!(
+                "http_server_request_duration_seconds_count{{method=\"{}\",route=\"{}\",surface=\"{}\",status_class=\"{}\"}} {}\n",
+                labels.method, labels.route, labels.surface, labels.status_class, hist.count
+            ));
+        }
+        out.push_str("# HELP http_server_active_requests Current HTTP concurrency\n");
+        out.push_str("# TYPE http_server_active_requests gauge\n");
+        let g2 = self.active.read();
+        for (labels, v) in g2.iter() {
+            out.push_str(&format!(
+                "http_server_active_requests{{method=\"{}\",route=\"{}\",surface=\"{}\"}} {}\n",
+                labels.method, labels.route, labels.surface, v
+            ));
+        }
+    }
+
+    #[cfg(test)]
+    pub fn clear(&self) {
+        self.active.write().clear();
+        self.durations.write().clear();
+    }
+
+    #[cfg(test)]
+    pub fn series_count(&self) -> usize {
+        self.durations.read().len()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Store metrics
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StoreLabels {
+    pub backend: String,
+    pub operation: String,
+    pub outcome: String,
+}
+
+#[derive(Debug, Default)]
+pub struct StoreMetrics {
+    durations: RwLock<HashMap<StoreLabels, Histogram>>,
+    consecutive_failures: RwLock<HashMap<String, u64>>, // backend -> count
+}
+
+impl StoreMetrics {
+    pub fn observe(&self, backend: &str, operation: &str, outcome: &str, duration: Duration) {
+        let labels = StoreLabels {
+            backend: backend.to_string(),
+            operation: operation.to_string(),
+            outcome: outcome.to_string(),
+        };
+        let mut g = self.durations.write();
+        let hist = g
+            .entry(labels)
+            .or_insert_with(|| Histogram::new(STORE_BUCKETS));
+        hist.observe(duration.as_secs_f64());
+
+        // Update consecutive failures
+        let mut cf = self.consecutive_failures.write();
+        if outcome == "error" {
+            *cf.entry(backend.to_string()).or_insert(0) += 1;
+        } else {
+            cf.insert(backend.to_string(), 0);
+        }
+    }
+
+    pub fn render(&self, out: &mut String) {
+        out.push_str("# HELP preloop_store_operation_duration_seconds Store operation latency\n");
+        out.push_str("# TYPE preloop_store_operation_duration_seconds histogram\n");
+        let g = self.durations.read();
+        for (labels, hist) in g.iter() {
+            for (le, cnt) in &hist.buckets {
+                out.push_str(&format!(
+                    "preloop_store_operation_duration_seconds_bucket{{backend=\"{}\",operation=\"{}\",outcome=\"{}\",le=\"{}\"}} {}\n",
+                    labels.backend, labels.operation, labels.outcome, le, cnt
+                ));
+            }
+            out.push_str(&format!(
+                "preloop_store_operation_duration_seconds_bucket{{backend=\"{}\",operation=\"{}\",outcome=\"{}\",le=\"+Inf\"}} {}\n",
+                labels.backend, labels.operation, labels.outcome, hist.count
+            ));
+            out.push_str(&format!(
+                "preloop_store_operation_duration_seconds_sum{{backend=\"{}\",operation=\"{}\",outcome=\"{}\"}} {}\n",
+                labels.backend, labels.operation, labels.outcome, hist.sum
+            ));
+            out.push_str(&format!(
+                "preloop_store_operation_duration_seconds_count{{backend=\"{}\",operation=\"{}\",outcome=\"{}\"}} {}\n",
+                labels.backend, labels.operation, labels.outcome, hist.count
+            ));
+        }
+        out.push_str("# HELP preloop_store_consecutive_failures Restart-durability risk\n");
+        out.push_str("# TYPE preloop_store_consecutive_failures gauge\n");
+        let g2 = self.consecutive_failures.read();
+        for (backend, v) in g2.iter() {
+            out.push_str(&format!(
+                "preloop_store_consecutive_failures{{backend=\"{}\"}} {}\n",
+                backend, v
+            ));
+        }
+    }
+
+    #[cfg(test)]
+    pub fn clear(&self) {
+        self.durations.write().clear();
+        self.consecutive_failures.write().clear();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default)]
+pub struct MetricsRegistry {
+    pub http: HttpMetrics,
+    pub store: StoreMetrics,
+}
+
+impl MetricsRegistry {
+    pub fn render(&self) -> String {
+        let mut out = String::new();
+        self.http.render(&mut out);
+        self.store.render(&mut out);
+        out
+    }
+
+    #[cfg(test)]
+    pub fn clear(&self) {
+        self.http.clear();
+        self.store.clear();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — surface classification and route normalization
+// ---------------------------------------------------------------------------
+
+/// Classify a normalized route template into a finite surface.
+pub fn classify_surface(route: &str) -> &'static str {
+    if route == "/healthz" || route == "/readyz" || route == "/metrics" {
+        return "public";
+    }
+    if route.starts_with("/api/v1") {
+        return "native";
+    }
+    if route.starts_with("/_apis") || route.starts_with("/runner") {
+        return "runner";
+    }
+    if route.starts_with("/broker") {
+        return "broker";
+    }
+    if route.starts_with("/twirp") || route.starts_with("/twirp-blob") {
+        return "results";
+    }
+    if route.starts_with("/ws/live-logs") {
+        return "live_logs";
+    }
+    if route.starts_with("/snapshots") || route.starts_with("/repos") {
+        return "git";
+    }
+    if route.starts_with("/oidc") || route.starts_with("/.well-known") {
+        return "oidc";
+    }
+    if route == "/webhook" || route.starts_with("/webhook") {
+        return "webhook";
+    }
+    if route.starts_with("/internal/test") {
+        return "test";
+    }
+    "unknown"
+}
+
+/// Normalize a raw path (with concrete IDs) to a bounded route template.
+///
+/// Uses Axum's matched templates where available; otherwise falls back to
+/// prefix matching for the known route set. Query strings are stripped.
+pub fn normalize_route(raw: &str) -> String {
+    // Strip query
+    let path = raw.split('?').next().unwrap_or(raw);
+    // Already a template? (contains ':')
+    if path.contains(':') {
+        return path.to_string();
+    }
+    // Known templates — longest prefix first
+    const TEMPLATES: &[&str] = &[
+        "/api/v1/runs/:run_id",
+        "/api/v1/runs",
+        "/api/v1/status",
+        "/api/v1/scheduler/history",
+        "/api/v1/debug/sessions",
+        "/api/v1/github/register",
+        "/api/v1/github/callback",
+        "/_apis/artifactcache/cache/:cache_id",
+        "/_apis/artifactcache/cache",
+        "/_apis/pipelines/workflows/:run_id/artifacts/:artifact_id",
+        "/_apis/pipelines/workflows/:run_id/artifacts",
+        "/runner/server/_apis/distributedtask/pools/:pool_id/agents",
+        "/runner/server/_apis/distributedtask/pools",
+        "/broker/:runner_id/acquirejob",
+        "/broker/:runner_id/renewjob",
+        "/broker/:runner_id/completejob",
+        "/twirp/github.actions.results.api.v1.ArtifactService/CreateArtifact",
+        "/twirp/github.actions.results.api.v1.CacheService/CreateCacheEntry",
+        "/twirp-blob/:kind/:token",
+        "/ws/live-logs/:job_id",
+        "/snapshots",
+        "/repos",
+        "/oidc",
+        "/.well-known",
+        "/webhook",
+        "/healthz",
+        "/readyz",
+        "/metrics",
+    ];
+    for tmpl in TEMPLATES {
+        // Template without params matches exactly
+        if !tmpl.contains(':') && path == *tmpl {
+            return tmpl.to_string();
+        }
+        // Template with params: match prefix up to first ':'
+        if let Some(colon) = tmpl.find(':') {
+            let prefix = &tmpl[..colon - 1]; // up to '/' before ':'
+            if path.starts_with(prefix) {
+                // Ensure it's a segment boundary: /api/v1/runs/abc should match /api/v1/runs/:run_id
+                // but /api/v1/runsXYZ should not.
+                let rest = &path[prefix.len()..];
+                if rest.is_empty() || rest.starts_with('/') {
+                    return tmpl.to_string();
+                }
+            }
+        }
+    }
+    // Unknown — constant label, never raw path
+    "/unknown".to_string()
+}
+
+pub fn status_class(status: u16) -> &'static str {
+    match status {
+        200..=299 => "2xx",
+        300..=399 => "3xx",
+        400..=499 => "4xx",
+        500..=599 => "5xx",
+        _ => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_concrete_id_to_template() {
+        assert_eq!(
+            normalize_route("/api/v1/runs/abc123"),
+            "/api/v1/runs/:run_id"
+        );
+        assert_eq!(
+            normalize_route("/api/v1/runs/abc123?foo=bar"),
+            "/api/v1/runs/:run_id"
+        );
+        assert_eq!(normalize_route("/api/v1/status"), "/api/v1/status");
+        assert_eq!(normalize_route("/unknown/path/xyz"), "/unknown");
+    }
+
+    #[test]
+    fn classify() {
+        assert_eq!(classify_surface("/api/v1/runs"), "native");
+        assert_eq!(classify_surface("/_apis/artifactcache/cache"), "runner");
+        assert_eq!(classify_surface("/broker/42/acquirejob"), "broker");
+        assert_eq!(classify_surface("/ws/live-logs/123"), "live_logs");
+        assert_eq!(classify_surface("/healthz"), "public");
+        assert_eq!(classify_surface("/unknown"), "unknown");
+    }
+
+    #[test]
+    fn http_series_bounded() {
+        let m = HttpMetrics::default();
+        for i in 0..1000 {
+            let route = format!("/api/v1/runs/{}", i);
+            let tmpl = normalize_route(&route);
+            let labels = HttpLabels {
+                method: "GET".to_string(),
+                route: tmpl,
+                surface: "native".to_string(),
+                status_class: "2xx".to_string(),
+            };
+            m.observe_duration(labels, Duration::from_millis(10));
+        }
+        assert_eq!(m.series_count(), 1, "1000 distinct IDs must be 1 series");
+    }
+}

--- a/crates/preloop-observability/src/metrics.rs
+++ b/crates/preloop-observability/src/metrics.rs
@@ -274,12 +274,19 @@ pub struct SessionTransitionLabels {
     pub reason: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ConcurrencyDecisionLabels {
+    pub queue_mode: String,
+    pub action: String,
+}
+
 #[derive(Debug, Default)]
 pub struct LifecycleMetrics {
     job_completed: RwLock<HashMap<JobCompletedLabels, u64>>,
     queue_wait: RwLock<HashMap<QueueWaitLabels, Histogram>>,
     broker_poll: RwLock<HashMap<BrokerPollLabels, u64>>,
     session_transition: RwLock<HashMap<SessionTransitionLabels, u64>>,
+    concurrency_decision: RwLock<HashMap<ConcurrencyDecisionLabels, u64>>,
 }
 
 impl LifecycleMetrics {
@@ -315,6 +322,14 @@ impl LifecycleMetrics {
             reason: reason.to_string(),
         };
         *self.session_transition.write().entry(labels).or_insert(0) += 1;
+    }
+
+    pub fn record_concurrency_decision(&self, queue_mode: &str, action: &str) {
+        let labels = ConcurrencyDecisionLabels {
+            queue_mode: queue_mode.to_string(),
+            action: action.to_string(),
+        };
+        *self.concurrency_decision.write().entry(labels).or_insert(0) += 1;
     }
 
     pub fn render(&self, out: &mut String) {
@@ -364,6 +379,14 @@ impl LifecycleMetrics {
                 labels.operation, labels.reason, cnt
             ));
         }
+        out.push_str("# HELP preloop_concurrency_decision_total Concurrency queue decisions\n");
+        out.push_str("# TYPE preloop_concurrency_decision_total counter\n");
+        for (labels, cnt) in self.concurrency_decision.read().iter() {
+            out.push_str(&format!(
+                "preloop_concurrency_decision_total{{queue_mode=\"{}\",action=\"{}\"}} {}\n",
+                labels.queue_mode, labels.action, cnt
+            ));
+        }
     }
 
     #[cfg(test)]
@@ -372,6 +395,7 @@ impl LifecycleMetrics {
         self.queue_wait.write().clear();
         self.broker_poll.write().clear();
         self.session_transition.write().clear();
+        self.concurrency_decision.write().clear();
     }
 
     #[cfg(test)]

--- a/crates/preloop-observability/src/metrics.rs
+++ b/crates/preloop-observability/src/metrics.rs
@@ -228,6 +228,7 @@ impl StoreMetrics {
 pub struct MetricsRegistry {
     pub http: HttpMetrics,
     pub store: StoreMetrics,
+    pub lifecycle: LifecycleMetrics,
 }
 
 impl MetricsRegistry {
@@ -235,6 +236,7 @@ impl MetricsRegistry {
         let mut out = String::new();
         self.http.render(&mut out);
         self.store.render(&mut out);
+        self.lifecycle.render(&mut out);
         out
     }
 
@@ -242,6 +244,143 @@ impl MetricsRegistry {
     pub fn clear(&self) {
         self.http.clear();
         self.store.clear();
+        self.lifecycle.clear();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle metrics — run/job, queue, broker, runner
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct JobCompletedLabels {
+    pub conclusion: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct QueueWaitLabels {
+    pub outcome: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BrokerPollLabels {
+    pub outcome: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SessionTransitionLabels {
+    pub operation: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Default)]
+pub struct LifecycleMetrics {
+    job_completed: RwLock<HashMap<JobCompletedLabels, u64>>,
+    queue_wait: RwLock<HashMap<QueueWaitLabels, Histogram>>,
+    broker_poll: RwLock<HashMap<BrokerPollLabels, u64>>,
+    session_transition: RwLock<HashMap<SessionTransitionLabels, u64>>,
+}
+
+impl LifecycleMetrics {
+    pub fn record_job_completed(&self, conclusion: &str, reason: &str) {
+        let labels = JobCompletedLabels {
+            conclusion: conclusion.to_string(),
+            reason: reason.to_string(),
+        };
+        *self.job_completed.write().entry(labels).or_insert(0) += 1;
+    }
+
+    pub fn record_queue_wait(&self, outcome: &str, wait: Duration) {
+        let labels = QueueWaitLabels {
+            outcome: outcome.to_string(),
+        };
+        let mut g = self.queue_wait.write();
+        let hist = g
+            .entry(labels)
+            .or_insert_with(|| Histogram::new(QUEUE_BUCKETS));
+        hist.observe(wait.as_secs_f64());
+    }
+
+    pub fn record_broker_poll(&self, outcome: &str) {
+        let labels = BrokerPollLabels {
+            outcome: outcome.to_string(),
+        };
+        *self.broker_poll.write().entry(labels).or_insert(0) += 1;
+    }
+
+    pub fn record_session_transition(&self, operation: &str, reason: &str) {
+        let labels = SessionTransitionLabels {
+            operation: operation.to_string(),
+            reason: reason.to_string(),
+        };
+        *self.session_transition.write().entry(labels).or_insert(0) += 1;
+    }
+
+    pub fn render(&self, out: &mut String) {
+        out.push_str("# HELP preloop_job_completed Terminal jobs by conclusion and reason\n");
+        out.push_str("# TYPE preloop_job_completed counter\n");
+        for (labels, cnt) in self.job_completed.read().iter() {
+            out.push_str(&format!(
+                "preloop_job_completed{{conclusion=\"{}\",reason=\"{}\"}} {}\n",
+                labels.conclusion, labels.reason, cnt
+            ));
+        }
+        out.push_str("# HELP preloop_job_queue_wait_seconds Queue wait until claim or terminal\n");
+        out.push_str("# TYPE preloop_job_queue_wait_seconds histogram\n");
+        for (labels, hist) in self.queue_wait.read().iter() {
+            for (le, cnt) in &hist.buckets {
+                out.push_str(&format!(
+                    "preloop_job_queue_wait_seconds_bucket{{outcome=\"{}\",le=\"{}\"}} {}\n",
+                    labels.outcome, le, cnt
+                ));
+            }
+            out.push_str(&format!(
+                "preloop_job_queue_wait_seconds_bucket{{outcome=\"{}\",le=\"+Inf\"}} {}\n",
+                labels.outcome, hist.count
+            ));
+            out.push_str(&format!(
+                "preloop_job_queue_wait_seconds_sum{{outcome=\"{}\"}} {}\n",
+                labels.outcome, hist.sum
+            ));
+            out.push_str(&format!(
+                "preloop_job_queue_wait_seconds_count{{outcome=\"{}\"}} {}\n",
+                labels.outcome, hist.count
+            ));
+        }
+        out.push_str("# HELP preloop_broker_poll_total Broker poll outcomes\n");
+        out.push_str("# TYPE preloop_broker_poll_total counter\n");
+        for (labels, cnt) in self.broker_poll.read().iter() {
+            out.push_str(&format!(
+                "preloop_broker_poll_total{{outcome=\"{}\"}} {}\n",
+                labels.outcome, cnt
+            ));
+        }
+        out.push_str("# HELP preloop_runner_session_transition_total Session lifecycle\n");
+        out.push_str("# TYPE preloop_runner_session_transition_total counter\n");
+        for (labels, cnt) in self.session_transition.read().iter() {
+            out.push_str(&format!(
+                "preloop_runner_session_transition_total{{operation=\"{}\",reason=\"{}\"}} {}\n",
+                labels.operation, labels.reason, cnt
+            ));
+        }
+    }
+
+    #[cfg(test)]
+    pub fn clear(&self) {
+        self.job_completed.write().clear();
+        self.queue_wait.write().clear();
+        self.broker_poll.write().clear();
+        self.session_transition.write().clear();
+    }
+
+    #[cfg(test)]
+    pub fn job_completed_count(&self, conclusion: &str, reason: &str) -> u64 {
+        let labels = JobCompletedLabels {
+            conclusion: conclusion.to_string(),
+            reason: reason.to_string(),
+        };
+        *self.job_completed.read().get(&labels).unwrap_or(&0)
     }
 }
 

--- a/crates/preloop-observability/src/status.rs
+++ b/crates/preloop-observability/src/status.rs
@@ -1,7 +1,6 @@
 //!OperationalSnapshot and supporting types.
 //!
 
-
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
@@ -236,7 +235,7 @@ impl PoolStatus {
 }
 
 // ---------------------------------------------------------------------------
-// VMs 
+// VMs
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -402,7 +401,6 @@ pub struct TaskEntry {
     pub state: String,
 }
 
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Condition {
     pub code: String,
@@ -418,10 +416,6 @@ pub struct ConditionExemplar {
     pub runner_id: Option<String>,
     pub machine_name: Option<String>,
 }
-
-// ---------------------------------------------------------------------------
-// OperationalSnapshot — the versioned status body
-// ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OperationalSnapshot {

--- a/crates/preloop-observability/src/status.rs
+++ b/crates/preloop-observability/src/status.rs
@@ -1,0 +1,484 @@
+//! Step 3 DTOs — OperationalSnapshot and supporting types.
+//!
+//! Neutral, serializable DTOs shared by server and CLI. No dependency on
+//! server/orchestrator internals. Metric labels use only bounded enums.
+
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Overall
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Overall {
+    Ok,
+    Degraded,
+    Blocked,
+    ShuttingDown,
+}
+
+impl Default for Overall {
+    fn default() -> Self {
+        Self::Ok
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServiceSnapshot {
+    pub version: String,
+    pub instance_id: String,
+    pub uptime_seconds: u64,
+    pub shutdown_requested: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Runs / Jobs / Concurrency / Scheduler / Runners
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RunsSnapshot {
+    pub queued: u32,
+    pub in_progress: u32,
+    pub completed: u32,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct JobsSnapshot {
+    pub ready: u32,
+    pub dependency_blocked: u32,
+    pub concurrency_blocked: u32,
+    pub pending_expansion: u32,
+    pub expanding: u32,
+    pub claimable: u32,
+    pub unclaimable: u32,
+    pub oldest_ready_seconds: Option<f64>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ConcurrencySnapshot {
+    pub groups_active: u32,
+    pub groups_contended: u32,
+    pub pending_holders: u32,
+    pub deepest_group_pending: u32,
+    pub queue_max_pending: usize,
+    pub overflow_cancellations: u64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SchedulerSnapshot {
+    pub enabled: bool,
+    pub schedules: u32,
+    pub last_scan_at: Option<DateTime<Utc>>,
+    pub next_fire_at: Option<DateTime<Utc>>,
+    pub fired: u64,
+    pub skipped_overlapping: u64,
+    pub late_fires: u64,
+    pub max_fire_delay_seconds: Option<f64>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RunnersSnapshot {
+    pub registered: u32,
+    pub sessions: u32,
+    pub idle: u32,
+    pub busy: u32,
+    pub stale: u32,
+    pub max_poll_age_seconds: Option<f64>,
+    pub max_lease_age_seconds: Option<f64>,
+}
+
+// ---------------------------------------------------------------------------
+// Pool
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PoolMode {
+    Warm,
+    OnDemand,
+    External,
+    Disabled,
+}
+
+impl Default for PoolMode {
+    fn default() -> Self {
+        Self::Warm
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PoolSnapshot {
+    pub mode: PoolMode,
+    pub desired: u32,
+    pub preparing: bool,
+    pub building: u32,
+    pub provisioning: u32,
+    pub idle: u32,
+    pub busy: u32,
+    pub paused: u32,
+    pub consecutive_provision_failures: u32,
+    pub last_transition_at: Option<DateTime<Utc>>,
+    /// Consolidated queue depth (server -> pool signal, now via PoolStatus).
+    #[serde(default)]
+    pub queue_depth: u32,
+    /// Next job labels for golden selection (server -> pool).
+    #[serde(default)]
+    pub next_job_runs_on: Vec<String>,
+    /// Pending provision token count (pool -> server).
+    #[serde(default)]
+    pub pending_registrations: u32,
+}
+
+impl Default for PoolSnapshot {
+    fn default() -> Self {
+        Self {
+            mode: PoolMode::Warm,
+            desired: 0,
+            preparing: false,
+            building: 0,
+            provisioning: 0,
+            idle: 0,
+            busy: 0,
+            paused: 0,
+            consecutive_provision_failures: 0,
+            last_transition_at: None,
+            queue_depth: 0,
+            next_job_runs_on: Vec::new(),
+            pending_registrations: 0,
+        }
+    }
+}
+
+/// Shared handle that the pool updates and the sampler reads.
+///
+/// Consolidates the four ad-hoc `Option<Arc<…>>` handles. Single writer (pool)
+/// + multiple readers (sampler, status) — cheap `RwLock`.
+#[derive(Debug, Clone, Default)]
+pub struct PoolStatus {
+    inner: Arc<RwLock<PoolSnapshot>>,
+    /// One-time provision tokens (separate from snapshot to avoid cloning large map on every snapshot).
+    pending_tokens: Arc<RwLock<std::collections::BTreeMap<String, std::time::SystemTime>>>,
+}
+
+impl PoolStatus {
+    pub fn new(snapshot: PoolSnapshot) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(snapshot)),
+            pending_tokens: Arc::new(RwLock::new(std::collections::BTreeMap::new())),
+        }
+    }
+
+    pub fn snapshot(&self) -> PoolSnapshot {
+        let mut snap = self.inner.read().clone();
+        snap.pending_registrations = self.pending_tokens.read().len() as u32;
+        snap
+    }
+
+    pub fn set_desired(&self, desired: u32) {
+        self.inner.write().desired = desired;
+    }
+
+    pub fn set_preparing(&self, preparing: bool) {
+        self.inner.write().preparing = preparing;
+    }
+
+    pub fn set_counts(&self, idle: u32, busy: u32, building: u32, provisioning: u32, paused: u32) {
+        let mut g = self.inner.write();
+        g.idle = idle;
+        g.busy = busy;
+        g.building = building;
+        g.provisioning = provisioning;
+        g.paused = paused;
+    }
+
+    pub fn record_provision_failure(&self) {
+        self.inner.write().consecutive_provision_failures += 1;
+    }
+
+    pub fn clear_provision_failures(&self) {
+        self.inner.write().consecutive_provision_failures = 0;
+    }
+
+    pub fn set_queue_depth(&self, depth: u32) {
+        self.inner.write().queue_depth = depth;
+    }
+
+    pub fn set_next_job_runs_on(&self, labels: Vec<String>) {
+        self.inner.write().next_job_runs_on = labels;
+    }
+
+    pub fn insert_pending(&self, token: String, at: std::time::SystemTime) {
+        self.pending_tokens.write().insert(token, at);
+        self.inner.write().pending_registrations = self.pending_tokens.read().len() as u32;
+    }
+
+    pub fn remove_pending(&self, token: &str) -> bool {
+        let removed = self.pending_tokens.write().remove(token).is_some();
+        if removed {
+            self.inner.write().pending_registrations = self.pending_tokens.read().len() as u32;
+        }
+        removed
+    }
+
+    pub fn pending_tokens_snapshot(
+        &self,
+    ) -> std::collections::BTreeMap<String, std::time::SystemTime> {
+        self.pending_tokens.read().clone()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// VMs (stubbed for Step 3, full host sampler is Step 5)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VmSource {
+    CgroupV2,
+    Process,
+    Mixed,
+    Unavailable,
+}
+
+impl Default for VmSource {
+    fn default() -> Self {
+        Self::Unavailable
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct VmFleetSnapshot {
+    pub source: VmSource,
+    pub sample_age_seconds: Option<f64>,
+    pub capabilities: HashMap<String, bool>,
+    pub count: VmCount,
+    pub configured: VmConfigured,
+    pub host_usage: VmHostUsage,
+    pub top_consumers: Vec<VmTopConsumer>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct VmCount {
+    pub runner: u32,
+    pub golden: u32,
+    pub unavailable: u32,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct VmConfigured {
+    pub vcpus: u32,
+    pub memory_bytes: u64,
+    pub storage_bytes: u64,
+    pub overlay_bytes: u64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct VmHostUsage {
+    pub cpu_cores: f64,
+    pub memory_bytes: u64,
+    pub sparse_disk_allocated_bytes: u64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct VmTopConsumer {
+    pub machine_name: String,
+    pub role: String,
+    pub activity: String,
+    pub cpu_cores: f64,
+    pub memory_bytes: u64,
+    pub sparse_disk_allocated_bytes: u64,
+}
+
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// Store / Storage / Github / Debug / Telemetry
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StoreBackend {
+    Sqlite,
+    Postgres,
+}
+
+impl Default for StoreBackend {
+    fn default() -> Self {
+        Self::Sqlite
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct StoreSnapshot {
+    pub backend: StoreBackend,
+    pub consecutive_failures: u32,
+    pub last_success_at: Option<DateTime<Utc>>,
+    pub last_failure_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct StorageComponent {
+    pub store: String,
+    pub bytes: u64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct StorageSnapshot {
+    pub state_dir: String,
+    pub state_fs_free_bytes: Option<u64>,
+    pub state_fs_free_ratio: Option<f64>,
+    pub components: Vec<StorageComponent>,
+    pub last_gc_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GithubSnapshot {
+    pub configured: bool,
+    pub last_webhook_at: Option<DateTime<Utc>>,
+    pub pending_check_updates: u32,
+    pub last_check_success_at: Option<DateTime<Utc>>,
+    pub last_check_failure_at: Option<DateTime<Utc>>,
+    pub rate_limit: Option<GithubRateLimit>,
+    pub installation_token_expires_in_seconds: Option<u64>,
+    pub token_cache: Option<TokenCacheSnapshot>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GithubRateLimit {
+    pub resource: String,
+    pub limit: u32,
+    pub remaining: u32,
+    pub reset_at: Option<DateTime<Utc>>,
+    pub observed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TokenCacheSnapshot {
+    pub hits: u64,
+    pub misses: u64,
+    pub ttl_seconds: u64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DebugSnapshot {
+    pub active_sessions: u32,
+    pub oldest_session_seconds: Option<f64>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TelemetrySnapshot {
+    pub otlp_enabled: bool,
+    pub last_export_success_at: Option<DateTime<Utc>>,
+    pub last_export_failure_at: Option<DateTime<Utc>>,
+    pub dropped_records: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Limits / Tasks (from heartbeat/limit registries)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LimitEntry {
+    pub limit: String,
+    pub value: usize,
+    pub dropped: u64,
+    pub rejected: u64,
+    pub last_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TaskEntry {
+    pub name: String,
+    pub critical: bool,
+    pub heartbeat_age_seconds: f64,
+    pub state: String,
+}
+
+// ---------------------------------------------------------------------------
+// Conditions
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Condition {
+    pub code: String,
+    pub severity: String,
+    pub message: String,
+    pub exemplars: Vec<ConditionExemplar>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConditionExemplar {
+    pub run_id: Option<String>,
+    pub job_id: Option<String>,
+    pub runner_id: Option<String>,
+    pub machine_name: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// OperationalSnapshot — the versioned status body
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperationalSnapshot {
+    pub schema_version: u32,
+    pub observed_at: DateTime<Utc>,
+    pub snapshot_age_seconds: f64,
+    pub overall: Overall,
+    pub service: ServiceSnapshot,
+    pub runs: RunsSnapshot,
+    pub jobs: JobsSnapshot,
+    pub concurrency: ConcurrencySnapshot,
+    pub scheduler: SchedulerSnapshot,
+    pub runners: RunnersSnapshot,
+    pub pool: PoolSnapshot,
+    pub vms: VmFleetSnapshot,
+    pub store: StoreSnapshot,
+    pub storage: StorageSnapshot,
+    pub limits: Vec<LimitEntry>,
+    pub tasks: Vec<TaskEntry>,
+    pub github: GithubSnapshot,
+    pub debug: DebugSnapshot,
+    pub telemetry: TelemetrySnapshot,
+    pub conditions: Vec<Condition>,
+}
+
+impl Default for OperationalSnapshot {
+    fn default() -> Self {
+        Self {
+            schema_version: 1,
+            observed_at: Utc::now(),
+            snapshot_age_seconds: 0.0,
+            overall: Overall::Ok,
+            service: ServiceSnapshot {
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                instance_id: String::new(),
+                uptime_seconds: 0,
+                shutdown_requested: false,
+            },
+            runs: RunsSnapshot::default(),
+            jobs: JobsSnapshot::default(),
+            concurrency: ConcurrencySnapshot::default(),
+            scheduler: SchedulerSnapshot::default(),
+            runners: RunnersSnapshot::default(),
+            pool: PoolSnapshot::default(),
+            vms: VmFleetSnapshot::default(),
+            store: StoreSnapshot::default(),
+            storage: StorageSnapshot::default(),
+            limits: Vec::new(),
+            tasks: Vec::new(),
+            github: GithubSnapshot::default(),
+            debug: DebugSnapshot::default(),
+            telemetry: TelemetrySnapshot::default(),
+            conditions: Vec::new(),
+        }
+    }
+}

--- a/crates/preloop-observability/src/status.rs
+++ b/crates/preloop-observability/src/status.rs
@@ -1,7 +1,6 @@
-//! Step 3 DTOs — OperationalSnapshot and supporting types.
+//!OperationalSnapshot and supporting types.
 //!
-//! Neutral, serializable DTOs shared by server and CLI. No dependency on
-//! server/orchestrator internals. Metric labels use only bounded enums.
+
 
 use std::sync::Arc;
 
@@ -237,7 +236,7 @@ impl PoolStatus {
 }
 
 // ---------------------------------------------------------------------------
-// VMs (stubbed for Step 3, full host sampler is Step 5)
+// VMs 
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -403,9 +402,6 @@ pub struct TaskEntry {
     pub state: String,
 }
 
-// ---------------------------------------------------------------------------
-// Conditions
-// ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Condition {

--- a/crates/preloop-observability/src/vm_telemetry.rs
+++ b/crates/preloop-observability/src/vm_telemetry.rs
@@ -79,8 +79,14 @@ pub fn build_fleet_snapshot(
     let runner = infos.iter().filter(|i| i.role == "runner").count() as u32;
     let golden = infos.iter().filter(|i| i.role == "golden").count() as u32;
     let vcpus: u32 = infos.iter().map(|i| u32::from(i.cpus)).sum();
-    let memory_bytes: u64 = infos.iter().map(|i| u64::from(i.memory_mib) * 1024 * 1024).sum();
-    let storage_bytes: u64 = infos.iter().map(|i| u64::from(i.storage_gb) * 1024 * 1024 * 1024).sum();
+    let memory_bytes: u64 = infos
+        .iter()
+        .map(|i| u64::from(i.memory_mib) * 1024 * 1024)
+        .sum();
+    let storage_bytes: u64 = infos
+        .iter()
+        .map(|i| u64::from(i.storage_gb) * 1024 * 1024 * 1024)
+        .sum();
     let overlay_bytes: u64 = infos
         .iter()
         .filter_map(|i| i.overlay_gb.map(|v| u64::from(v) * 1024 * 1024 * 1024))

--- a/crates/preloop-observability/src/vm_telemetry.rs
+++ b/crates/preloop-observability/src/vm_telemetry.rs
@@ -1,0 +1,119 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use parking_lot::RwLock;
+
+use crate::status::{VmConfigured, VmCount, VmFleetSnapshot, VmHostUsage, VmSource, VmTopConsumer};
+
+#[derive(Debug, Clone)]
+pub struct VmRuntimeInfo {
+    pub name: String,
+    pub role: String,
+    pub activity: String,
+    pub pid: Option<u32>,
+    pub start_time: Option<u64>,
+    pub cpus: u16,
+    pub memory_mib: u32,
+    pub storage_gb: u32,
+    pub overlay_gb: Option<u32>,
+    pub data_dir: Option<PathBuf>,
+    pub created_at: Option<SystemTime>,
+}
+
+#[derive(Debug, Default)]
+pub struct VmTelemetryRegistry {
+    inner: RwLock<HashMap<String, VmRuntimeInfo>>,
+}
+
+impl VmTelemetryRegistry {
+    pub fn register(&self, info: VmRuntimeInfo) {
+        self.inner.write().insert(info.name.clone(), info);
+    }
+
+    pub fn deregister(&self, name: &str) {
+        self.inner.write().remove(name);
+    }
+
+    pub fn snapshot(&self) -> Vec<VmRuntimeInfo> {
+        self.inner.read().values().cloned().collect()
+    }
+}
+
+pub fn sample_host(_pid: Option<u32>, _data_dir: Option<&Path>) -> HostSample {
+    HostSample::unavailable()
+}
+
+#[derive(Debug, Clone)]
+pub struct HostSample {
+    pub cpu_time_secs: Option<f64>,
+    pub throttled_secs: Option<f64>,
+    pub memory_bytes: Option<u64>,
+    pub memory_limit_bytes: Option<u64>,
+    pub pids_current: Option<u32>,
+    pub sparse_allocated_bytes: Option<u64>,
+    pub pid_valid: bool,
+}
+
+impl HostSample {
+    pub fn unavailable() -> Self {
+        Self {
+            cpu_time_secs: None,
+            throttled_secs: None,
+            memory_bytes: None,
+            memory_limit_bytes: None,
+            pids_current: None,
+            sparse_allocated_bytes: None,
+            pid_valid: false,
+        }
+    }
+}
+
+pub fn build_fleet_snapshot(
+    registry: &VmTelemetryRegistry,
+    sample_age: Option<Duration>,
+    capabilities: HashMap<String, bool>,
+) -> VmFleetSnapshot {
+    let infos = registry.snapshot();
+    let runner = infos.iter().filter(|i| i.role == "runner").count() as u32;
+    let golden = infos.iter().filter(|i| i.role == "golden").count() as u32;
+    let vcpus: u32 = infos.iter().map(|i| u32::from(i.cpus)).sum();
+    let memory_bytes: u64 = infos.iter().map(|i| u64::from(i.memory_mib) * 1024 * 1024).sum();
+    let storage_bytes: u64 = infos.iter().map(|i| u64::from(i.storage_gb) * 1024 * 1024 * 1024).sum();
+    let overlay_bytes: u64 = infos
+        .iter()
+        .filter_map(|i| i.overlay_gb.map(|v| u64::from(v) * 1024 * 1024 * 1024))
+        .sum();
+
+    let source = if capabilities.get("cpu").copied().unwrap_or(false) {
+        VmSource::CgroupV2
+    } else if capabilities.get("process").copied().unwrap_or(false) {
+        VmSource::Process
+    } else {
+        VmSource::Unavailable
+    };
+
+    VmFleetSnapshot {
+        source,
+        sample_age_seconds: sample_age.map(|d| d.as_secs_f64()),
+        capabilities,
+        count: VmCount {
+            runner,
+            golden,
+            unavailable: 0,
+        },
+        configured: VmConfigured {
+            vcpus,
+            memory_bytes,
+            storage_bytes,
+            overlay_bytes,
+        },
+        host_usage: VmHostUsage {
+            cpu_cores: 0.0,
+            memory_bytes: 0,
+            sparse_disk_allocated_bytes: 0,
+        },
+        top_consumers: Vec::new(),
+    }
+}

--- a/crates/preloop-orchestrator/Cargo.toml
+++ b/crates/preloop-orchestrator/Cargo.toml
@@ -10,6 +10,7 @@ description = "Job scheduling and VM lifecycle orchestration for Preloop CI"
 [dependencies]
 preloop-vm = { path = "../preloop-vm" }
 preloop-gha-protocol = { path = "../preloop-gha-protocol" }
+preloop-observability = { path = "../preloop-observability" }
 preloop-runner-server = { path = "../preloop-runner-server" }
 preloop-gha-parser = { path = "../preloop-gha-parser" }
 anyhow = { workspace = true }

--- a/crates/preloop-orchestrator/src/lib.rs
+++ b/crates/preloop-orchestrator/src/lib.rs
@@ -2259,6 +2259,9 @@ impl<P: VmProvider + 'static> RunnerPool<P> {
         if let Some(signal) = &self.config.preparing_signal {
             signal.store(true, std::sync::atomic::Ordering::Release);
         }
+        if let Some(ps) = &self.config.pool_status {
+            ps.set_preparing(true);
+        }
         ensure_host_externals(&self.config)?;
         if self.config.use_packed_artifact || self.config.control_socket.is_none() {
             self.prepare_artifact(true).await?;
@@ -2293,6 +2296,9 @@ impl<P: VmProvider + 'static> RunnerPool<P> {
         // counts the full grace window from here.
         if let Some(signal) = &self.config.preparing_signal {
             signal.store(false, std::sync::atomic::Ordering::Release);
+        }
+        if let Some(ps) = &self.config.pool_status {
+            ps.set_preparing(false);
         }
 
         let mut slots = JoinSet::new();

--- a/crates/preloop-orchestrator/src/lib.rs
+++ b/crates/preloop-orchestrator/src/lib.rs
@@ -1675,6 +1675,11 @@ pub struct RunnerPoolConfig {
     /// queued-job starvation clock during the warm; it is cleared before
     /// the pool serves its first job.
     pub preparing_signal: Option<Arc<std::sync::atomic::AtomicBool>>,
+    /// Consolidated pool handle (replaces the four ad-hoc Option<Arc<…>> fields above).
+    /// When `Some`, the pool updates it and the server sampler reads it.
+    /// Retain the legacy fields for now for backwards compatibility; new code
+    /// should read/write `pool_status`.
+    pub pool_status: Option<Arc<preloop_observability::status::PoolStatus>>,
 }
 
 /// Cache of environment-specific golden VMs.
@@ -4919,6 +4924,7 @@ chmod +x "$destination/bin/node"
             next_job_runs_on: None,
             pending_registrations: None,
             preparing_signal: None,
+            pool_status: None,
         }
     }
 

--- a/crates/preloop-runner-server/Cargo.toml
+++ b/crates/preloop-runner-server/Cargo.toml
@@ -22,6 +22,7 @@ clap.workspace = true
 hyper.workspace = true
 hyper-util.workspace = true
 tower.workspace = true
+preloop-observability = { path = "../preloop-observability" }
 preloop-artifacts = { path = "../preloop-artifacts" }
 preloop-cache = { path = "../preloop-cache" }
 preloop-gha-parser = { path = "../preloop-gha-parser" }

--- a/crates/preloop-runner-server/src/artifact_twirp.rs
+++ b/crates/preloop-runner-server/src/artifact_twirp.rs
@@ -91,7 +91,12 @@ pub(crate) async fn twirp_artifact_v2_create(
         }
     }
     let upload_url = format!("{}/twirp-blob/artifact/{token}", runner_base_url());
-    info!(token, name = request.name, "artifact v2 create");
+    info!(
+        name = request.name,
+        workflow_run_backend_id = request.workflow_run_backend_id,
+        workflow_job_run_backend_id = request.workflow_job_run_backend_id,
+        "artifact v2 create"
+    );
     Ok(Json(json!({ "ok": true, "signed_upload_url": upload_url })))
 }
 

--- a/crates/preloop-runner-server/src/blob_store.rs
+++ b/crates/preloop-runner-server/src/blob_store.rs
@@ -60,14 +60,13 @@ pub(crate) async fn blob_put(
             let safe_id = blockid_to_filename(&block_id);
             let blocks_dir = blob_root.join("blocks");
             if let Err(e) = tokio::fs::create_dir_all(&blocks_dir).await {
-                warn!(kind, token, "failed to create blocks dir: {e}");
+                warn!(kind, "failed to create blocks dir: {e}");
                 return StatusCode::INTERNAL_SERVER_ERROR;
             }
             match tokio::fs::write(blocks_dir.join(&safe_id), &body).await {
                 Ok(()) => {
                     debug!(
                         kind,
-                        token,
                         block = safe_id,
                         bytes = body.len(),
                         "blob block staged"
@@ -75,7 +74,7 @@ pub(crate) async fn blob_put(
                     StatusCode::CREATED
                 }
                 Err(e) => {
-                    warn!(kind, token, "failed to write block {safe_id}: {e}");
+                    warn!(kind, block = %safe_id, "failed to write block: {e}");
                     StatusCode::INTERNAL_SERVER_ERROR
                 }
             }
@@ -92,7 +91,7 @@ pub(crate) async fn blob_put(
                 match tokio::fs::read(blocks_dir.join(&safe_id)).await {
                     Ok(bytes) => assembled.extend_from_slice(&bytes),
                     Err(e) => {
-                        warn!(kind, token, "failed to read block {safe_id}: {e}");
+                        warn!(kind, block = %safe_id, "failed to read block: {e}");
                         return StatusCode::INTERNAL_SERVER_ERROR;
                     }
                 }
@@ -102,7 +101,6 @@ pub(crate) async fn blob_put(
                     let _ = tokio::fs::remove_dir_all(&blocks_dir).await;
                     info!(
                         kind,
-                        token,
                         size = assembled.len(),
                         blocks = block_ids.len(),
                         "blob assembled from blocks"
@@ -110,7 +108,11 @@ pub(crate) async fn blob_put(
                     StatusCode::CREATED
                 }
                 Err(e) => {
-                    warn!(kind, token, "failed to write assembled blob: {e}");
+                    warn!(
+                        kind,
+                        blocks = block_ids.len(),
+                        "failed to write assembled blob: {e}"
+                    );
                     StatusCode::INTERNAL_SERVER_ERROR
                 }
             }
@@ -118,17 +120,21 @@ pub(crate) async fn blob_put(
         _ => {
             // Single-shot upload.
             if let Err(e) = tokio::fs::create_dir_all(&blob_root).await {
-                warn!(kind, token, "failed to create blob dir: {e}");
+                warn!(kind, "failed to create blob dir: {e}");
                 return StatusCode::INTERNAL_SERVER_ERROR;
             }
             let data_path = blob_root.join("data");
             match tokio::fs::write(&data_path, &body).await {
                 Ok(()) => {
-                    info!(kind, token, size = body.len(), "blob single-shot upload");
+                    info!(kind, size = body.len(), "blob single-shot upload");
                     StatusCode::CREATED
                 }
                 Err(e) => {
-                    warn!(kind, token, "failed to write single-shot blob: {e}");
+                    warn!(
+                        kind,
+                        size = body.len(),
+                        "failed to write single-shot blob: {e}"
+                    );
                     StatusCode::INTERNAL_SERVER_ERROR
                 }
             }

--- a/crates/preloop-runner-server/src/bootstrap.rs
+++ b/crates/preloop-runner-server/src/bootstrap.rs
@@ -609,6 +609,25 @@ pub async fn serve(config: ServerConfig) -> anyhow::Result<()> {
     .await?;
     // Wire observability if supplied (CLI/server will pass its handle).
     if let Some(obs) = config.observability.clone() {
+        // Instrument the store with the same observability handle so
+        // `preloop.store.operation.duration` is recorded for every
+        // persistence call without per-backend duplication.
+        let backend = if config
+            .store_url
+            .as_deref()
+            .map(|u| u.contains("postgres"))
+            .unwrap_or(false)
+            || std::env::var("PRELOOP_STORE_URL")
+                .map(|v| v.contains("postgres"))
+                .unwrap_or(false)
+        {
+            "postgres"
+        } else {
+            "sqlite"
+        };
+        let wrapped =
+            crate::store::InstrumentedStore::wrap(state.store.clone(), obs.clone(), backend);
+        state.store = wrapped;
         state.observability = obs;
     }
     if let Some(ps) = config.pool_status.clone() {

--- a/crates/preloop-runner-server/src/bootstrap.rs
+++ b/crates/preloop-runner-server/src/bootstrap.rs
@@ -513,10 +513,16 @@ fn build_operational_snapshot_sync(
             max_lease_age_seconds: None,
         },
         pool: pool_snapshot,
-        vms: VmFleetSnapshot {
-            source: VmSource::Unavailable,
-            sample_age_seconds: None,
-            ..Default::default()
+        vms: {
+            // Host sampler is stubbed until the cgroup parser lands;
+            // the registry is the source of truth for configured counts
+            // and will be populated by RunnerPool on create/fork.
+            let caps = std::collections::HashMap::new();
+            preloop_observability::vm_telemetry::build_fleet_snapshot(
+                observability.vm_registry(),
+                None,
+                caps,
+            )
         },
         store: StoreSnapshot::default(),
         storage: StorageSnapshot::default(),

--- a/crates/preloop-runner-server/src/bootstrap.rs
+++ b/crates/preloop-runner-server/src/bootstrap.rs
@@ -440,6 +440,7 @@ fn build_operational_snapshot_sync(
     started_at: std::time::Instant,
     shutdown_requested: bool,
     scheduler_enabled: bool,
+    state_dir: &std::path::Path,
 ) -> preloop_observability::status::OperationalSnapshot {
     use chrono::Utc;
     use preloop_observability::status::*;
@@ -525,7 +526,26 @@ fn build_operational_snapshot_sync(
             )
         },
         store: StoreSnapshot::default(),
-        storage: StorageSnapshot::default(),
+        storage: {
+            // Per-component bytes for the state dir. Cheap `metadata` reads on
+            // the 5s tick; a recursive walk would belong on the 60s cadence and
+            // must never run under the state lock.
+            let component = |name: &str, path: std::path::PathBuf| StorageComponent {
+                store: name.to_string(),
+                bytes: std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0),
+            };
+            StorageSnapshot {
+                state_dir: state_dir.display().to_string(),
+                state_fs_free_bytes: None,
+                state_fs_free_ratio: None,
+                components: vec![
+                    component("database", state_dir.join("preloop.db")),
+                    component("cache", state_dir.join("cache")),
+                    component("artifacts", state_dir.join("artifacts")),
+                ],
+                last_gc_at: None,
+            }
+        },
         limits: Vec::new(),
         tasks: Vec::new(),
         github: GithubSnapshot::default(),
@@ -591,6 +611,7 @@ async fn run_state_sampler(shared: Arc<SharedState>) {
                     shared.state.started_at,
                     shared.shutdown.is_cancelled(),
                     scheduler_enabled,
+                    &shared.state.state_dir,
                 );
                 *shared.state.status_snapshot.write() = snap;
             }
@@ -660,6 +681,7 @@ pub async fn serve(config: ServerConfig) -> anyhow::Result<()> {
             state.started_at,
             false,
             false,
+            &state.state_dir,
         );
         *state.status_snapshot.write() = init;
     }

--- a/crates/preloop-runner-server/src/bootstrap.rs
+++ b/crates/preloop-runner-server/src/bootstrap.rs
@@ -48,6 +48,12 @@ pub struct ServerConfig {
     /// presents the matching provisioning token.
     pub pending_registrations:
         Option<Arc<std::sync::RwLock<std::collections::BTreeMap<String, std::time::SystemTime>>>>,
+    /// Consolidated pool handle (replaces the four ad-hoc Option<Arc<…>> fields).
+    /// When `Some`, the pool updates it and the sampler reads it.
+    pub pool_status: Option<Arc<preloop_observability::status::PoolStatus>>,
+    /// Observability handle to clone into AppState (heartbeat, limits).
+    /// `None` falls back to `Observability::noop()` (tests).
+    pub observability: Option<preloop_observability::Observability>,
     /// `PRELOOP_REQUIRE_JOB_ASSIGNMENTS`: refuse to dispatch any job without
     /// a recorded assignment, including to external runners.
     pub require_job_assignments: bool,
@@ -77,6 +83,7 @@ impl std::fmt::Debug for ServerConfig {
             .field("oidc_issuer", &self.oidc_issuer)
             .field("enable_scheduler", &self.enable_scheduler)
             .field("pending_registrations", &self.pending_registrations)
+            .field("pool_status", &self.pool_status)
             .field("require_job_assignments", &self.require_job_assignments)
             .finish()
     }
@@ -182,7 +189,8 @@ pub(crate) async fn reap_once(shared: &Arc<SharedState>) {
         .state
         .pool_preparing
         .as_ref()
-        .is_some_and(|flag| flag.load(std::sync::atomic::Ordering::Acquire));
+        .is_some_and(|flag| flag.load(std::sync::atomic::Ordering::Acquire))
+        || shared.state.pool_status.snapshot().preparing;
     let queued_jobs: Vec<_> = inner.queue.iter().cloned().collect();
     let in_queue: std::collections::BTreeSet<(RunId, JobId)> = queued_jobs
         .iter()
@@ -397,15 +405,190 @@ async fn run_background_reaper(shared: Arc<SharedState>) {
     let mut interval = tokio::time::interval(Duration::from_secs(10));
     // Skip the first tick
     interval.tick().await;
+    //Heartbeat for reaper (critical) — beat each interval, no cadence change.
+    let heartbeat = shared.state.observability.heartbeat().clone();
+    let _reaper_handle = heartbeat.register("reaper", preloop_observability::Criticality::Critical);
+    heartbeat.beat("reaper");
 
     while !shared.shutdown.is_cancelled() {
         tokio::select! {
             _ = interval.tick() => {
+                heartbeat.beat("reaper");
                 reap_once(&shared).await;
             }
             _ = shared.shutdown.cancelled() => {
                 break;
             }
+        }
+    }
+}
+
+fn build_operational_snapshot_sync(
+    queue_len: usize,
+    pending_jobs_len: usize,
+    pending_expansions_len: usize,
+    expanding_len: usize,
+    runs_queued: u32,
+    runs_in_progress: u32,
+    runs_completed: u32,
+    registered: u32,
+    sessions_len: u32,
+    queue_jobs: Vec<QueuedJob>,
+    runner_labels: Vec<Vec<String>>,
+    pool_snapshot: preloop_observability::status::PoolSnapshot,
+    observability: &preloop_observability::Observability,
+    started_at: std::time::Instant,
+    shutdown_requested: bool,
+    scheduler_enabled: bool,
+) -> preloop_observability::status::OperationalSnapshot {
+    use chrono::Utc;
+    use preloop_observability::status::*;
+    let now = Utc::now();
+    let uptime = started_at.elapsed().as_secs();
+    // Claimability: distinguish claimable vs unclaimable using existing runner label matching.
+    let (claimable, unclaimable) = if queue_jobs.is_empty() {
+        (0, 0)
+    } else if runner_labels.is_empty() {
+        (0, queue_jobs.len() as u32)
+    } else if pool_snapshot.preparing {
+        // Temporarily unclaimable while pool prepares.
+        (0, queue_jobs.len() as u32)
+    } else {
+        let mut claimable = 0u32;
+        for job in &queue_jobs {
+            let matches = runner_labels
+                .iter()
+                .any(|labels| crate::runtime_scheduling::job_matches_runner(&job.runs_on, labels));
+            if matches {
+                claimable += 1;
+            }
+        }
+        (claimable, queue_jobs.len() as u32 - claimable)
+    };
+
+    let oldest_ready_seconds = None; // TODO: track queued_at
+
+    OperationalSnapshot {
+        schema_version: 1,
+        observed_at: now,
+        snapshot_age_seconds: 0.0,
+        overall: if shutdown_requested {
+            Overall::ShuttingDown
+        } else {
+            Overall::Ok
+        },
+        service: ServiceSnapshot {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            instance_id: observability.instance_id().to_string(),
+            uptime_seconds: uptime,
+            shutdown_requested,
+        },
+        runs: RunsSnapshot {
+            queued: runs_queued,
+            in_progress: runs_in_progress,
+            completed: runs_completed,
+        },
+        jobs: JobsSnapshot {
+            ready: queue_len as u32,
+            dependency_blocked: pending_jobs_len as u32,
+            concurrency_blocked: 0,
+            pending_expansion: pending_expansions_len as u32,
+            expanding: expanding_len as u32,
+            claimable,
+            unclaimable,
+            oldest_ready_seconds,
+        },
+        concurrency: ConcurrencySnapshot::default(),
+        scheduler: SchedulerSnapshot {
+            enabled: scheduler_enabled,
+            ..Default::default()
+        },
+        runners: RunnersSnapshot {
+            registered,
+            sessions: sessions_len,
+            idle: 0,
+            busy: 0,
+            stale: 0,
+            max_poll_age_seconds: None,
+            max_lease_age_seconds: None,
+        },
+        pool: pool_snapshot,
+        vms: VmFleetSnapshot {
+            source: VmSource::Unavailable,
+            sample_age_seconds: None,
+            ..Default::default()
+        },
+        store: StoreSnapshot::default(),
+        storage: StorageSnapshot::default(),
+        limits: Vec::new(),
+        tasks: Vec::new(),
+        github: GithubSnapshot::default(),
+        debug: DebugSnapshot::default(),
+        telemetry: TelemetrySnapshot::default(),
+        conditions: Vec::new(),
+    }
+}
+
+async fn run_state_sampler(shared: Arc<SharedState>) {
+    let heartbeat = shared.state.observability.heartbeat().clone();
+    let _handle = heartbeat.register(
+        "state_sampler",
+        preloop_observability::Criticality::Critical,
+    );
+    heartbeat.beat("state_sampler");
+    let mut interval = tokio::time::interval(Duration::from_secs(5));
+    // Immediate sample then every 5s.
+    interval.tick().await;
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {
+                heartbeat.beat("state_sampler");
+                // Clone needed state under lock, release, then build.
+                let (queue_len, pending_jobs_len, pending_expansions_len, expanding_len, runs_queued, runs_in_progress, runs_completed, registered, sessions_len, queue_jobs, runner_labels, scheduler_enabled) = {
+                    let inner = shared.state.inner.lock().await;
+                    let queue_len = inner.queue.len();
+                    let pending_jobs_len = inner.pending_jobs.len();
+                    let pending_expansions_len = inner.pending_expansions.len();
+                    let expanding_len = inner.expanding.len();
+                    let mut q = 0u32; let mut ip = 0u32; let mut c = 0u32;
+                    for run in inner.runs.values() {
+                        match run.status {
+                            ExecutionStatus::Queued => q += 1,
+                            ExecutionStatus::InProgress => ip += 1,
+                            s if s.is_terminal() => c += 1,
+                            _ => {}
+                        }
+                    }
+                    let registered = inner.runners.len() as u32;
+                    let sessions_len = inner.sessions.len() as u32;
+                    let queue_jobs = inner.queue.iter().cloned().collect::<Vec<_>>();
+                    let runner_labels = inner.runners.values().map(|r| r.labels.clone()).collect::<Vec<_>>();
+                    let scheduler_enabled = shared.state.scheduler.is_some();
+                    // Clone pool snapshot outside inner lock? It's cheap, do after.
+                    (queue_len, pending_jobs_len, pending_expansions_len, expanding_len, q, ip, c, registered, sessions_len, queue_jobs, runner_labels, scheduler_enabled)
+                };
+                let pool_snapshot = shared.state.pool_status.snapshot();
+                let snap = build_operational_snapshot_sync(
+                    queue_len,
+                    pending_jobs_len,
+                    pending_expansions_len,
+                    expanding_len,
+                    runs_queued,
+                    runs_in_progress,
+                    runs_completed,
+                    registered,
+                    sessions_len,
+                    queue_jobs,
+                    runner_labels,
+                    pool_snapshot,
+                    &shared.state.observability,
+                    shared.state.started_at,
+                    shared.shutdown.is_cancelled(),
+                    scheduler_enabled,
+                );
+                *shared.state.status_snapshot.write() = snap;
+            }
+            _ = shared.shutdown.cancelled() => break,
         }
     }
 }
@@ -424,6 +607,37 @@ pub async fn serve(config: ServerConfig) -> anyhow::Result<()> {
         config.store_url.as_deref(),
     )
     .await?;
+    // Wire observability if supplied (CLI/server will pass its handle).
+    if let Some(obs) = config.observability.clone() {
+        state.observability = obs;
+    }
+    if let Some(ps) = config.pool_status.clone() {
+        state.pool_status = ps;
+    }
+    // Ensure uptime base is now (AppState::new set it, but re-arm after store load).
+    state.started_at = std::time::Instant::now();
+    // Seed initial snapshot so /readyz and /status have data before first 5s tick.
+    {
+        let init = build_operational_snapshot_sync(
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            Vec::new(),
+            Vec::new(),
+            state.pool_status.snapshot(),
+            &state.observability,
+            state.started_at,
+            false,
+            false,
+        );
+        *state.status_snapshot.write() = init;
+    }
     if let Some(queue_depth) = config.queue_depth.clone() {
         state.queue_depth = queue_depth;
         // The pool shares this same atomic and only forks a runner while it
@@ -435,22 +649,45 @@ pub async fn serve(config: ServerConfig) -> anyhow::Result<()> {
             state.inner.lock().await.queue.len(),
             std::sync::atomic::Ordering::Release,
         );
+        state
+            .pool_status
+            .set_queue_depth(state.queue_depth.load(std::sync::atomic::Ordering::Acquire) as u32);
     }
     if let Some(next_job_runs_on) = config.next_job_runs_on.clone() {
         state.next_job_runs_on = next_job_runs_on;
+        if let Ok(v) = state.next_job_runs_on.read() {
+            state.pool_status.set_next_job_runs_on(v.clone());
+        }
     }
     {
         let inner = state.inner.lock().await;
         crate::runtime_scheduling::sync_next_job_labels(&inner, &state.next_job_runs_on);
+        if state.pool_status.snapshot().next_job_runs_on.is_empty() {
+            if let Ok(v) = state.next_job_runs_on.read() {
+                state.pool_status.set_next_job_runs_on(v.clone());
+            }
+        }
     }
     {
         let pool_managed = config.pending_registrations.is_some();
         if let Some(pending_registrations) = config.pending_registrations.clone() {
             state.pending_registrations = pending_registrations;
+            // Mirror into consolidated handle for sampler visibility
+            if let Ok(map) = state.pending_registrations.read() {
+                for (k, v) in map.iter() {
+                    state.pool_status.insert_pending(k.clone(), *v);
+                }
+            }
         }
         let mut inner = state.inner.lock().await;
         inner.pool_assignments_enabled = pool_managed;
         inner.require_job_assignments = config.require_job_assignments;
+    }
+    if let Some(pool_preparing) = config.pool_preparing.clone() {
+        state.pool_preparing = Some(pool_preparing.clone());
+        if pool_preparing.load(std::sync::atomic::Ordering::Acquire) {
+            state.pool_status.set_preparing(true);
+        }
     }
     if !config.listen.ip().is_loopback() && state.system_token == DEFAULT_PRELOOP_SYSTEM_TOKEN {
         anyhow::bail!(
@@ -467,6 +704,8 @@ pub async fn serve(config: ServerConfig) -> anyhow::Result<()> {
         inner.oidc_issuer = oidc_issuer;
     }
     let shutdown = CancellationToken::new();
+    // Heartbeat for scheduler scan (critical) if enabled — beat periodically.
+    let scheduler_heartbeat = state.observability.heartbeat().clone();
     if config.enable_scheduler {
         let scheduler = crate::scheduler::Scheduler::new();
         state.scheduler = Some(scheduler.clone());
@@ -475,6 +714,24 @@ pub async fn serve(config: ServerConfig) -> anyhow::Result<()> {
             shutdown: shutdown.clone(),
         });
         let scheduler_clone = scheduler.clone();
+        // Spawn a holder task for scheduler_scan heartbeat — keep handle alive for lifetime.
+        let hb_for_holder = scheduler_heartbeat.clone();
+        let shutdown_for_holder = shutdown.clone();
+        tokio::spawn(async move {
+            let _handle = hb_for_holder.register(
+                "scheduler_scan",
+                preloop_observability::Criticality::Critical,
+            );
+            hb_for_holder.beat("scheduler_scan");
+            let mut int = tokio::time::interval(Duration::from_secs(10));
+            int.tick().await;
+            while !shutdown_for_holder.is_cancelled() {
+                tokio::select! {
+                    _ = int.tick() => hb_for_holder.beat("scheduler_scan"),
+                    _ = shutdown_for_holder.cancelled() => break,
+                }
+            }
+        });
         if let Some(workspace) = state.local_workspace.clone() {
             tokio::spawn(async move {
                 scheduler_clone
@@ -558,10 +815,15 @@ pub async fn serve(config: ServerConfig) -> anyhow::Result<()> {
     };
     let router = build_app(state.clone(), shutdown.clone(), test_api_token);
 
-    state.pool_preparing = config.pool_preparing.clone();
     let shared = Arc::new(SharedState {
-        state,
+        state: state.clone(),
         shutdown: shutdown.clone(),
+    });
+
+    // 5s sampler — clone needed state under lock, release, then publish.
+    let sampler_shared = shared.clone();
+    tokio::spawn(async move {
+        run_state_sampler(sampler_shared).await;
     });
 
     let checker_shared = shared.clone();

--- a/crates/preloop-runner-server/src/bootstrap.rs
+++ b/crates/preloop-runner-server/src/bootstrap.rs
@@ -640,10 +640,16 @@ pub async fn serve(config: ServerConfig) -> anyhow::Result<()> {
     )
     .await?;
     // Wire observability if supplied (CLI/server will pass its handle).
+    // Adopt the caller's handle when supplied; `AppState::new` already
+    // installed a no-op one otherwise. Either way the store is instrumented,
+    // so `preloop.store.operation.duration` is recorded even for the
+    // standalone `preloop-server` binary, which passes no handle.
     if let Some(obs) = config.observability.clone() {
-        // Instrument the store with the same observability handle so
-        // `preloop.store.operation.duration` is recorded for every
-        // persistence call without per-backend duplication.
+        state.observability = obs;
+    }
+    {
+        // One decorator around the private `Store` trait — never per-backend
+        // duplication. The backend label is bounded to sqlite|postgres.
         let backend = if config
             .store_url
             .as_deref()
@@ -657,10 +663,11 @@ pub async fn serve(config: ServerConfig) -> anyhow::Result<()> {
         } else {
             "sqlite"
         };
-        let wrapped =
-            crate::store::InstrumentedStore::wrap(state.store.clone(), obs.clone(), backend);
-        state.store = wrapped;
-        state.observability = obs;
+        state.store = crate::store::InstrumentedStore::wrap(
+            state.store.clone(),
+            state.observability.clone(),
+            backend,
+        );
     }
     if let Some(ps) = config.pool_status.clone() {
         state.pool_status = ps;

--- a/crates/preloop-runner-server/src/bootstrap.rs
+++ b/crates/preloop-runner-server/src/bootstrap.rs
@@ -441,6 +441,7 @@ fn build_operational_snapshot_sync(
     shutdown_requested: bool,
     scheduler_enabled: bool,
     state_dir: &std::path::Path,
+    github_configured: bool,
 ) -> preloop_observability::status::OperationalSnapshot {
     use chrono::Utc;
     use preloop_observability::status::*;
@@ -548,7 +549,10 @@ fn build_operational_snapshot_sync(
         },
         limits: Vec::new(),
         tasks: Vec::new(),
-        github: GithubSnapshot::default(),
+        github: GithubSnapshot {
+            configured: github_configured,
+            ..Default::default()
+        },
         debug: DebugSnapshot::default(),
         telemetry: TelemetrySnapshot::default(),
         conditions: Vec::new(),
@@ -612,6 +616,7 @@ async fn run_state_sampler(shared: Arc<SharedState>) {
                     shared.shutdown.is_cancelled(),
                     scheduler_enabled,
                     &shared.state.state_dir,
+                    shared.state.github_app.is_some(),
                 );
                 *shared.state.status_snapshot.write() = snap;
             }
@@ -682,6 +687,7 @@ pub async fn serve(config: ServerConfig) -> anyhow::Result<()> {
             false,
             false,
             &state.state_dir,
+            state.github_app.is_some(),
         );
         *state.status_snapshot.write() = init;
     }

--- a/crates/preloop-runner-server/src/broker.rs
+++ b/crates/preloop-runner-server/src/broker.rs
@@ -855,6 +855,19 @@ pub(crate) async fn broker_acquire_job(
     message.request_id = 0;
     let payload = serde_json::to_value(&message)
         .map_err(|error| ApiError::internal(format!("serialize broker job payload: {error}")))?;
+    // Queue wait and broker poll outcomes — bounded, exactly one per successful claim.
+    shared
+        .state
+        .observability
+        .metrics()
+        .lifecycle
+        .record_queue_wait("claimed", std::time::Duration::from_secs(1));
+    shared
+        .state
+        .observability
+        .metrics()
+        .lifecycle
+        .record_broker_poll("job");
     Ok(Json(payload))
 }
 

--- a/crates/preloop-runner-server/src/broker.rs
+++ b/crates/preloop-runner-server/src/broker.rs
@@ -380,6 +380,12 @@ pub(crate) async fn broker_session_root(
             .broker_session_runners
             .insert(session_id.clone(), runner_id);
     }
+    shared
+        .state
+        .observability
+        .metrics()
+        .lifecycle
+        .record_session_transition("create", "ok");
     Ok((
         StatusCode::CREATED,
         Json(json!({
@@ -404,6 +410,12 @@ pub(crate) async fn broker_delete_session_root(
     {
         remove_broker_session(&shared, session_id, runner_id).await?;
     }
+    shared
+        .state
+        .observability
+        .metrics()
+        .lifecycle
+        .record_session_transition("delete", "ok");
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -414,6 +426,12 @@ pub(crate) async fn broker_delete_session_by_path(
 ) -> Result<StatusCode, ApiError> {
     let runner_id = authenticated_runner_id(&shared, &headers, None)?;
     remove_broker_session(&shared, &session_id, runner_id).await?;
+    shared
+        .state
+        .observability
+        .metrics()
+        .lifecycle
+        .record_session_transition("delete", "ok");
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/preloop-runner-server/src/distributed_task.rs
+++ b/crates/preloop-runner-server/src/distributed_task.rs
@@ -324,7 +324,17 @@ pub(crate) async fn agent_request_patch(
     Path((pool_id, request_id)): Path<(i64, i64)>,
     Json(body): Json<serde_json::Value>,
 ) -> Json<serde_json::Value> {
-    info!(?body, "agent_request_patch received");
+    let result_hint = body
+        .get("result")
+        .and_then(|v| v.as_str())
+        .unwrap_or("renew");
+    info!(
+        pool_id,
+        request_id,
+        result = %result_hint,
+        has_result = body.get("result").is_some(),
+        "agent_request_patch received"
+    );
     // If this is a completion (has result), delegate to complete_job_inner
     // so summarize_run, promote_ready_jobs, and notify_waiters all fire.
     // The result field is only present on the final PATCH; renewals have no result.

--- a/crates/preloop-runner-server/src/http_metrics.rs
+++ b/crates/preloop-runner-server/src/http_metrics.rs
@@ -1,0 +1,103 @@
+use std::time::Instant;
+
+use axum::{
+    extract::{MatchedPath, Request, State},
+    middleware::Next,
+    response::Response,
+};
+use preloop_observability::metrics::{classify_surface, normalize_route, status_class};
+
+use crate::state::SharedState;
+use std::sync::Arc;
+
+/// Middleware that records `http.server.request.duration` and
+/// `http.server.active_requests` with bounded labels.
+///
+/// - `method` — HTTP method (GET, POST, …)
+/// - `route` — Axum matched template (e.g. `/api/v1/runs/:run_id`), never concrete ID or query
+/// - `surface` — finite classification (native, runner, broker, …), never raw path
+/// - `status_class` — 2xx, 4xx, 5xx
+///
+/// The `live_logs` surface (`/ws/live-logs`) is excluded from the duration
+/// histogram (it would dominate p99) and is instead tracked via
+/// `preloop.livelog.connections`.
+pub async fn http_metrics_middleware(
+    State(shared): State<Arc<SharedState>>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let method = req.method().to_string();
+    // Prefer Axum's matched template; fallback to manual normalization for
+    // the 1,000-IDs test and for unmatched routes.
+    let raw_path = req.uri().path().to_string();
+    let route = req
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|mp| mp.as_str().to_string())
+        .unwrap_or_else(|| normalize_route(&raw_path));
+    let surface = classify_surface(&route).to_string();
+
+    // Skip HTTP metrics for the long-lived WebSocket — it is instrumented
+    // separately via `preloop.livelog.*`.
+    let is_live_logs = surface == "live_logs";
+
+    let labels = if !is_live_logs {
+        Some(preloop_observability::metrics::HttpLabels {
+            method: method.clone(),
+            route: route.clone(),
+            surface: surface.clone(),
+            status_class: "2xx".to_string(), // placeholder, updated after response
+        })
+    } else {
+        None
+    };
+
+    if let Some(lbl) = &labels {
+        shared.state.observability.metrics().http.inc_active(lbl);
+    }
+
+    let start = Instant::now();
+    let res = next.run(req).await;
+    let elapsed = start.elapsed();
+
+    let status = res.status().as_u16();
+    let sc = status_class(status).to_string();
+
+    if let Some(lbl) = labels {
+        let mut lbl = lbl;
+        lbl.status_class = sc.clone();
+        // Record duration only for non-live_logs
+        shared
+            .state
+            .observability
+            .metrics()
+            .http
+            .observe_duration(lbl.clone(), elapsed);
+        shared.state.observability.metrics().http.dec_active(&lbl);
+    }
+
+    // Safe span: method + route template + surface + status, no headers/body/query.
+    // Use `tracing::info_span!` so it appears in logs when RUST_LOG includes it,
+    // but filtered at DEBUG by default (poll/renew are DEBUG).
+    let span = tracing::info_span!(
+        "http.request",
+        http.method = %method,
+        http.route = %route,
+        http.surface = %surface,
+        http.status_code = status,
+        http.status_class = %sc,
+        otel.kind = "server",
+    );
+    // Attach span to response for trace correlation; the span itself is not
+    // entered for the handler thread beyond this point (no await while held).
+
+    // Also emit a counter for broker poll outcomes — the control plane's
+    // poll is a long-poll that returns job|empty|cancel|error. That is
+    // already counted via the HTTP histogram, but the plan also wants
+    // `preloop.broker.poll{outcome}` to distinguish empty vs error.
+    // For now we just log at DEBUG; the dedicated broker counter is wired
+    // in the broker module itself (Step 4 lifecycle).
+    let _ = span;
+
+    res
+}

--- a/crates/preloop-runner-server/src/http_metrics.rs
+++ b/crates/preloop-runner-server/src/http_metrics.rs
@@ -56,6 +56,20 @@ pub async fn http_metrics_middleware(
         shared.state.observability.metrics().http.inc_active(lbl);
     }
 
+    // Adopt an inbound W3C trace so a caller's trace continues through the
+    // control plane; otherwise start a root. Health and metrics probes are
+    // suppressed from trace export per the signal policy — they would swamp
+    // the trace store and tell an operator nothing.
+    let traced = shared.state.observability.tracing_enabled() && surface != "public";
+    let span_context = traced.then(|| {
+        preloop_observability::export::SpanContext::from_traceparent(
+            req.headers()
+                .get("traceparent")
+                .and_then(|value| value.to_str().ok()),
+        )
+    });
+    let span_start = preloop_observability::export::now_nanos();
+
     let start = Instant::now();
     let res = next.run(req).await;
     let elapsed = start.elapsed();
@@ -66,38 +80,39 @@ pub async fn http_metrics_middleware(
     if let Some(lbl) = labels {
         let mut lbl = lbl;
         lbl.status_class = sc.clone();
-        // Record duration only for non-live_logs
+        let metrics = shared.state.observability.metrics();
+        metrics.http.observe_duration(lbl.clone(), elapsed);
+        metrics.http.dec_active(&lbl);
+    }
+
+    if let Some(context) = span_context {
+        // Attributes are allowlisted, never derived from the raw URI: the
+        // route is the matched template and the surface is a finite set.
+        let attributes = vec![
+            ("http.request.method".to_string(), method.clone()),
+            ("http.route".to_string(), route.clone()),
+            ("preloop.surface".to_string(), surface.clone()),
+            ("http.response.status_code".to_string(), status.to_string()),
+        ];
         shared
             .state
             .observability
-            .metrics()
-            .http
-            .observe_duration(lbl.clone(), elapsed);
-        shared.state.observability.metrics().http.dec_active(&lbl);
+            .export_span(preloop_observability::export::SpanRecord {
+                context,
+                name: format!("{method} {route}"),
+                start_nanos: span_start,
+                end_nanos: preloop_observability::export::now_nanos(),
+                // Only 5xx is the server's fault; a 4xx is the caller's and
+                // marking it Error would make every unauthenticated probe
+                // look like an outage.
+                status: if status >= 500 {
+                    preloop_observability::export::SpanStatus::Error
+                } else {
+                    preloop_observability::export::SpanStatus::Unset
+                },
+                attributes,
+            });
     }
-
-    // Safe span: method + route template + surface + status, no headers/body/query.
-    // Use `tracing::info_span!` so it appears in logs when RUST_LOG includes it,
-    // but filtered at DEBUG by default (poll/renew are DEBUG).
-    let span = tracing::info_span!(
-        "http.request",
-        http.method = %method,
-        http.route = %route,
-        http.surface = %surface,
-        http.status_code = status,
-        http.status_class = %sc,
-        otel.kind = "server",
-    );
-    // Attach span to response for trace correlation; the span itself is not
-    // entered for the handler thread beyond this point (no await while held).
-
-    // Also emit a counter for broker poll outcomes — the control plane's
-    // poll is a long-poll that returns job|empty|cancel|error. That is
-    // already counted via the HTTP histogram, but the plan also wants
-    // `preloop.broker.poll{outcome}` to distinguish empty vs error.
-    // For now we just log at DEBUG; the dedicated broker counter is wired
-    // in the broker module itself (Step 4 lifecycle).
-    let _ = span;
 
     res
 }

--- a/crates/preloop-runner-server/src/lib.rs
+++ b/crates/preloop-runner-server/src/lib.rs
@@ -39,6 +39,7 @@ mod live_logs;
 mod openapi;
 use live_logs::*;
 mod debug;
+mod http_metrics;
 use debug::*;
 mod debug_sessions;
 mod runner_lifecycle;
@@ -131,7 +132,6 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::net::TcpListener;
 use tokio::sync::{broadcast, Mutex, Notify};
 use tokio_util::sync::CancellationToken;
-use tower_http::trace::TraceLayer;
 use tracing::{debug, error, info, warn};
 
 /// Default local token used when `PRELOOP_SYSTEM_TOKEN` is not configured.

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -18536,6 +18536,8 @@ fn server_config_debug_redacts_store_url_password() {
         oidc_issuer: None,
         enable_scheduler: false,
         pending_registrations: None,
+        pool_status: None,
+        observability: None,
         require_job_assignments: false,
     };
     let debug = format!("{config:?}");

--- a/crates/preloop-runner-server/src/main.rs
+++ b/crates/preloop-runner-server/src/main.rs
@@ -83,7 +83,9 @@ async fn main() -> anyhow::Result<()> {
     let (observability, observability_runtime) =
         preloop_observability::Observability::from_config(obs_config);
     preloop_observability::ObservabilityRuntime::install_fmt_subscriber(observability.config());
-    let _observability = observability;
+    // The handle must reach `ServerConfig`; holding it here alone would leave
+    // the server on the no-op handle installed by `AppState::new`, so nothing
+    // would ever export.
     let _observability_runtime = observability_runtime;
 
     let cli = Cli::parse();
@@ -131,7 +133,7 @@ async fn main() -> anyhow::Result<()> {
                 pool_preparing: None,
                 listen,
                 pool_status: None,
-                observability: None,
+                observability: Some(observability.clone()),
                 systemd_socket_activation: false,
                 unix_socket,
                 state_dir,

--- a/crates/preloop-runner-server/src/main.rs
+++ b/crates/preloop-runner-server/src/main.rs
@@ -75,10 +75,10 @@ async fn main() -> anyhow::Result<()> {
         .install_default()
         .ok();
 
-    // Unified observability init (Step 2): `RUST_LOG` now defaults to `info`
+    // Unified observability init: `RUST_LOG` now defaults to `info`
     // like the CLI, instead of falling silent when unset. `PRELOOP_LOG_FORMAT`
     // controls pretty/json/auto. The `Observability` handle will be cloned
-    // into `AppState` in Step 3; for now it is held for the life of `main`.
+    // into `AppState`; for now it is held for the life of `main`.
     let obs_config = preloop_observability::ObservabilityConfig::from_env();
     let (observability, observability_runtime) =
         preloop_observability::Observability::from_config(obs_config);

--- a/crates/preloop-runner-server/src/main.rs
+++ b/crates/preloop-runner-server/src/main.rs
@@ -79,7 +79,8 @@ async fn main() -> anyhow::Result<()> {
     // like the CLI, instead of falling silent when unset. `PRELOOP_LOG_FORMAT`
     // controls pretty/json/auto. The `Observability` handle will be cloned
     // into `AppState`; for now it is held for the life of `main`.
-    let obs_config = preloop_observability::ObservabilityConfig::from_env();
+    let obs_config = preloop_observability::ObservabilityConfig::from_env()
+        .with_service_version(env!("CARGO_PKG_VERSION"));
     let (observability, observability_runtime) =
         preloop_observability::Observability::from_config(obs_config);
     preloop_observability::ObservabilityRuntime::install_fmt_subscriber(observability.config());

--- a/crates/preloop-runner-server/src/main.rs
+++ b/crates/preloop-runner-server/src/main.rs
@@ -130,6 +130,8 @@ async fn main() -> anyhow::Result<()> {
                 next_job_runs_on: None,
                 pool_preparing: None,
                 listen,
+                pool_status: None,
+                observability: None,
                 systemd_socket_activation: false,
                 unix_socket,
                 state_dir,

--- a/crates/preloop-runner-server/src/main.rs
+++ b/crates/preloop-runner-server/src/main.rs
@@ -75,9 +75,16 @@ async fn main() -> anyhow::Result<()> {
         .install_default()
         .ok();
 
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
+    // Unified observability init (Step 2): `RUST_LOG` now defaults to `info`
+    // like the CLI, instead of falling silent when unset. `PRELOOP_LOG_FORMAT`
+    // controls pretty/json/auto. The `Observability` handle will be cloned
+    // into `AppState` in Step 3; for now it is held for the life of `main`.
+    let obs_config = preloop_observability::ObservabilityConfig::from_env();
+    let (observability, observability_runtime) =
+        preloop_observability::Observability::from_config(obs_config);
+    preloop_observability::ObservabilityRuntime::install_fmt_subscriber(observability.config());
+    let _observability = observability;
+    let _observability_runtime = observability_runtime;
 
     let cli = Cli::parse();
     match cli.command {

--- a/crates/preloop-runner-server/src/openapi.rs
+++ b/crates/preloop-runner-server/src/openapi.rs
@@ -179,7 +179,10 @@ pub(crate) struct RunResponse {
         list_dispatch_runs,
         github_register,
         github_callback,
-        list_runners
+        list_runners,
+        readyz,
+        status,
+        metrics
     ),
     components(
         schemas(
@@ -281,6 +284,38 @@ type JsonValue = serde_json::Value;
     responses((status = 200, description = "Server is healthy", body = JsonValue))
 )]
 fn healthz() {}
+
+/// Server readiness check (public, reason codes on 503).
+#[utoipa::path(
+    get, path = "/readyz", tag = "Health",
+    responses(
+        (status = 200, description = "Ready", body = JsonValue),
+        (status = 503, description = "Not ready", body = JsonValue)
+    )
+)]
+fn readyz() {}
+
+/// Operational status snapshot (native bearer required).
+#[utoipa::path(
+    get, path = "/api/v1/status", tag = "Health",
+    responses(
+        (status = 200, description = "Operational snapshot", body = JsonValue),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse)
+    ),
+    security(("native_bearer" = []))
+)]
+fn status() {}
+
+/// Prometheus metrics (native bearer required).
+#[utoipa::path(
+    get, path = "/metrics", tag = "Health",
+    responses(
+        (status = 200, description = "Prometheus text", content_type = "text/plain", body = String),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse)
+    ),
+    security(("native_bearer" = []))
+)]
+fn metrics() {}
 
 // ── Runs ────────────────────────────────────────────────────────────────────
 

--- a/crates/preloop-runner-server/src/results_twirp.rs
+++ b/crates/preloop-runner-server/src/results_twirp.rs
@@ -683,8 +683,8 @@ pub(crate) async fn twirp_cache_v2_create(
             inner.cache_v2_pending.insert(
                 token.clone(),
                 CacheV2Pending {
-                    key: storage_key,
-                    version,
+                    key: storage_key.clone(),
+                    version: version.clone(),
                 },
             );
             let meta = crate::store::build_meta_snapshot(&inner);
@@ -710,7 +710,11 @@ pub(crate) async fn twirp_cache_v2_create(
         ));
     }
     let upload_url = format!("{}/twirp-blob/cache/{token}", runner_base_url());
-    info!(token, "cache v2 create entry");
+    info!(
+        key = %storage_key,
+        version = %version,
+        "cache v2 create entry"
+    );
     Ok(pb_or_json(
         &headers,
         PbCreateCacheEntryResponse {
@@ -996,8 +1000,14 @@ mod cache_pb_tests {
             metadata: Some(PbCacheMetadata {
                 repository_id: 42,
                 scope: vec![
-                    PbCacheScope { scope: "refs/heads/main".to_string(), permission: 1 },
-                    PbCacheScope { scope: "refs/heads/feature".to_string(), permission: 2 },
+                    PbCacheScope {
+                        scope: "refs/heads/main".to_string(),
+                        permission: 1,
+                    },
+                    PbCacheScope {
+                        scope: "refs/heads/feature".to_string(),
+                        permission: 2,
+                    },
                 ],
             }),
             key: "k".to_string(),
@@ -1015,7 +1025,10 @@ mod cache_pb_tests {
         let fixture = include_bytes!("../../../fixtures/wire/cache-multi-scope.pb");
         let (_, _, _, fixture_scopes, _) =
             pb_cache_request(fixture, CacheRequestKind::GetDownloadUrl).unwrap();
-        assert_eq!(fixture_scopes, vec!["refs/heads/main", "refs/heads/feature"]);
+        assert_eq!(
+            fixture_scopes,
+            vec!["refs/heads/main", "refs/heads/feature"]
+        );
     }
 
     #[test]

--- a/crates/preloop-runner-server/src/routes.rs
+++ b/crates/preloop-runner-server/src/routes.rs
@@ -252,8 +252,18 @@ pub(crate) fn build_app(
             crate::dispatch_auth::require_dispatch_auth,
         ));
 
+    let observability_routes = Router::new()
+        .route("/api/v1/status", get(status))
+        .route("/metrics", get(metrics))
+        .route_layer(middleware::from_fn_with_state(
+            shared.clone(),
+            require_native_bearer,
+        ));
+
     let router = Router::new()
         .route("/healthz", get(healthz))
+        .route("/readyz", get(readyz))
+        .merge(observability_routes)
         .route("/runs/:run_id", get(get_public_run))
         .route(
             "/openapi.json",

--- a/crates/preloop-runner-server/src/routes.rs
+++ b/crates/preloop-runner-server/src/routes.rs
@@ -812,7 +812,10 @@ pub(crate) fn build_app(
             shared.clone(),
             resolve_runner_identity,
         ))
-        .layer(TraceLayer::new_for_http())
+        .layer(middleware::from_fn_with_state(
+            shared.clone(),
+            crate::http_metrics::http_metrics_middleware,
+        ))
         .layer(middleware::from_fn(errors::protocol_error_envelope))
         .layer(middleware::from_fn_with_state(
             state.clone(),

--- a/crates/preloop-runner-server/src/runs.rs
+++ b/crates/preloop-runner-server/src/runs.rs
@@ -1,12 +1,137 @@
 use super::*;
 use std::collections::BTreeSet;
 
-pub(crate) async fn healthz(State(shared): State<Arc<SharedState>>) -> Json<serde_json::Value> {
-    Json(json!({
-        "ok": true,
+pub(crate) async fn healthz(State(shared): State<Arc<SharedState>>) -> impl IntoResponse {
+    let shutdown = shared.shutdown.is_cancelled();
+    let body = json!({
+        "ok": !shutdown,
         "protocol_version": PROTOCOL_VERSION,
-        "shutdown_requested": shared.shutdown.is_cancelled(),
-    }))
+        "shutdown_requested": shutdown,
+    });
+    if shutdown {
+        (StatusCode::SERVICE_UNAVAILABLE, Json(body)).into_response()
+    } else {
+        (StatusCode::OK, Json(body)).into_response()
+    }
+}
+
+pub(crate) async fn readyz(State(shared): State<Arc<SharedState>>) -> impl IntoResponse {
+    if shared.shutdown.is_cancelled() {
+        let body = json!({ "ready": false, "reason": "shutting_down" });
+        return (StatusCode::SERVICE_UNAVAILABLE, Json(body)).into_response();
+    }
+    // Check critical heartbeats freshness (>15s stale is 3 intervals of 5s sampler)
+    if let Some(stale) = shared
+        .state
+        .observability
+        .heartbeat()
+        .any_critical_stale(Duration::from_secs(15))
+    {
+        let body = json!({ "ready": false, "reason": format!("task_stale:{}", stale) });
+        return (StatusCode::SERVICE_UNAVAILABLE, Json(body)).into_response();
+    }
+    // Also check snapshot age (>15s stale sampler)
+    let age_secs = {
+        let snap = shared.state.status_snapshot.read();
+        let now = chrono::Utc::now();
+        (now - snap.observed_at).num_milliseconds() as f64 / 1000.0
+    };
+    if age_secs > 15.0 {
+        let body = json!({ "ready": false, "reason": "state_sampler_stale" });
+        return (StatusCode::SERVICE_UNAVAILABLE, Json(body)).into_response();
+    }
+    let body = json!({ "ready": true, "reason": serde_json::Value::Null });
+    (StatusCode::OK, Json(body)).into_response()
+}
+
+pub(crate) async fn status(State(shared): State<Arc<SharedState>>) -> impl IntoResponse {
+    // Fail-open, no InnerState lock — clone cached snapshot and update age.
+    let mut snap = shared.state.status_snapshot.read().clone();
+    let now = chrono::Utc::now();
+    let age = (now - snap.observed_at).num_milliseconds() as f64 / 1000.0;
+    snap.snapshot_age_seconds = if age.is_finite() && age >= 0.0 {
+        age
+    } else {
+        0.0
+    };
+    // Also surface current heartbeat tasks without holding InnerState
+    // (best-effort: caller sees last sampler's tasks plus live heartbeat snapshot)
+    // We keep sampler's tasks but also append live task snapshot if empty.
+    if snap.tasks.is_empty() {
+        snap.tasks = shared
+            .state
+            .observability
+            .heartbeat()
+            .snapshot()
+            .into_iter()
+            .map(|t| preloop_observability::status::TaskEntry {
+                name: t.name.to_string(),
+                critical: t.critical == preloop_observability::Criticality::Critical,
+                heartbeat_age_seconds: t.heartbeat_age.as_secs_f64(),
+                state: if t.exited {
+                    "exited".to_string()
+                } else if t.heartbeat_age > Duration::from_secs(15) {
+                    "stale".to_string()
+                } else {
+                    "running".to_string()
+                },
+            })
+            .collect();
+    }
+    Json(snap).into_response()
+}
+
+pub(crate) async fn metrics(State(shared): State<Arc<SharedState>>) -> impl IntoResponse {
+    let snap = shared.state.status_snapshot.read().clone();
+    let mut out = String::new();
+    out.push_str("# HELP preloop_service_uptime_seconds Service uptime in seconds.\n");
+    out.push_str("# TYPE preloop_service_uptime_seconds gauge\n");
+    out.push_str(&format!(
+        "preloop_service_uptime_seconds {}\n",
+        snap.service.uptime_seconds
+    ));
+    out.push_str("# HELP preloop_pool_desired Desired pool size.\n");
+    out.push_str("# TYPE preloop_pool_desired gauge\n");
+    out.push_str(&format!("preloop_pool_desired {}\n", snap.pool.desired));
+    out.push_str("# HELP preloop_pool_preparing Pool preparing signal.\n");
+    out.push_str("# TYPE preloop_pool_preparing gauge\n");
+    out.push_str(&format!(
+        "preloop_pool_preparing {}\n",
+        if snap.pool.preparing { 1 } else { 0 }
+    ));
+    out.push_str("# HELP preloop_pool_idle Idle runners in pool.\n");
+    out.push_str("# TYPE preloop_pool_idle gauge\n");
+    out.push_str(&format!("preloop_pool_idle {}\n", snap.pool.idle));
+    out.push_str("# HELP preloop_pool_busy Busy runners in pool.\n");
+    out.push_str("# TYPE preloop_pool_busy gauge\n");
+    out.push_str(&format!("preloop_pool_busy {}\n", snap.pool.busy));
+    out.push_str("# HELP preloop_job_queue_depth Number of jobs by queue.\n");
+    out.push_str("# TYPE preloop_job_queue_depth gauge\n");
+    out.push_str(&format!(
+        "preloop_job_queue_depth{{queue=\"ready\"}} {}\n",
+        snap.jobs.ready
+    ));
+    out.push_str(&format!(
+        "preloop_job_queue_depth{{queue=\"claimable\"}} {}\n",
+        snap.jobs.claimable
+    ));
+    out.push_str(&format!(
+        "preloop_job_queue_depth{{queue=\"unclaimable\"}} {}\n",
+        snap.jobs.unclaimable
+    ));
+    out.push_str(&format!(
+        "preloop_job_queue_depth{{queue=\"dependency_blocked\"}} {}\n",
+        snap.jobs.dependency_blocked
+    ));
+    let body = out;
+    (
+        [(
+            header::CONTENT_TYPE,
+            "text/plain; version=0.0.4; charset=utf-8",
+        )],
+        body,
+    )
+        .into_response()
 }
 
 /// GitHub's `system.orchestrationId`: `{planId}.{jobId}.{suffix}` where the

--- a/crates/preloop-runner-server/src/runs.rs
+++ b/crates/preloop-runner-server/src/runs.rs
@@ -123,6 +123,8 @@ pub(crate) async fn metrics(State(shared): State<Arc<SharedState>>) -> impl Into
         "preloop_job_queue_depth{{queue=\"dependency_blocked\"}} {}\n",
         snap.jobs.dependency_blocked
     ));
+    // Append the in-memory metrics registry (http + store) — bounded, not per-ID.
+    out.push_str(&shared.state.observability.metrics().render());
     let body = out;
     (
         [(

--- a/crates/preloop-runner-server/src/state.rs
+++ b/crates/preloop-runner-server/src/state.rs
@@ -841,6 +841,16 @@ impl AppState {
             _ => None,
         };
         let has_run_projection = run_id.is_some();
+        if let NdjsonEvent::RunAccepted { queued_jobs, .. } = &event {
+            self.observability.export_log(
+                "INFO",
+                "run.accepted",
+                vec![
+                    ("event.name".to_string(), "run.accepted".to_string()),
+                    ("queued_jobs".to_string(), queued_jobs.to_string()),
+                ],
+            );
+        }
         // Record job terminal transitions exactly once. Guard with is_terminal
         // so we don't double-count non-terminal status updates. The event
         // itself is the proof of old→terminal movement, so we record here
@@ -876,6 +886,19 @@ impl AppState {
                     .metrics()
                     .lifecycle
                     .record_job_completed(conclusion, bounded_reason);
+                self.observability.export_log(
+                    if *status == preloop_gha_protocol::ExecutionStatus::Success {
+                        "INFO"
+                    } else {
+                        "WARN"
+                    },
+                    "job.completed",
+                    vec![
+                        ("event.name".to_string(), "job.completed".to_string()),
+                        ("conclusion".to_string(), conclusion.to_string()),
+                        ("reason".to_string(), bounded_reason.to_string()),
+                    ],
+                );
             }
             NdjsonEvent::JobCompleted { status, .. } if status.is_terminal() => {
                 let conclusion = match status {
@@ -889,6 +912,14 @@ impl AppState {
                     .metrics()
                     .lifecycle
                     .record_job_completed(conclusion, "completed");
+                self.observability.export_log(
+                    "INFO",
+                    "job.completed",
+                    vec![
+                        ("event.name".to_string(), "job.completed".to_string()),
+                        ("conclusion".to_string(), conclusion.to_string()),
+                    ],
+                );
             }
             _ => {}
         }

--- a/crates/preloop-runner-server/src/state.rs
+++ b/crates/preloop-runner-server/src/state.rs
@@ -597,8 +597,19 @@ fn bounded_termination_reason(value: &str) -> &'static str {
         "startup_orphan" => return "startup_orphan",
         _ => {}
     }
-    // Prose paths — match on the stable leading phrase, never the whole
-    // string, so an interpolated label cannot change the classification.
+    // Prose paths — match on the invariant phrase, never the whole string, so
+    // an interpolated label or platform cannot change the classification.
+    //
+    // Two distinct never-claimable conditions, and conflating them would hide
+    // the difference between "wait or add capacity" and "this will never work
+    // until you register that platform":
+    //   - the starvation sweep, which fires after a grace window;
+    //   - the external-host check, where the server has no runner of that
+    //     platform class at all (`no {platform} runner is registered with
+    //     this server, so `runs-on: …` cannot be scheduled`).
+    if value.contains("runner is registered with this server") {
+        return "no_platform_runner";
+    }
     if value.starts_with("no runner is registered for") {
         return "no_runner";
     }
@@ -938,11 +949,22 @@ impl AppState {
                     // separate JobCompleted event; naming both `job.completed`
                     // conflated two distinct records in the log stream.
                     "job.status.terminal",
-                    vec![
-                        ("event.name".to_string(), "job.status.terminal".to_string()),
-                        ("conclusion".to_string(), conclusion.to_string()),
-                        ("reason".to_string(), bounded_reason.to_string()),
-                    ],
+                    {
+                        let mut attributes = vec![
+                            ("event.name".to_string(), "job.status.terminal".to_string()),
+                            ("conclusion".to_string(), conclusion.to_string()),
+                            ("reason".to_string(), bounded_reason.to_string()),
+                        ];
+                        // The bounded code is the metric dimension; the prose
+                        // is what an operator actually needs to act. Logs may
+                        // carry it (they are not a label space), and without
+                        // it an `unrecognized` classification is a dead end —
+                        // you cannot tell which path produced it.
+                        if let Some(detail) = reason.as_deref() {
+                            attributes.push(("reason.detail".to_string(), detail.to_string()));
+                        }
+                        attributes
+                    },
                 );
             }
             NdjsonEvent::JobCompleted { status, .. } if status.is_terminal() => {
@@ -1439,6 +1461,32 @@ mod termination_reason_tests {
         let bounded = bounded_termination_reason(prose);
         assert_eq!(bounded, "no_runner");
         assert!(!bounded.contains("attacker"));
+    }
+
+    #[test]
+    fn external_host_prose_is_its_own_code() {
+        // `{platform}` is interpolated, so match the invariant phrase.
+        for platform in ["windows", "macos", "freebsd-13"] {
+            let prose = format!(
+                "no {platform} runner is registered with this server, so \
+                 `runs-on: {platform}-latest` cannot be scheduled"
+            );
+            assert_eq!(
+                bounded_termination_reason(&prose),
+                "no_platform_runner",
+                "{platform} must classify distinctly from the starvation sweep"
+            );
+        }
+    }
+
+    #[test]
+    fn platform_and_starvation_do_not_collide() {
+        let starved = "no runner is registered for `runs-on: self-hosted, Linux, ARM64` and none \
+                       appeared within 120s, so the job cannot be scheduled";
+        let platform = "no windows runner is registered with this server, so \
+                        `runs-on: windows-latest` cannot be scheduled";
+        assert_eq!(bounded_termination_reason(starved), "no_runner");
+        assert_eq!(bounded_termination_reason(platform), "no_platform_runner");
     }
 
     #[test]

--- a/crates/preloop-runner-server/src/state.rs
+++ b/crates/preloop-runner-server/src/state.rs
@@ -561,6 +561,62 @@ pub(crate) enum JobSetAdmissionResult {
     Blocked,
 }
 
+/// Bounded conclusion label for a terminal execution status.
+fn execution_conclusion(status: preloop_gha_protocol::ExecutionStatus) -> &'static str {
+    use preloop_gha_protocol::ExecutionStatus as S;
+    match status {
+        S::Success => "success",
+        S::Failure => "failure",
+        S::Cancelled => "cancelled",
+        S::Skipped => "skipped",
+        // Non-terminal statuses never reach here; the guard filters them.
+        _ => "unrecognized",
+    }
+}
+
+/// Classify a termination reason into a bounded code.
+///
+/// The control plane's `reason` is not a code — several paths build a prose
+/// sentence that interpolates the job's `runs-on` labels (see the starvation
+/// sweep in `bootstrap.rs`). Those values are user-controlled, so the raw
+/// string must never reach a metric label: it would both explode cardinality
+/// and export workflow content. Classify by the stable prefix each path
+/// writes, and fall back to `unrecognized` rather than passing prose through.
+///
+/// The full message is still available on the structured log record; only the
+/// metric dimension is bounded.
+fn bounded_termination_reason(value: &str) -> &'static str {
+    // Exact codes first — these come from `concurrency::*_reason()`.
+    match value {
+        "concurrency_pending" => return "concurrency_pending",
+        "concurrency_cancelled" => return "concurrency_cancelled",
+        "timeout" => return "timeout",
+        "no_runner" => return "no_runner",
+        "lease_expired" => return "lease_expired",
+        "deaf_runner" => return "deaf_runner",
+        "startup_orphan" => return "startup_orphan",
+        _ => {}
+    }
+    // Prose paths — match on the stable leading phrase, never the whole
+    // string, so an interpolated label cannot change the classification.
+    if value.starts_with("no runner is registered for") {
+        return "no_runner";
+    }
+    if value.starts_with("job exceeded its timeout")
+        || value.starts_with("timed out")
+        || value.contains("timeout-minutes")
+    {
+        return "timeout";
+    }
+    if value.starts_with("runner stopped polling") || value.contains("deaf") {
+        return "deaf_runner";
+    }
+    if value.contains("lease expired") {
+        return "lease_expired";
+    }
+    "unrecognized"
+}
+
 impl AppState {
     pub async fn new(state_dir: PathBuf) -> anyhow::Result<Self> {
         let config_path = crate::config::config_path();
@@ -858,29 +914,15 @@ impl AppState {
         // duplicate `store_run_event` emits.
         match &event {
             NdjsonEvent::JobStatus { status, reason, .. } if status.is_terminal() => {
-                let conclusion = match status {
-                    preloop_gha_protocol::ExecutionStatus::Success => "success",
-                    preloop_gha_protocol::ExecutionStatus::Failure => "failure",
-                    preloop_gha_protocol::ExecutionStatus::Cancelled => "cancelled",
-                    preloop_gha_protocol::ExecutionStatus::Skipped => "skipped",
-                    _ => "unknown",
-                };
-                let reason_str = reason.as_deref().unwrap_or("unknown");
-                // Bound the reason to the finite set the plan allows; unknown
-                // reasons are mapped to "unknown" so they don't create new series.
-                let bounded_reason = match reason_str {
-                    "timeout"
-                    | "no_runner"
-                    | "lease_expired"
-                    | "deaf_runner"
-                    | "startup_orphan"
-                    | "concurrency_cancelled"
-                    | "concurrency_pending"
-                    | "success"
-                    | "failure"
-                    | "cancelled"
-                    | "skipped" => reason_str,
-                    _ => "unknown",
+                let conclusion = execution_conclusion(*status);
+                // `reason: None` is the common case (most terminal transitions
+                // carry none) and means "no reason supplied" — not
+                // "unrecognized". Only a value outside the emitted set is
+                // `unrecognized`, which keeps the label bounded without
+                // mislabelling the majority.
+                let bounded_reason = match reason.as_deref() {
+                    None => "unspecified",
+                    Some(value) => bounded_termination_reason(value),
                 };
                 self.observability
                     .metrics()
@@ -892,22 +934,19 @@ impl AppState {
                     } else {
                         "WARN"
                     },
-                    "job.completed",
+                    // A terminal JobStatus is a status transition, not the
+                    // separate JobCompleted event; naming both `job.completed`
+                    // conflated two distinct records in the log stream.
+                    "job.status.terminal",
                     vec![
-                        ("event.name".to_string(), "job.completed".to_string()),
+                        ("event.name".to_string(), "job.status.terminal".to_string()),
                         ("conclusion".to_string(), conclusion.to_string()),
                         ("reason".to_string(), bounded_reason.to_string()),
                     ],
                 );
             }
             NdjsonEvent::JobCompleted { status, .. } if status.is_terminal() => {
-                let conclusion = match status {
-                    preloop_gha_protocol::ExecutionStatus::Success => "success",
-                    preloop_gha_protocol::ExecutionStatus::Failure => "failure",
-                    preloop_gha_protocol::ExecutionStatus::Cancelled => "cancelled",
-                    preloop_gha_protocol::ExecutionStatus::Skipped => "skipped",
-                    _ => "unknown",
-                };
+                let conclusion = execution_conclusion(*status);
                 self.observability
                     .metrics()
                     .lifecycle
@@ -1367,5 +1406,59 @@ mod tests {
             !state.verify_action_ticket("acme", "repo\nv1", "x", expires_at, &signature),
             "a ticket for one action must not validate for a newline-split twin"
         );
+    }
+}
+
+#[cfg(test)]
+mod termination_reason_tests {
+    use super::bounded_termination_reason;
+
+    #[test]
+    fn exact_codes_pass_through() {
+        assert_eq!(
+            bounded_termination_reason("concurrency_cancelled"),
+            "concurrency_cancelled"
+        );
+        assert_eq!(bounded_termination_reason("timeout"), "timeout");
+    }
+
+    #[test]
+    fn starvation_prose_classifies_to_no_runner() {
+        // The starvation sweep builds this sentence with the job's runs-on
+        // labels interpolated. It must classify, not pass through.
+        let prose = "no runner is registered for `runs-on: self-hosted, Linux, ARM64` and none \
+                     appeared within 120s, so the job cannot be scheduled";
+        assert_eq!(bounded_termination_reason(prose), "no_runner");
+    }
+
+    #[test]
+    fn user_controlled_labels_never_become_the_label() {
+        // A hostile or merely unusual `runs-on` must not reach the metric.
+        let prose = "no runner is registered for `runs-on: attacker-controlled-\u{1F4A5}-label` \
+                     and none appeared within 120s, so the job cannot be scheduled";
+        let bounded = bounded_termination_reason(prose);
+        assert_eq!(bounded, "no_runner");
+        assert!(!bounded.contains("attacker"));
+    }
+
+    #[test]
+    fn unknown_prose_is_bounded_not_passed_through() {
+        let bounded = bounded_termination_reason("something entirely new happened with id-99999");
+        assert_eq!(bounded, "unrecognized");
+        assert!(!bounded.contains("99999"));
+    }
+
+    #[test]
+    fn classification_is_a_finite_set() {
+        // Drive 1,000 distinct prose strings; the label set must stay bounded.
+        let mut seen = std::collections::BTreeSet::new();
+        for i in 0..1000 {
+            let prose = format!(
+                "no runner is registered for `runs-on: label-{i}` and none appeared within 120s"
+            );
+            seen.insert(bounded_termination_reason(&prose));
+            seen.insert(bounded_termination_reason(&format!("novel reason {i}")));
+        }
+        assert_eq!(seen.len(), 2, "expected exactly no_runner + unrecognized");
     }
 }

--- a/crates/preloop-runner-server/src/state.rs
+++ b/crates/preloop-runner-server/src/state.rs
@@ -841,6 +841,57 @@ impl AppState {
             _ => None,
         };
         let has_run_projection = run_id.is_some();
+        // Record job terminal transitions exactly once. Guard with is_terminal
+        // so we don't double-count non-terminal status updates. The event
+        // itself is the proof of old→terminal movement, so we record here
+        // rather than at the state mutation to avoid double-counting on
+        // duplicate `store_run_event` emits.
+        match &event {
+            NdjsonEvent::JobStatus { status, reason, .. } if status.is_terminal() => {
+                let conclusion = match status {
+                    preloop_gha_protocol::ExecutionStatus::Success => "success",
+                    preloop_gha_protocol::ExecutionStatus::Failure => "failure",
+                    preloop_gha_protocol::ExecutionStatus::Cancelled => "cancelled",
+                    preloop_gha_protocol::ExecutionStatus::Skipped => "skipped",
+                    _ => "unknown",
+                };
+                let reason_str = reason.as_deref().unwrap_or("unknown");
+                // Bound the reason to the finite set the plan allows; unknown
+                // reasons are mapped to "unknown" so they don't create new series.
+                let bounded_reason = match reason_str {
+                    "timeout"
+                    | "no_runner"
+                    | "lease_expired"
+                    | "deaf_runner"
+                    | "startup_orphan"
+                    | "concurrency_cancelled"
+                    | "concurrency_pending"
+                    | "success"
+                    | "failure"
+                    | "cancelled"
+                    | "skipped" => reason_str,
+                    _ => "unknown",
+                };
+                self.observability
+                    .metrics()
+                    .lifecycle
+                    .record_job_completed(conclusion, bounded_reason);
+            }
+            NdjsonEvent::JobCompleted { status, .. } if status.is_terminal() => {
+                let conclusion = match status {
+                    preloop_gha_protocol::ExecutionStatus::Success => "success",
+                    preloop_gha_protocol::ExecutionStatus::Failure => "failure",
+                    preloop_gha_protocol::ExecutionStatus::Cancelled => "cancelled",
+                    preloop_gha_protocol::ExecutionStatus::Skipped => "skipped",
+                    _ => "unknown",
+                };
+                self.observability
+                    .metrics()
+                    .lifecycle
+                    .record_job_completed(conclusion, "completed");
+            }
+            _ => {}
+        }
         // Capture the projection under the lock, then persist after releasing
         // it: a slow or unavailable backend must not stall the control plane
         // (runner polling, heartbeats, other state mutations).

--- a/crates/preloop-runner-server/src/state.rs
+++ b/crates/preloop-runner-server/src/state.rs
@@ -364,6 +364,15 @@ pub struct AppState {
     /// lock.  Monotonically increases; the inner counter is no longer the
     /// source of truth once this is in use.
     pub(crate) next_request_id: Arc<std::sync::atomic::AtomicI64>,
+    /// Observability handle (cloneable, holds heartbeat & limit registries).
+    pub(crate) observability: preloop_observability::Observability,
+    /// Cached operational snapshot, updated every 5s by the sampler without holding `inner`.
+    pub status_snapshot:
+        Arc<parking_lot::RwLock<preloop_observability::status::OperationalSnapshot>>,
+    /// Consolidated pool handle replacing the four ad-hoc Option<Arc<…>> fields.
+    pub pool_status: Arc<preloop_observability::status::PoolStatus>,
+    /// When this AppState was created (for uptime).
+    pub(crate) started_at: std::time::Instant,
     /// Jobs accepted and still waiting for a runner, refreshed whenever one
     /// is claimed. A supervising runner pool reads it to decide whether the
     /// work already queued outruns the runners it has left.
@@ -786,6 +795,12 @@ impl AppState {
             events,
             message_notify: Arc::new(Notify::new()),
             next_request_id: Arc::new(std::sync::atomic::AtomicI64::new(next_request_id)),
+            observability: preloop_observability::Observability::noop(),
+            status_snapshot: Arc::new(parking_lot::RwLock::new(
+                preloop_observability::status::OperationalSnapshot::default(),
+            )),
+            pool_status: Arc::new(preloop_observability::status::PoolStatus::default()),
+            started_at: std::time::Instant::now(),
             // Mirror the recovered ready-queue size so an on-demand runner
             // pool spawns against the right workload after restart.
             queue_depth: Arc::new(std::sync::atomic::AtomicUsize::new(recovered_queue_len)),

--- a/crates/preloop-runner-server/src/store.rs
+++ b/crates/preloop-runner-server/src/store.rs
@@ -18,8 +18,8 @@ use async_trait::async_trait;
 use preloop_gha_protocol::SessionId;
 use rusqlite::{params, Connection, OptionalExtension, Transaction};
 use sha2::Digest;
-use std::sync::Mutex as StdMutex;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex as StdMutex;
 
 const DATABASE_FILE: &str = "preloop.db";
 pub(crate) const SNAPSHOT_FORMAT: u8 = 2;

--- a/crates/preloop-runner-server/src/store.rs
+++ b/crates/preloop-runner-server/src/store.rs
@@ -19,7 +19,9 @@ use preloop_gha_protocol::SessionId;
 use rusqlite::{params, Connection, OptionalExtension, Transaction};
 use sha2::Digest;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
+use std::time::Instant;
 
 const DATABASE_FILE: &str = "preloop.db";
 pub(crate) const SNAPSHOT_FORMAT: u8 = 2;
@@ -58,6 +60,147 @@ pub(crate) trait Store: Send + Sync {
     ) -> anyhow::Result<()>;
     /// Append a control event (`run_accepted` / `run_status` / `job_status`).
     async fn append_event(&self, event: &NdjsonEvent) -> anyhow::Result<()>;
+}
+
+/// Decorator that records `preloop.store.operation.duration` for every
+/// `Store` method. One wrapper, not per-backend duplication.
+pub(crate) struct InstrumentedStore {
+    inner: Arc<dyn Store>,
+    observability: preloop_observability::Observability,
+    backend: String,
+}
+
+impl InstrumentedStore {
+    pub(crate) fn new(
+        inner: Arc<dyn Store>,
+        observability: preloop_observability::Observability,
+        backend: &str,
+    ) -> Self {
+        Self {
+            inner,
+            observability,
+            backend: backend.to_string(),
+        }
+    }
+
+    pub(crate) fn wrap(
+        inner: Arc<dyn Store>,
+        observability: preloop_observability::Observability,
+        backend: &str,
+    ) -> Arc<dyn Store> {
+        Arc::new(Self::new(inner, observability, backend))
+    }
+}
+
+#[async_trait]
+impl Store for InstrumentedStore {
+    async fn load_into(&self, inner: &mut InnerState) -> anyhow::Result<()> {
+        let start = Instant::now();
+        let res = self.inner.load_into(inner).await;
+        let outcome = if res.is_ok() { "ok" } else { "error" };
+        self.observability.metrics().store.observe(
+            &self.backend,
+            "load_into",
+            outcome,
+            start.elapsed(),
+        );
+        res
+    }
+
+    async fn store_inner(&self, snapshot: &StoreSnapshot) -> anyhow::Result<()> {
+        let start = Instant::now();
+        let res = self.inner.store_inner(snapshot).await;
+        let outcome = if res.is_ok() { "ok" } else { "error" };
+        self.observability.metrics().store.observe(
+            &self.backend,
+            "store_inner",
+            outcome,
+            start.elapsed(),
+        );
+        res
+    }
+
+    async fn store_meta_only(&self, meta: &MetaSnapshot) -> anyhow::Result<()> {
+        let start = Instant::now();
+        let res = self.inner.store_meta_only(meta).await;
+        let outcome = if res.is_ok() { "ok" } else { "error" };
+        self.observability.metrics().store.observe(
+            &self.backend,
+            "store_meta_only",
+            outcome,
+            start.elapsed(),
+        );
+        res
+    }
+
+    async fn store_run_event(&self, projection: RunProjection) -> anyhow::Result<()> {
+        let start = Instant::now();
+        let res = self.inner.store_run_event(projection).await;
+        let outcome = if res.is_ok() { "ok" } else { "error" };
+        self.observability.metrics().store.observe(
+            &self.backend,
+            "store_run_event",
+            outcome,
+            start.elapsed(),
+        );
+        res
+    }
+
+    async fn store_workflow_run_counter(
+        &self,
+        workflow_path: &str,
+        next_run_number: u64,
+    ) -> anyhow::Result<()> {
+        let start = Instant::now();
+        let res = self
+            .inner
+            .store_workflow_run_counter(workflow_path, next_run_number)
+            .await;
+        let outcome = if res.is_ok() { "ok" } else { "error" };
+        self.observability.metrics().store.observe(
+            &self.backend,
+            "store_workflow_run_counter",
+            outcome,
+            start.elapsed(),
+        );
+        res
+    }
+
+    async fn store_log_chunk(
+        &self,
+        key: &str,
+        chunk_index: i64,
+        payload: &[u8],
+        byte_count: i64,
+        line_count: i64,
+    ) -> anyhow::Result<()> {
+        let start = Instant::now();
+        let res = self
+            .inner
+            .store_log_chunk(key, chunk_index, payload, byte_count, line_count)
+            .await;
+        let outcome = if res.is_ok() { "ok" } else { "error" };
+        self.observability.metrics().store.observe(
+            &self.backend,
+            "store_log_chunk",
+            outcome,
+            start.elapsed(),
+        );
+        res
+    }
+
+    async fn append_event(&self, event: &NdjsonEvent) -> anyhow::Result<()> {
+        let start = Instant::now();
+        let res = self.inner.append_event(event).await;
+        let outcome = if res.is_ok() { "ok" } else { "error" };
+        self.observability.metrics().store.observe(
+            &self.backend,
+            "append_event",
+            outcome,
+            start.elapsed(),
+        );
+        res
+    }
 }
 
 /// Owned projection of the in-memory state that a full snapshot persists.

--- a/crates/preloop-runner/Cargo.toml
+++ b/crates/preloop-runner/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
+preloop-observability = { path = "../preloop-observability" }
 preloop-gha-protocol = { path = "../preloop-gha-protocol" }
 preloop-gha-expressions = { path = "../preloop-gha-expressions" }
 preloop-gha-parser = { path = "../preloop-gha-parser" }

--- a/crates/preloop-runner/src/main.rs
+++ b/crates/preloop-runner/src/main.rs
@@ -16,7 +16,8 @@ async fn main() -> Result<()> {
 
     // Runner gets structured local logging only — never OTLP export by default.
     // `PRELOOP_LOG_FORMAT` still controls pretty/json/auto for consistency.
-    let obs_config = preloop_observability::ObservabilityConfig::from_env();
+    let obs_config = preloop_observability::ObservabilityConfig::from_env()
+        .with_service_version(env!("CARGO_PKG_VERSION"));
     let (observability, observability_runtime) =
         preloop_observability::Observability::from_config(obs_config);
     preloop_observability::ObservabilityRuntime::install_fmt_subscriber(observability.config());

--- a/crates/preloop-runner/src/main.rs
+++ b/crates/preloop-runner/src/main.rs
@@ -14,12 +14,14 @@ const MAX_REUSABLE_WORKFLOW_DEPTH: usize = 4;
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
-        )
-        .init();
+    // Runner gets structured local logging only — never OTLP export by default.
+    // `PRELOOP_LOG_FORMAT` still controls pretty/json/auto for consistency.
+    let obs_config = preloop_observability::ObservabilityConfig::from_env();
+    let (observability, observability_runtime) =
+        preloop_observability::Observability::from_config(obs_config);
+    preloop_observability::ObservabilityRuntime::install_fmt_subscriber(observability.config());
+    let _observability = observability;
+    let _observability_runtime = observability_runtime;
 
     match cli.command {
         Commands::Configure(args) => {

--- a/crates/preloop-vm/Cargo.toml
+++ b/crates/preloop-vm/Cargo.toml
@@ -9,6 +9,7 @@ description = "VM provider abstraction for Preloop CI"
 
 [dependencies]
 async-trait = { workspace = true }
+preloop-observability = { path = "../preloop-observability" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/preloop-vm/src/lib.rs
+++ b/crates/preloop-vm/src/lib.rs
@@ -14,6 +14,8 @@ use tokio::process::Command;
 use tokio::sync::mpsc;
 use tracing::warn;
 
+pub mod telemetry;
+
 const DEFAULT_CAPTURE_LIMIT: usize = 1024 * 1024;
 
 /// A validated persistent SmolVM machine name.

--- a/crates/preloop-vm/src/telemetry.rs
+++ b/crates/preloop-vm/src/telemetry.rs
@@ -1,0 +1,6 @@
+//! Re-export VM telemetry types from `preloop-observability` so `preloop-vm`
+//! and `preloop-orchestrator` share the same registry without a circular dep.
+
+pub use preloop_observability::vm_telemetry::{
+    build_fleet_snapshot, sample_host, HostSample, VmRuntimeInfo, VmTelemetryRegistry,
+};

--- a/docs/internal/observability.md
+++ b/docs/internal/observability.md
@@ -1,0 +1,87 @@
+# Observability — Internal Signal & Security Contract
+
+> **Status:** Step 1 of Plan 002 (`plans/002-observability-strategy.md` revised at `673bdfa0`). This is the **internal** contract that must land before any OTLP export is wired. The public `docs/observability.md` will be a redacted subset later. Do not publish this file.
+
+## Why
+
+Preloop can report healthy while the pool repeatedly fails to provision, can't distinguish "no runner" from "stale runner," and diverges two servers sharing the same SQLite file. The only aggregate view is `preloop logs`. This contract makes every control-plane question answerable from one endpoint.
+
+## Architecture — Three Layers
+
+1. **Zero-dependency diagnostics** — `/healthz`, `/readyz`, `GET /api/v1/status`, `preloop status --json`, structured `stderr`/`journald`, `GET /metrics` (Prometheus text). No sidecar. Answers "why is this job not moving?" with no backend.
+2. **Vendor-neutral telemetry** — OpenTelemetry metrics/logs/short traces via bounded `OTLP/HTTP` batches only when `OTEL_EXPORTER_OTLP_ENDPOINT` is set. Fail-open: export never rejects/delays a workflow.
+3. **Optional reference backend** — pinned single-node OpenObserve (SQLite + local disk, loopback) + importable dashboards. Product boundary is `OTLP + Prometheus`; any backend is interchangeable.
+
+```
+CLI --bearer--> /api/v1/status
+probes --------> /healthz + /readyz
+prom ----------> /metrics (bearer)
+control plane + pool + host VM sampler --> preloop-observability --> stderr/journald
+                                                          `--> /metrics
+                                                          -. OTLP/HTTP .-> OpenObserve (opt-in)
+```
+
+## Security — What Must Not Be Exported
+
+**Scrubbed at `673bdfa0`:**
+
+- `crates/preloop-runner-server/src/artifact_twirp.rs:94` — `info!(token, name)` → `info!(name, workflow_run_backend_id, workflow_job_run_backend_id)` (token removed, keep registry coordinates)
+- `crates/preloop-runner-server/src/results_twirp.rs:713` — `info!(token, "cache v2 create")` → `info!(key, version)` (storage identity, not capability)
+- `crates/preloop-runner-server/src/blob_store.rs:63,78,95,113,121,127,131` — all `warn!/info!(kind, token)` → `kind` + `block`/`size`/`blocks` (blob operation, not token)
+- `crates/preloop-runner-server/src/distributed_task.rs:327` — `info!(?body, …)` full PATCH JSON → `info!(pool_id, request_id, result, has_result)` (bounded enum, not raw body)
+- `crates/preloop-runner-server/src/recording.rs:1-90` — **exempt** conformance capture (headers + bodies, mode `0600`, never through OTLP). Rule explicitly ignores this file.
+
+**Guard:** `rules/no-sensitive-log-fields.yml` rejects `INFO/WARN/ERROR` fields `token`, `authorization`, `cookie`, `headers`, `body`, `payload`, `signed_url` outside `recording.rs`. Run `just sg-scan-strict` — must be `0`.
+
+**Never log:** raw URLs/query strings, error text into metrics, workflow `stdout/stderr` (stays in `live_logs.rs:25` run-log store, 64 MiB cap), environment values, secrets.
+
+## Cardinality Rules
+
+- Allowed metric attributes: bounded enums / finite route templates — HTTP method + matched `route` (never raw URI), queue kind, pool mode/state, backend, `limit` constant name (finite set), `task` registry name (finite set).
+- Forbidden: `run_id`, `job_id`, `runner_id`, `machine_name`, repo/workflow/ref/SHA, `runs-on` values, cache keys, artifact names, raw URL/query, `x-delivery-id`, tokens.
+- IDs belong in **logs/traces only** (`event.name` + `run.id`/`job.id`/`machine.name`), correlated via `trace_id`/`span_id`.
+- Test: drive 1,000 distinct IDs through instrumentation, gather Prometheus registry, assert fixed series count, no sentinel in exposition.
+
+## Status Semantics
+
+- **`GET /healthz`** — public, shallow, lock-free. `200` while process serves, `503` during shutdown. Fields: `schema_version`, `ok`, `protocol_version`, `shutdown_requested`. Touches nothing (no DB, no SmolVM, no `InnerState`).
+- **`GET /readyz`** — public, reason codes. `200` when durable state restored + every **critical** `TaskHeartbeat` fresh (state sampler, reaper `bootstrap.rs:396`, scheduler scan `bootstrap.rs:479`, PG `store_pg.rs:95`). `503` → `starting | task_stale{task} | shutting_down`. Non-critical staleness does not gate readiness.
+- **`GET /api/v1/status`** — `bearer` required, `schema_version: 1`, sampled every 5s without holding `InnerState`, reports `snapshot_age_seconds`. Full shape in `plans/002-observability-strategy.md` § Operator surfaces — includes `jobs`, `concurrency`, `scheduler`, `pool`, `vms` (with `capabilities` + 5 top consumers), `store`, `storage`, `limits[]`, `tasks[]`, `github` (with `rate_limit`, `token_cache`), `conditions[]` (bounded stable codes, ≤5 exemplars, safe messages).
+- **`preloop status`** — unit variant → `Status(StatusArgs)` with `--json` (shape of `PlanArgs` at `main.rs:706`). Human output ordered 1..10 (service → queue → concurrency/scheduler → pool/runners → VM fleet → store/storage/GitHub/debug/telemetry → non-zero limits/tasks → conditions → recent runs). `--json` prints the endpoint body exactly.
+- **`GET /metrics`** — `bearer` required, Prometheus text from the same snapshot, never per-machine labels.
+
+`wait_for_engine_socket` (`main.rs:1458`) now probes `/readyz` and surfaces the last `reason` on 30s timeout.
+
+## Log Classes
+
+- `INFO` — low-frequency control-plane/pool/scheduler transitions
+- `WARN` — recoverable degradation (`vm.host.memory.pressure`, `limit.exceeded{limit="QUEUE_MAX_PENDING"}`, `github.rate_limit.low`, `vm.unreachable`)
+- `ERROR` — supervisor death, invariant break, `store.connection.lost` (PG), `task.exited{critical=true}`
+- `DEBUG` — successful long-poll/renew (never `INFO` per poll)
+
+Catalog (excerpt): `job.concurrency.cancelled` (hash of group key, not raw — branch names are PII), `schedule.fired/skipped`, `task.exited`, `limit.exceeded` (rate-limited), `vm.unreachable/reachable`, `store.connection.lost`, `storage.pressure`, `github.rate_limit.low`, `debug.audit.evicted`.
+
+## VM Telemetry Contract
+
+- `VmProvider::status` at `preloop-vm/src/lib.rs:1018` today substring-matches human text — replaced with typed `machine status --json` (one machine on lifecycle path) + `machine ls --json` (whole fleet, one subprocess per 60s slow pass, already parsed in `list` at `1045`) + `machine data-dir` for disk paths, at `smolvm 1.8.1` floor (`versions.toml:8`, `machine_status_json` at `src/cli/vm_common.rs:2360`).
+- `state` includes `Unreachable` (vsock probe, `src/agent/state_probe.rs:41`) → `MachineState::Unreachable` metric + `vm_unreachable` condition. A missing `vm-<pid>` cgroup leaf (SmolVM creates it, `src/process.rs:375`) degrades to process fallback, `capability=false`, never zero.
+- Host-only: `cpu.stat usage_usec`, `memory.current`, `pids.current`, `st_blocks` + `statvfs`. Never guest `free/df/ps`.
+
+## Deployment Profiles
+
+- **Default local** — no backend, pretty on TTY / JSON when piped, `PRELOOP_LOG_FORMAT=auto`.
+- **Local enhanced** — single OpenObserve container, loopback, persistent volume, short retention, resource caps.
+- **Self-hosted single node** — Preloop + OpenObserve may share a host only with separate volumes + caps.
+- **Existing estate** — point same OTLP at your backend.
+- **Optional Collector** — whole-node host telemetry + fan-out (VM `preloop.vm.*` does not need it).
+- **Quickwit+S3 alternative** — `Vector → Quickwit → S3` for cheap searchable logs/traces; metrics stay on `Mimir`/`VictoriaMetrics` until Quickwit metrics matures.
+
+## Flow Capture
+
+`recording.rs` is an explicit local conformance facility, stored `0600`, never through the normal logging/OTLP pipeline. Verified at creation.
+
+## References
+
+- Plan: `plans/002-observability-strategy.md` (and HTML companion with mockups)
+- Code anchors re-verified at `673bdfa0`; re-run `git diff --stat 673bdfa0..HEAD -- …` before each step
+- Rules mirror `rules/no-expose-in-loop.yml` / `no-raw-secret-replace.yml` / `no-inline-masking.yml`

--- a/docs/internal/observability.md
+++ b/docs/internal/observability.md
@@ -1,6 +1,6 @@
 # Observability — Internal Signal & Security Contract
 
-> **Status:** Step 1 of Plan 002 (`plans/002-observability-strategy.md` revised at `673bdfa0`). This is the **internal** contract that must land before any OTLP export is wired. The public `docs/observability.md` will be a redacted subset later. Do not publish this file.
+> **Status:** Internal contract for Plan 002 (`plans/002-observability-strategy.md` revised at `673bdfa0`). This is the **internal** contract that must land before any OTLP export is wired. The public `docs/observability.md` will be a redacted subset later. Do not publish this file.
 
 ## Why
 

--- a/plans/002-observability-strategy.html
+++ b/plans/002-observability-strategy.html
@@ -1,0 +1,1725 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Plan 002 — Make Preloop Observable Without Making a Backend Mandatory</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Source+Serif+4:ital,opsz,wght@0,8..60,300;0,8..60,400;0,8..60,600;0,8..60,700;1,8..60,400&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: oklch(97.5% 0.005 240);
+    --bg-sheet: oklch(100% 0 0);
+    --bg-raised: oklch(96% 0.005 240);
+    --bg-code: oklch(97% 0.006 240);
+    --bg-code-inline: oklch(93% 0.015 240);
+    --bg-terminal: oklch(18% 0.015 240);
+    --bg-terminal-header: oklch(22% 0.012 240);
+    --border: oklch(88% 0.008 240);
+    --border-strong: oklch(80% 0.01 240);
+    --text: oklch(20% 0.012 240);
+    --text-secondary: oklch(40% 0.008 240);
+    --text-muted: oklch(53% 0.006 240);
+    --accent: oklch(52% 0.16 240);
+    --accent-soft: oklch(94% 0.04 240);
+    --accent-hover: oklch(45% 0.18 240);
+    --teal: oklch(52% 0.10 195);
+    --teal-soft: oklch(94% 0.03 195);
+    --green: oklch(52% 0.13 155);
+    --green-soft: oklch(94% 0.04 155);
+    --amber: oklch(65% 0.14 75);
+    --amber-soft: oklch(95% 0.04 75);
+    --purple: oklch(52% 0.15 295);
+    --purple-soft: oklch(94% 0.04 295);
+    --red: oklch(55% 0.18 25);
+    --red-soft: oklch(94% 0.04 25);
+    --toc-width: 260px;
+    --content-max: 76ch;
+    --font-display: 'Outfit', system-ui, sans-serif;
+    --font-body: 'Source Serif 4', Georgia, serif;
+    --font-mono: 'Fira Code', Menlo, monospace;
+  }
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+  html { scroll-behavior: smooth; scroll-padding-top: 1.5rem; }
+  body {
+    font-family: var(--font-body);
+    font-size: 1.02rem;
+    line-height: 1.7;
+    color: var(--text);
+    background: var(--bg);
+    -webkit-font-smoothing: antialiased;
+  }
+  a { color: var(--accent); text-decoration-thickness: 1px; text-underline-offset: 2px; }
+  a:hover { color: var(--accent-hover); }
+
+  /* Layout */
+  .page-grid {
+    display: grid;
+    grid-template-columns: var(--toc-width) minmax(0, 1fr);
+    gap: 2.5rem;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2.5rem 2rem 5rem;
+  }
+  /* TOC */
+  .toc {
+    position: sticky;
+    top: 1.5rem;
+    align-self: start;
+    max-height: calc(100vh - 3rem);
+    overflow-y: auto;
+    padding-right: 0.75rem;
+    scrollbar-width: thin;
+    scrollbar-color: var(--border-strong) transparent;
+  }
+  .toc-title {
+    font-family: var(--font-display);
+    font-size: 0.68rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-muted);
+    margin-bottom: 0.75rem;
+  }
+  .toc ol { list-style: none; }
+  .toc li { margin-bottom: 0.22rem; }
+  .toc a {
+    font-family: var(--font-display);
+    font-size: 0.74rem;
+    font-weight: 400;
+    color: var(--text-secondary);
+    text-decoration: none;
+    line-height: 1.4;
+    display: block;
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    transition: all 0.15s;
+  }
+  .toc a:hover { color: var(--accent); background: var(--accent-soft); }
+  .toc a.active { color: var(--accent); font-weight: 600; background: var(--accent-soft); }
+  .toc .toc-h3 { padding-left: 1rem; font-size: 0.71rem; }
+  .toc .toc-h4 { padding-left: 1.8rem; font-size: 0.68rem; opacity: 0.85; }
+  .toc-sep { border: none; border-top: 1px solid var(--border); margin: 0.75rem 0; }
+
+  /* Content */
+  .content { min-width: 0; max-width: var(--content-max); }
+
+  /* Hero */
+  .hero {
+    margin-bottom: 2.5rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .hero-eyebrow {
+    font-family: var(--font-display);
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--accent);
+    margin-bottom: 0.6rem;
+  }
+  .hero h1 {
+    font-family: var(--font-display);
+    font-size: clamp(1.85rem, 3.8vw, 2.6rem);
+    font-weight: 800;
+    line-height: 1.1;
+    color: var(--text);
+    letter-spacing: -0.02em;
+    margin-bottom: 0.85rem;
+  }
+  .hero-sub {
+    font-size: 1.05rem;
+    color: var(--text-secondary);
+    line-height: 1.6;
+    margin-bottom: 1.25rem;
+  }
+  .hero-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem 1.25rem;
+    font-family: var(--font-display);
+    font-size: 0.75rem;
+    color: var(--text-muted);
+  }
+  .hero-meta .meta-label { font-weight: 600; color: var(--text-secondary); }
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.15rem 0.55rem;
+    border-radius: 100px;
+    font-family: var(--font-display);
+    font-size: 0.68rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+  }
+  .badge-todo { background: var(--amber-soft); color: oklch(42% 0.12 75); }
+  .badge-todo::before { content:''; width:6px; height:6px; border-radius:50%; background: var(--amber); }
+  .badge-revised { background: var(--accent-soft); color: var(--accent); border: 1px solid oklch(85% 0.05 240); }
+
+  /* Drift banner */
+  .drift-banner {
+    background: var(--amber-soft);
+    border: 1px solid oklch(85% 0.08 75);
+    border-radius: 8px;
+    padding: 0.85rem 1.1rem;
+    margin-bottom: 1.5rem;
+    font-family: var(--font-display);
+    font-size: 0.8rem;
+    line-height: 1.5;
+    color: oklch(30% 0.06 75);
+  }
+  .drift-banner strong { color: oklch(35% 0.10 75); }
+  .drift-banner code {
+    font-family: var(--font-mono);
+    font-size: 0.78em;
+    background: oklch(98% 0.02 75);
+    padding: 0.1em 0.3em;
+    border-radius: 3px;
+  }
+
+  /* Sections */
+  .content > h2 {
+    font-family: var(--font-display);
+    font-size: clamp(1.25rem, 2.4vw, 1.55rem);
+    font-weight: 700;
+    line-height: 1.25;
+    color: var(--text);
+    margin-top: 3rem;
+    margin-bottom: 0.85rem;
+    letter-spacing: -0.015em;
+    scroll-margin-top: 1.5rem;
+    padding-bottom: 0.4rem;
+    border-bottom: 2px solid var(--border);
+  }
+  .content > h3 {
+    font-family: var(--font-display);
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--text);
+    margin-top: 2rem;
+    margin-bottom: 0.5rem;
+    scroll-margin-top: 1.5rem;
+  }
+  .content > h4 {
+    font-family: var(--font-display);
+    font-size: 0.92rem;
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin-top: 1.4rem;
+    margin-bottom: 0.35rem;
+  }
+  .content > p, .content > ul, .content > ol { margin-bottom: 0.9rem; }
+  .content > ul, .content > ol { padding-left: 1.35rem; }
+  .content li { margin-bottom: 0.28rem; }
+  .content li::marker { color: var(--accent); }
+
+  /* Priority list */
+  .priority-list {
+    list-style: none;
+    counter-reset: priority;
+    padding-left: 0;
+    margin: 1rem 0 1.25rem;
+  }
+  .priority-list li {
+    counter-increment: priority;
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
+    padding: 0.7rem 0;
+    border-bottom: 1px solid var(--border);
+  }
+  .priority-list li:last-child { border-bottom: none; }
+  .priority-list li::before {
+    content: counter(priority);
+    font-family: var(--font-display);
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: white;
+    background: var(--accent);
+    min-width: 1.55rem;
+    height: 1.55rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    flex-shrink: 0;
+    margin-top: 0.15rem;
+  }
+  .priority-list li strong { color: var(--text); }
+
+  /* Tables */
+  .table-wrap {
+    overflow-x: auto;
+    margin: 1rem 0 1.25rem;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--bg-sheet);
+  }
+  table { width: 100%; border-collapse: collapse; font-size: 0.84rem; line-height: 1.5; }
+  thead { background: var(--bg-raised); }
+  th {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-secondary);
+    text-align: left;
+    padding: 0.6rem 0.85rem;
+    border-bottom: 1px solid var(--border-strong);
+    white-space: nowrap;
+  }
+  td { padding: 0.5rem 0.85rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+  tr:last-child td { border-bottom: none; }
+  tbody tr:hover { background: oklch(98% 0.004 240); }
+  td code, th code {
+    font-family: var(--font-mono);
+    font-size: 0.82em;
+    background: var(--bg-code-inline);
+    padding: 0.1em 0.3em;
+    border-radius: 3px;
+  }
+  td .mono { font-family: var(--font-mono); font-size: 0.82em; }
+
+  /* Code */
+  pre {
+    background: var(--bg-code);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.9rem 1.1rem;
+    overflow-x: auto;
+    margin: 0.85rem 0 1.15rem;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    line-height: 1.6;
+    color: var(--text);
+    scrollbar-width: thin;
+  }
+  pre code { background: none; padding: 0; }
+  .content > p code, .content > li code {
+    font-family: var(--font-mono);
+    font-size: 0.84em;
+    background: var(--bg-code-inline);
+    padding: 0.1em 0.3em;
+    border-radius: 3px;
+  }
+
+  /* Callouts */
+  .callout {
+    border-radius: 8px;
+    padding: 0.9rem 1.1rem;
+    margin: 1rem 0;
+    font-size: 0.88rem;
+    line-height: 1.6;
+  }
+  .callout-title {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    margin-bottom: 0.35rem;
+  }
+  .callout-blue { background: var(--accent-soft); border: 1px solid oklch(82% 0.05 240); }
+  .callout-blue .callout-title { color: var(--accent); }
+  .callout-green { background: var(--green-soft); border: 1px solid oklch(82% 0.04 155); }
+  .callout-green .callout-title { color: var(--green); }
+  .callout-amber { background: var(--amber-soft); border: 1px solid oklch(82% 0.06 75); }
+  .callout-amber .callout-title { color: oklch(42% 0.12 75); }
+  .callout-red { background: var(--red-soft); border: 1px solid oklch(82% 0.04 25); }
+  .callout-red .callout-title { color: var(--red); }
+  .callout-purple { background: var(--purple-soft); border: 1px solid oklch(82% 0.04 295); }
+  .callout-purple .callout-title { color: var(--purple); }
+  .callout-teal { background: var(--teal-soft); border: 1px solid oklch(82% 0.04 195); }
+  .callout-teal .callout-title { color: var(--teal); }
+
+  /* Invariant grid */
+  .invariant-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 0.6rem;
+    margin: 1rem 0 1.25rem;
+  }
+  .invariant-card {
+    background: var(--bg-sheet);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.75rem 0.9rem;
+    display: flex;
+    gap: 0.65rem;
+    align-items: flex-start;
+  }
+  .invariant-num {
+    font-family: var(--font-display);
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: white;
+    background: var(--accent);
+    min-width: 1.4rem;
+    height: 1.4rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    flex-shrink: 0;
+    margin-top: 0.1rem;
+  }
+  .invariant-card strong { font-family: var(--font-display); font-size: 0.82rem; color: var(--text); }
+  .invariant-card p { font-size: 0.78rem; color: var(--text-secondary); line-height: 1.5; margin-top: 0.15rem; }
+
+  /* Architecture diagram */
+  .arch-wrap {
+    background: var(--bg-sheet);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.25rem;
+    margin: 1.25rem 0;
+    overflow-x: auto;
+  }
+  .arch-wrap .arch-title {
+    font-family: var(--font-display);
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    margin-bottom: 0.85rem;
+    text-align: center;
+  }
+  .arch-svg { width: 100%; min-height: 340px; display: block; }
+  .arch-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+    justify-content: center;
+    margin-top: 0.85rem;
+    font-family: var(--font-display);
+    font-size: 0.68rem;
+    color: var(--text-muted);
+  }
+  .arch-legend span { display: inline-flex; align-items: center; gap: 0.3rem; }
+  .arch-legend .dot { width: 10px; height: 10px; border-radius: 3px; display: inline-block; }
+
+  /* Terminal mockup */
+  .terminal {
+    background: var(--bg-terminal);
+    border-radius: 10px;
+    overflow: hidden;
+    margin: 1rem 0 1.25rem;
+    border: 1px solid oklch(25% 0.01 240);
+    box-shadow: 0 8px 30px oklch(15% 0.02 240 / 0.25);
+  }
+  .terminal-header {
+    background: var(--bg-terminal-header);
+    padding: 0.55rem 0.9rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    border-bottom: 1px solid oklch(28% 0.01 240);
+  }
+  .terminal-dots { display: flex; gap: 0.35rem; }
+  .terminal-dots span { width: 11px; height: 11px; border-radius: 50%; display: block; }
+  .dot-r { background: oklch(62% 0.18 25); }
+  .dot-y { background: oklch(75% 0.14 75); }
+  .dot-g { background: oklch(58% 0.13 155); }
+  .terminal-title {
+    font-family: var(--font-display);
+    font-size: 0.7rem;
+    font-weight: 500;
+    color: oklch(70% 0.01 240);
+    margin-left: 0.5rem;
+    letter-spacing: 0.02em;
+  }
+  .terminal-body {
+    padding: 1rem 1.1rem;
+    font-family: var(--font-mono);
+    font-size: 0.74rem;
+    line-height: 1.65;
+    color: oklch(85% 0.01 240);
+    overflow-x: auto;
+    white-space: pre;
+  }
+  .terminal-body .t-dim { color: oklch(55% 0.01 240); }
+  .terminal-body .t-green { color: oklch(68% 0.13 155); }
+  .terminal-body .t-amber { color: oklch(72% 0.14 75); }
+  .terminal-body .t-red { color: oklch(65% 0.18 25); }
+  .terminal-body .t-blue { color: oklch(68% 0.12 240); }
+  .terminal-body .t-purple { color: oklch(70% 0.13 295); }
+  .terminal-body .t-cyan { color: oklch(70% 0.09 195); }
+  .terminal-body .t-bold { font-weight: 600; color: oklch(92% 0.01 240); }
+  .terminal-body .t-warn { color: oklch(72% 0.14 75); background: oklch(35% 0.06 75 / 0.35); padding: 0 0.25em; border-radius: 2px; }
+  .terminal-body .t-ok { color: oklch(68% 0.13 155); }
+
+  /* JSON viewer */
+  .json-viewer {
+    background: var(--bg-terminal);
+    border-radius: 10px;
+    overflow: hidden;
+    margin: 1rem 0 1.25rem;
+    border: 1px solid oklch(25% 0.01 240);
+  }
+  .json-header {
+    background: var(--bg-terminal-header);
+    padding: 0.5rem 0.9rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid oklch(28% 0.01 240);
+  }
+  .json-header .json-title {
+    font-family: var(--font-display);
+    font-size: 0.7rem;
+    font-weight: 500;
+    color: oklch(70% 0.01 240);
+  }
+  .json-badge {
+    font-family: var(--font-display);
+    font-size: 0.62rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 0.15rem 0.4rem;
+    border-radius: 4px;
+    background: oklch(30% 0.04 240);
+    color: oklch(75% 0.02 240);
+  }
+  .json-body {
+    padding: 1rem 1.1rem;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    line-height: 1.6;
+    color: oklch(85% 0.01 240);
+    overflow-x: auto;
+  }
+  .json-body .jk { color: oklch(72% 0.10 240); }
+  .json-body .js { color: oklch(68% 0.11 155); }
+  .json-body .jn { color: oklch(72% 0.12 75); }
+  .json-body .jb { color: oklch(68% 0.14 295); }
+  .json-body .jc { color: oklch(45% 0.01 240); }
+
+  /* Tabs */
+  .tabs { margin: 1.25rem 0; }
+  .tabs-nav {
+    display: flex;
+    gap: 0;
+    border-bottom: 1px solid var(--border);
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .tabs-nav button {
+    font-family: var(--font-display);
+    font-size: 0.74rem;
+    font-weight: 600;
+    padding: 0.6rem 1rem;
+    border: none;
+    background: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+    white-space: nowrap;
+    transition: all 0.15s;
+  }
+  .tabs-nav button:hover { color: var(--text-secondary); }
+  .tabs-nav button.active { color: var(--accent); border-bottom-color: var(--accent); }
+  .tab-panel { display: none; padding-top: 1rem; }
+  .tab-panel.active { display: block; }
+
+  /* Metrics table highlight */
+  .metric-row-highlight td { background: var(--accent-soft); }
+
+  /* Dashboard grid */
+  .dashboard-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+    margin: 1rem 0 1.25rem;
+  }
+  @media (min-width: 700px) {
+    .dashboard-grid { grid-template-columns: 1fr 1fr; }
+  }
+  .dashboard-card {
+    background: var(--bg-sheet);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    overflow: hidden;
+  }
+  .dashboard-card-header {
+    padding: 0.7rem 0.9rem 0.5rem;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .dashboard-card-header h4 {
+    font-family: var(--font-display);
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--text);
+    margin: 0;
+  }
+  .dashboard-card-header .dash-badge {
+    font-family: var(--font-display);
+    font-size: 0.6rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 0.15rem 0.4rem;
+    border-radius: 4px;
+  }
+  .dash-badge-blue { background: var(--accent-soft); color: var(--accent); }
+  .dash-badge-green { background: var(--green-soft); color: var(--green); }
+  .dash-badge-amber { background: var(--amber-soft); color: oklch(42% 0.12 75); }
+  .dash-badge-purple { background: var(--purple-soft); color: var(--purple); }
+  .dash-badge-teal { background: var(--teal-soft); color: var(--teal); }
+  .dash-badge-red { background: var(--red-soft); color: var(--red); }
+  .dashboard-card-body { padding: 0.75rem 0.9rem 0.9rem; }
+  .mini-panels {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+  }
+  .mini-panel {
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.55rem 0.65rem;
+  }
+  .mini-panel-label {
+    font-family: var(--font-display);
+    font-size: 0.62rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    margin-bottom: 0.25rem;
+  }
+  .mini-panel-value {
+    font-family: var(--font-display);
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: var(--text);
+    line-height: 1.1;
+  }
+  .mini-panel-value.green { color: var(--green); }
+  .mini-panel-value.amber { color: oklch(48% 0.14 75); }
+  .mini-panel-value.red { color: var(--red); }
+  .mini-panel-value.accent { color: var(--accent); }
+  .mini-panel-sub {
+    font-family: var(--font-display);
+    font-size: 0.62rem;
+    color: var(--text-muted);
+    margin-top: 0.15rem;
+  }
+  .sparkline { width: 100%; height: 28px; margin-top: 0.35rem; }
+  .sparkline path { fill: none; stroke-width: 1.6; stroke-linecap: round; stroke-linejoin: round; }
+  .sparkline .area { fill-opacity: 0.08; stroke: none; }
+
+  /* Alert cards */
+  .alert-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
+    margin: 1rem 0;
+  }
+  @media (min-width: 600px) { .alert-grid { grid-template-columns: 1fr 1fr; } }
+  .alert-card {
+    border-radius: 8px;
+    padding: 0.7rem 0.85rem;
+    display: flex;
+    gap: 0.6rem;
+    align-items: flex-start;
+    font-size: 0.82rem;
+    line-height: 1.5;
+  }
+  .alert-card .alert-icon {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.7rem;
+    flex-shrink: 0;
+    margin-top: 0.05rem;
+  }
+  .alert-page { background: var(--red-soft); border: 1px solid oklch(84% 0.05 25); }
+  .alert-page .alert-icon { background: var(--red); color: white; }
+  .alert-warn { background: var(--amber-soft); border: 1px solid oklch(84% 0.07 75); }
+  .alert-warn .alert-icon { background: var(--amber); color: white; }
+  .alert-info { background: var(--accent-soft); border: 1px solid oklch(84% 0.05 240); }
+  .alert-info .alert-icon { background: var(--accent); color: white; }
+
+  /* Step timeline */
+  .step-timeline { margin: 1rem 0; }
+  .step-item {
+    display: grid;
+    grid-template-columns: 42px 1fr;
+    gap: 0;
+    position: relative;
+  }
+  .step-line {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+  .step-dot {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--font-display);
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: white;
+    background: var(--accent);
+    flex-shrink: 0;
+    z-index: 1;
+  }
+  .step-dot.done { background: var(--green); }
+  .step-connector {
+    width: 2px;
+    flex: 1;
+    background: var(--border);
+    margin: 0.25rem 0;
+    min-height: 16px;
+  }
+  .step-item:last-child .step-connector { display: none; }
+  .step-content {
+    padding: 0.15rem 0 1.25rem 0.5rem;
+  }
+  .step-content h4 {
+    font-family: var(--font-display);
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: var(--text);
+    margin: 0 0 0.25rem;
+  }
+  .step-content p { font-size: 0.82rem; color: var(--text-secondary); line-height: 1.55; margin: 0 0 0.4rem; }
+  .step-content code { font-family: var(--font-mono); font-size: 0.78em; background: var(--bg-code-inline); padding: 0.1em 0.3em; border-radius: 3px; }
+  .step-tag {
+    display: inline-flex;
+    font-family: var(--font-display);
+    font-size: 0.62rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 0.1rem 0.35rem;
+    border-radius: 3px;
+    margin-right: 0.3rem;
+  }
+  .tag-security { background: var(--red-soft); color: var(--red); }
+  .tag-crate { background: var(--accent-soft); color: var(--accent); }
+  .tag-api { background: var(--green-soft); color: var(--green); }
+  .tag-instrument { background: var(--purple-soft); color: var(--purple); }
+  .tag-vm { background: var(--amber-soft); color: oklch(42% 0.12 75); }
+  .tag-dash { background: var(--teal-soft); color: var(--teal); }
+  .tag-docs { background: oklch(94% 0.02 240); color: var(--text-muted); }
+
+  /* Condition chips */
+  .condition-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin: 0.75rem 0;
+  }
+  .condition-chip {
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    padding: 0.2rem 0.5rem;
+    border-radius: 100px;
+    border: 1px solid var(--border);
+    background: var(--bg-sheet);
+    color: var(--text-secondary);
+  }
+  .condition-chip.critical { background: var(--red-soft); border-color: oklch(82% 0.04 25); color: var(--red); }
+  .condition-chip.warn { background: var(--amber-soft); border-color: oklch(82% 0.06 75); color: oklch(42% 0.12 75); }
+
+  /* Prometheus */
+  .prom-block {
+    background: var(--bg-terminal);
+    border-radius: 8px;
+    padding: 0.9rem 1rem;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    line-height: 1.6;
+    color: oklch(80% 0.01 240);
+    overflow-x: auto;
+    margin: 0.85rem 0;
+    border: 1px solid oklch(25% 0.01 240);
+  }
+  .prom-block .pm-comment { color: oklch(50% 0.01 240); }
+  .prom-block .pm-name { color: oklch(72% 0.12 240); }
+  .prom-block .pm-label { color: oklch(68% 0.11 155); }
+
+  /* Divider */
+  .section-divider { border: none; border-top: 1px solid var(--border); margin: 2rem 0 0; }
+
+  /* Responsive */
+  @media (max-width: 900px) {
+    .page-grid { grid-template-columns: 1fr; padding: 1.5rem 1.25rem 4rem; gap: 0; }
+    .toc {
+      position: static;
+      max-height: none;
+      overflow: visible;
+      padding-right: 0;
+      margin-bottom: 1.5rem;
+      padding-bottom: 1.25rem;
+      border-bottom: 1px solid var(--border);
+    }
+    .hero h1 { font-size: 1.7rem; }
+    .invariant-grid { grid-template-columns: 1fr; }
+  }
+  @media print {
+    .toc { display: none; }
+    .page-grid { grid-template-columns: 1fr; max-width: 100%; }
+    body { background: white; }
+    .terminal, .json-viewer, .prom-block { break-inside: avoid; }
+  }
+  /* Scrollbar for code */
+  pre::-webkit-scrollbar, .terminal-body::-webkit-scrollbar { height: 6px; }
+  pre::-webkit-scrollbar-thumb, .terminal-body::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 3px; }
+  /* Anchor offset */
+  h2, h3 { scroll-margin-top: 1.5rem; }
+  /* Inline kbd */
+  kbd {
+    font-family: var(--font-mono);
+    font-size: 0.75em;
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-bottom-width: 2px;
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+  }
+</style>
+</head>
+<body>
+<div class="page-grid">
+
+<nav class="toc" aria-label="Table of contents">
+  <div class="toc-title">Plan 002 — Contents</div>
+  <ol>
+    <li><a href="#status">Status</a></li>
+    <li><a href="#executive-decision">Executive Decision</a></li>
+    <li><a href="#why-matters">Why This Matters</a></li>
+    <li><a href="#current-state">Current State</a></li>
+    <li><a href="#blind-spots" class="toc-h3">Six Blind Spots</a></li>
+    <li><a href="#architecture">Architecture &amp; Invariants</a></li>
+    <li><a href="#operator-surfaces">Operator Surfaces</a></li>
+    <li><a href="#mockups" class="toc-h3">UI Mockups — Live Preview</a></li>
+    <li><a href="#signal-contract">Signal Contract</a></li>
+    <li><a href="#vm-contract" class="toc-h3">VM Telemetry Contract</a></li>
+    <li><a href="#log-catalog">Structured Logs</a></li>
+    <li><a href="#trace-policy">Trace Policy</a></li>
+    <li><a href="#slos">SLOs &amp; Alerts</a></li>
+    <li><a href="#dashboards" class="toc-h3">Dashboard Gallery</a></li>
+    <li><a href="#openobserve">OpenObserve Evaluation</a></li>
+    <li><a href="#config">Configuration</a></li>
+    <li><a href="#scope">Scope</a></li>
+    <li><a href="#steps">Implementation Steps</a></li>
+    <li><a href="#test-plan">Test Plan</a></li>
+    <li><a href="#done">Done Criteria</a></li>
+    <li><a href="#stop">Stop Conditions</a></li>
+    <li><a href="#maintenance">Maintenance Notes</a></li>
+  </ol>
+  <hr class="toc-sep">
+  <div class="toc-title" style="margin-top:0.5rem;">Artifacts</div>
+  <ol>
+    <li><a href="#mockups">↗ Interactive Mockups</a></li>
+    <li><a href="#dashboards">↗ Dashboard Gallery</a></li>
+    <li><a href="https://github.com/preloopdev/preloop/blob/main/plans/002-observability-strategy.md" target="_blank">↗ Markdown Source</a></li>
+  </ol>
+</nav>
+
+<main class="content">
+
+<header class="hero">
+  <div class="hero-eyebrow">Plan 002 · Observability · Architecture &amp; Operations</div>
+  <h1>Make Preloop observable without making a backend mandatory</h1>
+  <p class="hero-sub">Every important control-plane question answerable from one authenticated endpoint, with no sidecar. OpenTelemetry and an optional single-node OpenObserve layer on top — fail-open, by design.</p>
+  <div class="hero-meta">
+    <span class="badge badge-todo">P1 — In Review</span>
+    <span><span class="meta-label">Effort</span> L · 7 PRs</span>
+    <span><span class="meta-label">Risk</span> MED</span>
+    <span><span class="meta-label">Category</span> direction · architecture · operations · security · DX</span>
+  </div>
+  <div class="hero-meta" style="margin-top:0.5rem;">
+    <span><span class="meta-label">Planned</span> <code>84d92cfd</code> · 2026-08-17</span>
+    <span class="badge badge-revised">Revised at <code>673bdfa0</code> · 2026-08-20</span>
+  </div>
+</header>
+
+<div class="drift-banner">
+  <strong>⚠ Drift check — run first.</strong> Every file:line anchor and version pin below was re-verified at <code>673bdfa0</code>. If the repository has moved, compare the excerpts with live code — a semantic mismatch is a <strong>STOP condition</strong>.
+  <br><code style="margin-top:0.4rem; display:inline-block;">git diff --stat 673bdfa0..HEAD -- Cargo.toml Cargo.lock crates/preloop-observability crates/preloop-cli crates/preloop-runner-server crates/preloop-orchestrator crates/preloop-vm crates/preloop-runner docs contrib/openobserve scripts rules justfile versions.toml CHANGELOG.md</code>
+</div>
+
+<!-- ════════════════════ STATUS ════════════════════ -->
+<h2 id="status">Status</h2>
+<table style="width:100%; font-size:0.84rem; border:1px solid var(--border); border-radius:8px; overflow:hidden; border-collapse:collapse;">
+  <thead><tr><th>Field</th><th>Value</th></tr></thead>
+  <tbody>
+    <tr><td style="padding:0.5rem 0.85rem; border-bottom:1px solid var(--border);"><strong>Priority</strong></td><td style="padding:0.5rem 0.85rem; border-bottom:1px solid var(--border);">P1</td></tr>
+    <tr><td style="padding:0.5rem 0.85rem; border-bottom:1px solid var(--border);"><strong>Effort</strong></td><td style="padding:0.5rem 0.85rem; border-bottom:1px solid var(--border);">L — seven independently reviewable PRs</td></tr>
+    <tr><td style="padding:0.5rem 0.85rem; border-bottom:1px solid var(--border);"><strong>Risk</strong></td><td style="padding:0.5rem 0.85rem; border-bottom:1px solid var(--border);">MED — HTTP/runner lifecycle are protocol-critical; telemetry must be fail-open</td></tr>
+    <tr><td style="padding:0.5rem 0.85rem;"><strong>Depends on</strong></td><td style="padding:0.5rem 0.85rem;">none — independent of Plan 001</td></tr>
+  </tbody>
+</table>
+<div class="callout callout-blue" style="margin-top:0.85rem;">
+  <div class="callout-title">Dependency note</div>
+  Plan 002 owns the stable observability contract. When Plan 001 touches cache/artifact operations it must emit through <code>preloop.storage.*</code> and register caps with <code>LimitRegistry</code> rather than inventing a parallel family.
+</div>
+
+<!-- ════════════════════ EXECUTIVE DECISION ════════════════════ -->
+<h2 id="executive-decision">Executive Decision</h2>
+<p>Build observability in three layers, in this order:</p>
+<ol class="priority-list">
+  <li><div><strong>Zero-dependency operator diagnostics</strong> — truthful liveness/readiness, an authenticated aggregate status endpoint, <code>preloop status --json</code>, structured stderr/journald logs, and authenticated Prometheus text at <code>/metrics</code>, including host-observed resource use for Preloop-owned microVMs. No sidecar. Answers “why is this job not moving?” when no telemetry backend exists.</div></li>
+  <li><div><strong>Vendor-neutral telemetry</strong> — OpenTelemetry metrics, logs, and short-lived traces exported through bounded OTLP/HTTP batches only when standard <code>OTEL_*</code> configuration is present. Export failure never rejects, delays, or cancels a workflow.</div></li>
+  <li><div><strong>OpenObserve as an optional reference backend</strong> — a pinned, private single-node deployment plus importable dashboards and alerts. Preloop neither embeds nor requires OpenObserve. Any OTLP backend remains interchangeable.</div></li>
+</ol>
+<div class="callout callout-green">
+  <div class="callout-title">Product boundary</div>
+  OpenObserve single-node is one binary/container, SQLite + local disk, OTLP ingest, dashboards and alerts. Its HA mode needs Kubernetes, object storage, Postgres, NATS, and five roles — not minimal. Keep the boundary at <strong>OTLP and Prometheus</strong>. The highest-priority deliverable is not a dashboard. It is <code>preloop status</code>.
+</div>
+
+<!-- ════════════════════ WHY MATTERS ════════════════════ -->
+<h2 id="why-matters">Why This Matters</h2>
+<p>Today Preloop can accept work while the pool repeatedly fails to provision, can leave an operator unable to distinguish “no compatible runner” from “runner has stopped polling,” and can report a healthy process while critical background behavior is degraded. The only built-in aggregate view is a recent-runs table.</p>
+<div class="table-wrap"><table>
+  <thead><tr><th>Operator question</th><th>Answered today?</th><th>After this plan</th></tr></thead>
+  <tbody>
+    <tr><td>Is the critical event loop making progress?</td><td style="color:var(--red);">No — process can be wedged while <code>/healthz</code> returns 200</td><td><code>/readyz</code> + <code>TaskHeartbeat</code> registry</td></tr>
+    <tr><td>Why is this job not claimed?</td><td style="color:var(--red);">No</td><td><code>/api/v1/status</code> jobs + concurrency + pool blocks</td></tr>
+    <tr><td>Are runners polling / renewing leases?</td><td style="color:var(--red);">No visibility</td><td>runner poll/lease gauges + reaper heartbeat</td></tr>
+    <tr><td>Is VM CPU/memory/disk limiting capacity?</td><td style="color:var(--red);">No surface</td><td>VM fleet sample w/ host cgroup/process</td></tr>
+    <tr><td>Are store / GitHub writes succeeding?</td><td style="color:var(--red);">Silent divergent DB</td><td>store + GitHub budget gauges</td></tr>
+    <tr><td>Is telemetry itself healthy?</td><td style="color:var(--red);">No self-health</td><td><code>preloop.telemetry.export</code> + status</td></tr>
+    <tr><td>Is data being silently dropped?</td><td style="color:var(--red);">9 caps, zero counters</td><td><code>preloop.limit.*</code> + status <code>limits</code> array</td></tr>
+  </tbody>
+</table></div>
+
+<!-- ════════════════════ CURRENT STATE ════════════════════ -->
+<h2 id="current-state">Current State</h2>
+
+<h3>Logging is local, duplicated, and not export-ready</h3>
+<p><code>crates/preloop-cli/src/main.rs:743-745</code> initializes a plain formatting subscriber; the standalone server (<code>preloop-runner-server/src/main.rs:78-80</code>, no <code>info</code> fallback) and the Rust runner (<code>preloop-runner/src/main.rs:17-21</code>) each do the same. Three binaries, three slightly different filter defaults, no JSON selection, no OTLP pipeline.</p>
+<div class="callout callout-red">
+  <div class="callout-title">Security gate — four unsafe sites at <code>673bdfa0</code></div>
+  <ul style="margin:0; padding-left:1.2rem; font-size:0.84rem;">
+    <li><code>artifact_twirp.rs:94</code> — <code>info!(token, …)</code> capability token</li>
+    <li><code>results_twirp.rs:713</code> — <code>info!(token, …)</code> capability token</li>
+    <li><code>blob_store.rs:63,78,95,113,121,127,131</code> — seven <code>warn!/info!(kind, token)</code> sites</li>
+    <li><code>distributed_task.rs:327</code> — <code>info!(?body, …)</code> full PATCH JSON body</li>
+    <li><code>recording.rs:1-90</code> — deliberate full-header/body capture (excluded from export, mode 0600)</li>
+  </ul>
+  <p style="margin-top:0.6rem; font-size:0.82rem;">Three of these moved between <code>84d92cfd</code> and <code>673bdfa0</code>. Re-run the scan: <code>grep -rnE '(info|warn|error)!\(' crates/preloop-runner-server/src | grep -E '\b(token|authorization|cookie|headers|body|payload|signed_url)\b'</code></p>
+</div>
+
+<h3>Health and status do not diagnose the control plane</h3>
+<p><code>crates/preloop-runner-server/src/runs.rs:4-9</code> always returns <code>ok: true</code>. The router exposes only <code>GET /healthz</code> (<code>routes.rs:256</code>) and installs <code>TraceLayer::new_for_http()</code> at <code>routes.rs:805</code> — whose default span leaks raw URIs. No <code>/readyz</code>, no <code>/metrics</code>, no Prometheus dependency.</p>
+<p><code>preloop status</code> at <code>crates/preloop-cli/src/main.rs:2831</code> calls only <code>GET /api/v1/runs?limit=20</code>. <code>wait_for_engine_socket</code> (<code>main.rs:1458-1475</code>) probes <code>http://localhost/healthz</code> over 30 s, treating “accepts connections” as “usable”.</p>
+
+<h3>The state needed for useful diagnostics already exists</h3>
+<p><code>AppState</code> (<code>state.rs:358-503</code>) and <code>InnerState</code> (<code>state.rs:1067-1153</code>) already contain ready/dependency/concurrency/expansion queues, runners/sessions/claims/leases, pool reservations, debug sessions, plus the GitHub App surface added since the first draft. <code>AppState::emit</code> (<code>state.rs:819</code>, lock released at <code>827-832</code>) releases the mutex before persistence — in-memory is authoritative.</p>
+
+<h3>Six blind spots the first draft missed</h3>
+<p id="blind-spots">Re-auditing at <code>673bdfa0</code> found six classes of state with no surface at all. Each can independently make Preloop behave incorrectly with no visible signal.</p>
+
+<h4>1 · Bounded buffers and hard limits drop data silently</h4>
+<div class="table-wrap"><table>
+  <thead><tr><th>Limit</th><th>Location</th><th>Value</th><th>Observable?</th></tr></thead>
+  <tbody>
+    <tr><td>per-job live-log bytes</td><td class="mono">live_logs.rs:25</td><td>64 MiB</td><td style="color:var(--red); font-weight:600;">No — tail-drop</td></tr>
+    <tr><td>oversized live-log batch</td><td class="mono">live_logs.rs:250</td><td>&gt; cap</td><td style="color:var(--amber);">WARN only</td></tr>
+    <tr><td><code>queue: max</code> pending holders</td><td class="mono">concurrency.rs:255</td><td>100</td><td style="color:var(--red); font-weight:600;">No — cancels a job</td></tr>
+    <tr><td>archived debug sessions</td><td class="mono">debug_sessions.rs:64</td><td>64</td><td style="color:var(--red);">Ring eviction</td></tr>
+    <tr><td>debug session events</td><td class="mono">debug_sessions.rs:68</td><td>512</td><td style="color:var(--red);">Ring eviction</td></tr>
+    <tr><td>debug session audit</td><td class="mono">debug_sessions.rs:71</td><td>512</td><td style="color:var(--red); font-weight:600;">Silent audit loss</td></tr>
+    <tr><td>completed debug ops</td><td class="mono">debug_sessions.rs:74</td><td>256</td><td style="color:var(--red);">Ring eviction</td></tr>
+    <tr><td>git request body</td><td class="mono">snapshots.rs:20</td><td>16 MiB</td><td>Rejected, not counted</td></tr>
+    <tr><td>reusable workflow depth</td><td class="mono">remote_workflows.rs:6</td><td>4</td><td>Rejected, not counted</td></tr>
+  </tbody>
+</table></div>
+<div class="callout callout-red">
+  <div class="callout-title">Why this matters</div>
+  A cap that silently discards data is worse than an outage. <code>queue: max</code> overflow cancels a user's job with no distinction from any other cancellation. Silent audit eviction is a compliance defect. Fix: one bounded <code>preloop.limit.*</code> family whose <code>limit</code> attribute is the constant's name — a compile-time-finite set.
+</div>
+
+<h4>2 · Scheduled workflows have a history endpoint and no telemetry</h4>
+<p><code>scheduler.rs</code> drives cron workflows from <code>bootstrap.rs:479/485</code> and exposes <code>GET /api/v1/scheduler/history</code>. Nothing reports whether a schedule fired, fired late, was skipped for overlap, or stopped because the scan task died.</p>
+
+<h4>3 · GitHub dependency budget is untracked</h4>
+<p>Caches at <code>dispatch_auth.rs:46,49</code> (60 s TTL), <code>oidc.rs:25</code> (300 s), <code>actions.rs:32</code> (6 h). No <code>x-ratelimit-*</code> parsing, no token-expiry tracking, no hit-rate reporting. Rate-limit exhaustion is indistinguishable from “GitHub is slow”.</p>
+
+<h4>4 · Persistent storage growth is unbounded and unreported</h4>
+<p>State dir, cache, artifacts, run logs, snapshots, VM images all grow. Only the VM volume gets a free-space signal in the first draft. A full state-dir filesystem is a hard outage; the first symptom today is a store write failure with no capacity context.</p>
+
+<h4>5 · Fifteen background tasks, two proposed heartbeats</h4>
+<div class="table-wrap"><table>
+  <thead><tr><th>Task</th><th>Location</th><th>Cadence</th></tr></thead>
+  <tbody>
+    <tr><td>reaper</td><td class="mono">bootstrap.rs:396-410</td><td>10 s</td></tr>
+    <tr><td>scheduler scan</td><td class="mono">bootstrap.rs:479, 485</td><td>timer</td></tr>
+    <tr><td>GitHub App event loop</td><td class="mono">bootstrap.rs:497, 517</td><td>event-driven</td></tr>
+    <tr><td>shutdown supervisor</td><td class="mono">bootstrap.rs:568</td><td>event-driven</td></tr>
+    <tr><td>listener accept loops</td><td class="mono">bootstrap.rs:601,615,660,679</td><td>per-conn</td></tr>
+    <tr><td>snapshot GC</td><td class="mono">snapshots.rs:1896</td><td>periodic</td></tr>
+    <tr><td>replay prune</td><td class="mono">distributed_task.rs:895</td><td>periodic</td></tr>
+    <tr><td>Postgres connection</td><td class="mono">store_pg.rs:95</td><td>lifetime</td></tr>
+    <tr><td>GitHub check dispatch</td><td class="mono">github.rs:1064</td><td>event-driven</td></tr>
+    <tr><td>auto-PR gate</td><td class="mono">github_pr.rs:397</td><td>event-driven</td></tr>
+    <tr><td>pool supervisor</td><td class="mono">orchestrator/lib.rs:1880-2100</td><td>loop</td></tr>
+    <tr><td>guest pause watchers</td><td class="mono">orchestrator/lib.rs:3027</td><td>per-VM</td></tr>
+    <tr><td>key rotation</td><td class="mono">orchestrator/keys.rs:74</td><td>periodic</td></tr>
+  </tbody>
+</table></div>
+<p>Hand-wiring two heartbeats and leaving thirteen silent reproduces the failure mode. Fix: one <code>TaskHeartbeat</code> registry — register at spawn, beat each iteration, deregister on drop; readiness reads only the critical subset.</p>
+
+<h4>6 · HTTP surfaces are wider than classified</h4>
+<p><code>routes.rs</code> serves thirteen path families, not eight: <code>/_apis</code>, <code>/broker</code>, <code>/runner</code>, <code>/twirp</code>, <code>/api/v1</code>, <code>/ws/live-logs</code>, <code>/snapshots</code>, <code>/repos</code>, <code>/oidc</code>, etc. Two need different treatment from a duration histogram: the WebSocket and the git-object path.</p>
+
+<!-- ════════════════════ ARCHITECTURE ════════════════════ -->
+<h2 id="architecture">Architecture &amp; Invariants</h2>
+
+<div class="arch-wrap">
+  <div class="arch-title">Three layers — zero-dependency diagnostics first, vendor-neutral telemetry second, optional backend third</div>
+  <svg class="arch-svg" viewBox="0 0 860 420" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Observability architecture — three layers">
+    <defs>
+      <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#94a3b8"/></marker>
+      <marker id="arr-dash" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M 0 0 L 10 5 L 0 10 z" fill="#94a3b8"/></marker>
+      <filter id="shadow" x="-8%" y="-8%" width="116%" height="116%"><feDropShadow dx="0" dy="2" stdDeviation="3" flood-opacity="0.08"/></filter>
+    </defs>
+
+    <!-- Layer labels -->
+    <text x="20" y="22" font-family="Outfit, sans-serif" font-size="9" font-weight="700" letter-spacing="0.1em" fill="#94a3b8">LAYER 1 — ZERO-DEPENDENCY</text>
+    <text x="20" y="152" font-family="Outfit, sans-serif" font-size="9" font-weight="700" letter-spacing="0.1em" fill="#94a3b8">LAYER 2 — VENDOR-NEUTRAL TELEMETRY</text>
+    <text x="20" y="270" font-family="Outfit, sans-serif" font-size="9" font-weight="700" letter-spacing="0.1em" fill="#94a3b8">LAYER 3 — OPTIONAL BACKEND</text>
+
+    <!-- Layer 1 boxes: CLI, Probes, Prometheus -->
+    <!-- CLI -->
+    <g filter="url(#shadow)">
+      <rect x="20" y="32" width="150" height="48" rx="8" fill="white" stroke="#0ea5e9" stroke-width="1.4"/>
+      <text x="95" y="50" text-anchor="middle" font-family="Outfit, sans-serif" font-size="11" font-weight="700" fill="#0ea5e9">preloop status</text>
+      <text x="95" y="64" text-anchor="middle" font-family="Outfit, sans-serif" font-size="8.5" fill="#64748b">CLI · native bearer</text>
+    </g>
+    <!-- Probes -->
+    <g filter="url(#shadow)">
+      <rect x="200" y="32" width="150" height="48" rx="8" fill="white" stroke="#10b981" stroke-width="1.4"/>
+      <text x="275" y="50" text-anchor="middle" font-family="Outfit, sans-serif" font-size="11" font-weight="700" fill="#10b981">systemd / probes</text>
+      <text x="275" y="64" text-anchor="middle" font-family="Outfit, sans-serif" font-size="8.5" fill="#64748b">health checks</text>
+    </g>
+    <!-- Prometheus scraper -->
+    <g filter="url(#shadow)">
+      <rect x="380" y="32" width="150" height="48" rx="8" fill="white" stroke="#8b5cf6" stroke-width="1.4"/>
+      <text x="455" y="50" text-anchor="middle" font-family="Outfit, sans-serif" font-size="11" font-weight="700" fill="#8b5cf6">Prometheus</text>
+      <text x="455" y="64" text-anchor="middle" font-family="Outfit, sans-serif" font-size="8.5" fill="#64748b">scraper · bearer auth</text>
+    </g>
+
+    <!-- Endpoints -->
+    <g>
+      <rect x="40" y="100" width="110" height="32" rx="16" fill="#e0f2fe" stroke="#0ea5e9" stroke-width="1"/>
+      <text x="95" y="120" text-anchor="middle" font-family="Fira Code, monospace" font-size="9" font-weight="600" fill="#0369a1">/api/v1/status</text>
+    </g>
+    <g>
+      <rect x="220" y="100" width="110" height="32" rx="16" fill="#dcfce7" stroke="#10b981" stroke-width="1"/>
+      <text x="275" y="114" text-anchor="middle" font-family="Fira Code, monospace" font-size="8.5" font-weight="600" fill="#065f46">/healthz  /readyz</text>
+      <text x="275" y="125" text-anchor="middle" font-family="Fira Code, monospace" font-size="7" fill="#065f46">public · shallow</text>
+    </g>
+    <g>
+      <rect x="400" y="100" width="110" height="32" rx="16" fill="#ede9fe" stroke="#8b5cf6" stroke-width="1"/>
+      <text x="455" y="120" text-anchor="middle" font-family="Fira Code, monospace" font-size="9" font-weight="600" fill="#5b21b6">/metrics</text>
+    </g>
+
+    <!-- Arrows L1 -->
+    <line x1="95" y1="80" x2="95" y2="100" stroke="#94a3b8" stroke-width="1.2" marker-end="url(#arr)"/>
+    <line x1="275" y1="80" x2="275" y2="100" stroke="#94a3b8" stroke-width="1.2" marker-end="url(#arr)"/>
+    <line x1="455" y1="80" x2="455" y2="100" stroke="#94a3b8" stroke-width="1.2" marker-end="url(#arr)"/>
+
+    <!-- Control plane + Pool + VM sampler -> Observability -->
+    <g filter="url(#shadow)">
+      <rect x="100" y="162" width="170" height="52" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1.2"/>
+      <text x="185" y="182" text-anchor="middle" font-family="Outfit, sans-serif" font-size="11" font-weight="700" fill="white">Control plane</text>
+      <text x="185" y="197" text-anchor="middle" font-family="Fira Code, monospace" font-size="7.5" fill="#94a3b8">broker · store · scheduler</text>
+    </g>
+    <g filter="url(#shadow)">
+      <rect x="300" y="162" width="150" height="52" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1.2"/>
+      <text x="375" y="182" text-anchor="middle" font-family="Outfit, sans-serif" font-size="11" font-weight="700" fill="white">Runner pool</text>
+      <text x="375" y="197" text-anchor="middle" font-family="Fira Code, monospace" font-size="7.5" fill="#94a3b8">provision · slots · goldens</text>
+    </g>
+    <g filter="url(#shadow)">
+      <rect x="480" y="162" width="170" height="52" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1.2"/>
+      <text x="565" y="182" text-anchor="middle" font-family="Outfit, sans-serif" font-size="11" font-weight="700" fill="white">Host VM sampler</text>
+      <text x="565" y="197" text-anchor="middle" font-family="Fira Code, monospace" font-size="7.5" fill="#94a3b8">cgroup · process · sparse disk</text>
+    </g>
+
+    <!-- Observability crate -->
+    <g filter="url(#shadow)">
+      <rect x="260" y="234" width="240" height="40" rx="8" fill="#0ea5e9" stroke="#0284c7" stroke-width="1.4"/>
+      <text x="380" y="252" text-anchor="middle" font-family="Outfit, sans-serif" font-size="11" font-weight="700" fill="white">preloop-observability</text>
+      <text x="380" y="265" text-anchor="middle" font-family="Fira Code, monospace" font-size="7" fill="white" opacity="0.85">metrics · logs · traces · status snapshot</text>
+    </g>
+    <!-- arrows into observability -->
+    <line x1="185" y1="214" x2="310" y2="234" stroke="#475569" stroke-width="1.2" marker-end="url(#arr)"/>
+    <line x1="375" y1="214" x2="380" y2="234" stroke="#475569" stroke-width="1.2" marker-end="url(#arr)"/>
+    <line x1="565" y1="214" x2="470" y2="234" stroke="#475569" stroke-width="1.2" marker-end="url(#arr)"/>
+
+    <!-- Outputs from observability -->
+    <g>
+      <rect x="80" y="298" width="130" height="32" rx="6" fill="white" stroke="#64748b" stroke-width="1"/>
+      <text x="145" y="314" text-anchor="middle" font-family="Fira Code, monospace" font-size="8.5" font-weight="600" fill="#334155">stderr / journald</text>
+      <text x="145" y="324" text-anchor="middle" font-family="Outfit, sans-serif" font-size="7" fill="#64748b">always retained</text>
+    </g>
+    <g>
+      <rect x="240" y="298" width="110" height="32" rx="6" fill="#ede9fe" stroke="#8b5cf6" stroke-width="1"/>
+      <text x="295" y="318" text-anchor="middle" font-family="Fira Code, monospace" font-size="8.5" font-weight="600" fill="#5b21b6">/metrics</text>
+    </g>
+    <g>
+      <rect x="380" y="298" width="140" height="32" rx="6" fill="#e0f2fe" stroke="#0ea5e9" stroke-width="1" stroke-dasharray="5 4"/>
+      <text x="450" y="314" text-anchor="middle" font-family="Outfit, sans-serif" font-size="9" font-weight="600" fill="#0369a1">OTLP/HTTP</text>
+      <text x="450" y="324" text-anchor="middle" font-family="Outfit, sans-serif" font-size="7" fill="#64748b">bounded · optional</text>
+    </g>
+    <line x1="310" y1="274" x2="145" y2="298" stroke="#64748b" stroke-width="1.2" marker-end="url(#arr)"/>
+    <line x1="360" y1="274" x2="295" y2="298" stroke="#8b5cf6" stroke-width="1.2" marker-end="url(#arr)"/>
+    <line x1="410" y1="274" x2="450" y2="298" stroke="#0ea5e9" stroke-width="1.2" stroke-dasharray="5 4" marker-end="url(#arr)"/>
+
+    <!-- OpenObserve -->
+    <g filter="url(#shadow)">
+      <rect x="560" y="298" width="160" height="48" rx="8" fill="white" stroke="#f59e0b" stroke-width="1.4" stroke-dasharray="6 4"/>
+      <text x="640" y="318" text-anchor="middle" font-family="Outfit, sans-serif" font-size="11" font-weight="700" fill="#92400e">OpenObserve</text>
+      <text x="640" y="332" text-anchor="middle" font-family="Outfit, sans-serif" font-size="7.5" fill="#92400e">or any OTLP backend</text>
+    </g>
+    <line x1="520" y1="314" x2="560" y2="322" stroke="#f59e0b" stroke-width="1.2" stroke-dasharray="5 4" marker-end="url(#arr-dash)"/>
+    <text x="540" y="308" text-anchor="middle" font-family="Outfit, sans-serif" font-size="6.5" fill="#94a3b8">opt-in</text>
+
+    <!-- Collector (optional) -->
+    <g opacity="0.75">
+      <rect x="560" y="360" width="160" height="32" rx="6" fill="white" stroke="#94a3b8" stroke-width="1" stroke-dasharray="4 3"/>
+      <text x="640" y="376" text-anchor="middle" font-family="Outfit, sans-serif" font-size="8.5" font-weight="600" fill="#64748b">OTel Collector — optional</text>
+      <text x="640" y="386" text-anchor="middle" font-family="Outfit, sans-serif" font-size="7" fill="#94a3b8">host telemetry · fan-out</text>
+    </g>
+    <line x1="640" y1="346" x2="640" y2="360" stroke="#94a3b8" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#arr)"/>
+
+    <!-- Side: run logs + capture -->
+    <text x="740" y="175" font-family="Outfit, sans-serif" font-size="7" font-weight="600" fill="#94a3b8" letter-spacing="0.06em">SIDE CHANNELS — NOT TELEMETRY</text>
+    <g opacity="0.65">
+      <rect x="700" y="185" width="140" height="28" rx="6" fill="white" stroke="#94a3b8" stroke-width="1"/>
+      <text x="770" y="202" text-anchor="middle" font-family="Fira Code, monospace" font-size="7.5" fill="#64748b">run-log store</text>
+    </g>
+    <g opacity="0.65">
+      <rect x="700" y="220" width="140" height="28" rx="6" fill="white" stroke="#94a3b8" stroke-width="1"/>
+      <text x="770" y="237" text-anchor="middle" font-family="Fira Code, monospace" font-size="7.5" fill="#64748b">flow capture · 0600</text>
+    </g>
+    <line x1="270" y1="188" x2="700" y2="199" stroke="#94a3b8" stroke-width="0.8" stroke-dasharray="3 3" opacity="0.5"/>
+    <line x1="270" y1="192" x2="700" y2="234" stroke="#94a3b8" stroke-width="0.8" stroke-dasharray="3 3" opacity="0.5"/>
+
+  </svg>
+  <div class="arch-legend">
+    <span><span class="dot" style="background:#0ea5e9;"></span> Layer 1 — always on</span>
+    <span><span class="dot" style="background:#1e293b;"></span> In-process</span>
+    <span><span class="dot" style="background:white; border:1px dashed #f59e0b;"></span> Optional</span>
+    <span><span class="dot" style="background:white; border:1px dashed #94a3b8;"></span> Side channel</span>
+    <span>— solid = always · - - dashed = opt-in</span>
+  </div>
+</div>
+
+<h3>New crate — <code>preloop-observability</code></h3>
+<p>Small, explicit API with no dependency on server or orchestrator internals. Both <code>preloop</code> and standalone <code>preloop-server</code> construct one handle/runtime before building <code>ServerConfig</code>; the same handle is cloned into <code>AppState</code> and <code>RunnerPoolConfig</code>.</p>
+<div class="table-wrap"><table>
+  <thead><tr><th>Symbol</th><th>Role</th></tr></thead>
+  <tbody>
+    <tr><td class="mono">ObservabilityConfig::from_env()</td><td>Parses <code>PRELOOP_LOG_FORMAT</code> + standard <code>OTEL_*</code> without exposing header values in <code>Debug</code></td></tr>
+    <tr><td class="mono">Observability::noop()</td><td>Allocation-light handle for tests — zero network I/O</td></tr>
+    <tr><td class="mono">Observability</td><td>Cloneable handle: instruments, cached snapshot, pool/VM handles, heartbeats, export health</td></tr>
+    <tr><td class="mono">TaskHeartbeat</td><td><code>register(name, critical) → HeartbeatHandle</code> · <code>beat()</code> · <code>Drop</code> deregisters</td></tr>
+    <tr><td class="mono">LimitRegistry</td><td><code>record_drop(limit, n)</code> / <code>record_reject(limit)</code> — <code>limit</code> is a <code>&amp;'static str</code> constant name</td></tr>
+    <tr><td class="mono">ObservabilityRuntime</td><td>Owns provider guards; bounded 2 s flush on shutdown</td></tr>
+  </tbody>
+</table></div>
+
+<h3>Non-negotiable invariants</h3>
+<div class="invariant-grid">
+  <div class="invariant-card"><span class="invariant-num">1</span><div><strong>Fail open</strong><p>Telemetry failure produces a warning + condition, never a failed request.</p></div></div>
+  <div class="invariant-card"><span class="invariant-num">2</span><div><strong>No request-path export</strong><p>Bounded non-blocking batches. Queue overflow drops telemetry, increments health.</p></div></div>
+  <div class="invariant-card"><span class="invariant-num">3</span><div><strong>Bounded shutdown</strong><p>Flush ≤ 2 s after pool shutdown. Then exit.</p></div></div>
+  <div class="invariant-card"><span class="invariant-num">4</span><div><strong>No backend by default</strong><p>Absent OTEL endpoint = disabled. <em>Documented deviation from spec default localhost:4318.</em></p></div></div>
+  <div class="invariant-card"><span class="invariant-num">5</span><div><strong>Always retain stderr</strong><p>OTLP augments, never replaces journald.</p></div></div>
+  <div class="invariant-card"><span class="invariant-num">6</span><div><strong>No wire changes</strong><p>No field/status/body changes on runner protocol routes.</p></div></div>
+  <div class="invariant-card"><span class="invariant-num">7</span><div><strong>No high-cardinality labels</strong><p>IDs and user strings are logs/traces only.</p></div></div>
+  <div class="invariant-card"><span class="invariant-num">8</span><div><strong>No workflow output export</strong><p>Workflow stdout stays in the run-log store.</p></div></div>
+  <div class="invariant-card"><span class="invariant-num">9</span><div><strong>No raw HTTP capture</strong><p>Allowlisted trace attributes, not denylisted.</p></div></div>
+  <div class="invariant-card"><span class="invariant-num">10</span><div><strong>No state-lock callbacks</strong><p>Sampler updates a cached snapshot; exporters read it.</p></div></div>
+  <div class="invariant-card"><span class="invariant-num">11</span><div><strong>No hot-path allocation</strong><p>Prebuilt instruments; poll/renew is metrics-only.</p></div></div>
+  <div class="invariant-card"><span class="invariant-num">12</span><div><strong>No guest polling</strong><p>Host cgroup/process/filesystem only. Never <code>free</code> inside the VM.</p></div></div>
+  <div class="invariant-card"><span class="invariant-num">13</span><div><strong>No fake zeroes</strong><p>Unsupported = absent + capability false.</p></div></div>
+  <div class="invariant-card" style="border-color: oklch(82% 0.04 25);"><span class="invariant-num" style="background:var(--red);">14</span><div><strong>No silent drop</strong><p>Any cap that discards data must record it via <code>LimitRegistry</code>.</p></div></div>
+  <div class="invariant-card" style="border-color: oklch(82% 0.04 25);"><span class="invariant-num" style="background:var(--red);">15</span><div><strong>No unregistered task</strong><p>Every long-lived spawn registers a <code>TaskHeartbeat</code>.</p></div></div>
+</div>
+
+<!-- ════════════════════ OPERATOR SURFACES ════════════════════ -->
+<h2 id="operator-surfaces">Operator Surfaces</h2>
+
+<h3><code>/healthz</code> — liveness only</h3>
+<p>Unauthenticated, shallow. 200 while serving, 503 during shutdown. Must not touch DB, GitHub, SmolVM, or <code>InnerState</code>.</p>
+<div class="json-viewer"><div class="json-header"><span class="json-title">GET /healthz — 200</span><span class="json-badge">public</span></div><div class="json-body"><span class="jc">// always lock-free</span>
+{<br>&nbsp;&nbsp;<span class="jk">"schema_version"</span>: <span class="jn">1</span>,<br>&nbsp;&nbsp;<span class="jk">"ok"</span>: <span class="jb">true</span>,<br>&nbsp;&nbsp;<span class="jk">"protocol_version"</span>: <span class="js">"0.1.0"</span>,<br>&nbsp;&nbsp;<span class="jk">"shutdown_requested"</span>: <span class="jb">false</span><br>}</div></div>
+
+<h3><code>/readyz</code> — critical-loop readiness</h3>
+<p>Unauthenticated, boolean + stable reason codes. 200 when the state sampler and every <strong>critical</strong> heartbeat are fresh. 503 for <code>starting</code>, <code>task_stale</code> (with the stale task's registry name), or <code>shutting_down</code>. Non-critical staleness never gates readiness.</p>
+<div class="callout callout-blue"><div class="callout-title">Critical set</div>State sampler · reaper (<code>bootstrap.rs:396</code>) · scheduler scan (<code>bootstrap.rs:479</code>) · store connection task when Postgres (<code>store_pg.rs:95</code>). Everything else degrades to <code>/api/v1/status</code>.</div>
+<p><code>wait_for_engine_socket</code> (<code>preloop-cli/src/main.rs:1458-1475</code>) now probes <code>/readyz</code>; on 30 s timeout it surfaces the last reason code instead of a generic timeout.</p>
+
+<h3><code>/api/v1/status</code> — authenticated operational diagnosis</h3>
+<p>Versioned snapshot, 5-second sampler, never blocks on <code>InnerState</code>. Reports <code>snapshot_age_seconds</code>. Bearer auth required.</p>
+
+<!-- INTERACTIVE MOCKUPS -->
+<h3 id="mockups">UI Mockups — Live Preview</h3>
+<p style="font-size:0.88rem; color:var(--text-secondary);">Interactive previews of every operator surface. Switch tabs to compare the human CLI, the machine JSON, and the metric wire format.</p>
+
+<div class="tabs" id="surface-tabs">
+  <div class="tabs-nav" role="tablist">
+    <button role="tab" class="active" data-tab="cli">preloop status</button>
+    <button role="tab" data-tab="json">preloop status --json</button>
+    <button role="tab" data-tab="readyz">GET /readyz</button>
+    <button role="tab" data-tab="metrics">GET /metrics</button>
+    <button role="tab" data-tab="logs">Structured Logs</button>
+  </div>
+
+  <!-- CLI tab -->
+  <div class="tab-panel active" data-panel="cli">
+    <div class="terminal">
+      <div class="terminal-header"><div class="terminal-dots"><span class="dot-r"></span><span class="dot-y"></span><span class="dot-g"></span></div><span class="terminal-title">preloop status — human output (sections 1–10)</span></div>
+      <div class="terminal-body"><span class="t-dim">preloop v0.29.0 · instance 9f3a…c1 · up 2h 14m · snapshot 0.4s ago</span>  <span class="t-ok">● ok</span>
+
+<span class="t-bold">Queue</span>  <span class="t-dim">— oldest ready 14.2s</span>
+  <span class="t-cyan">ready</span>               2 jobs  · <span class="t-ok">1 claimable</span> · <span class="t-amber">1 unclaimable</span> (label mismatch)
+  dependency_blocked  1  ·  concurrency_blocked  1  ·  expanding  0
+
+<span class="t-bold">Concurrency</span>  <span class="t-dim">— groups 3 · contended 1 · queue max 100</span>
+  deepest pending  4  ·  overflow cancellations  <span class="t-ok">0</span>
+
+<span class="t-bold">Scheduler</span>  <span class="t-dim">— 4 schedules · last scan 3.1s ago</span>
+  fired 12  ·  skipped (overlap) 1  ·  late fires 0  ·  max delay 2.1s
+
+<span class="t-bold">Pool</span>  <span class="t-dim">— mode warm · desired 2 · preparing false</span>
+  idle 1  ·  busy 1  ·  building 0  ·  provisioning 0  ·  paused 0  ·  consecutive failures 0
+
+<span class="t-bold">Runners</span>  <span class="t-dim">— registered 2 · sessions 2</span>
+  idle 1  ·  busy 1  ·  stale 0  ·  max poll age 3.1s  ·  max lease age 8.0s
+
+<span class="t-bold">VMs</span>  <span class="t-dim">— source cgroup_v2 · sample 1.2s ago · capabilities: cpu ✓ mem ✓ throttle ✓ oom ✓ pids ✓ sparse ✓</span>
+  runner  2  ·  golden 1  ·  <span class="t-red">unreachable 0</span>
+  configured  10 vCPUs · 20 GiB mem · 80 GiB storage
+  host usage  2.4 cores · 7.0 GiB · sparse 12 GiB
+  top consumers <span class="t-dim">(by memory pressure)</span>
+    <span class="t-blue">preloop-runner-0</span>  busy  1.8 cores · 4.0 GiB / 7.0 GiB  <span class="t-amber">57%</span>
+    <span class="t-blue">preloop-runner-1</span>  idle  0.2 cores · 0.9 GiB / 7.0 GiB  13%
+
+<span class="t-bold">Store</span>  <span class="t-dim">— sqlite · consecutive failures 0 · conn up</span>
+<span class="t-bold">Storage</span>  <span class="t-dim">— state dir 41 GiB free (42%)</span> · largest: vm_images 64 GiB · cache 2.0 GiB
+<span class="t-bold">GitHub</span>  <span class="t-dim">— configured · rate 4812/5000 (reset in 18m) · token 47m · cache 91/4 hits</span>
+<span class="t-bold">Debug</span>  <span class="t-dim">— active 1 · oldest 3m · audit cap 512 (evicted 0)</span>
+<span class="t-bold">Telemetry</span>  <span class="t-dim">— OTLP disabled · dropped 0</span>
+
+<span class="t-amber">▸ condition: queue_label_mismatch</span>  <span class="t-dim">—</span> job <span class="t-blue">abc123</span> requires <span class="t-cyan">runs-on: gpu</span> but no runner advertises it <span class="t-dim">(1 exemplar)</span>
+<span class="t-dim">  action: add a runner with that label or change runs-on</span>
+
+<span class="t-bold">Recent runs</span>  <span class="t-dim">— last 5</span>
+  <span class="t-green">✓</span> #42  push main  abc123  1.2m  <span class="t-dim">queued → in_progress → completed</span>
+  <span class="t-green">✓</span> #41  pull_request  def456  58s
+  <span class="t-amber">●</span> #43  schedule nightly  —  queued  <span class="t-dim">14s</span></div>
+    </div>
+    <p style="font-size:0.78rem; color:var(--text-muted); margin-top:0.4rem;">Human output omits healthy limits/tasks (all zero) and clean conditions. <code>--json</code> includes everything. One-line actions on every condition, bounded to five exemplars.</p>
+  </div>
+
+  <!-- JSON tab -->
+  <div class="tab-panel" data-panel="json">
+    <div class="json-viewer">
+      <div class="json-header"><span class="json-title">GET /api/v1/status — 200 · bearer required</span><span class="json-badge">schema v1 · snapshot_age 0.4s</span></div>
+      <div class="json-body">{
+&nbsp;&nbsp;<span class="jk">"schema_version"</span>: <span class="jn">1</span>,
+&nbsp;&nbsp;<span class="jk">"observed_at"</span>: <span class="js">"2026-08-20T11:30:42Z"</span>,
+&nbsp;&nbsp;<span class="jk">"snapshot_age_seconds"</span>: <span class="jn">0.4</span>,
+&nbsp;&nbsp;<span class="jk">"overall"</span>: <span class="js">"degraded"</span>,
+&nbsp;&nbsp;<span class="jk">"service"</span>: { <span class="jk">"version"</span>: <span class="js">"0.29.0"</span>, <span class="jk">"instance_id"</span>: <span class="js">"9f3a…c1"</span>, <span class="jk">"uptime_seconds"</span>: <span class="jn">8040</span> },
+&nbsp;&nbsp;<span class="jk">"jobs"</span>: { <span class="jk">"ready"</span>: <span class="jn">2</span>, <span class="jk">"claimable"</span>: <span class="jn">1</span>, <span class="jk">"unclaimable"</span>: <span class="jn">1</span>, <span class="jk">"oldest_ready_seconds"</span>: <span class="jn">14.2</span> },
+&nbsp;&nbsp;<span class="jk">"concurrency"</span>: { <span class="jk">"groups_active"</span>: <span class="jn">3</span>, <span class="jk">"deepest_group_pending"</span>: <span class="jn">4</span>, <span class="jk">"overflow_cancellations"</span>: <span class="jn">0</span> },
+&nbsp;&nbsp;<span class="jk">"scheduler"</span>: { <span class="jk">"enabled"</span>: <span class="jb">true</span>, <span class="jk">"schedules"</span>: <span class="jn">4</span>, <span class="jk">"late_fires"</span>: <span class="jn">0</span>, <span class="jk">"max_fire_delay_seconds"</span>: <span class="jn">2.1</span> },
+&nbsp;&nbsp;<span class="jk">"pool"</span>: { <span class="jk">"mode"</span>: <span class="js">"warm"</span>, <span class="jk">"desired"</span>: <span class="jn">2</span>, <span class="jk">"idle"</span>: <span class="jn">1</span>, <span class="jk">"busy"</span>: <span class="jn">1</span> },
+&nbsp;&nbsp;<span class="jk">"vms"</span>: {
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="jk">"source"</span>: <span class="js">"cgroup_v2"</span>, <span class="jk">"count"</span>: { <span class="jk">"runner"</span>: <span class="jn">2</span>, <span class="jk">"golden"</span>: <span class="jn">1</span> },
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="jk">"host_usage"</span>: { <span class="jk">"cpu_cores"</span>: <span class="jn">2.4</span>, <span class="jk">"memory_bytes"</span>: <span class="jn">7516192768</span> },
+&nbsp;&nbsp;&nbsp;&nbsp;<span class="jk">"capabilities"</span>: { <span class="jk">"cpu_throttling"</span>: <span class="jb">true</span>, <span class="jk">"host_oom_events"</span>: <span class="jb">true</span> }<span class="jc">, … 5 top consumers</span>
+&nbsp;&nbsp;},
+&nbsp;&nbsp;<span class="jk">"storage"</span>: { <span class="jk">"state_fs_free_bytes"</span>: <span class="jn">41231234560</span>, <span class="jk">"components"</span>: [<span class="jc">… 6 entries</span>] },
+&nbsp;&nbsp;<span class="jk">"limits"</span>: [{ <span class="jk">"limit"</span>: <span class="js">"LIVE_LOG_MAX_BYTES"</span>, <span class="jk">"value"</span>: <span class="jn">67108864</span>, <span class="jk">"dropped"</span>: <span class="jn">0</span>, <span class="jk">"rejected"</span>: <span class="jn">0</span> }<span class="jc">, … 8 more — all caps even at zero</span>],
+&nbsp;&nbsp;<span class="jk">"tasks"</span>: [{ <span class="jk">"name"</span>: <span class="js">"reaper"</span>, <span class="jk">"critical"</span>: <span class="jb">true</span>, <span class="jk">"heartbeat_age_seconds"</span>: <span class="jn">3.2</span>, <span class="jk">"state"</span>: <span class="js">"running"</span> }<span class="jc">, … 14 more</span>],
+&nbsp;&nbsp;<span class="jk">"github"</span>: { <span class="jk">"rate_limit"</span>: { <span class="jk">"remaining"</span>: <span class="jn">4812</span>, <span class="jk">"limit"</span>: <span class="jn">5000</span> }, <span class="jk">"installation_token_expires_in_seconds"</span>: <span class="jn">2841</span> },
+&nbsp;&nbsp;<span class="jk">"conditions"</span>: [{ <span class="jk">"code"</span>: <span class="js">"queue_label_mismatch"</span>, <span class="jk">"severity"</span>: <span class="js">"warn"</span>, <span class="jk">"exemplars"</span>: [<span class="jc">… ≤5, with run/job IDs</span>] }]
+}</div>
+    </div>
+    <div class="callout callout-blue"><div class="callout-title">Contract</div>Field names are frozen at schema v1. New fields are additive. <code>limits</code> and <code>tasks</code> are arrays of constant-named entries so the contract survives new caps/tasks. <code>preloop status --json</code> prints this body byte-for-byte — pipe-friendly for <code>jq</code>.</div>
+  </div>
+
+  <!-- Readyz tab -->
+  <div class="tab-panel" data-panel="readyz">
+    <div style="display:grid; grid-template-columns:1fr 1fr; gap:1rem;">
+      <div class="json-viewer" style="margin:0;"><div class="json-header"><span class="json-title">GET /readyz — 200</span><span class="json-badge" style="background:var(--green); color:white;">ready</span></div><div class="json-body">{<br>&nbsp;&nbsp;<span class="jk">"ready"</span>: <span class="jb">true</span>,<br>&nbsp;&nbsp;<span class="jk">"checks"</span>: {<br>&nbsp;&nbsp;&nbsp;&nbsp;<span class="jk">"state_sampler"</span>: <span class="js">"ok"</span>,<br>&nbsp;&nbsp;&nbsp;&nbsp;<span class="jk">"reaper"</span>: <span class="js">"ok"</span>,<br>&nbsp;&nbsp;&nbsp;&nbsp;<span class="jk">"scheduler_scan"</span>: <span class="js">"ok"</span>,<br>&nbsp;&nbsp;&nbsp;&nbsp;<span class="jk">"store_connection"</span>: <span class="js">"ok"</span><br>&nbsp;&nbsp;}<br>}</div></div>
+      <div class="json-viewer" style="margin:0;"><div class="json-header"><span class="json-title">GET /readyz — 503</span><span class="json-badge" style="background:var(--red); color:white;">not ready</span></div><div class="json-body">{<br>&nbsp;&nbsp;<span class="jk">"ready"</span>: <span class="jb">false</span>,<br>&nbsp;&nbsp;<span class="jk">"reason"</span>: <span class="js">"task_stale"</span>,<br>&nbsp;&nbsp;<span class="jk">"task"</span>: <span class="js">"scheduler_scan"</span>,<br>&nbsp;&nbsp;<span class="jk">"heartbeat_age_seconds"</span>: <span class="jn">38.4</span>,<br>&nbsp;&nbsp;<span class="jk">"hint"</span>: <span class="js">"schedule fires delayed — see /api/v1/status"</span><br>}</div></div>
+    </div>
+    <p style="font-size:0.78rem; color:var(--text-muted); margin-top:0.6rem;">Only the four critical heartbeats gate readiness. A stale non-critical task (e.g. snapshot GC) surfaces in <code>/api/v1/status</code> but still returns 200.</p>
+  </div>
+
+  <!-- Metrics tab -->
+  <div class="tab-panel" data-panel="metrics">
+    <div class="prom-block"><span class="pm-comment"># HELP preloop_job_queue_depth Jobs by queue kind</span>
+<span class="pm-comment"># TYPE preloop_job_queue_depth gauge</span>
+<span class="pm-name">preloop_job_queue_depth</span>{<span class="pm-label">queue="ready"</span>} 2
+<span class="pm-name">preloop_job_queue_depth</span>{<span class="pm-label">queue="concurrency_blocked"</span>} 1
+<span class="pm-name">preloop_concurrency_pending_depth</span> 4
+<span class="pm-name">preloop_scheduler_fire</span>{<span class="pm-label">outcome="fired"</span>} 12
+<span class="pm-name">preloop_scheduler_fire</span>{<span class="pm-label">outcome="skipped_overlapping"</span>} 1
+<span class="pm-name">preloop_limit_dropped</span>{<span class="pm-label">limit="LIVE_LOG_MAX_BYTES"</span>} 0
+<span class="pm-name">preloop_limit_rejected</span>{<span class="pm-label">limit="QUEUE_MAX_PENDING"</span>} 0
+<span class="pm-name">preloop_task_heartbeat_age</span>{<span class="pm-label">task="reaper"</span>} 3.2
+<span class="pm-name">preloop_vm_host_memory_usage</span>{<span class="pm-label">role="runner",source="cgroup_v2"</span>} 7516192768
+<span class="pm-name">preloop_github_rate_limit_remaining</span>{<span class="pm-label">resource="core"</span>} 4812
+<span class="pm-name">preloop_storage_fs_available</span>{<span class="pm-label">mount="state_dir"</span>} 41231234560
+<span class="pm-comment"># HELP http_server_request_duration API latency — matched route, never raw URI</span>
+<span class="pm-name">http_server_request_duration_bucket</span>{<span class="pm-label">method="POST",route="/api/v1/runs",surface="native",le="0.25"</span>} 42</div>
+    <div class="callout callout-purple"><div class="callout-title">Cardinality guard</div>A bounded set of metric names × finite label values. 1,000 distinct run/job/runner IDs must not increase series count — tested by driving 1,000 sentinels and asserting the Prometheus exposition is constant.</div>
+  </div>
+
+  <!-- Logs tab -->
+  <div class="tab-panel" data-panel="logs">
+    <div class="terminal" style="margin-top:0;">
+      <div class="terminal-header"><div class="terminal-dots"><span class="dot-r"></span><span class="dot-y"></span><span class="dot-g"></span></div><span class="terminal-title">journalctl -u preloop -o json | jq — structured logs (OTLP + stderr)</span></div>
+      <div class="terminal-body"><span class="t-dim">2026-08-20T11:30:42Z</span> <span class="t-green">INFO</span>  <span class="t-cyan">job.claimed</span>          run_id=<span class="t-blue">abc123</span> job_id=<span class="t-blue">job_7</span> runner_id=<span class="t-blue">42</span> duration_ms=<span class="t-amber">12</span>
+<span class="t-dim">2026-08-20T11:30:43Z</span> <span class="t-amber">WARN</span>  <span class="t-cyan">vm.host.memory.pressure</span>  machine=<span class="t-blue">preloop-runner-0</span> ratio=<span class="t-amber">0.92</span> current=<span class="t-amber">6.6GiB</span> limit=7.0GiB source=cgroup_v2
+<span class="t-dim">2026-08-20T11:30:44Z</span> <span class="t-amber">WARN</span>  <span class="t-cyan">limit.exceeded</span>           limit=<span class="t-amber">QUEUE_MAX_PENDING</span> value=100 rejected=<span class="t-amber">1</span>  <span class="t-dim"># concurrency group overflow</span>
+<span class="t-dim">2026-08-20T11:30:44Z</span> <span class="t-amber">WARN</span>  <span class="t-cyan">github.rate_limit.low</span>    resource=core remaining=<span class="t-amber">412</span> limit=5000 reset_in=847s
+<span class="t-dim">2026-08-20T11:30:45Z</span> <span class="t-green">INFO</span>  <span class="t-cyan">schedule.fired</span>           schedule=<span class="t-blue">nightly@04:00</span> delay_s=<span class="t-amber">1.8</span>  <span class="t-dim"># cron</span>
+<span class="t-dim">2026-08-20T11:30:46Z</span> <span class="t-red">ERROR</span> <span class="t-cyan">store.connection.lost</span>    backend=postgres  <span class="t-dim"># connection task exited</span>
+<span class="t-dim">2026-08-20T11:30:47Z</span> <span class="t-amber">WARN</span>  <span class="t-cyan">vm.unreachable</span>           machine=<span class="t-blue">preloop-golden-0</span> pid=18412 age=67s  <span class="t-dim"># vsock probe — stop forking from it</span></div>
+    </div>
+    <p style="font-size:0.78rem; color:var(--text-muted); margin-top:0.4rem;"><code>event.name</code> + stable fields on every line. Trace/span IDs provide correlation — no second UUID. Workflow step output never appears here.</p>
+  </div>
+</div>
+
+<!-- ════════════════════ SIGNAL CONTRACT ════════════════════ -->
+<h2 id="signal-contract">Signal Contract</h2>
+
+<h3>Resource attributes on every signal</h3>
+<div class="table-wrap"><table>
+  <thead><tr><th>Attribute</th><th>Value</th></tr></thead>
+  <tbody>
+    <tr><td class="mono">service.name</td><td><code>preloop</code> (overridable via <code>OTEL_SERVICE_NAME</code>)</td></tr>
+    <tr><td class="mono">service.version</td><td>crate version</td></tr>
+    <tr><td class="mono">service.instance.id</td><td>UUID per process start — not a substitute for distributed coordination</td></tr>
+    <tr><td class="mono">deployment.environment.name</td><td>only when supplied via <code>OTEL_RESOURCE_ATTRIBUTES</code></td></tr>
+  </tbody>
+</table></div>
+
+<h3>Metric attribute policy</h3>
+<p>Allowed values are bounded enums or finite route templates. Forbidden: IDs, repo/workflow/ref/SHA, <code>runs-on</code> values, cache keys, artifact names, raw URLs, error text, tokens.</p>
+<p>Three narrow exceptions — all compile-time-finite: <code>limit</code> (cap constant names), <code>task</code> (heartbeat registry names), <code>store</code> (storage component names). A cardinality test drives 1,000 distinct IDs through instrumentation and asserts a fixed series bound and no sentinel leakage.</p>
+
+<h3>Metrics catalog — highlights</h3>
+<p>Full catalog is 50+ instruments. Key additions since the first draft:</p>
+<div class="table-wrap"><table>
+  <thead><tr><th>Instrument</th><th>Type</th><th>Key attributes</th><th>Purpose</th></tr></thead>
+  <tbody>
+    <tr style="background:var(--amber-soft);"><td class="mono">preloop.limit.dropped</td><td>counter</td><td>limit</td><td>tail-drops, ring evictions</td></tr>
+    <tr style="background:var(--amber-soft);"><td class="mono">preloop.limit.rejected</td><td>counter</td><td>limit</td><td>queue-max overflows, body rejections</td></tr>
+    <tr style="background:var(--amber-soft);"><td class="mono">preloop.limit.value</td><td>gauge</td><td>limit</td><td>configured ceiling — alerts compare against it</td></tr>
+    <tr><td class="mono">preloop.task.heartbeat.age</td><td>gauge</td><td>task</td><td>dead-loop detector (generic)</td></tr>
+    <tr><td class="mono">preloop.task.exited</td><td>counter</td><td>task, outcome</td><td>background task termination</td></tr>
+    <tr><td class="mono">preloop.concurrency.decision</td><td>counter</td><td>queue mode, action</td><td>why a job was parked/cancelled</td></tr>
+    <tr><td class="mono">preloop.scheduler.fire</td><td>counter</td><td>outcome</td><td>did the cron actually run</td></tr>
+    <tr><td class="mono">preloop.scheduler.fire.delay</td><td>histogram</td><td>—</td><td>schedule slot → dispatch (buckets 1s–3600s)</td></tr>
+    <tr><td class="mono">preloop.github.rate_limit.remaining</td><td>gauge</td><td>resource</td><td>x-ratelimit-remaining</td></tr>
+    <tr><td class="mono">preloop.github.token.expires_in</td><td>gauge</td><td>kind</td><td>credential countdown</td></tr>
+    <tr><td class="mono">preloop.storage.bytes</td><td>gauge</td><td>store</td><td>per-component footprint</td></tr>
+    <tr><td class="mono">preloop.storage.fs.available</td><td>gauge</td><td>mount</td><td>authoritative free space</td></tr>
+    <tr><td class="mono">preloop.store.connection.up</td><td>gauge</td><td>backend</td><td>Postgres connection liveness</td></tr>
+    <tr><td class="mono">preloop.snapshot.cache</td><td>counter</td><td>outcome</td><td>git object serving</td></tr>
+    <tr><td class="mono">preloop.livelog.connections</td><td>updown</td><td>—</td><td>WebSocket connections (not a duration)</td></tr>
+  </tbody>
+</table></div>
+<div class="callout callout-amber"><div class="callout-title">New bucket view</div>Scheduler fire delay: 1, 5, 15, 30, 60, 300, 900, 3600 s. A cron job is not late at 10 ms resolution — reusing HTTP buckets would waste eight of eleven boundaries. <code>/ws/live-logs</code> is excluded from <code>http.server.request.duration</code> entirely.</div>
+
+<h3 id="vm-contract">VM telemetry contract</h3>
+<p>VM metrics are first-class Preloop telemetry — the embedded pool owns these processes. General node telemetry remains optional via an OTel Collector.</p>
+<div class="table-wrap"><table>
+  <thead><tr><th>Signal</th><th>Linux source</th><th>macOS / fallback</th><th>Meaning</th></tr></thead>
+  <tbody>
+    <tr><td>configured CPU/mem/storage</td><td>cached SmolVM <code>--json</code></td><td>same</td><td>requested capacity, not use</td></tr>
+    <tr><td>CPU time / cores</td><td><code>cpu.stat usage_usec</code></td><td>VMM process CPU</td><td>host CPU for the VM runtime</td></tr>
+    <tr><td>CPU throttling</td><td><code>cpu.stat</code> throttle fields</td><td>unavailable</td><td>cgroup quota pressure</td></tr>
+    <tr><td>host memory</td><td><code>memory.current</code></td><td>VMM RSS</td><td>host memory charged to the VMM</td></tr>
+    <tr><td>host PIDs</td><td><code>pids.current</code></td><td>unavailable</td><td>VMM/helper processes, not guest</td></tr>
+    <tr><td>sparse disk</td><td><code>st_blocks × 512</code></td><td>same</td><td>physical blocks for VM files</td></tr>
+    <tr><td>free disk</td><td><code>statvfs</code></td><td>same</td><td>authoritative pressure — per-VM blocks are diagnostic only</td></tr>
+  </tbody>
+</table></div>
+<div class="callout callout-teal">
+  <div class="callout-title">SmolVM floor v1.8.1 — stronger than first draft assumed</div>
+  <p><code>machine status --json</code> and <code>machine ls --json</code> emit the <strong>same object</strong> from one helper (<code>machine_status_json</code>). <code>state</code> is vsock-probed and includes <code>Unreachable</code> — “VMM PID alive, guest agent not answering.” Fleet sampling needs <strong>one</strong> <code>machine ls --json</code> per slow pass, not one subprocess per VM (and <code>SmolVmProvider::list</code> already parses it).</p>
+  <p style="margin-top:0.5rem;">A missing <code>vm-&lt;pid&gt;</code> cgroup leaf (SmolVM's supervisor creates it, not Preloop) degrades to the process fallback — never an error, capability reported false.</p>
+</div>
+<div class="condition-grid">
+  <span class="condition-chip critical">vm_unreachable</span>
+  <span class="condition-chip warn">vm_host_memory_pressure</span>
+  <span class="condition-chip warn">vm_host_cpu_throttled</span>
+  <span class="condition-chip critical">vm_host_oom_kill</span>
+  <span class="condition-chip warn">vm_sparse_disk_pressure</span>
+  <span class="condition-chip warn">vm_sampler_stale</span>
+  <span class="condition-chip">vm_sampler_unavailable</span>
+</div>
+
+<h3 id="log-catalog">Structured log catalog</h3>
+<div class="table-wrap"><table>
+  <thead><tr><th>Event</th><th>Level</th><th>Key fields</th></tr></thead>
+  <tbody>
+    <tr><td class="mono">job.concurrency.cancelled</td><td><span style="background:var(--amber-soft); padding:0.1em 0.4em; border-radius:3px; font-size:0.78em;">WARN</span></td><td>run/job ID, queue mode, <strong>hash</strong> of group key (never raw)</td></tr>
+    <tr><td class="mono">schedule.fired / skipped</td><td>INFO / WARN</td><td>schedule ID, delay, reason</td></tr>
+    <tr><td class="mono">task.exited</td><td>WARN / ERROR</td><td>registry name, outcome; ERROR if critical</td></tr>
+    <tr><td class="mono">limit.exceeded</td><td>WARN</td><td>limit name, value, drop/reject delta (rate-limited)</td></tr>
+    <tr><td class="mono">vm.unreachable / reachable</td><td>WARN / INFO</td><td>machine, PID, age since reachable</td></tr>
+    <tr><td class="mono">store.connection.lost</td><td>ERROR</td><td>backend — Postgres connection task died</td></tr>
+    <tr><td class="mono">storage.pressure</td><td>WARN</td><td>mount, free bytes/ratio, largest component</td></tr>
+    <tr><td class="mono">github.rate_limit.low</td><td>WARN</td><td>resource, remaining, reset_in</td></tr>
+    <tr><td class="mono">debug.audit.evicted</td><td>WARN</td><td>session ID, evicted count, cap 512</td></tr>
+  </tbody>
+</table></div>
+<div class="callout callout-red"><div class="callout-title">Hash, don't leak</div><code>job.concurrency.cancelled</code> logs a <strong>hash</strong> of the group key, never the raw key — the expression interpolates branch names and PR titles. The hash still correlates all jobs in one group without exporting user data.</div>
+
+<h3 id="trace-policy">Trace policy</h3>
+<p>Short synchronous spans, not one hours-long workflow trace. Correlate via <code>run.id / job.id / runner.id / machine.name</code> fields. Suppress successful health probes, renewals, and empty long-polls.</p>
+
+<!-- ════════════════════ SLOs ════════════════════ -->
+<h2 id="slos">SLOs &amp; Alerts</h2>
+<div class="table-wrap"><table>
+  <thead><tr><th>SLI</th><th>Initial objective</th><th>Denominator</th></tr></thead>
+  <tbody>
+    <tr><td>Control API / broker availability</td><td>99.9%</td><td>exclude 4xx + empty long-polls</td></tr>
+    <tr><td>Dispatch latency</td><td>99% within 30 s</td><td>only claimable jobs; preparation reported separately</td></tr>
+    <tr><td>Terminal propagation</td><td>99% within 30 s</td><td>job terminal → run final + check ack</td></tr>
+    <tr><td>Durable-state writes</td><td>no failure &gt; 5 m</td><td>all store ops</td></tr>
+    <tr><td>Runner liveness</td><td>no deaf session beyond bound</td><td>active sessions</td></tr>
+    <tr><td>VM telemetry freshness</td><td>no stale fast sample &gt; 3 intervals</td><td>owned VMs</td></tr>
+    <tr style="background:var(--amber-soft);"><td><strong>Scheduled-trigger fidelity</strong></td><td>99% within 60 s</td><td>excludes deliberate overlap skips</td></tr>
+    <tr style="background:var(--amber-soft);"><td><strong>Critical-task liveness</strong></td><td>no critical heartbeat stale &gt; 3 intervals</td><td>registry critical set</td></tr>
+    <tr style="background:var(--amber-soft);"><td><strong>Data retention honesty</strong></td><td>zero unreported drops</td><td>every drop must have a visible condition</td></tr>
+  </tbody>
+</table></div>
+<p style="font-size:0.82rem; color:var(--text-muted);">Instrument first, baseline two weeks, then ratify. Do not page on workflow failure rate — user code fails legitimately.</p>
+
+<div class="alert-grid">
+  <div class="alert-card alert-page"><span class="alert-icon">!</span><div><strong>Telemetry absent</strong><br><span style="color:var(--text-secondary);">no <code>preloop.service.uptime</code> for 5 m</span></div></div>
+  <div class="alert-card alert-page"><span class="alert-icon">!</span><div><strong>Dispatch stalled</strong><br><span style="color:var(--text-secondary);">claimable job exceeds baseline while idle capacity exists</span></div></div>
+  <div class="alert-card alert-warn"><span class="alert-icon">⚠</span><div><strong>Unclaimable queue</strong><br><span style="color:var(--text-secondary);">label mismatch vs no runner — distinguished</span></div></div>
+  <div class="alert-card alert-page"><span class="alert-icon">!</span><div><strong>Pool deficit</strong><br><span style="color:var(--text-secondary);">desired &gt; idle+busy+building+provisioning</span></div></div>
+  <div class="alert-card alert-page"><span class="alert-icon">!</span><div><strong>Runner deaf</strong><br><span style="color:var(--text-secondary);">max poll/lease age near timeout</span></div></div>
+  <div class="alert-card alert-page"><span class="alert-icon">!</span><div><strong>Store failing</strong><br><span style="color:var(--text-secondary);">consecutive failures or connection down</span></div></div>
+  <div class="alert-card alert-warn"><span class="alert-icon">⚠</span><div><strong>Schedule did not fire</strong><br><span style="color:var(--text-secondary);">slot passed, no <code>scheduler.fire</code> — invisible to queue alerts</span></div></div>
+  <div class="alert-card alert-warn"><span class="alert-icon">⚠</span><div><strong>Concurrency overflow</strong><br><span style="color:var(--text-secondary);">user job cancelled by <code>queue: max</code> policy</span></div></div>
+  <div class="alert-card alert-warn"><span class="alert-icon">⚠</span><div><strong>Data being dropped</strong><br><span style="color:var(--text-secondary);">any <code>limit.dropped/rejected</code> — page on audit eviction</span></div></div>
+  <div class="alert-card alert-page"><span class="alert-icon">!</span><div><strong>GitHub budget low</strong><br><span style="color:var(--text-secondary);">remaining/limit &lt; 10% or token near expiry</span></div></div>
+  <div class="alert-card alert-page"><span class="alert-icon">!</span><div><strong>VM unreachable</strong><br><span style="color:var(--text-secondary);">wedged golden — stop forking from it</span></div></div>
+  <div class="alert-card alert-warn"><span class="alert-icon">⚠</span><div><strong>VM pressure</strong><br><span style="color:var(--text-secondary);">memory / CPU throttle / disk / OOM</span></div></div>
+  <div class="alert-card alert-page"><span class="alert-icon">!</span><div><strong>Background task dead</strong><br><span style="color:var(--text-secondary);"><code>task.heartbeat.age</code> &gt; 3 intervals or <code>task.exited</code></span></div></div>
+  <div class="alert-card alert-warn"><span class="alert-icon">⚠</span><div><strong>Storage capacity</strong><br><span style="color:var(--text-secondary);">free space low + component growing past GC</span></div></div>
+</div>
+
+<!-- ════════════════════ DASHBOARD GALLERY ════════════════════ -->
+<h3 id="dashboards">Dashboard Gallery — Six Importable Boards</h3>
+<p style="font-size:0.88rem; color:var(--text-secondary);">Every panel maps 1:1 to a metric in the catalog. No dashboard-only derivations for state the server already knows. Sparklines below are illustrative — real boards query the same Prometheus/OTLP source.</p>
+
+<div class="dashboard-grid">
+
+  <!-- 1 Overview -->
+  <div class="dashboard-card">
+    <div class="dashboard-card-header"><h4>1 · Overview</h4><span class="dash-badge dash-badge-blue">always on</span></div>
+    <div class="dashboard-card-body">
+      <div class="mini-panels">
+        <div class="mini-panel"><div class="mini-panel-label">Service uptime</div><div class="mini-panel-value accent">2h 14m</div><div class="mini-panel-sub">no-data heartbeat</div><svg class="sparkline" viewBox="0 0 100 28"><path class="area" d="M0,20 L0,8 L20,10 L40,6 L60,9 L80,5 L100,7 L100,20 Z" fill="#0ea5e9"/><path d="M0,8 L20,10 L40,6 L60,9 L80,5 L100,7" stroke="#0ea5e9"/></svg></div>
+        <div class="mini-panel"><div class="mini-panel-label">API p99 latency</div><div class="mini-panel-value green">42 ms</div><div class="mini-panel-sub">native + broker</div><svg class="sparkline" viewBox="0 0 100 28"><path class="area" d="M0,20 L0,14 L20,12 L40,16 L60,11 L80,13 L100,8 L100,20 Z" fill="#10b981"/><path d="M0,14 L20,12 L40,16 L60,11 L80,13 L100,8" stroke="#10b981"/></svg></div>
+        <div class="mini-panel"><div class="mini-panel-label">Runs active</div><div class="mini-panel-value">3</div><div class="mini-panel-sub">queued 1 · in_progress 2</div><svg class="sparkline" viewBox="0 0 100 28"><path d="M0,18 L20,16 L40,20 L60,12 L80,14 L100,10" stroke="#0ea5e9"/></svg></div>
+        <div class="mini-panel"><div class="mini-panel-label">Conditions</div><div class="mini-panel-value amber">1 warn</div><div class="mini-panel-sub">queue_label_mismatch</div></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 2 Scheduling / Queue -->
+  <div class="dashboard-card">
+    <div class="dashboard-card-header"><h4>2 · Scheduling &amp; Queue</h4><span class="dash-badge dash-badge-amber">new</span></div>
+    <div class="dashboard-card-body">
+      <div class="mini-panels">
+        <div class="mini-panel"><div class="mini-panel-label">Queue depth by kind</div><div class="mini-panel-value">2 ready</div><div class="mini-panel-sub">blocked 1 · expanding 0</div><svg class="sparkline" viewBox="0 0 100 28"><path d="M0,18 L20,14 L40,16 L60,8 L80,12 L100,6" stroke="#f59e0b"/></svg></div>
+        <div class="mini-panel"><div class="mini-panel-label">Oldest ready</div><div class="mini-panel-value amber">14.2 s</div><div class="mini-panel-sub">claimability: label mismatch</div></div>
+        <div class="mini-panel"><div class="mini-panel-label">Concurrency — deepest pending</div><div class="mini-panel-value">4</div><div class="mini-panel-sub">groups active 3 · contended 1</div><svg class="sparkline" viewBox="0 0 100 28"><path d="M0,20 L20,18 L40,20 L60,16 L80,10 L100,14" stroke="#f59e0b"/></svg></div>
+        <div class="mini-panel"><div class="mini-panel-label">Scheduler fires</div><div class="mini-panel-value green">12 · 1 skipped</div><div class="mini-panel-sub">max delay 2.1 s</div><svg class="sparkline" viewBox="0 0 100 28"><path d="M0,16 L20,8 L40,12 L60,6 L80,10 L100,4" stroke="#10b981"/></svg></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 3 Runners / Pool -->
+  <div class="dashboard-card">
+    <div class="dashboard-card-header"><h4>3 · Runners &amp; Pool</h4><span class="dash-badge dash-badge-green">capacity</span></div>
+    <div class="dashboard-card-body">
+      <div class="mini-panels">
+        <div class="mini-panel"><div class="mini-panel-label">Runners</div><div class="mini-panel-value">2 reg</div><div class="mini-panel-sub">idle 1 · busy 1 · stale 0</div><svg class="sparkline" viewBox="0 0 100 28"><path d="M0,16 L20,14 L40,12 L60,14 L80,12 L100,12" stroke="#10b981"/></svg></div>
+        <div class="mini-panel"><div class="mini-panel-label">Pool desired vs actual</div><div class="mini-panel-value">2 / 2</div><div class="mini-panel-sub">building 0 · provisioning 0</div><svg class="sparkline" viewBox="0 0 100 28"><path d="M0,12 L20,10 L40,14 L60,8 L80,10 L100,10" stroke="#10b981"/></svg></div>
+        <div class="mini-panel"><div class="mini-panel-label">Max poll age</div><div class="mini-panel-value green">3.1 s</div><div class="mini-panel-sub">max lease 8.0 s</div></div>
+        <div class="mini-panel"><div class="mini-panel-label">Session transitions</div><div class="mini-panel-value">—</div><div class="mini-panel-sub">create / delete / reap</div><svg class="sparkline" viewBox="0 0 100 28"><path d="M0,20 L20,18 L40,10 L60,14 L80,8 L100,12" stroke="#8b5cf6"/></svg></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 4 VM Host Resources -->
+  <div class="dashboard-card">
+    <div class="dashboard-card-header"><h4>4 · VM Host Resources</h4><span class="dash-badge dash-badge-amber">host-observed</span></div>
+    <div class="dashboard-card-body">
+      <div class="mini-panels">
+        <div class="mini-panel"><div class="mini-panel-label">Fleet</div><div class="mini-panel-value">3 VMs</div><div class="mini-panel-sub">runner 2 · golden 1 · unreachable 0</div></div>
+        <div class="mini-panel"><div class="mini-panel-label">Host CPU</div><div class="mini-panel-value">2.4 cores</div><div class="mini-panel-sub">of 10 vCPUs configured</div><svg class="sparkline" viewBox="0 0 100 28"><path class="area" d="M0,20 L0,12 L20,14 L40,8 L60,10 L80,6 L100,9 L100,20 Z" fill="#f59e0b"/><path d="M0,12 L20,14 L40,8 L60,10 L80,6 L100,9" stroke="#f59e0b"/></svg></div>
+        <div class="mini-panel"><div class="mini-panel-label">Host memory</div><div class="mini-panel-value amber">7.0 GiB</div><div class="mini-panel-sub">pressure events 0 · OOM 0</div><svg class="sparkline" viewBox="0 0 100 28"><path d="M0,14 L20,12 L40,15 L60,10 L80,12 L100,16" stroke="#f59e0b"/></svg></div>
+        <div class="mini-panel"><div class="mini-panel-label">Sparse disk</div><div class="mini-panel-value">12 GiB</div><div class="mini-panel-sub">free 41 GiB (42%) · capability ✓</div><svg class="sparkline" viewBox="0 0 100 28"><path d="M0,16 L20,14 L40,12 L60,10 L80,8 L100,6" stroke="#f59e0b"/></svg></div>
+      </div>
+      <div style="margin-top:0.6rem; font-family:var(--font-display); font-size:0.62rem; color:var(--text-muted); text-align:center; letter-spacing:0.04em;">Top consumers (authenticated <code>/api/v1/status</code> only — never metric labels)</div>
+    </div>
+  </div>
+
+  <!-- 5 Dependencies / Telemetry -->
+  <div class="dashboard-card">
+    <div class="dashboard-card-header"><h4>5 · Dependencies &amp; Telemetry</h4><span class="dash-badge dash-badge-purple">budget</span></div>
+    <div class="dashboard-card-body">
+      <div class="mini-panels">
+        <div class="mini-panel"><div class="mini-panel-label">GitHub rate limit</div><div class="mini-panel-value green">4812 / 5000</div><div class="mini-panel-sub">reset in 18 m · token 47 m</div><svg class="sparkline" viewBox="0 0 100 28"><path d="M0,6 L20,8 L40,10 L60,12 L80,14 L100,16" stroke="#8b5cf6"/></svg></div>
+        <div class="mini-panel"><div class="mini-panel-label">Token cache hit rate</div><div class="mini-panel-value green">96%</div><div class="mini-panel-sub">91 hits · 4 misses · TTL 60s</div></div>
+        <div class="mini-panel"><div class="mini-panel-label">Store</div><div class="mini-panel-value green">sqlite · 0 fail</div><div class="mini-panel-sub">conn up · WAL ckpt 128</div></div>
+        <div class="mini-panel"><div class="mini-panel-label">Telemetry export</div><div class="mini-panel-value">disabled</div><div class="mini-panel-sub">dropped 0 · OTLP opt-in</div></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 6 Limits & Tasks -->
+  <div class="dashboard-card" style="border-color: oklch(82% 0.04 25);">
+    <div class="dashboard-card-header"><h4>6 · Limits &amp; Background Tasks</h4><span class="dash-badge dash-badge-red">new</span></div>
+    <div class="dashboard-card-body">
+      <div class="mini-panels">
+        <div class="mini-panel" style="border-color: oklch(82% 0.04 155);"><div class="mini-panel-label">Caps registered</div><div class="mini-panel-value">9</div><div class="mini-panel-sub">all at 0 drops — clean</div></div>
+        <div class="mini-panel"><div class="mini-panel-label">Largest drop source</div><div class="mini-panel-value green">— none —</div><div class="mini-panel-sub">last drop: —</div></div>
+        <div class="mini-panel"><div class="mini-panel-label">Critical heartbeats</div><div class="mini-panel-value green">4 / 4 ok</div><div class="mini-panel-sub">sampler · reaper · scheduler · store</div><svg class="sparkline" viewBox="0 0 100 28"><path d="M0,12 L20,10 L40,12 L60,10 L80,10 L100,10" stroke="#10b981"/></svg></div>
+        <div class="mini-panel"><div class="mini-panel-label">All tasks</div><div class="mini-panel-value">15</div><div class="mini-panel-sub">11 non-critical · all running</div></div>
+      </div>
+      <div style="margin-top:0.6rem; font-family:var(--font-display); font-size:0.62rem; color:var(--text-muted); text-align:center;">Invariants 14 &amp; 15 — a new cap or spawn without a counter/heartbeat is a review failure.</div>
+    </div>
+  </div>
+
+</div>
+
+<!-- ════════════════════ OPENOBSERVE ════════════════════ -->
+<h2 id="openobserve">OpenObserve Evaluation</h2>
+<p>Verdict: use OpenObserve as the documented, optional “batteries available” backend. Do not make it a runtime dependency, embed it, or shape signals around its fields.</p>
+<div class="table-wrap"><table>
+  <thead><tr><th>Criterion</th><th>Assessment</th><th>Decision</th></tr></thead>
+  <tbody>
+    <tr><td>Minimal deployment</td><td>Good — single binary/container</td><td>Pinned compose, never auto-start</td></tr>
+    <tr><td>Unified signals</td><td>OTLP/HTTP + gRPC for logs/metrics/traces</td><td>Preloop does OTLP/HTTP first (no tonic)</td></tr>
+    <tr><td>Dashboards / alerts</td><td>Good</td><td>Six importable boards + 14 alerts</td></tr>
+    <tr><td>Storage</td><td>Another stateful volume</td><td>Short retention, persistent volume, backups</td></tr>
+    <tr><td>HA</td><td>Kubernetes + object store + PG + NATS + 5 roles</td><td>Not shipped; link upstream docs</td></tr>
+    <tr><td>Security</td><td>SSO/RBAC/audit are enterprise-only</td><td>Loopback by default, operator auth if shared</td></tr>
+    <tr><td>Licensing</td><td>AGPL-3.0</td><td>Separate process; legal review before bundling</td></tr>
+  </tbody>
+</table></div>
+<p style="font-size:0.84rem; color:var(--text-secondary);">Losing SQLite metadata makes the installation inoperable — persist and back up both metadata and stream data. Do not put the UI on the public webhook origin.</p>
+
+<!-- ════════════════════ CONFIG ════════════════════ -->
+<h2 id="config">Configuration Contract</h2>
+<p>One Preloop-specific setting: <code>PRELOOP_LOG_FORMAT=auto|pretty|json</code> (<code>auto</code> = TTY-aware, no ANSI in journald).</p>
+<p>Honor standard variables — do not invent backend-specific ones:</p>
+<div class="table-wrap"><table>
+  <thead><tr><th>Variable</th><th>Purpose</th></tr></thead>
+  <tbody>
+    <tr><td class="mono">RUST_LOG</td><td>filter (standalone server now gets the same <code>info</code> fallback as the CLI)</td></tr>
+    <tr><td class="mono">OTEL_SERVICE_NAME</td><td>overrides <code>service.name</code></td></tr>
+    <tr><td class="mono">OTEL_EXPORTER_OTLP_ENDPOINT</td><td>enables export — absent means <strong>disabled</strong> (deviation from spec default <code>localhost:4318</code>)</td></tr>
+    <tr><td class="mono">OTEL_EXPORTER_OTLP_PROTOCOL</td><td><code>http/protobuf</code> — only supported value in this plan</td></tr>
+    <tr><td class="mono">OTEL_TRACES/METRICS/LOGS_EXPORTER</td><td><code>none</code> disables the signal</td></tr>
+  </tbody>
+</table></div>
+<div class="callout callout-amber"><div class="callout-title">Spec deviation — document it</div>OTel's default endpoint is <code>http://localhost:4318</code>. Preloop treats an absent variable as disabled so a CI control plane does not emit background connection attempts. State this next to the variable list in <code>docs/observability.md</code>.</div>
+
+<!-- ════════════════════ SCOPE ════════════════════ -->
+<h2 id="scope">Scope</h2>
+<div style="display:grid; grid-template-columns:1fr 1fr; gap:1rem;">
+  <div>
+    <h4 style="margin-top:0; color:var(--green);">In scope</h4>
+    <ul style="font-size:0.82rem; padding-left:1.2rem;">
+      <li><code>Cargo.toml</code>, <code>versions.toml</code> (floor only if needed)</li>
+      <li>new <code>crates/preloop-observability</code></li>
+      <li>CLI + server + orchestrator + VM crates</li>
+      <li><code>docs/{architecture,self-hosting,cli_reference,observability}.md</code></li>
+      <li><code>contrib/openobserve/</code> — pinned compose + 6 boards</li>
+      <li>one <code>rules/</code> ast-grep guard</li>
+    </ul>
+  </div>
+  <div>
+    <h4 style="margin-top:0; color:var(--red);">Out of scope</h4>
+    <ul style="font-size:0.82rem; padding-left:1.2rem;">
+      <li>Runner protocol changes · guest export</li>
+      <li>Workflow step output export</li>
+      <li>OpenObserve HA · multi-server Preloop</li>
+      <li>eBPF / required Collector</li>
+      <li>Guest-kernel metrics until SmolVM exposes them</li>
+      <li>Per-machine metric labels · fake zeroes</li>
+      <li>A new web UI inside Preloop</li>
+    </ul>
+  </div>
+</div>
+
+<!-- ════════════════════ STEPS ════════════════════ -->
+<h2 id="steps">Implementation Steps — Seven PRs</h2>
+<p style="font-size:0.88rem; color:var(--text-secondary);">One commit per step. Keep protocol instrumentation separate from reference-backend assets.</p>
+
+<div class="step-timeline">
+  <div class="step-item">
+    <div class="step-line"><div class="step-dot">1</div><div class="step-connector"></div></div>
+    <div class="step-content"><h4>Freeze the signal/security contract and make existing logs safe</h4><p>Add <code>docs/observability.md</code>. Re-run the token/body grep and fix <strong>every</strong> hit (four moved between <code>84d92cfd</code> and <code>673bdfa0</code>). Add an ast-grep rule rejecting <code>token / authorization / cookie / headers / body / payload / signed_url</code> at INFO/WARN/ERROR. Audit all non-DEBUG macros.</p><span class="step-tag tag-security">security</span><span class="step-tag tag-docs">docs</span><p style="margin-top:0.4rem;"><code>just sg-scan-strict</code> + sentinel logging test — no sentinel appears, flow capture stays 0600.</p></div>
+  </div>
+  <div class="step-item">
+    <div class="step-line"><div class="step-dot">2</div><div class="step-connector"></div></div>
+    <div class="step-content"><h4>Add the observability crate and unify process initialization</h4><p>Workspace member <code>preloop-observability</code> at <code>opentelemetry 0.32 / tracing-opentelemetry 0.33 / prometheus 0.14 / sysinfo 0.39.6</code>. No-op / Prometheus-only / Prometheus+OTLP paths. <code>TaskHeartbeat</code> + <code>LimitRegistry</code> usable from the no-op handle. Fix standalone server's missing <code>info</code> fallback.</p><span class="step-tag tag-crate">crate</span><p style="margin-top:0.4rem;">No endpoint = no socket. Malformed endpoint never delays a request. Bounded queues, 2 s flush, sanitized <code>Debug</code>.</p></div>
+  </div>
+  <div class="step-item">
+    <div class="step-line"><div class="step-dot">3</div><div class="step-connector"></div></div>
+    <div class="step-content"><h4>Truthful liveness, readiness, aggregate status, and CLI output</h4><p>5 s sampler, <code>/readyz</code> gated on the four critical heartbeats, <code>/api/v1/status</code> + <code>/metrics</code> behind native bearer, consolidated <code>PoolStatus</code> replacing four ad-hoc handles. <code>preloop status --json</code> (copy <code>PlanArgs</code> shape) + 10-section human output.</p><span class="step-tag tag-api">api</span><span class="step-tag tag-crate">crate</span><p style="margin-top:0.4rem;">Health public/shallow; status/metrics 401 without bearer; claimability distinguishes absence / mismatch / preparing / provisioning.</p></div>
+  </div>
+  <div class="step-item">
+    <div class="step-line"><div class="step-dot">4</div><div class="step-connector"></div></div>
+    <div class="step-content"><h4>Instrument HTTP, runs/jobs, dispatch, runners, and the store</h4><p>Matched-route instrumentation, thirteen surfaces (WebSocket excluded from duration histogram), one <code>InstrumentedStore</code> wrapping <code>Arc&lt;dyn Store&gt;</code>, concurrency decisions + scheduler scan, Postgres connection liveness.</p><span class="step-tag tag-instrument">instrumentation</span><p style="margin-top:0.4rem;"><code>just conform-server-light</code> — no protocol diff. 1,000 IDs do not increase series.</p></div>
+  </div>
+  <div class="step-item">
+    <div class="step-line"><div class="step-dot">5</div><div class="step-connector"></div></div>
+    <div class="step-content"><h4>Instrument pool, VM resources, GitHub, webhook, cache/artifacts, and debug sessions</h4><p>Typed SmolVM inspection (<code>status --json</code> + <code>ls --json</code> fleet call), <code>MachineState::Unreachable</code>, 5 s / 60 s samplers, storage sampler, GitHub budget gauges, snapshot serving, ring-cap registrations.</p><span class="step-tag tag-vm">pool · vm · github</span><p style="margin-top:0.4rem;">Cgroup fixtures, PID-reuse safety, missing-leaf fallback, 1,000 ephemeral machines = constant series.</p></div>
+  </div>
+  <div class="step-item">
+    <div class="step-line"><div class="step-dot">6</div><div class="step-connector"></div></div>
+    <div class="step-content"><h4>Add the optional OpenObserve reference profile and assets</h4><p>Pinned compose (loopback, persistent volume, healthcheck, resource caps), six dashboards, 14 alerts. Measure resource caps — do not guess.</p><span class="step-tag tag-dash">compose · dashboards</span><p style="margin-top:0.4rem;"><code>just observability-openobserve-smoke</code> — one log, one metric, VM series, one trace queryable.</p></div>
+  </div>
+  <div class="step-item">
+    <div class="step-line"><div class="step-dot">7</div><div class="step-connector"></div></div>
+    <div class="step-content"><h4>Baseline, ratify alerts, document the incident workflow, and close the loop</h4><p>Two-week soak, tune buckets/thresholds, runbooks for every alert, architecture + self-hosting docs, <code>just test-ci && just conform-server-light && just dogfood</code>.</p><span class="step-tag tag-docs">docs · runbooks</span></div>
+  </div>
+</div>
+
+<!-- ════════════════════ TEST PLAN ════════════════════ -->
+<h2 id="test-plan">Test Plan</h2>
+<p>Permanent tests must defend observable contracts, not source text:</p>
+<div class="table-wrap"><table>
+  <thead><tr><th>#</th><th>Contract</th><th>How</th></tr></thead>
+  <tbody>
+    <tr><td>1</td><td>Disabled path</td><td>No OTEL endpoint → no DNS/socket, status/metrics still usable</td></tr>
+    <tr><td>2</td><td>Failure isolation</td><td>Malformed/down/slow/full/timeout never alters API result</td></tr>
+    <tr><td>3</td><td>Security</td><td>Sentinel tokens/headers/bodies never enter logs/traces/metrics</td></tr>
+    <tr><td>4</td><td>Cardinality</td><td>1,000 IDs → constant bounded series, no sentinel in exposition</td></tr>
+    <tr><td>5</td><td>HTTP semantics</td><td>Matched templates + finite surfaces; query values absent</td></tr>
+    <tr><td>6</td><td>Status</td><td>All queue/capacity/GitHub/debug states + auth + stale snapshot</td></tr>
+    <tr><td>7</td><td>Lifecycle exactness</td><td>Each terminal reason fires exactly once</td></tr>
+    <tr><td>8</td><td>Pool balance</td><td>No gauge leak on early return/cancellation</td></tr>
+    <tr><td>9</td><td>VM sampling</td><td>v1.8.1 JSON, cgroup fallback, PID reuse, sparse allocation</td></tr>
+    <tr><td>14</td><td>Limit honesty</td><td>Every cap driven past its ceiling → counter moves</td></tr>
+    <tr><td>15</td><td>Task liveness</td><td>Panicked/early-returned task reported; non-critical does not gate readiness</td></tr>
+  </tbody>
+</table></div>
+
+<!-- ════════════════════ DONE ════════════════════ -->
+<h2 id="done">Done Criteria</h2>
+<div class="callout callout-green"><div class="callout-title">All must hold before closing</div>
+<ul style="margin:0; padding-left:1.2rem; font-size:0.84rem;">
+  <li><code>preloop status</code> explains queue, capacity, runner freshness, and every condition names an action.</li>
+  <li><code>preloop status --json</code> returns schema v1 exactly — no prose.</li>
+  <li><code>/healthz</code> / <code>/readyz</code> / <code>/api/v1/status</code> / <code>/metrics</code> have specified auth/semantics.</li>
+  <li>No backend contacted when OTLP endpoint absent.</li>
+  <li>OTLP failure cannot block a request; shutdown flush ≤ 2 s.</li>
+  <li>Every cap registered — zero drops still reported — and every long-lived task has a heartbeat.</li>
+  <li>Scheduled workflows, concurrency overflow, GitHub budget, and storage capacity are visible.</li>
+  <li>Four ad-hoc <code>RunnerPoolConfig</code> handles gone, replaced by one <code>PoolStatus</code>.</li>
+  <li>VM <code>Unreachable</code> state honored end-to-end.</li>
+  <li>Six dashboards + 14 alerts import and query real fields.</li>
+  <li><code>cargo fmt --all --check</code>, <code>just sg-scan-strict</code>, <code>just test-ci</code>, <code>just conform-server-light</code>, <code>just dogfood</code>, <code>just observability-openobserve-smoke</code> pass.</li>
+</ul>
+</div>
+
+<!-- ════════════════════ STOP ════════════════════ -->
+<h2 id="stop">Stop Conditions</h2>
+<div class="callout callout-red"><div class="callout-title">Stop and report — do not improvise</div>
+<ul style="margin:0; padding-left:1.2rem; font-size:0.84rem;">
+  <li>Instrumentation would change a runner wire response.</li>
+  <li>OTel crate versions cannot provide Prometheus + OTLP without a second instrument set.</li>
+  <li>An exporter performs I/O on the handler thread.</li>
+  <li>SmolVM floor lacks <code>status --json / ls --json / data-dir</code> or changes field semantics — including dropping the shared <code>machine_status_json</code> shape.</li>
+  <li>Adding <code>MachineState::Unreachable</code> would require changing pool scheduling behavior in the same PR.</li>
+  <li>PID start identity cannot be validated on a supported host.</li>
+  <li>A metric needs a user-controlled label.</li>
+  <li>Current code no longer has the named centralized boundaries.</li>
+  <li>Conformance or dogfood changes after instrumentation.</li>
+</ul>
+</div>
+
+<!-- ════════════════════ MAINTENANCE ════════════════════ -->
+<h2 id="maintenance">Maintenance Notes</h2>
+<ul style="font-size:0.88rem;">
+  <li>Signal names, units, label sets, status schema, condition codes, and termination reasons are public operational APIs — additive first, documented migration when not.</li>
+  <li>Every new cap/ring/truncation must register with <code>LimitRegistry</code> in the same PR. Every new <code>tokio::spawn</code> that outlives a request must register a <code>TaskHeartbeat</code>. Both are review checklist items.</li>
+  <li>Anchors rot fast — prefer the greps and symbol names over line numbers; re-run the drift check before each step.</li>
+  <li>VM names/docs must retain the <code>host</code> distinction: cgroup RSS/PIDs/OOM are VMM observations, not guest-kernel counters.</li>
+  <li>Keep OpenObserve digests and assets tested together. Preloop's OTLP contract must work with other vendors.</li>
+</ul>
+
+<hr class="section-divider">
+<p style="font-family:var(--font-display); font-size:0.78rem; color:var(--text-muted); text-align:center; margin-top:1.25rem;">
+  Plan 002 · <code>673bdfa0</code> · 2026-08-20 · <a href="https://github.com/preloopdev/preloop/blob/main/plans/002-observability-strategy.md">Markdown source</a> · <a href="https://github.com/preloopdev/preloop/blob/main/plans/README.md">Plans index</a>
+</p>
+
+</main>
+</div>
+
+<script>
+// TOC active link
+const tocLinks = document.querySelectorAll('.toc a[href^="#"]');
+const sections = [...tocLinks].map(a => document.querySelector(a.getAttribute('href'))).filter(Boolean);
+const observer = new IntersectionObserver(entries => {
+  entries.forEach(e => {
+    if (e.isIntersecting) {
+      tocLinks.forEach(a => a.classList.remove('active'));
+      const active = document.querySelector(`.toc a[href="#${e.target.id}"]`);
+      if (active) active.classList.add('active');
+    }
+  });
+}, { rootMargin: '-20% 0px -70% 0px', threshold: 0 });
+sections.forEach(s => observer.observe(s));
+
+// Tabs
+document.querySelectorAll('.tabs').forEach(tabs => {
+  const btns = tabs.querySelectorAll('[role="tab"]');
+  const panels = tabs.querySelectorAll('.tab-panel');
+  btns.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const tab = btn.dataset.tab;
+      btns.forEach(b => b.classList.toggle('active', b === btn));
+      panels.forEach(p => p.classList.toggle('active', p.dataset.panel === tab));
+    });
+  });
+});
+</script>
+</body>
+</html>

--- a/plans/002-observability-strategy.md
+++ b/plans/002-observability-strategy.md
@@ -1,0 +1,1841 @@
+# Plan 002: Make Preloop observable without making a backend mandatory
+
+> **Executor instructions**: Implement this plan as the ordered PR-sized steps below. Run every
+> verification command and confirm the expected result before moving to the next step. Preserve the
+> official runner wire exactly. If a STOP condition occurs, stop and report it instead of improvising.
+>
+> **Drift check (run first)**:
+>
+> ```sh
+> git diff --stat 673bdfa0..HEAD -- \
+>   Cargo.toml Cargo.lock \
+>   crates/preloop-observability crates/preloop-cli crates/preloop-runner-server \
+>   crates/preloop-orchestrator crates/preloop-vm crates/preloop-runner \
+>   docs contrib/openobserve scripts rules justfile versions.toml CHANGELOG.md
+> ```
+>
+> If any in-scope file changed since this plan was written, compare the current-state excerpts and
+> named symbols below with live code. A semantic mismatch is a STOP condition.
+
+## Status
+
+- **Priority**: P1
+- **Effort**: L, split into seven independently reviewable changes
+- **Risk**: MED; the HTTP and runner lifecycle paths are protocol-critical, while telemetry must be fail-open
+- **Depends on**: none
+- **Category**: direction, architecture, operations, security, DX
+- **Planned at**: commit `84d92cfd`, 2026-08-17
+- **Revised at**: commit `673bdfa0`, 2026-08-20. Every current-state excerpt, file:line anchor, and
+  external version claim below was re-verified against live code at that commit. The revision also
+  closed six coverage gaps the first draft missed: bounded-buffer/limit drops, the scheduled-workflow
+  subsystem, concurrency-group queueing, GitHub rate-limit budget, persistent-storage growth, and a
+  general background-task heartbeat registry (the first draft named only two loops out of fifteen).
+
+## Executive decision
+
+Build observability in three layers, in this order:
+
+1. **Zero-dependency operator diagnostics**: truthful liveness/readiness, an authenticated aggregate
+   status endpoint, `preloop status --json`, structured stderr/journald logs, and authenticated
+   Prometheus text at `/metrics`, including host-observed resource use for Preloop-owned microVMs.
+   These work with no sidecar and answer “why is this job not moving?” even when no telemetry backend
+   exists.
+2. **Vendor-neutral telemetry**: OpenTelemetry metrics, logs, and short-lived traces, exported through
+   bounded OTLP/HTTP batches only when standard `OTEL_*` configuration is present. Export failure must
+   never reject, delay, cancel, or change a workflow.
+3. **OpenObserve as an optional reference backend**: a pinned, private single-node deployment plus
+   importable dashboards and alerts. Preloop must neither embed OpenObserve nor require it. Any OTLP
+   backend remains interchangeable.
+
+OpenObserve is a good fit for the optional third layer: its single-node mode is one binary/container,
+uses SQLite plus local disk by default, accepts logs/metrics/traces over OTLP, and includes dashboards
+and standard alerts. It is not a sound architectural dependency and its HA mode is not minimal. Keep
+the product boundary at OTLP and Prometheus.
+
+The highest-priority deliverable is not a dashboard. It is `preloop status`: backend telemetry is
+least useful during exporter, network, credential, or storage failures, which are exactly when an
+operator needs a direct answer.
+
+## Why this matters
+
+Today Preloop can accept work while the pool repeatedly fails to provision, can leave an operator
+unable to distinguish “no compatible runner” from “runner has stopped polling,” and can report a
+healthy process while critical background behavior is degraded. The only built-in aggregate view is
+a recent-runs table. That makes incident diagnosis depend on manually correlating unstructured logs,
+HTTP endpoints, server state, and VM state.
+
+This plan makes every important control-plane question answerable:
+
+- Is the process alive and is its critical event loop making progress?
+- How many jobs are ready, dependency-blocked, concurrency-blocked, expanding, or unclaimable?
+- Is compatible capacity absent, preparing, provisioning, idle, busy, paused, or stale?
+- Are runners polling and renewing leases?
+- Are VM CPU, host memory, throttling, sparse-disk allocation, or runtime health limiting capacity?
+- Are durable-state writes and GitHub check updates succeeding?
+- Is telemetry itself exporting, dropping, or failing?
+- Which run/job/session/machine was involved, without putting identifiers into metric labels?
+
+## Current state
+
+### Logging is local, duplicated, and not export-ready
+
+`crates/preloop-cli/src/main.rs:743-745` initializes a plain formatting subscriber:
+
+```rust
+tracing_subscriber::fmt()
+    .with_env_filter(
+        tracing_subscriber::EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+    )
+    .init();
+```
+
+The standalone server (`crates/preloop-runner-server/src/main.rs:78-80`, which uses
+`EnvFilter::from_default_env()` and therefore has no `info` fallback) and the Rust runner
+(`crates/preloop-runner/src/main.rs:17-21`) each initialize their own subscriber. Three binaries,
+three slightly different filter defaults, no JSON selection, no OTLP pipeline, no metrics provider,
+no exporter-health state, and no coordinated flush.
+
+`tracing-subscriber` is already a workspace dependency at `0.3` with features
+`["env-filter", "json"]`, so `PRELOOP_LOG_FORMAT=json` needs a layer switch, not a new dependency.
+
+**Security gate**: current INFO/WARN events are unsafe to export unchanged:
+
+- `crates/preloop-runner-server/src/artifact_twirp.rs:94` —
+  `info!(token, name = request.name, "artifact v2 create")` logs an artifact upload capability token.
+- `crates/preloop-runner-server/src/results_twirp.rs:713` —
+  `info!(token, "cache v2 create entry")` logs a cache upload capability token.
+- `crates/preloop-runner-server/src/blob_store.rs:63, 78, 95, 113, 121, 127, 131` — seven
+  `warn!`/`info!` sites carry `kind, token` blob capability tokens.
+- `crates/preloop-runner-server/src/distributed_task.rs:327` —
+  `info!(?body, "agent_request_patch received")` logs the complete runner PATCH JSON body.
+- `crates/preloop-runner-server/src/recording.rs:1-90` deliberately records every header and both
+  bodies for conformance capture, including authorization material.
+
+Do not enable log export until the first four are removed or reduced to safe fields. Flow recording
+must remain an explicit local conformance facility, stored mode 0600, and must never pass through the
+normal logging/OTLP pipeline.
+
+The step-1 audit must be a scan, not a fixed list: the four sites above are the ones that exist at
+`673bdfa0`, and the churn between `84d92cfd` and `673bdfa0` moved three of them. Re-run the scan
+rather than trusting these anchors:
+
+```sh
+grep -rnE '(info|warn|error)!\(' crates/preloop-runner-server/src crates/preloop-orchestrator/src \
+  | grep -E '\b(token|authorization|cookie|headers|body|payload|signed_url|secret|password)\b'
+```
+
+### Health and status do not diagnose the control plane
+
+`crates/preloop-runner-server/src/runs.rs:4-9` always returns `ok: true`:
+
+```rust
+pub(crate) async fn healthz(State(shared): State<Arc<SharedState>>) -> Json<serde_json::Value> {
+    Json(json!({
+        "ok": true,
+        "protocol_version": PROTOCOL_VERSION,
+        "shutdown_requested": shared.shutdown.is_cancelled(),
+    }))
+}
+```
+
+The router exposes only `GET /healthz` for health and installs
+`TraceLayer::new_for_http()` at `crates/preloop-runner-server/src/routes.rs:805`. The default trace
+span records the request URI; exporting it would leak query strings and create unbounded URI values.
+Use Axum's matched route template, never raw URI/path-and-query, in telemetry. There is no
+`/readyz`, no `/metrics`, and no Prometheus dependency anywhere in the workspace today; `/healthz`
+at `routes.rs:256` is the only health surface.
+
+`preloop status` at `crates/preloop-cli/src/main.rs:2831` calls only
+`GET /api/v1/runs?limit=20` and renders recent runs. The native runner API can already report queued
+versus claimable work for a run (`runner_lifecycle.rs:145-164`), but there is no one-call operational
+snapshot. `wait_for_engine_socket` (`crates/preloop-cli/src/main.rs:1458-1475`) probes
+`http://localhost/healthz` with a 500 ms per-attempt timeout over a 30 s window, so CLI startup
+currently treats "process accepts connections" as "server is usable".
+
+`Command::Status` is a unit variant. The repository already has a `--json` convention to copy:
+`PlanArgs { #[arg(long)] json: bool }` at `crates/preloop-cli/src/main.rs:706-707`.
+
+### The state needed for useful diagnostics already exists
+
+`AppState` (`crates/preloop-runner-server/src/state.rs:358-503`) and `InnerState`
+(`state.rs:1067-1153`) already contain:
+
+- ready, dependency-held, concurrency-blocked, and expansion queues;
+  `pending_jobs`, `pending_expansions`, `expanding`, `queued_at`;
+- registered runners, sessions, last-poll timestamps, claims, active requests, and leases;
+  `session_last_seen`, `runner_liveness_timeout`, `inflight_messages`, `broker_messages`,
+  `claimed_jobs`, `cancellation_queue`;
+- pool assignment/provision reservations and the `queue_depth` / `pool_preparing` atomics;
+  `job_assignments`, `pool_pending`, `pool_proven_runners`, `pool_assignments_enabled`,
+  `require_job_assignments`;
+- debug sessions and scheduler state, plus the GitHub App surface added since the first draft:
+  `github_app`, `github_apps`, `dispatch_token_cache`, `dispatch_actor_cache`, `github_pat`,
+  `github_urls`, `pr_config`, `action_sha_cache`, `pending_registrations`, `secrets`.
+
+`AppState::emit` (`state.rs:819`, lock released at `state.rs:827-832`) deliberately releases the state lock before persistence,
+logs store failure, and broadcasts regardless. In-memory state is authoritative; the database is a
+restart source. `docs/architecture.md:39-56` explicitly says two servers sharing SQLite or Postgres
+still diverge. Every signal must include `service.instance.id`; this plan does not imply Preloop HA.
+
+Core lifecycle boundaries are centralized enough to instrument without scattering counters:
+
+- session create/delete: `broker.rs:368-410`;
+- broker polling, claim, acquire, renew, and complete: `broker.rs:637-1202`;
+- restart orphan reconciliation: `broker.rs:959-975`;
+- no-matching-runner, job timeout, expired lease, and deaf-runner reaping: the reaper loop at
+  `bootstrap.rs:396-410`, which ticks on a 10-second `tokio::time::interval`;
+- store abstraction: the private `Store` trait at `store.rs:33-55`, declared `#[async_trait]` and
+  `pub(crate) trait Store: Send + Sync` with exactly seven methods — `load_into`, `store_inner`,
+  `store_meta_only`, `store_run_event`, `store_workflow_run_counter`, `store_log_chunk`,
+  `append_event`.
+
+Instrument `Store` once with a decorator in `store.rs`; do not duplicate measurement in SQLite and
+Postgres implementations. The decorator is cheap because `#[async_trait]` already erases the futures
+and the trait is consumed as `Arc<dyn Store>` (`state.rs:360`), constructed in one factory at
+`store.rs:261-267`. Wrap the value that factory returns; no call site changes.
+
+`store_pg.rs:95-103` spawns a detached `tokio-postgres` connection task that logs one ERROR and exits
+if the connection dies. Every subsequent store call then fails. Instrument the connection task's
+liveness directly (`preloop.store.connection.up`), not only the per-operation failures it causes.
+
+### Embedded pool state is not visible to the server
+
+`RunnerPool::run` in `crates/preloop-orchestrator/src/lib.rs:1880-2100` owns its idle, building,
+provisioning, golden-registry, and slot state.
+
+`RunnerPoolConfig` does not merely expose "selected shared atomics" — it already carries **four
+independent ad-hoc shared handles** wired one at a time as needs arose:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `pending_jobs` | `Option<Arc<AtomicUsize>>` | queue depth pushed into the pool |
+| `preparing_signal` | `Option<Arc<AtomicBool>>` | golden/image warm state pushed out |
+| `next_job_runs_on` | `Option<Arc<RwLock<Vec<String>>>>` | label hint pushed into the pool |
+| `pending_registrations` | `Option<Arc<RwLock<BTreeMap<String, SystemTime>>>>` | in-flight registrations |
+
+Therefore the directive is **consolidation, not addition**: introduce one neutral `PoolStatus` handle
+in `preloop-observability`, move these four channels onto it, and delete the ad-hoc fields. Adding a
+fifth parallel channel beside four existing ones is a regression, and four `Option<Arc<…>>` fields
+that may each independently be `None` already make "what is the pool doing" unanswerable. Do not add a
+server-to-orchestrator dependency and do not make the status endpoint shell out to SmolVM.
+
+### VM resource telemetry has stable host-side inputs but no Preloop surface
+
+`VmProvider` in `crates/preloop-vm/src/lib.rs:290-331` exposes lifecycle plus `MachineState` only
+(`create`, `start`, `start_forkable`, `fork`, `stop`, `delete`, `status`, `list`, `exec`,
+`exec_with_secret_env`, `exec_stream`, `rearm_fork_base`, `copy`, `pack`).
+`SmolVmProvider::status` at `crates/preloop-vm/src/lib.rs:1018-1043` shells out to `smolvm machine status` and substring-
+matches lowercased human text, discarding the PID and configured resource data needed for telemetry:
+
+```rust
+let text = String::from_utf8_lossy(&output.stdout).to_ascii_lowercase();
+Ok(if text.contains("running") {
+    MachineState::Running
+} else if text.contains("stopped") {
+    MachineState::Stopped
+} else {
+    MachineState::Unknown
+})
+```
+
+The supported SmolVM floor is **`1.8.1`** (`versions.toml:8`, `smolvm_min_version`); the golden pin is
+`1.8.2` (`versions.toml:16`). The v1.8.1 contract is stronger than the first draft assumed:
+
+- `machine status --json` (`src/cli/machine.rs:3783-3789` → `vm_common::status_vm_json`) and
+  `machine ls --json` (`src/cli/machine.rs:3857-3862`) emit **the same per-machine object**, built by
+  one shared `machine_status_json` helper (`src/cli/vm_common.rs:2360-2412`) explicitly so "the two
+  outputs never drift apart".
+- Fields: `name`, `state`, `cpus`, `memory_mib`, `pid`, `mounts`, `ports`, `created_at`, `storage_gb`,
+  `overlay_gb`, `image`, `ephemeral`, `forkable`, `forkpoint_held`, `labels`, `restart_policy`,
+  `restart_max_retries`, `restart_count`, `health_cmd`, `health_interval_secs`, `health_timeout_secs`,
+  `health_retries`, `health_startup_grace_secs`, `network`, plus GPU/CUDA fields.
+- `state` is **not** the persisted record state. `machine_status_json` resolves it through
+  `agent::state_probe::resolve_state`, a vsock liveness probe that yields a distinct
+  **`Unreachable`** state when the record says `Running` and the VMM PID is alive but the guest agent
+  does not answer (`src/agent/state_probe.rs:6-76`). That is a first-class "the VM is wedged" signal
+  Preloop currently throws away by substring-matching for `running`.
+- `machine data-dir` is a public command (`src/cli/machine.rs:365, 4290-4310`) exposing the
+  hash-derived machine path; the JSON object does not carry it, so disk-path resolution still needs
+  this call.
+
+Because `machine ls --json` returns the identical object for every machine in one process, the fleet
+sampler needs **one subprocess per pass, not one per VM** — and Preloop already parses exactly this
+output today in `SmolVmProvider::list` (`crates/preloop-vm/src/lib.rs:1045-1060`). Use `machine ls
+--json` for periodic fleet inspection and `machine status --json` only for a single machine on a
+lifecycle/reconciliation path. Never call either from `/metrics` or `/api/v1/status`.
+
+On Linux, Preloop already establishes a delegated cgroup-v2 root and enables `cpu`, `memory`, and
+`pids` before the pool starts (`init_vm_cgroup_delegation`, `preloop-vm/src/lib.rs:1360` ff., and
+`preloop-cli/src/main.rs:1057-1067`). SmolVM's own supervisor then creates a capped per-VMM
+`vm-<pid>` leaf under that delegated root — this is upstream-documented behavior at the supported
+floor (`smolvm v1.8.1 src/process.rs:375-393`, `place_in_cgroup`), not a Preloop-side invariant, so a
+missing leaf must degrade to the process fallback rather than be treated as an error. Those
+host files provide CPU time/throttling, host memory current/limit/events, and VMM/helper PID counts.
+On macOS and cgroup-unavailable Linux, fall back to host process CPU time and RSS with PID-start-time
+validation.
+
+These are **host-observed VM/VMM metrics**, not guest-kernel metrics. Host RSS is not guest “memory
+used”; cgroup PID counts are VMM/helper processes, not processes inside the guest; host cgroup OOM
+events do not detect every guest-kernel OOM. Never run periodic commands inside the guest to fill the
+gap: that changes the workload being measured and can hang behind a sick guest.
+
+### Local and self-hosted topology is deliberately small
+
+`docs/self-hosting.md` defines `preloop serve` as one process containing the control plane and VM pool.
+The native API is bearer-authenticated and loopback/private by default; only the GitHub webhook needs
+a public route. The systemd unit captures stdout/stderr in journald. Therefore the default profile
+must add no process and must retain stderr/journald output even when OTLP is configured.
+
+### Six blind spots the first draft missed
+
+Re-auditing at `673bdfa0` found six classes of operator-visible state with no surface at all. They are
+not refinements of the sections above; each can independently make Preloop behave incorrectly in a way
+no log line, metric, or status field currently reports.
+
+#### 1. Bounded buffers and hard limits drop data silently
+
+Preloop enforces several caps. Most discard user-visible data with no counter and, in the worst cases,
+no log line at all:
+
+| Limit | Location | Value | Observable today? |
+|---|---|---|---|
+| per-job live-log retained bytes | `live_logs.rs:25` `DEFAULT_MAX_BYTES` | 64 MiB | **No.** Tail-drops oldest wrappers silently (`live_logs.rs:46`) |
+| oversized live-log batch | `live_logs.rs:250` | > per-job cap | WARN only, no counter |
+| `concurrency: queue max` pending holders | `concurrency.rs:255` `QUEUE_MAX_PENDING` | 100 | **No.** Overflow sets `cancel_arrival` and cancels a user's job (`concurrency.rs:281`) |
+| archived debug sessions | `debug_sessions.rs:64` `MAX_ARCHIVED_SESSIONS` | 64 | **No.** Ring eviction |
+| debug session events | `debug_sessions.rs:68` `MAX_SESSION_EVENTS` | 512 | **No.** Ring eviction |
+| debug session **audit** entries | `debug_sessions.rs:71` `MAX_SESSION_AUDIT` | 512 | **No.** Ring eviction — silent audit-trail loss |
+| completed debug operations | `debug_sessions.rs:74` `MAX_COMPLETED_OPS` | 256 | **No.** Ring eviction |
+| git request body | `snapshots.rs:20` `MAX_GIT_REQUEST_BYTES` | 16 MiB | Rejected, not counted |
+| reusable-workflow nesting | `remote_workflows.rs:6` `MAX_REUSABLE_WORKFLOW_DEPTH` | 4 | Rejected, not counted |
+
+A cap that silently discards data is worse than an outage: the operator sees a plausible but wrong
+answer. `queue max` overflow is the sharpest case — a user's job is cancelled by policy and nothing
+distinguishes that from any other cancellation. Silent audit eviction is a compliance problem, not a
+telemetry nicety.
+
+This plan therefore adds one bounded instrument family, `preloop.limit.*`, whose `limit` attribute is
+the **constant's name** (a compile-time-finite set), never a value or an identifier. Every constant in
+the table above must be registered through it, and any future cap must be added with it.
+
+#### 2. Scheduled workflows have a history endpoint and no telemetry
+
+`scheduler.rs` drives cron/scheduled workflows, spawns its scan from `bootstrap.rs:479` and
+`bootstrap.rs:485`, and exposes `GET /api/v1/scheduler/history` (`routes.rs:419`). Nothing reports
+whether a schedule fired, fired late, was skipped because the previous instance was still running, or
+silently stopped firing because the scan task died. "My nightly job did not run" is a first-order
+operator question with a zero-coverage answer today.
+
+#### 3. GitHub dependency budget is untracked
+
+`AppState` holds `dispatch_token_cache` and `dispatch_actor_cache` (60 s TTL,
+`dispatch_auth.rs:46, 49`), `action_sha_cache`, `github_pat`, and `github_app`/`github_apps`.
+`actions.rs:32` sets `ACTION_TICKET_TTL_SECS` to six hours; `oidc.rs:25` sets `TOKEN_TTL_SECS` to 300.
+Nothing reads `x-ratelimit-remaining`/`x-ratelimit-reset`, tracks installation-token expiry, or reports
+cache hit rate. GitHub secondary-rate-limit exhaustion is the single most common integration outage
+for a control plane of this shape, and it is currently indistinguishable from "GitHub is slow".
+
+#### 4. Persistent storage growth is unbounded and unreported
+
+Preloop writes to the state dir (`preloop.db` plus WAL, checkpointed every
+`store.rs:211` `WAL_CHECKPOINT_INTERVAL` = 128 commits), the cache and artifact stores, the run-log
+store, the snapshot object cache (`snapshots.rs:1187` `ObjectCache`, GC spawned at `snapshots.rs:1896`),
+replay results (pruned at `distributed_task.rs:895`), and VM images/overlays. Only the VM volume gets a
+free-space signal in the first draft. A full state-dir filesystem is a hard outage, and the first
+symptom today is a store write failure with no capacity context.
+
+Plan 001 owns cache quotas and eviction policy. Plan 002 owns the measurement contract: 001 must emit
+through the `preloop.storage.*` family defined here rather than inventing its own.
+
+#### 5. Fifteen background tasks, two proposed heartbeats
+
+The first draft made `/readyz` depend on "the state sampler and reaper heartbeats". The real inventory
+of long-lived tasks whose death is currently silent:
+
+| Task | Location | Cadence |
+|---|---|---|
+| reaper (timeouts, leases, deaf runners) | `bootstrap.rs:396-410` | 10 s interval |
+| scheduler scan | `bootstrap.rs:479`, `bootstrap.rs:485` | timer |
+| GitHub App event loop | `bootstrap.rs:497`, `bootstrap.rs:517` | event-driven |
+| shutdown/lifecycle supervisor | `bootstrap.rs:568` | event-driven |
+| listener accept loops (TCP + unix) | `bootstrap.rs:601, 615, 660, 679, 720` | per connection |
+| snapshot object-cache GC | `snapshots.rs:1896` | periodic |
+| replay-result prune | `distributed_task.rs:895` | periodic |
+| Postgres connection task | `store_pg.rs:95-103` | lifetime |
+| GitHub check dispatch | `github.rs:1064` | event-driven |
+| auto-PR gate | `github_pr.rs:397` | event-driven |
+| `RunnerPool::run` supervisor | `preloop-orchestrator/src/lib.rs:1880-2100` | loop |
+| guest pause watchers | `preloop-orchestrator/src/lib.rs:3027, 4395, 4450` | per VM |
+| pool run/watch tasks | `preloop-orchestrator/src/lib.rs:3367, 3532, 5854, 5875` | per operation |
+| key rotation | `preloop-orchestrator/src/keys.rs:74` | periodic |
+
+Hand-wiring two heartbeats and leaving twelve silent is the same failure mode this plan exists to fix.
+Replace the ad-hoc approach with one `TaskHeartbeat` registry in `preloop-observability`: a task
+registers a stable name at spawn, beats each iteration, and deregisters on clean exit. Readiness and
+status read the registry; a task that stops beating or panics is visible generically. Only the tasks
+marked "critical" in the registry gate `/readyz`, so an event-driven task idling is not a failure.
+
+#### 6. HTTP surfaces are wider than the first draft's classification
+
+`routes.rs` serves thirteen path families, not the eight the first draft enumerated: `/_apis`,
+`/broker`, `/runner`, `/runner/server`, `/api/v1`, `/twirp`, `/twirp-blob`, `/internal/test`,
+`/ws/live-logs`, `/snapshots`, `/.well-known`, `/oidc`, `/repos`, plus `/healthz`. Routers are
+assembled by merge (`routes.rs:39` `protected_apis`, `:209` `results_metadata`, `:233` `dispatch_api`,
+merged at `:349, 797, 799, 813`). Four middlewares carry the auth contract: `require_native_bearer`,
+`require_results_bearer`, `require_job_runtime_bearer`, and `resolve_runner_identity`, with
+`auth.rs::runner_surface_only` layered only on the unix router.
+
+Two of these need different treatment from a request-duration histogram:
+
+- `/ws/live-logs` is a long-lived WebSocket. A duration histogram over its lifetime measures nothing
+  useful and pollutes the latency SLI. Use a connection gauge plus a close-reason counter.
+- `/snapshots` and `/repos` serve git objects to VMs. These are the path by which workflow source
+  reaches a job; a failure here fails every job with a misleading in-workflow error.
+
+## Architecture and invariants
+
+```mermaid
+flowchart LR
+    CLI[preloop status] -->|native bearer| STATUS[/api/v1/status]
+    PROBE[systemd / operator probes] --> LIVE[/healthz + /readyz]
+    PROM[Prometheus-compatible scraper] -->|native bearer| METRICS[/metrics]
+
+    SERVER[Control plane] --> OBS[preloop-observability]
+    POOL[Runner pool] --> OBS
+    VMHOST[Host VM sampler: cgroup/process/sparse disk] --> OBS
+    OBS --> STDERR[stderr / journald]
+    OBS --> METRICS
+    OBS -. optional bounded OTLP/HTTP .-> O2[OpenObserve or any OTLP backend]
+    COLLECTOR[Optional OTel Collector for host telemetry] -.-> O2
+
+    SERVER --> RUNLOGS[Existing workflow run-log store]
+    CAPTURE[Explicit protocol flow capture] --> LOCALFILE[Local 0600 capture file]
+```
+
+### New crate
+
+Create `crates/preloop-observability` with a small, explicit API and no dependency on server or
+orchestrator internals:
+
+- `ObservabilityConfig::from_env()` parses logging and standard OTel configuration without exposing
+  header values in `Debug` or errors.
+- `Observability::noop()` is allocation-light and makes unit tests and library-only consumers perform
+  no network I/O.
+- `Observability` is a cloneable handle containing pre-created instruments, the cached operational
+  snapshot, pool/VM-status handles, critical-task heartbeats, and telemetry-export health.
+- `TaskHeartbeat` registry: `register(name, criticality) -> HeartbeatHandle`, `beat()`,
+  `Drop` deregisters. Names come from a compile-time-finite set; readiness reads only entries marked
+  critical. This replaces per-task ad-hoc `AtomicU64` timestamps.
+- `LimitRegistry`: `record_drop(limit, count)` / `record_reject(limit)` where `limit` is a
+  `&'static str` constant name, backing the `preloop.limit.*` family and the status `limits` block.
+- `ObservabilityRuntime` owns subscriber/provider guards and performs bounded shutdown/flush.
+- `OperationalSnapshot`, `Condition`, `PoolSnapshot`, `VmFleetSnapshot`, `VmSample`, and their bounded
+  enums are serializable DTOs shared by server and CLI.
+- OpenTelemetry API/instrument types are always available; SDK, OTLP/HTTP, Prometheus, tracing bridge,
+  and formatting layers are host-only Cargo features. Disable default features on exporter crates and
+  do not pull the tonic/gRPC stack in the first implementation.
+
+Both `preloop` and standalone `preloop-server` construct one handle/runtime before building
+`ServerConfig`; the same handle is cloned into `AppState` and `RunnerPoolConfig`. The guest
+`preloop-runner` gets only the structured local logger and never exports directly by default.
+
+### Non-negotiable invariants
+
+1. **Fail open**: telemetry creation or export failure produces a sanitized warning and status
+   condition, never a failed request or process exit. It cannot change queue, runner, or run state.
+2. **No request-path export**: logs, metrics, and spans enqueue into bounded nonblocking SDK batches.
+   No handler awaits an exporter. Queue overflow drops telemetry and increments local drop health.
+3. **Bounded shutdown**: attempt flush for at most two seconds after server/pool shutdown. Then exit.
+4. **No backend by default**: absent explicit `OTEL_EXPORTER_OTLP_*` endpoint configuration, Preloop
+   opens no telemetry connection. Local metrics/status/logging still work. This is a **deliberate
+   deviation from the OTel specification**, whose default `OTEL_EXPORTER_OTLP_ENDPOINT` is
+   `http://localhost:4318`. Preloop treats an absent variable as "disabled", not "localhost", because
+   a CI control plane must not emit background connection attempts on an operator's machine. Document
+   the deviation in `docs/observability.md`; an operator who wants spec behavior sets the variable.
+5. **Always retain stderr**: OTLP augments, never replaces, terminal/journald logs.
+6. **No wire changes**: do not add fields, alter status codes, or change bodies on `/_apis`, `/broker`,
+   `/runner`, or Twirp/result-service routes. Instrument around existing behavior.
+7. **No high-cardinality metric attributes**: IDs and user-controlled strings are logs/traces only.
+8. **No workflow output export**: workflow stdout/stderr stays in the existing run-log store.
+9. **No raw HTTP capture**: do not collect headers, bodies, raw URI, query strings, or error text into
+   metrics. Trace attributes are allowlisted, not denylisted.
+10. **No state-lock callbacks**: OTel observable callbacks cannot await or lock `InnerState`. A periodic
+    async sampler updates a small cached snapshot; exporters read that snapshot.
+11. **No avoidable hot-path allocation**: instruments and attribute arrays are prebuilt where static;
+    poll/renew success is metrics-only and DEBUG-filtered, not an INFO log allocation.
+12. **No guest polling**: VM sampling reads host cgroup/process/filesystem state only. It never executes
+    `free`, `df`, `ps`, `dmesg`, or another command inside a runner VM.
+13. **No fake zeroes**: an unsupported or stale VM metric is absent and its capability is reported
+    unavailable. Zero means the source measured zero.
+14. **No silent drop**: any code path that discards, evicts, truncates, or rejects data because of a
+    cap MUST record it through `LimitRegistry`. A cap without a counter is a defect. This applies to
+    telemetry's own bounded queues as much as to live-log buffers and concurrency queues.
+15. **No unregistered long-lived task**: every `tokio::spawn` that outlives a request registers a
+    `TaskHeartbeat`. A background loop whose death is invisible is the failure this plan exists to
+    remove; the fifteen-task inventory above is the acceptance baseline, not an example list.
+
+## Operator surfaces
+
+### `/healthz`: liveness only
+
+Keep it unauthenticated and intentionally shallow. Return 200 while the process can serve requests and
+503 once shutdown begins. Response fields: schema version, `ok`, protocol version. It must not call
+SQLite/Postgres, GitHub, OpenObserve, SmolVM, or acquire `InnerState`.
+
+### `/readyz`: critical-loop readiness
+
+Keep it unauthenticated but reveal only boolean state and stable reason codes. Return 200 after durable
+state restoration and router startup, while every `TaskHeartbeat` marked critical is fresh and
+shutdown has not started. Return 503 for `starting`, `shutting_down`, or `task_stale` with the stale
+task's registry name as the reason code. The critical set is exactly: the state sampler, the reaper
+(`bootstrap.rs:396`), the scheduler scan (`bootstrap.rs:479`), and — when the backend is Postgres —
+the connection task (`store_pg.rs:95`). Everything else is reported in `/api/v1/status` but does not
+gate readiness.
+
+Reason codes are the registry names, so adding a critical task adds a code without a schema change.
+Non-critical task staleness must never return 503: an event-driven task with no events is healthy.
+
+Do **not** make readiness depend on runner capacity, GitHub reachability, store write success, workflow
+success, or telemetry export. This is a single-authoritative-process design; making a dependency
+failure fail readiness would hide the only control plane that can explain it and could create a
+restart loop. Rich degradation belongs in `/api/v1/status`.
+
+Change `wait_for_engine_socket` (`crates/preloop-cli/src/main.rs:1458-1475`) to probe `/readyz`, not
+`/healthz`. Keep its 500 ms per-attempt timeout and 30 s window; on window expiry, report the last
+`/readyz` reason code instead of a generic timeout, so "server started but the scheduler never came
+up" is distinguishable from "server never bound".
+
+### `/api/v1/status`: authenticated operational diagnosis
+
+Add an authenticated native endpoint returning a stable, versioned snapshot. It reads the most recent
+sampler snapshot without waiting on `InnerState` and reports `snapshot_age_seconds`; sampling every
+five seconds is sufficiently current and remains responsive when the state lock is the incident.
+Limit problem exemplars to five per condition.
+
+Required shape (field names may be Rust snake_case internally but the JSON contract is fixed):
+
+```json
+{
+  "schema_version": 1,
+  "observed_at": "RFC3339 timestamp",
+  "snapshot_age_seconds": 0.4,
+  "overall": "ok|degraded|blocked|shutting_down",
+  "service": {
+    "version": "0.x.y",
+    "instance_id": "uuid-per-process",
+    "uptime_seconds": 123,
+    "shutdown_requested": false
+  },
+  "runs": {"queued": 0, "in_progress": 1, "completed": 12},
+  "jobs": {
+    "ready": 2,
+    "dependency_blocked": 1,
+    "concurrency_blocked": 0,
+    "pending_expansion": 0,
+    "expanding": 0,
+    "claimable": 1,
+    "unclaimable": 1,
+    "oldest_ready_seconds": 14.2
+  },
+  "concurrency": {
+    "groups_active": 3,
+    "groups_contended": 1,
+    "pending_holders": 4,
+    "deepest_group_pending": 4,
+    "queue_max_pending": 100,
+    "overflow_cancellations": 0
+  },
+  "scheduler": {
+    "enabled": true,
+    "schedules": 4,
+    "last_scan_at": "RFC3339 timestamp",
+    "next_fire_at": "RFC3339 timestamp",
+    "fired": 12,
+    "skipped_overlapping": 1,
+    "late_fires": 0,
+    "max_fire_delay_seconds": 2.1
+  },
+  "runners": {
+    "registered": 2,
+    "sessions": 2,
+    "idle": 1,
+    "busy": 1,
+    "stale": 0,
+    "max_poll_age_seconds": 3.1,
+    "max_lease_age_seconds": 8.0
+  },
+  "pool": {
+    "mode": "warm|on_demand|external|disabled",
+    "desired": 2,
+    "preparing": false,
+    "building": 0,
+    "provisioning": 0,
+    "idle": 1,
+    "busy": 1,
+    "paused": 0,
+    "consecutive_provision_failures": 0,
+    "last_transition_at": "RFC3339 timestamp"
+  },
+  "vms": {
+    "source": "cgroup_v2|process|mixed|unavailable",
+    "sample_age_seconds": 1.2,
+    "capabilities": {
+      "cpu": true,
+      "memory": true,
+      "cpu_throttling": true,
+      "host_oom_events": true,
+      "host_pids": true,
+      "sparse_disk_allocation": true,
+      "block_io": false,
+      "network_io": false,
+      "guest_os": false
+    },
+    "count": {"runner": 2, "golden": 1, "unavailable": 0},
+    "configured": {
+      "vcpus": 10,
+      "memory_bytes": 21474836480,
+      "storage_bytes": 85899345920,
+      "overlay_bytes": 21474836480
+    },
+    "host_usage": {
+      "cpu_cores": 2.4,
+      "memory_bytes": 7516192768,
+      "sparse_disk_allocated_bytes": 12884901888
+    },
+    "top_consumers": [
+      {
+        "machine_name": "preloop-runner-0",
+        "role": "runner",
+        "activity": "busy",
+        "run_id": "authenticated-detail-only",
+        "job_id": "authenticated-detail-only",
+        "cpu_cores": 1.8,
+        "memory_bytes": 4294967296,
+        "memory_limit_bytes": 7516192768,
+        "sparse_disk_allocated_bytes": 5368709120,
+        "host_cpu_throttled_seconds": 0.0,
+        "host_oom_kills": 0,
+        "sample_age_seconds": 1.2
+      }
+    ]
+  },
+  "store": {
+    "backend": "sqlite|postgres",
+    "consecutive_failures": 0,
+    "last_success_at": "RFC3339 timestamp",
+    "last_failure_at": null
+  },
+  "github": {
+    "configured": true,
+    "last_webhook_at": "RFC3339 timestamp",
+    "pending_check_updates": 0,
+    "last_check_success_at": "RFC3339 timestamp",
+    "last_check_failure_at": null
+  },
+  "debug": {"active_sessions": 0, "oldest_session_seconds": null},
+  "storage": {
+    "state_dir": "/var/lib/preloop",
+    "state_fs_free_bytes": 41231234560,
+    "state_fs_free_ratio": 0.42,
+    "components": [
+      {"store": "database", "bytes": 184549376},
+      {"store": "cache", "bytes": 2147483648},
+      {"store": "artifacts", "bytes": 536870912},
+      {"store": "run_logs", "bytes": 268435456},
+      {"store": "snapshots", "bytes": 1073741824},
+      {"store": "vm_images", "bytes": 68719476736}
+    ],
+    "last_gc_at": "RFC3339 timestamp"
+  },
+  "limits": [
+    {
+      "limit": "LIVE_LOG_MAX_BYTES",
+      "value": 67108864,
+      "dropped": 0,
+      "rejected": 0,
+      "last_at": null
+    }
+  ],
+  "tasks": [
+    {
+      "name": "reaper",
+      "critical": true,
+      "heartbeat_age_seconds": 3.2,
+      "state": "running|idle|stale|exited"
+    }
+  ],
+  "telemetry": {
+    "otlp_enabled": false,
+    "last_export_success_at": null,
+    "last_export_failure_at": null,
+    "dropped_records": 0
+  },
+  "conditions": []
+}
+```
+
+The `github` block gains dependency-budget fields, which are the difference between "GitHub is slow"
+and "we are rate limited":
+
+```json
+"github": {
+  "configured": true,
+  "last_webhook_at": "RFC3339 timestamp",
+  "pending_check_updates": 0,
+  "last_check_success_at": "RFC3339 timestamp",
+  "last_check_failure_at": null,
+  "rate_limit": {
+    "resource": "core",
+    "limit": 5000,
+    "remaining": 4812,
+    "reset_at": "RFC3339 timestamp",
+    "observed_at": "RFC3339 timestamp"
+  },
+  "installation_token_expires_in_seconds": 2841,
+  "token_cache": {"hits": 91, "misses": 4, "ttl_seconds": 60}
+}
+```
+
+`limits` and `tasks` are arrays, not fixed objects, because both sets grow with the code. Each entry's
+`limit`/`name` is a compile-time constant identifier, so the array length stays bounded and the JSON
+contract does not change when a cap or task is added. `limits` reports every registered cap, including
+those with zero drops — an operator must be able to see the ceiling before hitting it.
+
+Conditions use stable codes and safe messages. Initial codes:
+
+- `state_sampler_stale`
+- `task_stale`
+- `task_exited`
+- `queue_no_registered_runner`
+- `queue_label_mismatch`
+- `concurrency_queue_overflow`
+- `concurrency_group_starved`
+- `scheduler_scan_stale`
+- `scheduler_fire_late`
+- `scheduler_skipped_overlapping`
+- `pool_preparing`
+- `pool_provisioning_deficit`
+- `pool_repeated_provision_failure`
+- `runner_poll_stale`
+- `runner_lease_stale`
+- `vm_sampler_stale`
+- `vm_sample_unavailable`
+- `vm_unreachable`
+- `vm_host_memory_pressure`
+- `vm_host_cpu_throttled`
+- `vm_host_oom_kill`
+- `vm_sparse_disk_pressure`
+- `store_write_failure`
+- `store_connection_down`
+- `storage_capacity_pressure`
+- `limit_drop_active`
+- `limit_reject_active`
+- `github_check_update_failure`
+- `github_terminal_check_pending`
+- `github_rate_limit_low`
+- `github_installation_token_expiring`
+- `debug_session_stale`
+- `debug_audit_evicted`
+- `telemetry_export_failure`
+
+Authenticated condition exemplars may contain run/job/runner/session/machine IDs and `runs-on` labels,
+but never tokens, environment values, request bodies, or URLs with query strings. Metrics must contain
+only the condition code, never the exemplar fields.
+
+### `preloop status`
+
+Change `Status` to `Status(StatusArgs)` with `--json`. Human output must show, in order:
+
+1. service and snapshot age;
+2. ready/blocked queue classes and oldest wait;
+3. concurrency-group contention and scheduler state;
+4. pool capacity and runner/session freshness;
+5. VM fleet capacity, current host usage, capability gaps, and bounded top consumers;
+6. store, storage capacity, GitHub budget, debug, and telemetry state;
+7. any limit with a nonzero drop/reject count (omit clean limits from human output; keep all of them
+   in `--json`);
+8. background tasks that are stale or exited (omit healthy ones from human output);
+9. typed conditions with one-line actions;
+10. the existing recent-runs table.
+
+`--json` prints the endpoint response exactly and no prose, so operators can use `jq` and monitoring
+scripts. Preserve native bearer behavior. Do not add a watch loop in this plan.
+
+Follow the existing flag convention (`PlanArgs { #[arg(long)] json: bool }`,
+`crates/preloop-cli/src/main.rs:706-707`) rather than inventing a new one.
+
+## Signal contract
+
+### Resource attributes on every exported signal
+
+- `service.name=preloop` (overridable only through standard `OTEL_SERVICE_NAME`)
+- `service.version=<preloop package version>`
+- `service.instance.id=<new UUID each process start>`
+- `deployment.environment.name` only when supplied through standard resource attributes
+- host/OS attributes only from an explicitly enabled resource detector
+
+Do not attach repository, workflow, branch, SHA, runner name, or machine name as a resource attribute.
+
+### Metric attribute policy
+
+Allowed metric values are bounded enums or finite route templates:
+
+- HTTP method, Axum matched route, protocol surface, status-code class;
+- execution state/conclusion and stable termination reason;
+- queue kind, dispatch outcome, pool mode/state, operation, backend, result;
+- VM role/activity/runtime state, host sample source, storage kind, capability, and stable sample error;
+- webhook/check/cache/artifact/debug operation and stable outcome.
+- `&'static str` constant names from a compile-time-finite set: `limit` (cap identifiers),
+  `task` (heartbeat registry names), `store` (storage component identifiers). These are code
+  identifiers, not data, so their cardinality is bounded by the source, not by traffic.
+
+Forbidden metric attributes:
+
+- run/job/request/runner/session/machine IDs;
+- repository/workflow/ref/SHA, `runs-on` label values, cache keys, artifact names;
+- raw URL/path/query, webhook delivery ID, GitHub installation ID;
+- error message/type text, filenames, user agent, IP address;
+- any token, header, body, secret, or environment value.
+
+Add a cardinality test that drives at least 1,000 distinct IDs/names through instrumentation, gathers
+the Prometheus registry, asserts a fixed upper bound on series count, and asserts none of the unique
+values occur in exposition text.
+
+### Metrics catalog
+
+Use seconds for durations and bytes for sizes. Histograms count observations; do not add duplicate
+request counters when histogram count answers the same question.
+
+| Instrument | Type | Required attributes | Purpose |
+|---|---|---|---|
+| `http.server.request.duration` | histogram | method, matched route, surface, status class | API latency/error rate using OTel HTTP semantics |
+| `http.server.active_requests` | up/down counter | method, matched route, surface | current HTTP concurrency |
+| `preloop.broker.poll` | counter | surface, outcome=`job|cancel|empty|error` | distinguish healthy empty long-polls from dispatch failures |
+| `preloop.run.active` | observable gauge | state | runs by current state |
+| `preloop.run.completed` | counter | conclusion, termination reason | terminal runs without user identifiers |
+| `preloop.run.duration` | histogram | conclusion | run wall time |
+| `preloop.job.active` | observable gauge | state | jobs by current state |
+| `preloop.job.completed` | counter | conclusion, termination reason | terminal jobs and bounded failure taxonomy |
+| `preloop.job.duration` | histogram | conclusion | execution time after claim |
+| `preloop.job.queue.depth` | observable gauge | queue kind | ready/dependency/concurrency/expansion depth |
+| `preloop.job.queue.oldest_age` | observable gauge | queue kind | detect stalls, not just depth |
+| `preloop.job.queue.wait` | histogram | outcome | ready-to-claim or terminal-unclaimed wait |
+| `preloop.job.claimability` | observable gauge | reason | claimable vs temporary/permanent unclaimability |
+| `preloop.concurrency.group.active` | observable gauge | state=`holding|pending` | concurrency-group occupancy without group names |
+| `preloop.concurrency.pending.depth` | observable gauge | none | deepest pending queue across groups |
+| `preloop.concurrency.decision` | counter | queue mode, action=`park|cancel_pending|cancel_arrival|admit` | why a job was parked or cancelled by `concurrency:` policy |
+| `preloop.scheduler.fire` | counter | outcome=`fired|skipped_overlapping|error` | did a schedule actually run |
+| `preloop.scheduler.fire.delay` | histogram | none | scheduled time to actual dispatch |
+| `preloop.scheduler.schedules` | observable gauge | none | registered schedule count |
+| `preloop.runner.count` | observable gauge | state=`registered|idle|busy|stale` | runner inventory |
+| `preloop.runner.session.count` | observable gauge | state | active sessions |
+| `preloop.runner.session.transition` | counter | operation, reason, outcome | create/delete/reap/reconcile lifecycle |
+| `preloop.runner.poll.max_age` | observable gauge | none | deaf-runner leading indicator |
+| `preloop.runner.lease.max_age` | observable gauge | none | expired-lease leading indicator |
+| `preloop.pool.runner.count` | observable gauge | mode, state=`desired|idle|busy|building|provisioning|paused` | capacity and deficit |
+| `preloop.pool.preparing` | observable gauge | mode | image/golden warm state |
+| `preloop.pool.operation.duration` | histogram | operation, outcome, reason | prepare/provision/register/assign/delete/replace |
+| `preloop.vm.count` | observable gauge | role, activity, runtime state, pool mode | active runner/golden VM inventory |
+| `preloop.vm.configured.vcpus` | observable gauge | role, pool mode | configured virtual CPU capacity |
+| `preloop.vm.configured.memory` | observable gauge | role, pool mode | configured guest-memory ceiling in bytes |
+| `preloop.vm.configured.storage` | observable gauge | role, storage kind=`root|overlay` | configured logical disk capacity in bytes |
+| `preloop.vm.host.cpu.time` | counter | role, pool mode | sampled host CPU seconds attributable to VMM cgroups/processes |
+| `preloop.vm.host.cpu.cores` | observable gauge | role, activity, pool mode | current host CPU-seconds/second, expressed as cores |
+| `preloop.vm.host.cpu.throttled_time` | counter | role, pool mode | Linux cgroup throttle seconds; absent elsewhere |
+| `preloop.vm.host.cpu.throttled_periods` | counter | role, pool mode | Linux cgroup throttled-period count; absent elsewhere |
+| `preloop.vm.host.memory.usage` | observable gauge | role, activity, source | current cgroup memory or process RSS in bytes |
+| `preloop.vm.host.memory.limit` | observable gauge | role, source | cgroup/configured host memory limit in bytes |
+| `preloop.vm.host.memory.events` | counter | role, event=`low|high|max|oom|oom_kill` | Linux host-cgroup events; not guest-kernel OOM |
+| `preloop.vm.host.pids.current` | observable gauge | role | Linux VMM/helper process count; not guest process count |
+| `preloop.vm.host.pids.limit` | observable gauge | role | Linux VMM/helper process limit |
+| `preloop.vm.host.pids.events` | counter | role, event=`max` | Linux host-cgroup PID-limit events |
+| `preloop.vm.sparse_disk.allocated` | observable gauge | role, storage kind | physically allocated host blocks for VM-private/shared files |
+| `preloop.vm.storage.available` | observable gauge | storage class=`smolvm_data|preloop_state` | authoritative free bytes on the filesystem holding VM state |
+| `preloop.vm.age.max` | observable gauge | role, activity | oldest active VM age for leaked-machine detection |
+| `preloop.vm.sampler.available` | observable gauge | capability, source | whether each VM signal can be measured on this host |
+| `preloop.vm.sampler.age` | observable gauge | source | age of the last successful fast sample |
+| `preloop.vm.sampler.errors` | counter | source, reason | bounded sampler failures such as permission, parse, PID reuse, process gone |
+| `preloop.store.operation.duration` | histogram | backend, operation, outcome | one decorator around all store methods |
+| `preloop.store.consecutive_failures` | observable gauge | backend | restart-durability risk |
+| `preloop.store.connection.up` | observable gauge | backend | Postgres connection task alive; SQLite always 1 |
+| `preloop.storage.bytes` | observable gauge | store=`database|cache|artifacts|run_logs|snapshots|vm_images` | persistent footprint per component |
+| `preloop.storage.fs.available` | observable gauge | mount=`state_dir|smolvm_data` | authoritative free bytes |
+| `preloop.storage.gc` | counter | store, outcome | eviction/prune passes; Plan 001 emits through this |
+| `preloop.limit.dropped` | counter | limit | records discarded by a cap (live-log tail-drop, ring eviction) |
+| `preloop.limit.rejected` | counter | limit | requests/arrivals refused by a cap (queue max, body size, nesting depth) |
+| `preloop.limit.value` | observable gauge | limit | the configured ceiling, so alerts compare against it without hardcoding |
+| `preloop.task.heartbeat.age` | observable gauge | task | seconds since last beat; the generic dead-loop detector |
+| `preloop.task.exited` | counter | task, outcome=`clean|error|panic` | background task termination |
+| `preloop.github.operation.duration` | histogram | operation, outcome | token/check/API dependencies |
+| `preloop.github.check.propagation_delay` | histogram | outcome | terminal run to GitHub acknowledgement |
+| `preloop.github.rate_limit.remaining` | observable gauge | resource | `x-ratelimit-remaining` from the last response |
+| `preloop.github.rate_limit.limit` | observable gauge | resource | `x-ratelimit-limit` |
+| `preloop.github.rate_limit.reset_in` | observable gauge | resource | seconds until the window resets |
+| `preloop.github.token.expires_in` | observable gauge | kind=`installation|oidc|action_ticket` | credential expiry countdown |
+| `preloop.github.token.cache` | counter | kind, outcome=`hit|miss|expired` | dispatch/actor/action-SHA cache effectiveness |
+| `preloop.webhook.duration` | histogram | event class, outcome, dedup outcome | webhook processing without delivery/repo labels |
+| `preloop.cache.operation.duration` | histogram | operation, outcome | cache behavior |
+| `preloop.cache.transfer.bytes` | counter | direction, outcome | payload volume |
+| `preloop.artifact.operation.duration` | histogram | operation, outcome | artifact behavior |
+| `preloop.artifact.transfer.bytes` | counter | direction, outcome | payload volume |
+| `preloop.debug.session.count` | observable gauge | state | active/paused/detached sessions |
+| `preloop.debug.session.duration` | histogram | terminal reason | leaked-session detection |
+| `preloop.snapshot.operation.duration` | histogram | operation, outcome | git object serving that feeds every job |
+| `preloop.snapshot.cache` | counter | outcome=`hit|miss|evicted` | snapshot object-cache effectiveness |
+| `preloop.livelog.connections` | up/down counter | none | open `/ws/live-logs` WebSockets; not a duration histogram |
+| `preloop.livelog.connection.closed` | counter | reason | WebSocket termination taxonomy |
+| `preloop.livelog.buffer.bytes` | observable gauge | none | retained live-log bytes against the 64 MiB per-job cap |
+| `preloop.telemetry.export` | counter | signal, outcome | exporter self-health, visible locally at `/metrics` |
+| `preloop.service.uptime` | observable gauge | none | no-data heartbeat and process continuity |
+
+Use explicit bucket views:
+
+- HTTP/store/GitHub: 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10 seconds.
+- queue wait: 0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, 300, 900 seconds.
+- pool preparation/provision: 1, 5, 10, 30, 60, 120, 300, 600 seconds.
+- scheduler fire delay: 1, 5, 15, 30, 60, 300, 900, 3600 seconds. A cron job is not late at 10 ms
+  resolution, and reusing the HTTP buckets would waste eight of eleven boundaries.
+
+`/ws/live-logs` is deliberately excluded from `http.server.request.duration`. A long-lived WebSocket
+would otherwise dominate the p99 and silently break the availability SLI's denominator.
+
+The five-second sampler captures counts and bounded condition exemplars under `InnerState` once, then
+releases the mutex before updating the shared snapshot. It must not copy log buffers, artifacts,
+cache bytes, full run records, or bodies.
+
+### VM telemetry contract
+
+VM metrics are first-class Preloop application telemetry because the embedded pool owns these
+processes and already knows their lifecycle/assignment. General node telemetry remains optional.
+
+#### Collection architecture
+
+1. Replace the human-text `VmProvider::status` contract with one typed inspection contract that all
+   provider implementations and test fakes implement. For SmolVM at the `1.8.1` floor:
+   - single machine on a lifecycle path (start/fork/adoption/reconciliation): `machine status --json`;
+   - whole fleet on the slow sampler pass: **one** `machine ls --json` call, which returns the
+     identical per-machine object for every machine (upstream `smolvm src/cli/vm_common.rs:2360`
+     builds both outputs from one helper). `SmolVmProvider::list`
+     (`crates/preloop-vm/src/lib.rs:1045-1060`) already parses this response —
+     extend it to a full `VmRuntimeInfo` instead of discarding everything but `name`.
+   - `machine data-dir` only when a disk path is needed; the JSON object does not carry it.
+
+   Parse into a versioned internal `VmRuntimeInfo` and cache machine role, configured resources
+   (`cpus`, `memory_mib`, `storage_gb`, `overlay_gb`), `pid`, process start identity, `created_at`,
+   `restart_count`, `ephemeral`, `forkable`/`forkpoint_held`, and relevant disk paths. Migrate every
+   status caller; leave no text-parser alias.
+
+   Map `state` faithfully, including **`Unreachable`**. SmolVM resolves `state` through a vsock
+   liveness probe (`src/agent/state_probe.rs:41-76`), so `Unreachable` means "record says Running,
+   VMM PID alive, guest agent not answering" — a wedged VM. Today's `text.contains("running")` cannot
+   even represent it. Surface it as `MachineState::Unreachable`, metric attribute
+   `runtime_state=unreachable`, and status condition `vm_unreachable`. A pool that keeps forking from
+   an unreachable golden is a real and currently invisible failure.
+2. Register/deregister that runtime info with a `VmTelemetryRegistry` owned by the runner pool and
+   exposed through the neutral observability handle. Paused debug VMs remain registered until they are
+   actually deleted.
+3. Run one host sampler task, not one task or CLI subprocess per VM. Fast cadence: five seconds for
+   process identity, CPU, memory, cgroup events, and PID counts. Slow cadence: 60 seconds for sparse
+   allocated blocks, filesystem capacity, and the single `machine ls --json` fleet reconciliation.
+   The fast path touches only host cgroup/proc files and spawns no subprocess at all.
+4. Validate PID start identity on every fast sample. PID reuse invalidates the cache, records
+   `pid_reused`, and triggers one bounded re-inspection; never attribute a new process's resources to
+   an old VM.
+5. Publish one immutable fleet snapshot to status and observable gauges after a complete pass. A
+   partial/error sample preserves the last good values with explicit age and availability; it never
+   overwrites a missing field with zero.
+
+Do not run `smolvm machine status` during `/metrics` or `/api/v1/status`. Those endpoints read the
+cached snapshot only.
+
+#### Source priority and exact semantics
+
+| Signal | Linux preferred source | macOS/fallback source | Meaning |
+|---|---|---|---|
+| configured CPU/memory/storage | cached SmolVM status JSON | same | requested VM capacity, not current use |
+| CPU time | `cpu.stat` `usage_usec` | cumulative VMM process CPU time | host CPU consumed by the VM runtime |
+| current CPU cores | delta CPU seconds / delta monotonic wall seconds | same | host cores currently consumed; divide by configured vCPUs for a utilization ratio |
+| CPU throttling | `cpu.stat` throttle fields | unavailable | host cgroup quota pressure, not guest scheduler steal time |
+| host memory | `memory.current` / `memory.max` | VMM RSS plus configured limit | host memory charged to the VM runtime; not guest free/used memory |
+| host memory events | deltas from `memory.events` | unavailable | host cgroup events; `oom_kill` means the host killed VMM/helper work, not necessarily a guest process |
+| host PID count | `pids.current` / `pids.max` / `pids.events` | unavailable | VMM/helper host processes; not the guest process table |
+| disk allocation | filesystem allocated blocks (`st_blocks × 512`) for known VM files | same | physical blocks attributed to VM files, not sparse logical length |
+| host free disk | `statvfs`/equivalent on the VM state filesystem | same | authoritative capacity pressure for the host volume |
+
+Counter instruments record positive deltas between samples so they remain monotonic across VM
+deletion. A first sample establishes a baseline; PID change/restart establishes a new baseline rather
+than adding the new process's cumulative value.
+
+Sparse/CoW accounting has two caveats:
+
+- Count shared golden/image files once under `role=golden`; runner entries count only their private
+  overlay/runtime files.
+- `st_blocks` may still double-count shared extents on filesystems that do not expose exclusive-block
+  ownership. Therefore filesystem free bytes are authoritative for alerts; per-VM allocated bytes are
+  a comparative diagnostic, not a billing total.
+
+Network byte/packet/drop counters and block-I/O operation/byte counters are not available through the
+current stable SmolVM/Preloop boundary on every supported platform. Omit those series and report their
+capabilities false. Do not emit zero. Add them only after SmolVM exposes virtio counters or Preloop
+deliberately enables and validates a cgroup-IO/interface source at the supported runtime floor.
+
+Guest OS signals—guest memory free, guest load average, guest process count, guest filesystem free,
+guest OOM killer events, and guest network I/O—are likewise absent in this phase. A future
+implementation must use an out-of-band SmolVM agent push/snapshot API, not periodic guest shell
+commands and not a modified official Actions runner.
+
+#### Cardinality and diagnostics
+
+Metrics aggregate by bounded `role=runner|golden`, `activity=idle|busy|paused|unassigned`, runtime
+state, pool mode, source, capability, and storage kind. Never label a metric with machine, slot,
+runner, run, or job identity; ephemeral VM names would create permanent time-series churn.
+
+`/api/v1/status` returns aggregate totals plus at most five top consumers, ordered deterministically by
+pressure and carrying authenticated machine/run/job correlation. Emit transition-based,
+hysteresis/rate-limited structured events for historical attribution:
+
+- `vm.host.memory.pressure` / `.recovered`
+- `vm.host.cpu.throttled` / `.recovered`
+- `vm.host.oom_kill`
+- `vm.sparse_disk.pressure` / `.recovered`
+- `vm.sampler.unavailable` / `.recovered`
+
+Threshold events name the machine/run/job in logs/traces only. They must not log environment,
+commands, mounted paths, image credentials, or guest data.
+
+### Structured log catalog
+
+Use `event.name` plus stable fields. OTel trace/span IDs provide request correlation; do not allocate a
+second UUID on every HTTP poll.
+
+| Event name | Level | Required fields |
+|---|---|---|
+| `server.started` / `server.stopping` | INFO | instance ID, version, listen scheme/address, store backend, pool mode |
+| `run.accepted` / `run.completed` | INFO | run ID, workflow path/repository only when known, conclusion, duration |
+| `job.ready` / `job.claimed` / `job.completed` | INFO | run ID, job ID, request/runner ID when relevant, conclusion/reason |
+| `job.requeued` / `job.unclaimable` | WARN | run ID, job ID, stable reason, safe labels |
+| `job.concurrency.cancelled` | WARN | run ID, job ID, queue mode, group hash (not the raw group key), action |
+| `schedule.fired` / `schedule.skipped` | INFO/WARN | schedule ID, workflow path, delay seconds, reason |
+| `runner.registered` | INFO | runner ID, runner name, safe labels |
+| `runner.session.created` / `runner.session.deleted` | INFO | runner ID, session ID, reason |
+| `runner.session.reaped` | WARN | runner/session ID, `deaf|lease_expired|startup_orphan` |
+| `pool.prepare.started` / `pool.prepare.completed` | INFO | machine/golden name, mode, duration, outcome |
+| `pool.provision.started` / `pool.provision.completed` | INFO/WARN | machine name, slot, duration, stable outcome/reason |
+| `pool.supervisor.exited` | ERROR | stable reason; full safe error as log text |
+| `task.exited` | WARN/ERROR | registry task name, outcome, uptime; ERROR when the task is critical |
+| `limit.exceeded` | WARN | limit constant name, configured value, dropped/rejected delta; rate-limited per limit |
+| `vm.host.memory.pressure` / `vm.host.memory.recovered` | WARN/INFO | machine/run/job IDs, current bytes, limit bytes, ratio, source |
+| `vm.host.cpu.throttled` / `vm.host.cpu.recovered` | WARN/INFO | machine/run/job IDs, bounded interval/ratio, source |
+| `vm.host.oom_kill` | WARN | machine/run/job IDs, host event delta, source |
+| `vm.sparse_disk.pressure` / `vm.sparse_disk.recovered` | WARN/INFO | machine/run/job IDs, allocated bytes, host free bytes |
+| `vm.sampler.unavailable` / `vm.sampler.recovered` | WARN/INFO | capability, source, stable reason, sample age |
+| `vm.unreachable` / `vm.reachable` | WARN/INFO | machine name, role, run/job IDs, PID, age since last reachable |
+| `store.operation.failed` | ERROR | backend, operation, consecutive failures, safe error |
+| `store.connection.lost` | ERROR | backend, safe error; the Postgres connection task exiting |
+| `storage.pressure` / `storage.recovered` | WARN/INFO | mount, free bytes, free ratio, largest component |
+| `github.webhook.processed` | INFO/WARN | event class, delivery ID, dedup/outcome, duration |
+| `github.check.updated` | INFO/WARN | run ID, operation, outcome, duration |
+| `github.rate_limit.low` | WARN | resource, remaining, limit, reset-in seconds; never the token |
+| `debug.session.created` / `debug.session.closed` | INFO/WARN | run/job/session ID, terminal reason, duration |
+| `debug.audit.evicted` | WARN | session ID, evicted count, retained cap |
+| `telemetry.export.failed` | WARN | signal, failure class, consecutive failures; no endpoint/header |
+
+`job.concurrency.cancelled` logs a **hash** of the concurrency group key, never the key itself: the
+group expression is user-controlled and routinely interpolates branch names, PR titles, and inputs.
+The hash still correlates all jobs in one group without exporting user data.
+
+Level policy:
+
+- INFO: low-frequency control-plane, pool, and lifecycle transitions.
+- WARN: recoverable degradation requiring operator attention.
+- ERROR: process/supervisor terminal failure, invariant break, or sustained durability failure.
+- DEBUG: successful long-poll/renew/detail paths. Never INFO-log every poll or lease renewal.
+- A workflow's own failure is data, not an ERROR about Preloop.
+
+Export control-plane and pool/VM lifecycle logs. Keep workflow step output in its current run-log store.
+Keep protocol flow capture isolated. Do not add request/response body logging as a troubleshooting
+shortcut.
+
+### Trace policy
+
+Trace synchronous work, not an hours-long workflow:
+
+- HTTP server request spans using matched route and OTel HTTP semantic attributes;
+- workflow submission/build, webhook processing, broker claim/acquire;
+- SQLite/Postgres operations through the decorator;
+- GitHub token/check/API requests;
+- image/golden preparation and individual VM provision/register/assign/delete phases;
+- cache/artifact operations where they perform storage/network I/O.
+
+A run/job crosses many requests and processes. Correlate those transitions with structured
+`run.id`, `job.id`, `request.id`, `runner.id`, `session.id`, and `machine.name` fields on logs/traces.
+Do not retain one span for the complete run and do not persist span context in `InnerState` merely to
+force a single trace.
+
+Suppress successful health/metrics probes, successful renewals, and empty broker long-polls from
+normal trace export. Always record their metrics; trace errors and job/cancellation deliveries. The
+reference OpenObserve profile should set a standard parent-based ratio sampler for ordinary HTTP
+traffic and document how to raise it temporarily.
+
+## SLOs and alerts
+
+Instrument first, collect a two-week baseline, then ratify thresholds. Initial objectives are starting
+points, not promises:
+
+| SLI | Initial objective | Denominator/exclusions |
+|---|---|---|
+| Control API/broker availability | 99.9% successful | exclude user/auth 4xx and expected empty long-polls |
+| Dispatch latency | 99% within 30s | only ready jobs for which compatible capacity exists; pool preparation is reported separately |
+| Terminal propagation | 99% within 30s | job terminal to run finalization and configured GitHub check acknowledgement |
+| Durable-state writes | no sustained failure over 5m | all store operations; one transient failure warns, sustained failure pages |
+| Runner liveness | no deaf/leaked active session beyond configured bound | active sessions only; completed sessions excluded |
+| VM telemetry freshness | no stale fast sample beyond three intervals | Preloop-owned active VMs on hosts where the relevant source is supported |
+| Scheduled-trigger fidelity | 99% of schedules fire within 60s of their slot | excludes deliberate overlap skips and periods where the service was down |
+| Critical-task liveness | no critical `TaskHeartbeat` stale beyond three of its intervals | tasks marked critical in the registry |
+| Data retention honesty | zero unreported drops | every `preloop.limit.dropped` increment must have a matching visible condition |
+
+Reference alerts:
+
+1. **Telemetry absent**: no `preloop.service.uptime` for five minutes when the service is expected.
+2. **Dispatch stalled with capacity**: oldest claimable ready job exceeds the baseline threshold,
+   compatible idle/provisioning capacity exists, and pool preparation is false.
+3. **Unclaimable queue**: ready unclaimable jobs persist beyond grace with no preparing/provisioning
+   capacity; distinguish no registered runner from label mismatch.
+4. **Pool deficit**: desired exceeds idle+busy+building+provisioning while work is queued, or provision
+   failures repeat.
+5. **Runner deaf/lease stale**: max poll/lease age approaches its configured timeout or reap events occur.
+6. **Store failing**: consecutive failures or error rate persists; restart would risk losing live state.
+7. **GitHub terminal check pending**: a terminal run lacks successful check propagation beyond 30s.
+8. **Debug session stale**: a session remains active beyond its configured/operator-approved lifetime.
+9. **Exporter failing**: OTLP was configured but has not succeeded and local drop/failure counts rise.
+10. **VM host OOM event**: any increase in host-cgroup `oom_kill`; identify the VM/job from the
+    corresponding structured event.
+11. **VM memory pressure**: sustained aggregate or top-consumer host memory above 90% of its measured
+    limit while busy; baseline before paging because lazy/ballooned mappings differ by platform.
+12. **VM CPU throttling**: sustained throttled-period/time ratio while work is queued or running, not
+    a one-sample burst.
+13. **VM disk pressure**: VM-state filesystem has both low percentage and low absolute free space;
+    filesystem free bytes, not summed CoW allocation, is authoritative.
+14. **VM sampler stale/unavailable**: active owned VMs exist but the supported fast source is stale for
+    three intervals or errors persist.
+15. **Background task dead**: `preloop.task.heartbeat.age` for any critical task exceeds three of its
+    intervals, or `preloop.task.exited{outcome!="clean"}` increments. This is the generic replacement
+    for writing one bespoke alert per loop.
+16. **Schedule did not fire**: a registered schedule's slot passed with no `preloop.scheduler.fire`
+    increment, or `fire.delay` p99 exceeds the objective. Page separately from dispatch latency: a
+    cron that never fires produces no queued job and therefore trips no queue alert.
+17. **Concurrency overflow cancelling users' jobs**: `preloop.concurrency.decision{action="cancel_arrival"}`
+    increments. This is policy working as designed, so warn rather than page, but it must be visible —
+    the user sees an unexplained cancellation.
+18. **Data being dropped**: any `preloop.limit.dropped` or `preloop.limit.rejected` increase. Page on
+    `MAX_SESSION_AUDIT` eviction specifically; warn on the rest.
+19. **GitHub budget exhaustion**: `rate_limit.remaining / rate_limit.limit` below 10%, or
+    `github.token.expires_in` below twice the refresh interval. Both precede a total integration
+    outage by minutes and are currently invisible.
+20. **Storage capacity**: `preloop.storage.fs.available{mount="state_dir"}` low in both ratio and
+    absolute terms, or a single `preloop.storage.bytes` component growing monotonically across a full
+    GC interval.
+21. **VM unreachable**: any VM in `runtime_state=unreachable` for more than one slow-sample interval.
+    A wedged golden silently poisons every fork taken from it.
+
+Do not page on workflow failure rate. User code fails legitimately. VM-attributable host
+CPU/memory/disk pressure is part of the built-in application telemetry minimum. Whole-node load,
+unrelated processes, network interfaces, kernel health, and hardware remain optional collector
+signals.
+
+## OpenObserve evaluation
+
+### Verdict
+
+Use OpenObserve as the documented, optional “batteries available” backend. Do not make it a runtime
+dependency, do not embed/link it, and do not shape Preloop signals around OpenObserve-specific fields
+or APIs.
+
+| Criterion | Assessment | Decision |
+|---|---|---|
+| Minimal local deployment | Good: one native binary or container in single-node mode | Provide opt-in pinned compose/binary instructions, never auto-start it |
+| Unified signals | Good: OTLP/HTTP and OTLP/gRPC ingest logs, metrics, and traces | Preloop implements OTLP/HTTP first to avoid tonic/gRPC dependency |
+| Dashboards/alerts | Good: dashboards plus scheduled/realtime/composite standard alerts | Ship importable reference assets after signal names stabilize |
+| Storage | Good for small installs, but it is another stateful data volume | Short default retention, persistent volume, backup guidance |
+| HA | Poor fit for “minimal”: Kubernetes, object storage, PostgreSQL, NATS, and five roles | Do not ship an HA profile; link upstream docs |
+| Security | Basic private deployment is usable; SSO, RBAC, and audit trail are enterprise features | Bind UI to loopback/private network and front it with operator auth if shared |
+| Licensing | OSS repository is AGPL-3.0 | Keep it a separate process; do not vendor or relicense; legal review before distributing assets/binary bundles |
+| Failure isolation | Co-hosting can compete with runner VMs for CPU/RAM/disk | Opt-in, resource-capped; prefer a separate host/volume for durable self-hosting |
+
+OpenObserve's own documentation says single-node local mode uses SQLite and local disk (or object
+storage), while HA requires Kubernetes/Helm, object storage, PostgreSQL, NATS, and Router, Ingester,
+Compactor, Querier, and Scheduler roles. Its storage guide says losing SQLite metadata makes the
+installation inoperable. The optional profile must persist and back up both metadata and stream data;
+for stronger durability, use object storage and a separately protected metadata store according to
+upstream guidance.
+
+Do not put the OpenObserve UI on the public webhook origin. The OSS/enterprise feature split makes a
+private network or an external auth proxy the conservative default.
+
+### Deployment profiles
+
+1. **Default local**: no backend, pretty logs on a TTY, JSON/compact logs when noninteractive,
+   authenticated `/metrics`, direct status/health. Zero external process and zero export network.
+2. **Local enhanced**: one OpenObserve binary/container bound to loopback with persistent local volume,
+   short retention, resource caps, and direct OTLP/HTTP. Intended for debugging and baselining.
+3. **Self-hosted single node**: Preloop and OpenObserve may share a host only at measured low volume;
+   use separate persistent volumes, explicit CPU/memory/disk budgets, private networking, backups, and
+   preferably object storage for OpenObserve stream data.
+4. **Existing observability estate**: point the same OTLP output at the operator's backend. No
+   OpenObserve assets required.
+5. **Advanced host telemetry**: optional OpenTelemetry Collector receives Preloop OTLP and adds
+   whole-node CPU/memory/filesystem/network/kernel metrics unrelated to a specific Preloop VM, then
+   forwards. Built-in VM-attributable metrics do not require the collector.
+6. **OpenObserve HA**: operator-owned upstream deployment only. Preloop documents compatibility but
+   does not provision or support its dependencies.
+
+### Primary sources
+
+- Architecture and deployment modes: <https://openobserve.ai/docs/architecture/>
+- Single-node binary/container quickstart: <https://openobserve.ai/docs/getting-started/>
+- OTLP logs/metrics/traces over HTTP and gRPC:
+  <https://openobserve.ai/docs/ingestion/logs/otlp/>
+- Trace endpoint: <https://openobserve.ai/docs/ingestion/traces/opentelemetry/>
+- Prometheus remote-write support: <https://openobserve.ai/docs/ingestion/metrics/prometheus/>
+- Dashboards: <https://openobserve.ai/docs/user-guide/analytics/dashboards/dashboards-in-openobserve/>
+- Alerts: <https://openobserve.ai/docs/user-guide/analytics/alerts/>
+- Storage and SQLite metadata warning:
+  <https://openobserve.ai/docs/administration/maintenance/storage-management/storage/>
+- Enterprise-only SSO/RBAC/audit features: <https://openobserve.ai/docs/features/enterprise/>
+- OpenObserve repository license: <https://github.com/openobserve/openobserve/blob/main/LICENSE>
+- OTel Rust exporter guidance (Collector recommended for larger production topologies):
+  <https://opentelemetry.io/docs/languages/rust/exporters/>
+- SmolVM minimum-version (`v1.8.1`, `versions.toml:8`) JSON status contract — `machine_status_json`
+  at `src/cli/vm_common.rs:2360` and `status_vm_json` at `:2416`, shared with `machine ls --json`:
+  <https://github.com/smol-machines/smolvm/blob/v1.8.1/src/cli/vm_common.rs>
+- SmolVM `machine status --json` / `machine ls --json` flags and the public `machine data-dir`
+  command (`src/cli/machine.rs:365, 3783, 3857, 4290`):
+  <https://github.com/smol-machines/smolvm/blob/v1.8.1/src/cli/machine.rs>
+- SmolVM vsock state probe defining the `Unreachable` state (`src/agent/state_probe.rs:6-76`):
+  <https://github.com/smol-machines/smolvm/blob/v1.8.1/src/agent/state_probe.rs>
+- SmolVM per-VMM `vm-<pid>` cgroup-v2 leaf creation (`src/process.rs:375-393`, `place_in_cgroup`),
+  the upstream basis for Preloop's Linux VM metrics:
+  <https://github.com/smol-machines/smolvm/blob/v1.8.1/src/process.rs>
+- `sysinfo` 0.39.6 process API (`memory`, `start_time`, `cpu_usage`, and
+  `accumulated_cpu_time`) and feature controls:
+  <https://docs.rs/sysinfo/0.39.6/sysinfo/struct.Process.html>,
+  <https://docs.rs/crate/sysinfo/0.39.6/features>
+
+## Configuration contract
+
+Add only one Preloop-specific setting:
+
+- `PRELOOP_LOG_FORMAT=auto|pretty|json`; `auto` means human-readable on a TTY and structured JSON when
+  noninteractive, without ANSI in journald/files.
+
+Honor standard variables rather than inventing backend-specific ones:
+
+- `RUST_LOG`
+- `OTEL_SERVICE_NAME`
+- `OTEL_RESOURCE_ATTRIBUTES`
+- `OTEL_EXPORTER_OTLP_ENDPOINT` and signal-specific endpoint variants
+- `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`
+- `OTEL_EXPORTER_OTLP_HEADERS` and signal-specific header variants
+- `OTEL_EXPORTER_OTLP_TIMEOUT`
+- `OTEL_TRACES_EXPORTER`, `OTEL_METRICS_EXPORTER`, `OTEL_LOGS_EXPORTER`
+- `OTEL_TRACES_SAMPLER`, `OTEL_TRACES_SAMPLER_ARG`
+- standard batch/log/metric interval variables supported by the selected OTel Rust release
+
+Export is disabled unless an OTLP endpoint is explicitly present. `none` disables the corresponding
+signal. Reject unsupported protocol values from the telemetry pipeline with a sanitized status
+condition while continuing the control plane. Never print endpoints containing userinfo/query data or
+any header values.
+
+Absent-means-disabled is a documented deviation from the OTel default of `http://localhost:4318`
+(invariant 4). State it in `docs/observability.md` next to the variable list, because an operator who
+knows the spec will otherwise assume a local collector is being contacted.
+
+For OpenObserve, docs should show placeholder-only examples using the generic base endpoint without a
+trailing slash and signal-specific authorization/stream headers. Credentials belong in the protected
+systemd environment/credential mechanism already documented by Preloop, not committed compose files.
+
+## Commands the executor will need
+
+| Purpose | Command | Expected on success |
+|---|---|---|
+| Format check | `cargo fmt --all --check` | exit 0 |
+| Workspace check | `cargo check --locked --workspace` | exit 0 |
+| Observability crate tests | `cargo test --locked -p preloop-observability` | all pass |
+| Server observability tests | `cargo test --locked -p preloop-runner-server observability -- --nocapture` | all matching tests pass |
+| Pool observability tests | `cargo test --locked -p preloop-orchestrator observability -- --nocapture` | all matching tests pass |
+| VM telemetry tests | `cargo test --locked -p preloop-vm observability -- --nocapture` | cgroup/process/disk fixtures and capability cases pass |
+| CLI status tests | `cargo test --locked -p preloop-cli status -- --nocapture` | all matching tests pass |
+| Structural security rules | `just sg-scan-strict` | exit 0 |
+| Full local gate | `just test-ci` | ends with `CI: all checks passed` |
+| Official-server protocol check | `just conform-server-light` | no protocol diff |
+| Real runner smoke | `just dogfood` | workflow reaches expected terminal success |
+| OpenObserve integration | `just observability-openobserve-smoke` | one correlated log, metric, and trace query succeeds; assets import |
+
+All recipes above except `observability-openobserve-smoke` exist in the `justfile` at `673bdfa0`
+(`test-ci` at line 55, `sg-scan-strict` at 74, `dogfood` at 79, `serve` at 94, `conform-server-light`
+at 121). `observability-openobserve-smoke` is created by step 6. Note that `just test-ci` runs
+`fmt-check clippy zizmor test`, so the zizmor workflow gate applies to any CI workflow this plan adds.
+
+Match existing conventions: `anyhow` at binary boundaries, `ApiError` in HTTP handlers,
+`thiserror` in libraries, `Arc<Mutex<...>>` plus atomics/Notify for shared state, and
+`SecretString::expose()` only at protocol boundaries. Never await or export while holding the global
+state mutex.
+
+Toolchain and existing dependencies verified at `673bdfa0`:
+
+- `rust-toolchain.toml` pins channel `1.97`; workspace `rust-version = "1.97"`.
+- `tracing = "0.1"`, `tracing-subscriber = "0.3"` with `["env-filter", "json"]` already present.
+- `reqwest = "0.12"` with `["json", "rustls-tls", "stream"]` — reuse this exact client for OTLP
+  `http/protobuf` through `opentelemetry_http::HttpClient` rather than adding a second HTTP stack.
+- No `opentelemetry*`, `prometheus`, or `sysinfo` dependency exists yet; all are net-new.
+- The pinned versions named in step 2 were re-checked against crates.io on 2026-08-20 and are still
+  the current stable releases (`opentelemetry*` 0.32.x, `tracing-opentelemetry` 0.33.0,
+  `prometheus` 0.14.0, `sysinfo` 0.39.6). `opentelemetry-prometheus` 0.32.0 shipped the same day as
+  the core 0.32.0 release, so the historical lag that made that crate risky does not apply to this
+  release line. Re-verify before implementing; if it has fallen behind again, that is a STOP.
+
+## Scope
+
+**In scope**:
+
+- `Cargo.toml`, `Cargo.lock`, `versions.toml` (only if the SmolVM floor must move)
+- new `crates/preloop-observability/**`
+- `crates/preloop-cli/src/main.rs`, `crates/preloop-cli/src/server_install.rs`, its Cargo manifest/tests
+- `crates/preloop-runner-server/src/{main.rs,lib.rs,bootstrap.rs,routes.rs,runs.rs,state.rs,store.rs,store_pg.rs,broker.rs,runner_lifecycle.rs,scheduler.rs,concurrency.rs,live_logs.rs,snapshots.rs,github.rs,github_app.rs,github_pr.rs,github_push.rs,dispatch_auth.rs,oidc.rs,actions.rs,remote_workflows.rs,debug_sessions.rs,cache_artifacts.rs,artifact_twirp.rs,results_twirp.rs,blob_store.rs,distributed_task.rs,openapi.rs,lib_tests.rs}` and Cargo manifest
+- `crates/preloop-orchestrator/src/lib.rs` and its tests/Cargo manifest
+- `crates/preloop-vm/src/lib.rs` and its tests/Cargo manifest
+- `crates/preloop-runner/src/main.rs` only for safe local logging initialization
+- `docs/{architecture.md,self-hosting.md,cli_reference.md}` — note the file is `cli_reference.md`;
+  there is no `docs/cli.md` — plus new `docs/observability.md`
+- `contrib/openobserve/**` as optional, pinned deployment/dashboard/alert assets
+- `scripts/openobserve-observability-smoke.sh`, `justfile`
+- one structural rule under `rules/` preventing sensitive tracing fields, matching the ast-grep YAML
+  format of the three existing rules (`no-expose-in-loop.yml`, `no-inline-masking.yml`,
+  `no-raw-secret-replace.yml`)
+- `CHANGELOG.md`, `plans/README.md`
+
+**Out of scope**:
+
+- any official runner protocol body/status/header change;
+- exporting directly from guest runners;
+- exporting workflow step stdout/stderr, annotations, environment, or secrets;
+- changing protocol flow recording into general telemetry;
+- installing or starting OpenObserve automatically from `preloop serve`;
+- bundling or modifying the OpenObserve binary/image;
+- OpenObserve HA provisioning, multi-server Preloop, or a distributed state bus;
+- host eBPF, automatic kernel/container instrumentation, or a required OTel Collector;
+- periodic commands inside guests or changes to the official runner for telemetry;
+- guest-kernel memory/process/OOM/filesystem/network metrics until SmolVM provides a stable
+  out-of-band source;
+- per-machine metric labels, or fabricated network/block-I/O zeroes where no stable source exists;
+- retrying business operations because telemetry failed;
+- a new web UI inside Preloop; the direct CLI/API and reference backend are the deliverables.
+
+## Git workflow
+
+- Branch: `advisor/002-observability-strategy` unless the operator supplies another branch.
+- One commit/PR per implementation step below. Keep protocol instrumentation changes separate from
+  reference-backend assets.
+- Match the repository's imperative commit-message style observed in current history.
+- Do not push or open a PR unless instructed.
+
+## Implementation steps
+
+### Step 1: Freeze the signal/security contract and make existing logs safe
+
+Targets:
+
+- add `docs/observability.md` containing the architecture, cardinality rules, log classes, status
+  semantics, signal catalog, SLO definitions, deployment profiles, and runbook links from this plan;
+- re-run the grep in "Logging is local, duplicated, and not export-ready" and fix **every** hit, not
+  just the anchors below — three of the original four moved between `84d92cfd` and `673bdfa0`, so a
+  fixed list rots. At `673bdfa0` the hits are `artifact_twirp.rs:94`, `results_twirp.rs:713`,
+  `blob_store.rs:63, 78, 95, 113, 121, 127, 131`, and `distributed_task.rs:327`;
+- preserve useful fields: operation/kind, byte count, request ID, parsed terminal result, and duration;
+- add a structural `sg` rule rejecting INFO/WARN/ERROR tracing fields named `token`, `authorization`,
+  `cookie`, `headers`, `body`, `payload`, or `signed_url` unless the source is the explicitly excluded
+  `recording.rs` conformance path;
+- audit every non-DEBUG tracing macro in server/orchestrator code for raw URLs, query strings,
+  headers, bodies, secrets, and opaque Debug dumps;
+- document flow capture as sensitive local data and verify its permissions at creation.
+
+Do not “redact” tokens by logging a prefix, suffix, length, or stable hash; those are still unnecessary
+capability correlators. Log the operation and outcome instead.
+
+**Tests**:
+
+- behavioral logging test with sentinel token/body/header values captured by an in-memory subscriber;
+  assert no sentinel appears while safe operation fields remain;
+- flow-capture test remains local and proves its file mode is 0600 on Unix;
+- structural rule fixture accepts safe lifecycle fields and rejects a token/raw-body field.
+
+**Verify**:
+
+```sh
+just sg-scan-strict
+cargo test --locked -p preloop-runner-server observability_log_safety -- --nocapture
+```
+
+Expected: exit 0; sentinels absent; flow capture behavior unchanged.
+
+### Step 2: Add the observability crate and unify process initialization
+
+Targets:
+
+- add workspace-member `crates/preloop-observability` with the API described above;
+- pin the current compatible release line: `opentelemetry`, `opentelemetry_sdk`,
+  `opentelemetry-otlp`, `opentelemetry-prometheus`, `opentelemetry-appender-tracing`, and
+  `opentelemetry-semantic-conventions` at `0.32`, `tracing-opentelemetry` at `0.33`, and
+  `prometheus` at `0.14`;
+- disable default exporter features; enable OTLP `http-proto` plus `trace`, `metrics`, and `logs`
+  explicitly (the `http-proto` feature alone does not enable logs), using the existing
+  rustls/reqwest stack through an `opentelemetry_http::HttpClient` adapter rather than pulling the
+  tonic stack or a second reqwest major/minor line;
+- provide no-op, Prometheus-only, and Prometheus+OTLP initialization paths;
+- add the `TaskHeartbeat` registry and `LimitRegistry` described in "New crate"; both must be usable
+  from a no-op handle so `preloop-orchestrator` and `preloop-vm` can register without an SDK;
+- install stderr fmt/JSON, OTel trace layer, and OTel log bridge once in `preloop` and standalone
+  `preloop-server`; initialize the guest Rust runner with stderr only;
+- parse `PRELOOP_LOG_FORMAT`; preserve `RUST_LOG=info` fallback and give the standalone server the
+  same fallback the CLI has — `preloop-runner-server/src/main.rs:78-80` currently uses
+  `EnvFilter::from_default_env()`, so an unset `RUST_LOG` silently disables its logging;
+- create OTel resources and per-process instance ID;
+- add bounded queues/timeouts and a two-second explicit shutdown path around command completion;
+- sanitize all init/export errors and expose telemetry health through the shared handle.
+
+Do not make OTel globals the test seam. Constructors accept an explicit handle; tests use no-op or
+recording exporters with scoped subscribers.
+
+**Tests**:
+
+- no endpoint/env means no DNS/socket attempt and no exporter worker;
+- malformed/down endpoint does not fail initialization or delay a synthetic request;
+- queue capacity and shutdown timeout are bounded;
+- pretty/JSON/auto formats preserve structured fields and omit ANSI when noninteractive;
+- config `Debug` never reveals OTLP headers or credential-bearing endpoint components;
+- one event inside a span reaches the recording log exporter with trace/span correlation.
+- a registered heartbeat that stops beating becomes stale and a dropped `HeartbeatHandle`
+  deregisters; a registry with a critical stale entry reports not-ready;
+- `LimitRegistry` counts drops and rejects separately and reports registered limits with zero counts.
+
+**Verify**:
+
+```sh
+cargo test --locked -p preloop-observability
+cargo check --locked -p preloop-cli -p preloop-runner-server -p preloop-runner
+```
+
+Expected: all tests pass and all three binaries compile.
+
+### Step 3: Add truthful liveness, readiness, aggregate status, and CLI output
+
+Targets:
+
+- add `status.rs` in the observability crate for neutral DTOs/handles and in server for state sampling;
+- add a five-second sampler in `bootstrap.rs` with a heartbeat and bounded five-exemplar conditions;
+- register a `TaskHeartbeat` for every long-lived task in the fifteen-task inventory, without changing
+  any task's cadence or behavior; mark the state sampler, reaper, scheduler scan, and (Postgres only)
+  the store connection task critical;
+- wire the consolidated `PoolStatus` handle through `ServerConfig`, `RunnerPoolConfig`, and CLI
+  construction, **removing** the four ad-hoc handles (`pending_jobs`, `preparing_signal`,
+  `next_job_runs_on`, `pending_registrations`) rather than adding a fifth beside them;
+- register every cap in the limits table with `LimitRegistry` and report them in status;
+- add `/readyz` and authenticated `/api/v1/status`; make authenticated `/metrics` available from the
+  provider registry;
+- keep `/healthz` lock/dependency-free and return 503 during shutdown;
+- update OpenAPI for all operator routes and native bearer requirements;
+- replace `Command::Status` with `Status(StatusArgs)`, implement exact JSON plus sectional human output,
+  and preserve recent runs; copy the `#[arg(long)] json: bool` shape from `PlanArgs`
+  (`preloop-cli/src/main.rs:706-707`);
+- change `wait_for_engine_socket` (`preloop-cli/src/main.rs:1458-1475`) to probe `/readyz` and to
+  surface the last reason code on timeout.
+
+The sampler computes claimability using existing runner label matching. It distinguishes:
+
+- claimable now;
+- temporarily unclaimable because pool is preparing/provisioning;
+- no registered runner;
+- registered runners exist but labels do not match.
+
+It must not call the external backend and must remain responsive when OTLP is down.
+
+**Tests** (follow the existing router/auth test pattern in `lib_tests.rs`, which builds state with
+`AppState::new(temp.path().to_path_buf()).await.unwrap()` and the `app(...)` helper):
+
+- health is public/shallow; ready returns 503 with the stale task's registry name as reason, and a
+  stale **non-critical** task does not affect readiness;
+- status and metrics reject missing/invalid native bearer and accept valid bearer;
+- every queue class and pool mode appears correctly;
+- concurrency, scheduler, storage, limits, and tasks blocks render with correct values, and `limits`
+  includes registered caps whose counters are zero;
+- a `queue: max` overflow at `QUEUE_MAX_PENDING` produces the `concurrency_queue_overflow` condition;
+- claimability distinguishes absence, label mismatch, preparing, provisioning, and compatible runner;
+- VM fleet totals, source capabilities, sample age, and the deterministic five-entry top-consumer
+  bound render in status/CLI without creating metric labels;
+- snapshot fallback remains available when a deliberately held state lock prevents a fresh sample;
+- JSON schema version is fixed; CLI JSON is byte-for-byte valid endpoint JSON;
+- human output names an actionable cause for a stuck job.
+
+**Verify**:
+
+```sh
+cargo test --locked -p preloop-runner-server status_observability -- --nocapture
+cargo test --locked -p preloop-cli status -- --nocapture
+```
+
+Expected: all matching tests pass; unauthorized cases return 401; readiness cases return 200/503 as specified.
+
+### Step 4: Instrument HTTP, runs/jobs, dispatch, runners, and the store
+
+Targets:
+
+- replace default `TraceLayer` with custom matched-route/surface instrumentation;
+- classify routes into finite surfaces covering all thirteen path families actually served:
+  `native` (`/api/v1`), `runner` (`/_apis`, `/runner`, `/runner/server`), `broker` (`/broker`),
+  `results` (`/twirp`, `/twirp-blob`), `webhook`, `git` (`/snapshots`, `/repos`), `oidc`
+  (`/oidc`, `/.well-known`), `live_logs` (`/ws/live-logs`), `public` (`/healthz`, `/readyz`),
+  `test` (`/internal/test`), and `unknown`; `unknown` is a constant label, never a raw path;
+- exclude the `live_logs` surface from `http.server.request.duration` and instrument it with
+  `preloop.livelog.connections` plus a close-reason counter instead;
+- create exact HTTP metrics and safe spans without headers/body/query;
+- instrument run/job terminal transitions exactly once using central transition/event boundaries;
+- record queue wait at claim or terminal-unclaimed failure;
+- instrument poll outcomes, session transitions, renew errors, lease expiry, no-matching-runner,
+  deaf-runner reaping, and restart-orphan reconciliation;
+- wrap the private `Store` trait in `store.rs` with `InstrumentedStore`, including all methods and
+  backend/outcome; preserve every return/error and best-effort persistence rule. Wrap the
+  `Arc<dyn Store>` the factory at `store.rs:261-267` returns; because the trait is `#[async_trait]`
+  and already consumed as `Arc<dyn Store>` (`state.rs:360`), no call site changes;
+- instrument the Postgres connection task at `store_pg.rs:95-103` with a heartbeat plus
+  `preloop.store.connection.up`, so connection death is visible before the first failed write;
+- instrument concurrency-group decisions at `concurrency.rs::apply_queue_mode` — every
+  `park`/`cancel_pending`/`cancel_arrival`/`admit`, with `cancel_arrival` also recording a
+  `LimitRegistry` reject against `QUEUE_MAX_PENDING`;
+- instrument the scheduler scan: fire, late fire, overlap skip, and registered-schedule count;
+- feed gauges only from cached sampler values.
+
+Do not count an emitted duplicate status event as a second completion. Add transition guards or record
+at the state mutation that proves old-state to terminal-state movement.
+
+**Tests**:
+
+- route template is `/api/v1/runs/:run_id`, never a concrete ID/query;
+- 1,000 unique HTTP/run/job/runner IDs do not increase metric series beyond the fixed bound;
+- a claim emits one wait observation and one claim outcome;
+- successful completion, timeout, no runner, lease expiry, deaf runner, and startup orphan each emit
+  exactly one bounded terminal reason;
+- each `Store` method records one duration/outcome while preserving success/error values;
+- all seven `Store` methods are covered — a new trait method without instrumentation must fail a test,
+  not pass silently;
+- killing the Postgres connection task flips `store.connection.up` and emits `store.connection.lost`;
+- `queue: single`, `queue: max` under the cap, and `queue: max` at the cap each emit exactly one
+  bounded decision outcome, and the overflow case increments the limit reject counter;
+- slow/failing recording exporter does not measurably serialize handler completion; use paused time or
+  synchronization, not a flaky wall-clock threshold.
+
+**Verify**:
+
+```sh
+cargo test --locked -p preloop-runner-server observability -- --nocapture
+just conform-server-light
+```
+
+Expected: tests pass and official runner flow comparison has no diff.
+
+### Step 5: Instrument pool, VM resources, GitHub, webhook, cache/artifacts, and debug sessions
+
+Targets:
+
+- move pool idle/building/provisioning/busy/paused/preparing counters behind the consolidated
+  `PoolStatus` handle from step 3 and delete the four ad-hoc `Option<Arc<…>>` fields;
+- update state through RAII guards so cancellation/error cannot leak a count;
+- instrument golden/artifact preparation, provision phases, registration, assignment, pause/resume,
+  delete/replacement, and supervisor exit with stable outcomes/reasons;
+- replace the substring matching in `SmolVmProvider::status` (`preloop-vm/src/lib.rs:1018-1043`) with
+  typed inspection: `machine status --json` for one machine on a lifecycle path, and extend the
+  existing `machine ls --json` parser in `SmolVmProvider::list`
+  (`crates/preloop-vm/src/lib.rs:1045-1060`) into the
+  fleet-wide `VmRuntimeInfo` source used by the slow sampler. Resolve `machine data-dir` only when a
+  disk path is needed;
+- add `MachineState::Unreachable` and map SmolVM's vsock-probed `Unreachable` state to it end to end
+  (metric attribute, status condition `vm_unreachable`, `vm.unreachable` event). Audit every existing
+  `MachineState` match arm — adding a variant is a breaking change for the pool's decision logic, and
+  treating `Unreachable` as `Unknown` would silently keep forking from a wedged golden;
+- add workspace dependency
+  `sysinfo = { version = "0.39.6", default-features = false, features = ["system"] }` to
+  `preloop-vm`; retain one process snapshot and refresh only registered VMM PIDs rather than scanning
+  every process or enabling unrelated component, disk, network, and user collectors;
+- add the shared VM registry plus one five-second host resource sampler and one 60-second disk sampler;
+  register runner/golden role and assignment on create/fork/adopt, preserve paused debug VMs, and
+  unregister only after confirmed deletion;
+- on Linux, read the validated `vm-<pid>` cgroup-v2 CPU/memory/PID files under the root
+  `init_vm_cgroup_delegation` (`preloop-vm/src/lib.rs:1360` ff.) already delegates. The leaf is created
+  by SmolVM's supervisor, not by Preloop, so a missing leaf degrades to the process fallback and
+  records `capability=false`; it is never an error. On macOS/cgroup-unavailable hosts, read validated
+  process CPU/RSS; on every platform, sample known sparse-file allocated blocks and
+  state-filesystem free bytes;
+- compute counter deltas and CPU-core rate without attributing a reused PID; carry unsupported/stale
+  fields as unavailable rather than zero;
+- aggregate VM metrics by bounded role/activity/source and publish five authenticated top consumers;
+- emit rate-limited pressure/recovery events for host memory, CPU throttling, host OOM, sparse disk,
+  and sampler health;
+- instrument GitHub App token/check/API calls at centralized request boundaries, never token values;
+- parse `x-ratelimit-limit`/`x-ratelimit-remaining`/`x-ratelimit-reset` from every GitHub response and
+  publish the budget gauges; track installation-token expiry and the `dispatch_token_cache`
+  /`dispatch_actor_cache`/`action_sha_cache` hit rates (`dispatch_auth.rs:46, 49`);
+- track pending terminal check updates and propagation delay for status/SLOs;
+- instrument webhook processing/dedup with event class and outcome, delivery ID only in logs/traces;
+- instrument cache/artifact operations and bytes without key/name/token labels;
+- instrument snapshot/git object serving (`snapshots.rs`), including `ObjectCache` hit/miss/evict and
+  the GC pass at `snapshots.rs:1896`;
+- add the storage sampler: per-component bytes for database, cache, artifacts, run logs, snapshots,
+  and VM images, plus `statvfs` free bytes for the state-dir and SmolVM-data mounts. Run it on the
+  60-second cadence; a recursive directory walk must never run on the fast path or under a state lock;
+- instrument debug session create/pause/resume/detach/close/expire/crash and age;
+- register the four `debug_sessions.rs` ring caps with `LimitRegistry` and emit `debug.audit.evicted`
+  when `MAX_SESSION_AUDIT` evicts;
+- register the `live_logs.rs` per-job cap and count both tail-drops and oversized-batch rejects;
+- add short synchronous spans around these operations; no workflow-lifetime span.
+
+Pool status is authoritative from transitions, while the periodic server sampler merges it with queue
+and runner state. Avoid double-maintaining separate pool counters solely for metrics.
+
+**Tests**:
+
+- each pool state transition balances under success, error, cancellation, and paused-debug paths;
+- SmolVM JSON parsing covers every state **including `Unreachable`**, optional PID/resource field,
+  malformed output, missing machine, and a fixture captured from the supported floor `v1.8.1`;
+- `machine ls --json` fixture yields one `VmRuntimeInfo` per machine and the fast sampler spawns zero
+  subprocesses;
+- an `Unreachable` golden is not used as a fork source;
+- cgroup parser fixtures cover CPU units/deltas, throttle counters, `max` limits, memory events, PID
+  events, missing controller files, permission errors, counter reset, process exit, and PID reuse;
+- a missing `vm-<pid>` leaf falls back to the process source and reports the capability false rather
+  than erroring or emitting zero;
+- process fallback tests use injected process snapshots and prove unsupported cgroup-only values are
+  absent, not zero;
+- sparse-file tests compare allocated blocks rather than logical length, count shared goldens once,
+  enforce the slow cadence, and treat filesystem free space as authoritative;
+- cancellation, pause, adoption, replacement, and deletion keep the VM registry balanced and never
+  sample a deleted/reused process;
+- 1,000 ephemeral machine names produce a constant metric series set while status retains at most five
+  deterministic top consumers;
+- repeated provision failure produces status condition and metrics but does not create a log storm;
+- GitHub/check failure uses bounded outcome and retains safe correlation IDs;
+- rate-limit headers populate the budget gauges, and a response missing them leaves the previous
+  values with an explicit `observed_at`, never zero;
+- the storage sampler reports per-component bytes and free space from a temp-dir fixture and does not
+  block the fast sampler;
+- live-log tail-drop and debug-session ring eviction each increment `preloop.limit.dropped` with the
+  correct constant name;
+- cache/artifact unique keys and webhook delivery IDs never become metric labels;
+- debug session expiry/crash produces the correct terminal reason.
+
+**Verify**:
+
+```sh
+cargo test --locked -p preloop-vm observability -- --nocapture
+cargo test --locked -p preloop-orchestrator observability -- --nocapture
+cargo test --locked -p preloop-runner-server observability -- --nocapture
+```
+
+Expected: all matching tests pass with balanced gauges and bounded labels.
+
+### Step 6: Add the optional OpenObserve reference profile and assets
+
+Targets:
+
+- add `contrib/openobserve/compose.yml` pinned to a reviewed immutable OpenObserve version/digest;
+- bind the UI/API to loopback by default, use a persistent data volume, healthcheck, explicit CPU/memory
+  limits, short retention, and placeholder-only credentials sourced outside version control;
+- do not vendor the binary/image; include upstream license/source notices and a legal-review note;
+- add six importable dashboards: overview, scheduling/queue (including cron schedules and
+  concurrency-group contention), runners/pool, VM host resources, dependencies (GitHub budget, store,
+  storage capacity) and telemetry, and a "limits and background tasks" board showing every registered
+  cap and heartbeat;
+- add alert definitions matching the catalog above, with baseline placeholders where thresholds require
+  measured data;
+- add `docs/observability.md` setup for native binary, container, direct OTLP/HTTP, existing backend,
+  optional Collector, backup/retention, private access, and troubleshooting;
+- add a smoke script/just recipe that starts the pinned profile, starts Preloop with sentinel-safe OTLP
+  config, performs health/status and a small workflow, queries OpenObserve for at least one log,
+  metric, and trace sharing expected resource/correlation fields, exercises CPU/memory/disk activity
+  in one VM, imports assets, and tears down.
+
+Before choosing resource limits, measure idle and ingest/query use on the target host. OpenObserve's
+querier caching can consume substantial memory; do not guess a cap that starves the VM pool. Record the
+measured default and explain how to change it.
+
+**Verify**:
+
+```sh
+just observability-openobserve-smoke
+```
+
+Expected: the pinned single-node service becomes healthy; Preloop continues working; one safe log,
+one domain metric, VM CPU/memory/disk series, and one trace are queryable; dashboard/alert assets
+import; neither logs nor query results contain sentinel secrets.
+
+### Step 7: Baseline, ratify alerts, document the incident workflow, and close the loop
+
+Targets:
+
+- run local/self-hosted telemetry for two representative weeks or an agreed workload-equivalent soak;
+- record series count, logs/day, sampled spans/day, exporter drops, VM sampler overhead, VM CPU/RSS
+  correlation, sparse/CoW disk-accounting behavior, OpenObserve CPU/RAM/disk growth, and query latency;
+- tune histogram buckets, sampling, retention, and alert thresholds based on evidence without changing
+  signal names casually;
+- document runbooks for queue stall, pool deficit, VM host memory/throttling/OOM/disk pressure, stale
+  VM sampling, deaf runner, store failure, GitHub check lag, telemetry failure, and OpenObserve
+  disk/metadata recovery;
+- integrate direct diagnosis: every alert links first to `preloop status --json`, then dashboard/log/trace
+  queries, then existing `preloop debug` for a failed job;
+- update architecture, self-hosting, CLI docs and changelog;
+- run the complete compatibility and dogfood gates.
+
+**Verify**:
+
+```sh
+just test-ci
+just conform-server-light
+just dogfood
+```
+
+Expected: all gates pass; dogfood completes with official-runner protocol behavior unchanged; the
+status snapshot and reference dashboards explain every observed transition.
+
+## Test plan
+
+Permanent tests must defend observable contracts:
+
+1. **Disabled path**: no OTel endpoint creates no network work; status/metrics/logging remain usable.
+2. **Failure isolation**: malformed endpoint, unavailable backend, slow exporter, full queue, and flush
+   timeout never alter API result or workflow state.
+3. **Security**: sentinel tokens, headers, bodies, signed URLs, workflow output, and flow-capture bytes
+   never enter ordinary logs/traces/metrics.
+4. **Cardinality**: 1,000 unique user/domain identifiers produce a constant bounded metric series set.
+5. **HTTP semantics**: matched templates and finite surfaces only; query values absent.
+6. **Status**: all queue/capacity/store/GitHub/debug/telemetry states and conditions, with auth and stale
+   snapshot behavior.
+7. **Lifecycle exactness**: accepted/ready/claimed/completed/requeued/reaped/reconciled counters and
+   durations record once under success, error, retry, cancellation, and restart paths.
+8. **Pool balance**: no gauge leak under every early return/cancellation.
+9. **VM sampling**: minimum-version JSON fixtures, cgroup/process source fallback, PID reuse/counter
+   reset, missing capabilities, sparse allocation, filesystem pressure, cadence, registry lifecycle,
+   top-consumer bound, and sampler overhead.
+10. **VM semantics**: tests and docs never present host RSS/PIDs/OOM as guest memory/processes/OOM and
+    never emit unsupported network/block-I/O metrics as zero.
+11. **Shutdown**: exporters flush within the bound and process exits if backend is hung.
+12. **Backend E2E**: pinned OpenObserve ingests/query-correlates all three signals, VM resource series,
+    and imports assets.
+13. **Protocol fidelity**: committed conformance flows and real official runner remain byte/behavior
+    compatible.
+14. **Limit honesty**: every constant registered with `LimitRegistry` has a test that drives it past
+    its cap and asserts the drop/reject counter moved. A cap with no such test is an unproven claim.
+15. **Task liveness**: a task that panics, returns early, or stops beating is reported; a dropped
+    handle deregisters; a stale non-critical task does not fail readiness.
+16. **Scheduler**: a schedule that fires, one skipped for overlap, and one whose scan task is dead
+    produce distinct, correct signals.
+17. **GitHub budget**: rate-limit headers, a response lacking them, and an expiring installation token
+    each produce the right gauge/condition without exporting credential material.
+
+Avoid source-text unit tests, sleeps, and exact wall-clock assertions. Use in-memory exporters,
+paused Tokio time, barriers, real router requests, and Prometheus registry gathering.
+
+## Done criteria
+
+All must hold:
+
+- [ ] `preloop status` explains queue, capacity, runner freshness, store, GitHub, debug, and telemetry state.
+- [ ] `preloop status --json` returns the versioned authenticated snapshot with no prose.
+- [ ] `/healthz`, `/readyz`, `/api/v1/status`, and `/metrics` have the specified auth/semantics.
+- [ ] No backend is contacted when OTLP endpoint configuration is absent.
+- [ ] OTLP failure cannot block or fail a request/workflow; queues and shutdown are bounded.
+- [ ] Existing known capability-token/raw-body logs are removed and the structural guard passes.
+- [ ] Workflow output and flow recordings are absent from ordinary telemetry.
+- [ ] Metric labels pass the 1,000-identifier cardinality/sentinel test.
+- [ ] Pool, queue, runner, store, GitHub, cache/artifact, and debug lifecycle signals exist and are exact.
+- [ ] Every cap in the limits table is registered, reported in `/api/v1/status` even at zero, and
+      counted when exceeded; no code path discards data without a counter.
+- [ ] Every long-lived task in the fifteen-task inventory registers a heartbeat; the four critical
+      tasks gate `/readyz` and the rest are visible in status.
+- [ ] Scheduled workflows report fire, late fire, overlap skip, and scan-task liveness.
+- [ ] Concurrency-group contention and `queue: max` overflow cancellation are visible with a hashed —
+      never raw — group key.
+- [ ] GitHub rate-limit budget, installation-token expiry, and auth-cache hit rate are reported.
+- [ ] Per-component persistent storage bytes and state-dir free space are reported; Plan 001 emits
+      through `preloop.storage.*` rather than a parallel family.
+- [ ] The four ad-hoc `RunnerPoolConfig` shared handles are gone, replaced by one `PoolStatus`.
+- [ ] `MachineState::Unreachable` exists, is honored by pool fork decisions, and surfaces as a condition.
+- [ ] Active Preloop VMs expose bounded aggregate configured capacity, host CPU, host memory,
+      Linux throttling/events/PIDs when supported, sparse allocated disk, filesystem free space, and
+      sampler freshness without running a guest command.
+- [ ] `/api/v1/status` reports VM capability gaps and at most five correlated top consumers; unsupported
+      metrics are absent rather than zero.
+- [ ] OpenObserve remains optional, pinned, private-by-default, resource-capped, and separately licensed.
+- [ ] Six dashboards, including VM host resources and limits/tasks, and initial alerts import and query
+      real emitted fields.
+- [ ] `cargo fmt --all --check`, `just sg-scan-strict`, `just test-ci`, `just conform-server-light`,
+      `just dogfood`, and `just observability-openobserve-smoke` pass.
+- [ ] Docs include signal definitions, deployment profiles, retention/backup/security, SLOs, alerts, and
+      incident runbooks.
+- [ ] `plans/README.md` status row is updated.
+
+## STOP conditions
+
+Stop and report; do not improvise if:
+
+- instrumentation requires changing an official runner wire response or guest runner behavior;
+- OTel Rust crate versions cannot provide multiple metric readers (Prometheus plus OTLP) without a
+  second independently updated instrument set;
+- the selected OTel logs bridge cannot preserve trace/span correlation or bounded nonblocking export;
+- an exporter can perform network I/O on the handler thread/runtime path rather than a batch worker;
+- OpenObserve asset format/API is unstable across the pinned version and cannot be smoke-tested;
+- legal review rejects distributing the compose/dashboard/alert assets under the repository license;
+- status sampling must hold `InnerState` while awaiting I/O or copies unbounded payload/log data;
+- VM sampling requires one SmolVM subprocess per VM per scrape, periodic guest execution, or an
+  unsupported private SmolVM storage/database layout rather than the public CLI/cgroup/process
+  boundaries;
+- the supported SmolVM floor (`versions.toml` `smolvm_min_version`, currently `1.8.1`) lacks the
+  `machine status --json` / `machine ls --json` / `machine data-dir` contract, stops sharing one
+  `machine_status_json` shape between the two JSON outputs, or changes its field semantics;
+- `opentelemetry-prometheus` has fallen behind the `opentelemetry` release line again, forcing either
+  a downgrade of the whole OTel stack or a second independently versioned instrument set;
+- adding `MachineState::Unreachable` cannot be done without changing pool scheduling behavior — that
+  is a correctness fix, not an observability change, and belongs in its own reviewed PR;
+- PID start identity cannot be validated on a supported host, making cross-process attribution unsafe;
+- a metric requires a user-controlled/unbounded label to answer the intended question;
+- registering a cap or heartbeat would require changing the behavior of the code it observes;
+- the current code no longer has the named centralized lifecycle/store/pool boundaries;
+- conformance or dogfood changes after instrumentation, even if unit tests pass.
+
+## Maintenance notes
+
+- Signal names, units, label sets, status schema, condition codes, and termination reasons are public
+  operational APIs. Review changes like wire changes; additive first, documented migration when not.
+- Every new queue/state/runner failure path must update status, metrics, structured lifecycle logs, and
+  tests together. Do not add a dashboard-only derivation for state the server already knows.
+- Every new metric label needs a bounded-cardinality review and the unique-ID test.
+- Every new cap, ring buffer, or truncation point must be registered with `LimitRegistry` in the same
+  PR that introduces it. Every new long-lived `tokio::spawn` must register a `TaskHeartbeat`. Both are
+  review checklist items, not follow-ups — this plan exists because fifteen tasks and nine caps
+  accumulated without either.
+- Every new tracing field needs a secret/PII review. `Debug` on request/config/domain structs is unsafe
+  unless the type has an explicit redacted implementation.
+- Anchors in this plan rot fast: the churn from `84d92cfd` to `673bdfa0` moved three of four named
+  logging sites, the `TraceLayer` line, the `preloop status` implementation, the CLI subscriber, and
+  every `broker.rs` range. Prefer the greps and symbol names over the line numbers, and re-run the
+  drift check before each step.
+- VM metric names/documentation must retain the `host` distinction: cgroup/process RSS, PID, OOM, and
+  throttling are observations of the VMM on the host, not guest-kernel counters.
+- A new SmolVM release must run the JSON inspection and cgroup/process telemetry fixtures in the
+  existing runtime verification workflow before the verified version moves.
+- Network/block-I/O or guest OS telemetry requires a separate source/semantics review; absence is more
+  correct than a portable-looking zero from one platform.
+- Keep OpenObserve versions/digests and assets tested together. Preloop's OTLP contract must continue to
+  work with other vendors.
+- If Preloop later becomes multi-server, re-design gauges and status around a shared authoritative bus;
+  `service.instance.id` is not a substitute for distributed coordination.
+- If workflow-log export is ever proposed, treat it as a separate security/retention product decision:
+  workflow output is high-volume, user-controlled, and may contain masked or unrecognized secrets.

--- a/plans/002-observability-strategy.md
+++ b/plans/002-observability-strategy.md
@@ -1346,7 +1346,9 @@ Toolchain and existing dependencies verified at `673bdfa0`:
 
 Targets:
 
-- add `docs/observability.md` containing the architecture, cardinality rules, log classes, status
+- add `docs/internal/observability.md` (internal contract, kept in `docs/internal/` which is
+  `.gitignore`'d; the public `docs/observability.md` will be a redacted subset later) containing the
+  architecture, cardinality rules, log classes, status
   semantics, signal catalog, SLO definitions, deployment profiles, and runbook links from this plan;
 - re-run the grep in "Logging is local, duplicated, and not export-ready" and fix **every** hit, not
   just the anchors below — three of the original four moved between `84d92cfd` and `673bdfa0`, so a

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,0 +1,51 @@
+# Implementation Plans
+
+Generated and reconciled by the improve skill on 2026-08-17. Plan 002 was re-verified and revised
+against live code at commit `673bdfa0` on 2026-08-20. Execute plans in the order selected by the
+maintainer; the two current plans are independent. Each executor must read its plan fully, honor its
+STOP conditions, run every verification gate, and update the corresponding status row.
+
+## Execution order and status
+
+| Plan | Title | Priority | Effort | Depends on | Status |
+|---|---|---:|---:|---|---|
+| [001](001-caching-performance-strategy.md) | Caching strategy for local and self-hosted CI | P1 | L | — | TODO |
+| [002](002-observability-strategy.md) | Make Preloop observable without making a backend mandatory | P1 | L | — | TODO (revised at `673bdfa0`) |
+
+Status values: `TODO` | `IN PROGRESS` | `DONE` | `BLOCKED: <reason>` | `REJECTED: <reason>`.
+
+## Dependency notes
+
+- Plans 001 and 002 can execute independently.
+- When both touch cache/artifact operations, Plan 002 owns the stable observability contract and Plan
+  001 must emit through that contract rather than introduce separate metric/log conventions.
+- Plan 002 also owns the `preloop.storage.*` measurement contract. Plan 001 adds cache quotas and
+  eviction; it must report them through `preloop.storage.bytes` / `preloop.storage.gc` and register
+  any new cap with `LimitRegistry`, not invent a parallel family.
+- Plan 002 is intentionally split into seven PR-sized steps. Its security/log-safety step must land
+  before OTLP log export is enabled.
+
+## Findings considered and rejected
+
+- **Make OpenObserve a required or embedded Preloop component**: rejected. Direct status, local logs,
+  and Prometheus metrics must work with no backend; OTLP keeps backend choice interchangeable.
+- **Require an OpenTelemetry Collector for the minimum profile**: rejected. It adds another process;
+  direct bounded OTLP/HTTP is enough for low-volume application telemetry. Preloop collects
+  host-observed CPU, memory, throttling, PID, and sparse-disk metrics for VMs it owns; a Collector
+  remains optional for whole-node and unrelated-process metrics, buffering, sampling, or fan-out.
+- **Export workflow step logs by default**: rejected. They are high-volume, user-controlled, and may
+  contain secrets; they remain in Preloop's existing run-log store.
+- **Represent each workflow as one hours-long trace**: rejected. Workflows cross asynchronous requests,
+  sessions, and processes; use short operation traces plus structured run/job correlation fields.
+- **Treat OpenObserve HA as the self-hosted default**: rejected. Its Kubernetes, object storage,
+  PostgreSQL, NATS, and multi-role topology conflicts with the minimal-dependency requirement.
+- **Use observability to imply multi-server Preloop support**: rejected. In-memory state remains
+  authoritative per instance; shared database storage is only a restart source, not a shared bus.
+- **Keep the first draft's two ad-hoc readiness heartbeats**: rejected on revision. Preloop runs
+  fifteen long-lived tasks; wiring two by hand and leaving thirteen silent reproduces the problem the
+  plan is meant to solve. One `TaskHeartbeat` registry with a critical subset replaces it.
+- **Add a fifth shared handle to `RunnerPoolConfig`**: rejected on revision. Four ad-hoc
+  `Option<Arc<…>>` channels already exist; the plan consolidates them into one `PoolStatus` instead of
+  extending the pattern.
+- **Emit a duration histogram for `/ws/live-logs`**: rejected. A long-lived WebSocket would dominate
+  p99 and corrupt the availability SLI denominator; use a connection gauge and close-reason counter.

--- a/rules/no-sensitive-log-fields.yml
+++ b/rules/no-sensitive-log-fields.yml
@@ -1,0 +1,48 @@
+id: no-sensitive-log-fields
+message: |
+  INFO/WARN/ERROR tracing fields must not carry capability material: token,
+  authorization, cookie, headers, body, payload, or signed_url. These leak
+  bearer material into journald and OTLP. Use operation/kind/size/result
+  fields instead. The conformance flow recorder (recording.rs) is exempt.
+severity: error
+language: rust
+# recording.rs deliberately captures every header and body for conformance.
+ignores:
+  - "**/recording.rs"
+rule:
+  any:
+    # info!(token, …) / warn!(authorization = …, …)
+    - pattern: info!($$$ARGS, token, $$$REST)
+    - pattern: warn!($$$ARGS, token, $$$REST)
+    - pattern: error!($$$ARGS, token, $$$REST)
+    - pattern: info!(token, $$$REST)
+    - pattern: warn!(token, $$$REST)
+    - pattern: error!(token, $$$REST)
+    - pattern: info!($$$ARGS, authorization, $$$REST)
+    - pattern: warn!($$$ARGS, authorization, $$$REST)
+    - pattern: error!($$$ARGS, authorization, $$$REST)
+    - pattern: info!($$$ARGS, cookie, $$$REST)
+    - pattern: warn!($$$ARGS, cookie, $$$REST)
+    - pattern: error!($$$ARGS, cookie, $$$REST)
+    - pattern: info!($$$ARGS, headers, $$$REST)
+    - pattern: warn!($$$ARGS, headers, $$$REST)
+    - pattern: error!($$$ARGS, headers, $$$REST)
+    - pattern: info!($$$ARGS, signed_url, $$$REST)
+    - pattern: warn!($$$ARGS, signed_url, $$$REST)
+    - pattern: error!($$$ARGS, signed_url, $$$REST)
+    # ?body / body = … inside the macro
+    - pattern: info!(?body, $$$REST)
+    - pattern: warn!(?body, $$$REST)
+    - pattern: error!(?body, $$$REST)
+    - pattern: info!(body, $$$REST)
+    - pattern: warn!(body, $$$REST)
+    - pattern: error!(body, $$$REST)
+    - pattern: info!(%body, $$$REST)
+    - pattern: warn!(%body, $$$REST)
+    - pattern: error!(%body, $$$REST)
+    - pattern: info!(payload, $$$REST)
+    - pattern: warn!(payload, $$$REST)
+    - pattern: error!(payload, $$$REST)
+    - pattern: info!(?payload, $$$REST)
+    - pattern: warn!(?payload, $$$REST)
+    - pattern: error!(?payload, $$$REST)


### PR DESCRIPTION
## What & why

<!-- What this change does and the problem it solves. Link the issue if there is one. -->

## Protocol surface

<!--
Check whether this change touches the core runner protocol interface:
  - registration / `/_apis/...` request and response shapes
  - broker messages (job request, complete, renew) and NDJSON event shapes
  - Twirp results-service / artifact-service payloads
  - check-run or OAuth wire behavior

If it does, the gates below are REQUIRED before merge — preloop's compatibility
contract is byte-for-byte fidelity with the official runner (v2.336.0).
-->

- [ ] I confirm this change touches the runner protocol interface: **YES / NO**

## Required gates

- [ ] `just test-ci` passes locally (fmt-check + clippy `-D` + full test suite + runner-watch conformance)
- [ ] If protocol/wire shapes changed: the change is validated against the official runner (golden replay via `runner-watch`, or a live capture showing the official bytes), not only unit tests
- [ ] If the touched subsystem has property tests (`concurrency_properties`, scheduling, matrix expansion, …): they are extended for the changed contract and pass (`PROPTEST_CASES=256 cargo test -p preloop-runner-server`)
- [ ] New wire fields/events are additive and serde-defaulted where the official runner would not send them
- [ ] No secrets, credentials, or internal/deployment-specific paths are introduced (captures with live tokens must be redacted or excluded)

## Verification performed

<!-- Concrete evidence: commands run, test names, capture outputs. -->

## Checklist

- [ ] Tests added/updated for any new observable contract
- [ ] Docs updated (`docs/`, `CONTRIBUTING.md`) where behavior changed
- [ ] Changelog-worthy user-facing change described in the PR body

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a first-class, backend-optional observability layer and now exports logs, metrics, and traces over OTLP/HTTP. Operators get actionable health from new status/metrics/readiness endpoints; when `OTEL_*` is set, telemetry exports with bounded cardinality and fail-open behavior.

**Changes**
- Adds `preloop-observability`: env-driven logging (default `RUST_LOG=info`, `PRELOOP_LOG_FORMAT`), task heartbeats and limit counters, a shared metrics registry, W3C trace context, and a bounded OTLP/HTTP exporter that now sends logs, metrics (cumulative with process start) and traces; one background worker drains logs/spans and scrapes metrics; disabled unless `OTEL_*` is set.
- Server (`preloop-runner-server`): adds public `/readyz`, authenticated `/api/v1/status` and `/metrics`; replaces `TraceLayer` with safe HTTP metrics middleware (normalized route, bounded surface; excludes live-log websocket); instruments the store; samples status off-lock; `/healthz` returns 503 during shutdown. Records job terminal transitions with bounded reasons (adds `no_platform_runner`) and logs `reason.detail`; records queue wait, broker poll, and session create/delete. Adopts inbound `traceparent`, rejects all-zero IDs, marks only 5xx as errors, and suppresses health/metrics probes from tracing. OpenAPI documents routes; `rules/no-sensitive-log-fields.yml` forbids tokens/bodies in INFO/WARN/ERROR logs.
- CLI (`preloop`): unified logging; `status` becomes `status --json|--limit`, fetches `/api/v1/status`; readiness probe uses `/readyz`.
- Runner/Pool/VM: unified logging; runner keeps local logging only (no OTLP by default); `RunnerPoolConfig` adds `pool_status` (preparing flag); adds VM telemetry registry and host sampler stubs.
- Adds pinned, loopback-only `contrib/openobserve/compose.yml`; internal docs and plan updates.

**Rollout**
- Migrate scripts to: `preloop status --json | jq ...`.
- Keep `/api/v1/status` and `/metrics` behind the native bearer; do not expose publicly.
- To export via OTLP/HTTP, set `OTEL_SERVICE_NAME` and `OTEL_EXPORTER_OTLP_ENDPOINT` (and headers if needed). Absent endpoint disables export (intentional deviation from the spec’s localhost default). Ensure your backend accepts logs, metrics, and traces.
- Logs now include `traceId`/`spanId` in OTLP records; update any log parsing schemas.
- Expect `/healthz` to return 503 during shutdown.
- Fix any violations flagged by `rules/no-sensitive-log-fields.yml` before merge.

<sup>Written for commit 4faa700fd9516795f996dc61fe9197ea0bb9222b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `preloop-observability` crate and wire status, metrics, and readiness endpoints
> - Introduces a new `preloop-observability` crate providing `ObservabilityConfig` from env, log subscriber installation, task heartbeat and limit registries, bounded OTLP span/log export, Prometheus HTTP metrics, VM fleet telemetry, and a consolidated `OperationalSnapshot` model.
> - Server startup now installs the observability stack, wraps the store in `InstrumentedStore` for per-operation timing, runs a 5s state sampler that caches `OperationalSnapshot`, and exposes public `/readyz` plus bearer-auth `/api/v1/status` and `/metrics`.
> - `http_metrics_middleware` replaces `tower_http::TraceLayer`, recording bounded duration histograms and active-request gauges; live-log websockets are excluded from duration metrics.
> - CLI `status` subcommand is redesigned to fetch `/api/v1/status` with `--json` and `--limit` flags and render a multi-section human summary; the old single-run-id status mode is removed. Engine readiness probe switches from `/healthz` to `/readyz`.
> - Adds a semgrep-style rule [no-sensitive-log-fields.yml](https://github.com/preloopdev/preloop/pull/168/files#diff-2a379d0d71107c7925b75189ec06417319326b5b43ea19f8bd6422bb3e5956bf) and scrubs `token` and raw `body` from existing handler logs.
> - Behavioral Change: `/healthz` now returns 503 during shutdown; `readyz` returns 503 on shutdown, stale critical heartbeats (>15s), or stale snapshot (>15s). CLI `status` no longer accepts a positional run-id argument. `PoolStatus` handle marks `preparing` true/false during pool preparation phases, and `reap_once` skips work while preparing.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4faa700. 6 files reviewed, 14 issues evaluated, 7 issues filtered, 7 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>crates/preloop-observability/src/export.rs — 5 comments posted, 9 evaluated, 4 filtered</summary>
>
> - [line 88](https://github.com/preloopdev/preloop/blob/4faa700fd9516795f996dc61fe9197ea0bb9222b/crates/preloop-observability/src/export.rs#L88): `SpanContext::root` does not enforce the W3C non-zero ID invariant. `random_hex(8)` can return `0000000000000000` (and the trace generator can likewise return an all-zero trace ID), so the generated context is occasionally invalid and may be rejected by a conforming telemetry backend. Regenerate when either random ID is all zero. <b>[ Out of scope (post-validation triage) ]</b>
> - [line 108](https://github.com/preloopdev/preloop/blob/4faa700fd9516795f996dc61fe9197ea0bb9222b/crates/preloop-observability/src/export.rs#L108): `from_traceparent` accepts malformed W3C headers and adopts their caller-controlled trace ID. It never validates the fourth `trace-flags` field, accepts non-hex/forbidden `ff` versions, and accepts uppercase IDs even though the W3C grammar requires lowercase hex. For example, `00-<valid trace id>-<valid parent id>-zz` is treated as valid rather than starting a new root, causing unrelated or invalid requests to be correlated into the supplied trace. <b>[ Out of scope (post-validation triage) ]</b>
> - [line 131](https://github.com/preloopdev/preloop/blob/4faa700fd9516795f996dc61fe9197ea0bb9222b/crates/preloop-observability/src/export.rs#L131): `random_hex` samples every byte without rejecting the all-zero result. `SpanContext::root()` uses it for W3C trace/span IDs, but this change's own malformed-header test documents that all-zero IDs are invalid, so the generated context can very rarely contain an invalid trace ID (probability 2^-128) or span ID (2^-64). Regenerate when all sampled bytes are zero. <b>[ Out of scope (post-validation triage) ]</b>
> - [line 727](https://github.com/preloopdev/preloop/blob/4faa700fd9516795f996dc61fe9197ea0bb9222b/crates/preloop-observability/src/export.rs#L727): `traceparent_is_adopted_as_parent` asserts that a newly random 64-bit `span_id` cannot equal the incoming parent ID. `random_hex(8)` does not exclude that value, so this test has a 1-in-2^64 chance of failing despite correct child-generation behavior; the test should validate generation independently rather than require impossible collision-freedom. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
> <details>
> <summary>crates/preloop-observability/src/lib.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 450](https://github.com/preloopdev/preloop/blob/4faa700fd9516795f996dc61fe9197ea0bb9222b/crates/preloop-observability/src/lib.rs#L450): `from_config` passes whichever raw endpoint `from_env` found to a single exporter that unconditionally appends `/v1/logs`, `/v1/traces`, and `/v1/metrics`. When an operator uses a signal-specific variable such as `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://collector:4318/v1/traces`, OTLP requires that URL to be used as-is, but this sends traces to `/v1/traces/v1/traces` and also misroutes logs/metrics through that endpoint. Signal-specific endpoint configurations therefore silently fail or export signals to the wrong paths; endpoint kind and per-signal URLs must be preserved instead of collapsing them here. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>crates/preloop-observability/src/metrics.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 610](https://github.com/preloopdev/preloop/blob/4faa700fd9516795f996dc61fe9197ea0bb9222b/crates/preloop-observability/src/metrics.rs#L610): `otlp_bucket_counts` copies the histogram's Prometheus-style cumulative `le` counts directly into OTLP. OTLP explicit buckets require the count that fell within each disjoint bucket, so adjacent cumulative values must be differenced and the final `+Inf` bucket must be `self.count - last_cumulative_count`. As written, ordinary observations are counted repeatedly across buckets (and `self.count` is appended as another full-population bucket), producing malformed histograms whose bucket total greatly exceeds the declared `count` for both HTTP and store exports. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>crates/preloop-runner-server/src/state.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 610](https://github.com/preloopdev/preloop/blob/4faa700fd9516795f996dc61fe9197ea0bb9222b/crates/preloop-runner-server/src/state.rs#L610): `bounded_termination_reason` checks `value.contains("runner is registered with this server")` before recognizing the starvation prefix. Because that prose interpolates user-controlled `runs-on` labels, a label containing this phrase makes a starvation reason beginning with `no runner is registered for` get classified as `no_platform_runner` instead of `no_runner`. Match the stable prefix first (or avoid substring matching across interpolated text) so workflow content cannot alter the bounded classification. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added operational status, readiness, and Prometheus metrics endpoints.
  - Added structured service, queue, runner, VM, storage, scheduler, and task monitoring.
  - Added optional OTLP telemetry export and OpenObserve deployment support.
  - Added configurable JSON or human-readable CLI status output.
  - Added VM telemetry and runner-pool health tracking.

- **Bug Fixes**
  - Improved readiness responses with actionable failure reasons.
  - Prevented sensitive tokens and request contents from appearing in logs.

- **Documentation**
  - Added observability, security, deployment, and implementation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->