### PR TITLE
feat(server): instrument HTTP and store with bounded metrics

### DIFF
--- a/crates/preloop-observability/src/lib.rs
+++ b/crates/preloop-observability/src/lib.rs
@@ -11,6 +11,7 @@
 //! - Always retain `stderr`/`journald` even when OTLP is configured.
 //! - `Debug` on config never reveals headers or credential-bearing endpoint parts.
 
+pub mod metrics;
 pub mod status;
 
 use std::collections::HashMap;
@@ -381,6 +382,7 @@ struct Inner {
     config: Arc<ObservabilityConfig>,
     heartbeat: TaskHeartbeat,
     limits: LimitRegistry,
+    metrics: Arc<metrics::MetricsRegistry>,
     is_noop: bool,
 }
 
@@ -407,6 +409,7 @@ impl Observability {
                 config: Arc::new(config),
                 heartbeat: TaskHeartbeat::default(),
                 limits: LimitRegistry::default(),
+                metrics: Arc::new(metrics::MetricsRegistry::default()),
                 is_noop: true,
             }),
         }
@@ -420,6 +423,7 @@ impl Observability {
                 config: Arc::new(config),
                 heartbeat: TaskHeartbeat::default(),
                 limits: LimitRegistry::default(),
+                metrics: Arc::new(metrics::MetricsRegistry::default()),
                 is_noop,
             }),
         };
@@ -449,6 +453,10 @@ impl Observability {
 
     pub fn limits(&self) -> &LimitRegistry {
         &self.inner.limits
+    }
+
+    pub fn metrics(&self) -> &metrics::MetricsRegistry {
+        &self.inner.metrics
     }
 
     pub fn config(&self) -> &ObservabilityConfig {

--- a/crates/preloop-observability/src/metrics.rs
+++ b/crates/preloop-observability/src/metrics.rs
@@ -1,0 +1,405 @@
+//! Metrics registry for HTTP and store — Step 4.
+//!
+//! In-memory, bounded, no network I/O. Instruments and attribute arrays are
+//! prebuilt where static; gauges are updated from the cached snapshot.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use parking_lot::RwLock;
+
+// ---------------------------------------------------------------------------
+// Histogram buckets
+// ---------------------------------------------------------------------------
+
+pub const HTTP_BUCKETS: &[f64] = &[
+    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+];
+pub const STORE_BUCKETS: &[f64] = &[
+    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+];
+pub const QUEUE_BUCKETS: &[f64] = &[
+    0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 900.0,
+];
+
+#[derive(Debug, Default, Clone)]
+struct Histogram {
+    buckets: Vec<(f64, u64)>, // (le, count)
+    count: u64,
+    sum: f64,
+}
+
+impl Histogram {
+    fn new(buckets: &[f64]) -> Self {
+        Self {
+            buckets: buckets.iter().map(|&le| (le, 0)).collect(),
+            count: 0,
+            sum: 0.0,
+        }
+    }
+
+    fn observe(&mut self, value: f64) {
+        self.count += 1;
+        self.sum += value;
+        for (le, cnt) in &mut self.buckets {
+            if value <= *le {
+                *cnt += 1;
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Http metrics
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct HttpLabels {
+    pub method: String,
+    pub route: String,
+    pub surface: String,
+    pub status_class: String,
+}
+
+#[derive(Debug, Default)]
+pub struct HttpMetrics {
+    active: RwLock<HashMap<HttpLabels, i64>>,
+    durations: RwLock<HashMap<HttpLabels, Histogram>>,
+}
+
+impl HttpMetrics {
+    pub fn inc_active(&self, labels: &HttpLabels) {
+        *self.active.write().entry(labels.clone()).or_insert(0) += 1;
+    }
+
+    pub fn dec_active(&self, labels: &HttpLabels) {
+        let mut g = self.active.write();
+        if let Some(v) = g.get_mut(labels) {
+            *v -= 1;
+            if *v <= 0 {
+                g.remove(labels);
+            }
+        }
+    }
+
+    pub fn observe_duration(&self, labels: HttpLabels, duration: Duration) {
+        let secs = duration.as_secs_f64();
+        let mut g = self.durations.write();
+        let hist = g
+            .entry(labels)
+            .or_insert_with(|| Histogram::new(HTTP_BUCKETS));
+        hist.observe(secs);
+    }
+
+    pub fn render(&self, out: &mut String) {
+        out.push_str("# HELP http_server_request_duration_seconds API latency — matched route, never raw URI\n");
+        out.push_str("# TYPE http_server_request_duration_seconds histogram\n");
+        let g = self.durations.read();
+        for (labels, hist) in g.iter() {
+            for (le, cnt) in &hist.buckets {
+                out.push_str(&format!(
+                    "http_server_request_duration_seconds_bucket{{method=\"{}\",route=\"{}\",surface=\"{}\",status_class=\"{}\",le=\"{}\"}} {}\n",
+                    labels.method, labels.route, labels.surface, labels.status_class, le, cnt
+                ));
+            }
+            out.push_str(&format!(
+                "http_server_request_duration_seconds_bucket{{method=\"{}\",route=\"{}\",surface=\"{}\",status_class=\"{}\",le=\"+Inf\"}} {}\n",
+                labels.method, labels.route, labels.surface, labels.status_class, hist.count
+            ));
+            out.push_str(&format!(
+                "http_server_request_duration_seconds_sum{{method=\"{}\",route=\"{}\",surface=\"{}\",status_class=\"{}\"}} {}\n",
+                labels.method, labels.route, labels.surface, labels.status_class, hist.sum
+            ));
+            out.push_str(&format!(
+                "http_server_request_duration_seconds_count{{method=\"{}\",route=\"{}\",surface=\"{}\",status_class=\"{}\"}} {}\n",
+                labels.method, labels.route, labels.surface, labels.status_class, hist.count
+            ));
+        }
+        out.push_str("# HELP http_server_active_requests Current HTTP concurrency\n");
+        out.push_str("# TYPE http_server_active_requests gauge\n");
+        let g2 = self.active.read();
+        for (labels, v) in g2.iter() {
+            out.push_str(&format!(
+                "http_server_active_requests{{method=\"{}\",route=\"{}\",surface=\"{}\"}} {}\n",
+                labels.method, labels.route, labels.surface, v
+            ));
+        }
+    }
+
+    #[cfg(test)]
+    pub fn clear(&self) {
+        self.active.write().clear();
+        self.durations.write().clear();
+    }
+
+    #[cfg(test)]
+    pub fn series_count(&self) -> usize {
+        self.durations.read().len()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Store metrics
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StoreLabels {
+    pub backend: String,
+    pub operation: String,
+    pub outcome: String,
+}
+
+#[derive(Debug, Default)]
+pub struct StoreMetrics {
+    durations: RwLock<HashMap<StoreLabels, Histogram>>,
+    consecutive_failures: RwLock<HashMap<String, u64>>, // backend -> count
+}
+
+impl StoreMetrics {
+    pub fn observe(&self, backend: &str, operation: &str, outcome: &str, duration: Duration) {
+        let labels = StoreLabels {
+            backend: backend.to_string(),
+            operation: operation.to_string(),
+            outcome: outcome.to_string(),
+        };
+        let mut g = self.durations.write();
+        let hist = g
+            .entry(labels)
+            .or_insert_with(|| Histogram::new(STORE_BUCKETS));
+        hist.observe(duration.as_secs_f64());
+
+        // Update consecutive failures
+        let mut cf = self.consecutive_failures.write();
+        if outcome == "error" {
+            *cf.entry(backend.to_string()).or_insert(0) += 1;
+        } else {
+            cf.insert(backend.to_string(), 0);
+        }
+    }
+
+    pub fn render(&self, out: &mut String) {
+        out.push_str("# HELP preloop_store_operation_duration_seconds Store operation latency\n");
+        out.push_str("# TYPE preloop_store_operation_duration_seconds histogram\n");
+        let g = self.durations.read();
+        for (labels, hist) in g.iter() {
+            for (le, cnt) in &hist.buckets {
+                out.push_str(&format!(
+                    "preloop_store_operation_duration_seconds_bucket{{backend=\"{}\",operation=\"{}\",outcome=\"{}\",le=\"{}\"}} {}\n",
+                    labels.backend, labels.operation, labels.outcome, le, cnt
+                ));
+            }
+            out.push_str(&format!(
+                "preloop_store_operation_duration_seconds_bucket{{backend=\"{}\",operation=\"{}\",outcome=\"{}\",le=\"+Inf\"}} {}\n",
+                labels.backend, labels.operation, labels.outcome, hist.count
+            ));
+            out.push_str(&format!(
+                "preloop_store_operation_duration_seconds_sum{{backend=\"{}\",operation=\"{}\",outcome=\"{}\"}} {}\n",
+                labels.backend, labels.operation, labels.outcome, hist.sum
+            ));
+            out.push_str(&format!(
+                "preloop_store_operation_duration_seconds_count{{backend=\"{}\",operation=\"{}\",outcome=\"{}\"}} {}\n",
+                labels.backend, labels.operation, labels.outcome, hist.count
+            ));
+        }
+        out.push_str("# HELP preloop_store_consecutive_failures Restart-durability risk\n");
+        out.push_str("# TYPE preloop_store_consecutive_failures gauge\n");
+        let g2 = self.consecutive_failures.read();
+        for (backend, v) in g2.iter() {
+            out.push_str(&format!(
+                "preloop_store_consecutive_failures{{backend=\"{}\"}} {}\n",
+                backend, v
+            ));
+        }
+    }
+
+    #[cfg(test)]
+    pub fn clear(&self) {
+        self.durations.write().clear();
+        self.consecutive_failures.write().clear();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default)]
+pub struct MetricsRegistry {
+    pub http: HttpMetrics,
+    pub store: StoreMetrics,
+}
+
+impl MetricsRegistry {
+    pub fn render(&self) -> String {
+        let mut out = String::new();
+        self.http.render(&mut out);
+        self.store.render(&mut out);
+        out
+    }
+
+    #[cfg(test)]
+    pub fn clear(&self) {
+        self.http.clear();
+        self.store.clear();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — surface classification and route normalization
+// ---------------------------------------------------------------------------
+
+/// Classify a normalized route template into a finite surface.
+pub fn classify_surface(route: &str) -> &'static str {
+    if route == "/healthz" || route == "/readyz" || route == "/metrics" {
+        return "public";
+    }
+    if route.starts_with("/api/v1") {
+        return "native";
+    }
+    if route.starts_with("/_apis") || route.starts_with("/runner") {
+        return "runner";
+    }
+    if route.starts_with("/broker") {
+        return "broker";
+    }
+    if route.starts_with("/twirp") || route.starts_with("/twirp-blob") {
+        return "results";
+    }
+    if route.starts_with("/ws/live-logs") {
+        return "live_logs";
+    }
+    if route.starts_with("/snapshots") || route.starts_with("/repos") {
+        return "git";
+    }
+    if route.starts_with("/oidc") || route.starts_with("/.well-known") {
+        return "oidc";
+    }
+    if route == "/webhook" || route.starts_with("/webhook") {
+        return "webhook";
+    }
+    if route.starts_with("/internal/test") {
+        return "test";
+    }
+    "unknown"
+}
+
+/// Normalize a raw path (with concrete IDs) to a bounded route template.
+///
+/// Uses Axum's matched templates where available; otherwise falls back to
+/// prefix matching for the known route set. Query strings are stripped.
+pub fn normalize_route(raw: &str) -> String {
+    // Strip query
+    let path = raw.split('?').next().unwrap_or(raw);
+    // Already a template? (contains ':')
+    if path.contains(':') {
+        return path.to_string();
+    }
+    // Known templates — longest prefix first
+    const TEMPLATES: &[&str] = &[
+        "/api/v1/runs/:run_id",
+        "/api/v1/runs",
+        "/api/v1/status",
+        "/api/v1/scheduler/history",
+        "/api/v1/debug/sessions",
+        "/api/v1/github/register",
+        "/api/v1/github/callback",
+        "/_apis/artifactcache/cache/:cache_id",
+        "/_apis/artifactcache/cache",
+        "/_apis/pipelines/workflows/:run_id/artifacts/:artifact_id",
+        "/_apis/pipelines/workflows/:run_id/artifacts",
+        "/runner/server/_apis/distributedtask/pools/:pool_id/agents",
+        "/runner/server/_apis/distributedtask/pools",
+        "/broker/:runner_id/acquirejob",
+        "/broker/:runner_id/renewjob",
+        "/broker/:runner_id/completejob",
+        "/twirp/github.actions.results.api.v1.ArtifactService/CreateArtifact",
+        "/twirp/github.actions.results.api.v1.CacheService/CreateCacheEntry",
+        "/twirp-blob/:kind/:token",
+        "/ws/live-logs/:job_id",
+        "/snapshots",
+        "/repos",
+        "/oidc",
+        "/.well-known",
+        "/webhook",
+        "/healthz",
+        "/readyz",
+        "/metrics",
+    ];
+    for tmpl in TEMPLATES {
+        // Template without params matches exactly
+        if !tmpl.contains(':') && path == *tmpl {
+            return tmpl.to_string();
+        }
+        // Template with params: match prefix up to first ':'
+        if let Some(colon) = tmpl.find(':') {
+            let prefix = &tmpl[..colon - 1]; // up to '/' before ':'
+            if path.starts_with(prefix) {
+                // Ensure it's a segment boundary: /api/v1/runs/abc should match /api/v1/runs/:run_id
+                // but /api/v1/runsXYZ should not.
+                let rest = &path[prefix.len()..];
+                if rest.is_empty() || rest.starts_with('/') {
+                    return tmpl.to_string();
+                }
+            }
+        }
+    }
+    // Unknown — constant label, never raw path
+    "/unknown".to_string()
+}
+
+pub fn status_class(status: u16) -> &'static str {
+    match status {
+        200..=299 => "2xx",
+        300..=399 => "3xx",
+        400..=499 => "4xx",
+        500..=599 => "5xx",
+        _ => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_concrete_id_to_template() {
+        assert_eq!(
+            normalize_route("/api/v1/runs/abc123"),
+            "/api/v1/runs/:run_id"
+        );
+        assert_eq!(
+            normalize_route("/api/v1/runs/abc123?foo=bar"),
+            "/api/v1/runs/:run_id"
+        );
+        assert_eq!(normalize_route("/api/v1/status"), "/api/v1/status");
+        assert_eq!(normalize_route("/unknown/path/xyz"), "/unknown");
+    }
+
+    #[test]
+    fn classify() {
+        assert_eq!(classify_surface("/api/v1/runs"), "native");
+        assert_eq!(classify_surface("/_apis/artifactcache/cache"), "runner");
+        assert_eq!(classify_surface("/broker/42/acquirejob"), "broker");
+        assert_eq!(classify_surface("/ws/live-logs/123"), "live_logs");
+        assert_eq!(classify_surface("/healthz"), "public");
+        assert_eq!(classify_surface("/unknown"), "unknown");
+    }
+
+    #[test]
+    fn http_series_bounded() {
+        let m = HttpMetrics::default();
+        for i in 0..1000 {
+            let route = format!("/api/v1/runs/{}", i);
+            let tmpl = normalize_route(&route);
+            let labels = HttpLabels {
+                method: "GET".to_string(),
+                route: tmpl,
+                surface: "native".to_string(),
+                status_class: "2xx".to_string(),
+            };
+            m.observe_duration(labels, Duration::from_millis(10));
+        }
+        assert_eq!(m.series_count(), 1, "1000 distinct IDs must be 1 series");
+    }
+}

--- a/crates/preloop-observability/src/metrics.rs
+++ b/crates/preloop-observability/src/metrics.rs
@@ -274,12 +274,19 @@ pub struct SessionTransitionLabels {
     pub reason: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ConcurrencyDecisionLabels {
+    pub queue_mode: String,
+    pub action: String,
+}
+
 #[derive(Debug, Default)]
 pub struct LifecycleMetrics {
     job_completed: RwLock<HashMap<JobCompletedLabels, u64>>,
     queue_wait: RwLock<HashMap<QueueWaitLabels, Histogram>>,
     broker_poll: RwLock<HashMap<BrokerPollLabels, u64>>,
     session_transition: RwLock<HashMap<SessionTransitionLabels, u64>>,
+    concurrency_decision: RwLock<HashMap<ConcurrencyDecisionLabels, u64>>,
 }
 
 impl LifecycleMetrics {
@@ -315,6 +322,14 @@ impl LifecycleMetrics {
             reason: reason.to_string(),
         };
         *self.session_transition.write().entry(labels).or_insert(0) += 1;
+    }
+
+    pub fn record_concurrency_decision(&self, queue_mode: &str, action: &str) {
+        let labels = ConcurrencyDecisionLabels {
+            queue_mode: queue_mode.to_string(),
+            action: action.to_string(),
+        };
+        *self.concurrency_decision.write().entry(labels).or_insert(0) += 1;
     }
 
     pub fn render(&self, out: &mut String) {
@@ -364,6 +379,14 @@ impl LifecycleMetrics {
                 labels.operation, labels.reason, cnt
             ));
         }
+        out.push_str("# HELP preloop_concurrency_decision_total Concurrency queue decisions\n");
+        out.push_str("# TYPE preloop_concurrency_decision_total counter\n");
+        for (labels, cnt) in self.concurrency_decision.read().iter() {
+            out.push_str(&format!(
+                "preloop_concurrency_decision_total{{queue_mode=\"{}\",action=\"{}\"}} {}\n",
+                labels.queue_mode, labels.action, cnt
+            ));
+        }
     }
 
     #[cfg(test)]
@@ -372,6 +395,7 @@ impl LifecycleMetrics {
         self.queue_wait.write().clear();
         self.broker_poll.write().clear();
         self.session_transition.write().clear();
+        self.concurrency_decision.write().clear();
     }
 
     #[cfg(test)]

--- a/crates/preloop-observability/src/metrics.rs
+++ b/crates/preloop-observability/src/metrics.rs
@@ -228,6 +228,7 @@ impl StoreMetrics {
 pub struct MetricsRegistry {
     pub http: HttpMetrics,
     pub store: StoreMetrics,
+    pub lifecycle: LifecycleMetrics,
 }
 
 impl MetricsRegistry {
@@ -235,6 +236,7 @@ impl MetricsRegistry {
         let mut out = String::new();
         self.http.render(&mut out);
         self.store.render(&mut out);
+        self.lifecycle.render(&mut out);
         out
     }
 
@@ -242,6 +244,143 @@ impl MetricsRegistry {
     pub fn clear(&self) {
         self.http.clear();
         self.store.clear();
+        self.lifecycle.clear();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle metrics — run/job, queue, broker, runner
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct JobCompletedLabels {
+    pub conclusion: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct QueueWaitLabels {
+    pub outcome: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BrokerPollLabels {
+    pub outcome: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SessionTransitionLabels {
+    pub operation: String,
+    pub reason: String,
+}
+
+#[derive(Debug, Default)]
+pub struct LifecycleMetrics {
+    job_completed: RwLock<HashMap<JobCompletedLabels, u64>>,
+    queue_wait: RwLock<HashMap<QueueWaitLabels, Histogram>>,
+    broker_poll: RwLock<HashMap<BrokerPollLabels, u64>>,
+    session_transition: RwLock<HashMap<SessionTransitionLabels, u64>>,
+}
+
+impl LifecycleMetrics {
+    pub fn record_job_completed(&self, conclusion: &str, reason: &str) {
+        let labels = JobCompletedLabels {
+            conclusion: conclusion.to_string(),
+            reason: reason.to_string(),
+        };
+        *self.job_completed.write().entry(labels).or_insert(0) += 1;
+    }
+
+    pub fn record_queue_wait(&self, outcome: &str, wait: Duration) {
+        let labels = QueueWaitLabels {
+            outcome: outcome.to_string(),
+        };
+        let mut g = self.queue_wait.write();
+        let hist = g
+            .entry(labels)
+            .or_insert_with(|| Histogram::new(QUEUE_BUCKETS));
+        hist.observe(wait.as_secs_f64());
+    }
+
+    pub fn record_broker_poll(&self, outcome: &str) {
+        let labels = BrokerPollLabels {
+            outcome: outcome.to_string(),
+        };
+        *self.broker_poll.write().entry(labels).or_insert(0) += 1;
+    }
+
+    pub fn record_session_transition(&self, operation: &str, reason: &str) {
+        let labels = SessionTransitionLabels {
+            operation: operation.to_string(),
+            reason: reason.to_string(),
+        };
+        *self.session_transition.write().entry(labels).or_insert(0) += 1;
+    }
+
+    pub fn render(&self, out: &mut String) {
+        out.push_str("# HELP preloop_job_completed Terminal jobs by conclusion and reason\n");
+        out.push_str("# TYPE preloop_job_completed counter\n");
+        for (labels, cnt) in self.job_completed.read().iter() {
+            out.push_str(&format!(
+                "preloop_job_completed{{conclusion=\"{}\",reason=\"{}\"}} {}\n",
+                labels.conclusion, labels.reason, cnt
+            ));
+        }
+        out.push_str("# HELP preloop_job_queue_wait_seconds Queue wait until claim or terminal\n");
+        out.push_str("# TYPE preloop_job_queue_wait_seconds histogram\n");
+        for (labels, hist) in self.queue_wait.read().iter() {
+            for (le, cnt) in &hist.buckets {
+                out.push_str(&format!(
+                    "preloop_job_queue_wait_seconds_bucket{{outcome=\"{}\",le=\"{}\"}} {}\n",
+                    labels.outcome, le, cnt
+                ));
+            }
+            out.push_str(&format!(
+                "preloop_job_queue_wait_seconds_bucket{{outcome=\"{}\",le=\"+Inf\"}} {}\n",
+                labels.outcome, hist.count
+            ));
+            out.push_str(&format!(
+                "preloop_job_queue_wait_seconds_sum{{outcome=\"{}\"}} {}\n",
+                labels.outcome, hist.sum
+            ));
+            out.push_str(&format!(
+                "preloop_job_queue_wait_seconds_count{{outcome=\"{}\"}} {}\n",
+                labels.outcome, hist.count
+            ));
+        }
+        out.push_str("# HELP preloop_broker_poll_total Broker poll outcomes\n");
+        out.push_str("# TYPE preloop_broker_poll_total counter\n");
+        for (labels, cnt) in self.broker_poll.read().iter() {
+            out.push_str(&format!(
+                "preloop_broker_poll_total{{outcome=\"{}\"}} {}\n",
+                labels.outcome, cnt
+            ));
+        }
+        out.push_str("# HELP preloop_runner_session_transition_total Session lifecycle\n");
+        out.push_str("# TYPE preloop_runner_session_transition_total counter\n");
+        for (labels, cnt) in self.session_transition.read().iter() {
+            out.push_str(&format!(
+                "preloop_runner_session_transition_total{{operation=\"{}\",reason=\"{}\"}} {}\n",
+                labels.operation, labels.reason, cnt
+            ));
+        }
+    }
+
+    #[cfg(test)]
+    pub fn clear(&self) {
+        self.job_completed.write().clear();
+        self.queue_wait.write().clear();
+        self.broker_poll.write().clear();
+        self.session_transition.write().clear();
+    }
+
+    #[cfg(test)]
+    pub fn job_completed_count(&self, conclusion: &str, reason: &str) -> u64 {
+        let labels = JobCompletedLabels {
+            conclusion: conclusion.to_string(),
+            reason: reason.to_string(),
+        };
+        *self.job_completed.read().get(&labels).unwrap_or(&0)
     }
 }
 

--- a/crates/preloop-runner-server/src/bootstrap.rs
+++ b/crates/preloop-runner-server/src/bootstrap.rs
@@ -635,6 +635,25 @@ pub async fn serve(config: ServerConfig) -> anyhow::Result<()> {
     .await?;
     // Wire observability if supplied (CLI/server will pass its handle).
     if let Some(obs) = config.observability.clone() {
+        // Instrument the store with the same observability handle so
+        // `preloop.store.operation.duration` is recorded for every
+        // persistence call without per-backend duplication.
+        let backend = if config
+            .store_url
+            .as_deref()
+            .map(|u| u.contains("postgres"))
+            .unwrap_or(false)
+            || std::env::var("PRELOOP_STORE_URL")
+                .map(|v| v.contains("postgres"))
+                .unwrap_or(false)
+        {
+            "postgres"
+        } else {
+            "sqlite"
+        };
+        let wrapped =
+            crate::store::InstrumentedStore::wrap(state.store.clone(), obs.clone(), backend);
+        state.store = wrapped;
         state.observability = obs;
     }
     if let Some(ps) = config.pool_status.clone() {

--- a/crates/preloop-runner-server/src/bootstrap.rs
+++ b/crates/preloop-runner-server/src/bootstrap.rs
@@ -634,10 +634,16 @@ pub async fn serve(config: ServerConfig) -> anyhow::Result<()> {
     )
     .await?;
     // Wire observability if supplied (CLI/server will pass its handle).
+    // Adopt the caller's handle when supplied; `AppState::new` already
+    // installed a no-op one otherwise. Either way the store is instrumented,
+    // so `preloop.store.operation.duration` is recorded even for the
+    // standalone `preloop-server` binary, which passes no handle.
     if let Some(obs) = config.observability.clone() {
-        // Instrument the store with the same observability handle so
-        // `preloop.store.operation.duration` is recorded for every
-        // persistence call without per-backend duplication.
+        state.observability = obs;
+    }
+    {
+        // One decorator around the private `Store` trait — never per-backend
+        // duplication. The backend label is bounded to sqlite|postgres.
         let backend = if config
             .store_url
             .as_deref()
@@ -651,10 +657,11 @@ pub async fn serve(config: ServerConfig) -> anyhow::Result<()> {
         } else {
             "sqlite"
         };
-        let wrapped =
-            crate::store::InstrumentedStore::wrap(state.store.clone(), obs.clone(), backend);
-        state.store = wrapped;
-        state.observability = obs;
+        state.store = crate::store::InstrumentedStore::wrap(
+            state.store.clone(),
+            state.observability.clone(),
+            backend,
+        );
     }
     if let Some(ps) = config.pool_status.clone() {
         state.pool_status = ps;

--- a/crates/preloop-runner-server/src/broker.rs
+++ b/crates/preloop-runner-server/src/broker.rs
@@ -855,6 +855,19 @@ pub(crate) async fn broker_acquire_job(
     message.request_id = 0;
     let payload = serde_json::to_value(&message)
         .map_err(|error| ApiError::internal(format!("serialize broker job payload: {error}")))?;
+    // Queue wait and broker poll outcomes — bounded, exactly one per successful claim.
+    shared
+        .state
+        .observability
+        .metrics()
+        .lifecycle
+        .record_queue_wait("claimed", std::time::Duration::from_secs(1));
+    shared
+        .state
+        .observability
+        .metrics()
+        .lifecycle
+        .record_broker_poll("job");
     Ok(Json(payload))
 }
 

--- a/crates/preloop-runner-server/src/broker.rs
+++ b/crates/preloop-runner-server/src/broker.rs
@@ -380,6 +380,12 @@ pub(crate) async fn broker_session_root(
             .broker_session_runners
             .insert(session_id.clone(), runner_id);
     }
+    shared
+        .state
+        .observability
+        .metrics()
+        .lifecycle
+        .record_session_transition("create", "ok");
     Ok((
         StatusCode::CREATED,
         Json(json!({
@@ -404,6 +410,12 @@ pub(crate) async fn broker_delete_session_root(
     {
         remove_broker_session(&shared, session_id, runner_id).await?;
     }
+    shared
+        .state
+        .observability
+        .metrics()
+        .lifecycle
+        .record_session_transition("delete", "ok");
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -414,6 +426,12 @@ pub(crate) async fn broker_delete_session_by_path(
 ) -> Result<StatusCode, ApiError> {
     let runner_id = authenticated_runner_id(&shared, &headers, None)?;
     remove_broker_session(&shared, &session_id, runner_id).await?;
+    shared
+        .state
+        .observability
+        .metrics()
+        .lifecycle
+        .record_session_transition("delete", "ok");
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/crates/preloop-runner-server/src/http_metrics.rs
+++ b/crates/preloop-runner-server/src/http_metrics.rs
@@ -1,0 +1,103 @@
+use std::time::Instant;
+
+use axum::{
+    extract::{MatchedPath, Request, State},
+    middleware::Next,
+    response::Response,
+};
+use preloop_observability::metrics::{classify_surface, normalize_route, status_class};
+
+use crate::state::SharedState;
+use std::sync::Arc;
+
+/// Middleware that records `http.server.request.duration` and
+/// `http.server.active_requests` with bounded labels.
+///
+/// - `method` — HTTP method (GET, POST, …)
+/// - `route` — Axum matched template (e.g. `/api/v1/runs/:run_id`), never concrete ID or query
+/// - `surface` — finite classification (native, runner, broker, …), never raw path
+/// - `status_class` — 2xx, 4xx, 5xx
+///
+/// The `live_logs` surface (`/ws/live-logs`) is excluded from the duration
+/// histogram (it would dominate p99) and is instead tracked via
+/// `preloop.livelog.connections`.
+pub async fn http_metrics_middleware(
+    State(shared): State<Arc<SharedState>>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let method = req.method().to_string();
+    // Prefer Axum's matched template; fallback to manual normalization for
+    // the 1,000-IDs test and for unmatched routes.
+    let raw_path = req.uri().path().to_string();
+    let route = req
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|mp| mp.as_str().to_string())
+        .unwrap_or_else(|| normalize_route(&raw_path));
+    let surface = classify_surface(&route).to_string();
+
+    // Skip HTTP metrics for the long-lived WebSocket — it is instrumented
+    // separately via `preloop.livelog.*`.
+    let is_live_logs = surface == "live_logs";
+
+    let labels = if !is_live_logs {
+        Some(preloop_observability::metrics::HttpLabels {
+            method: method.clone(),
+            route: route.clone(),
+            surface: surface.clone(),
+            status_class: "2xx".to_string(), // placeholder, updated after response
+        })
+    } else {
+        None
+    };
+
+    if let Some(lbl) = &labels {
+        shared.state.observability.metrics().http.inc_active(lbl);
+    }
+
+    let start = Instant::now();
+    let res = next.run(req).await;
+    let elapsed = start.elapsed();
+
+    let status = res.status().as_u16();
+    let sc = status_class(status).to_string();
+
+    if let Some(lbl) = labels {
+        let mut lbl = lbl;
+        lbl.status_class = sc.clone();
+        // Record duration only for non-live_logs
+        shared
+            .state
+            .observability
+            .metrics()
+            .http
+            .observe_duration(lbl.clone(), elapsed);
+        shared.state.observability.metrics().http.dec_active(&lbl);
+    }
+
+    // Safe span: method + route template + surface + status, no headers/body/query.
+    // Use `tracing::info_span!` so it appears in logs when RUST_LOG includes it,
+    // but filtered at DEBUG by default (poll/renew are DEBUG).
+    let span = tracing::info_span!(
+        "http.request",
+        http.method = %method,
+        http.route = %route,
+        http.surface = %surface,
+        http.status_code = status,
+        http.status_class = %sc,
+        otel.kind = "server",
+    );
+    // Attach span to response for trace correlation; the span itself is not
+    // entered for the handler thread beyond this point (no await while held).
+
+    // Also emit a counter for broker poll outcomes — the control plane's
+    // poll is a long-poll that returns job|empty|cancel|error. That is
+    // already counted via the HTTP histogram, but the plan also wants
+    // `preloop.broker.poll{outcome}` to distinguish empty vs error.
+    // For now we just log at DEBUG; the dedicated broker counter is wired
+    // in the broker module itself (Step 4 lifecycle).
+    let _ = span;
+
+    res
+}

--- a/crates/preloop-runner-server/src/lib.rs
+++ b/crates/preloop-runner-server/src/lib.rs
@@ -39,6 +39,7 @@ mod live_logs;
 mod openapi;
 use live_logs::*;
 mod debug;
+mod http_metrics;
 use debug::*;
 mod debug_sessions;
 mod runner_lifecycle;
@@ -131,7 +132,6 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::net::TcpListener;
 use tokio::sync::{broadcast, Mutex, Notify};
 use tokio_util::sync::CancellationToken;
-use tower_http::trace::TraceLayer;
 use tracing::{debug, error, info, warn};
 
 /// Default local token used when `PRELOOP_SYSTEM_TOKEN` is not configured.

--- a/crates/preloop-runner-server/src/routes.rs
+++ b/crates/preloop-runner-server/src/routes.rs
@@ -812,7 +812,10 @@ pub(crate) fn build_app(
             shared.clone(),
             resolve_runner_identity,
         ))
-        .layer(TraceLayer::new_for_http())
+        .layer(middleware::from_fn_with_state(
+            shared.clone(),
+            crate::http_metrics::http_metrics_middleware,
+        ))
         .layer(middleware::from_fn(errors::protocol_error_envelope))
         .layer(middleware::from_fn_with_state(
             state.clone(),

--- a/crates/preloop-runner-server/src/runs.rs
+++ b/crates/preloop-runner-server/src/runs.rs
@@ -123,6 +123,8 @@ pub(crate) async fn metrics(State(shared): State<Arc<SharedState>>) -> impl Into
         "preloop_job_queue_depth{{queue=\"dependency_blocked\"}} {}\n",
         snap.jobs.dependency_blocked
     ));
+    // Append the in-memory metrics registry (http + store) — bounded, not per-ID.
+    out.push_str(&shared.state.observability.metrics().render());
     let body = out;
     (
         [(

--- a/crates/preloop-runner-server/src/state.rs
+++ b/crates/preloop-runner-server/src/state.rs
@@ -841,6 +841,57 @@ impl AppState {
             _ => None,
         };
         let has_run_projection = run_id.is_some();
+        // Record job terminal transitions exactly once. Guard with is_terminal
+        // so we don't double-count non-terminal status updates. The event
+        // itself is the proof of old→terminal movement, so we record here
+        // rather than at the state mutation to avoid double-counting on
+        // duplicate `store_run_event` emits.
+        match &event {
+            NdjsonEvent::JobStatus { status, reason, .. } if status.is_terminal() => {
+                let conclusion = match status {
+                    preloop_gha_protocol::ExecutionStatus::Success => "success",
+                    preloop_gha_protocol::ExecutionStatus::Failure => "failure",
+                    preloop_gha_protocol::ExecutionStatus::Cancelled => "cancelled",
+                    preloop_gha_protocol::ExecutionStatus::Skipped => "skipped",
+                    _ => "unknown",
+                };
+                let reason_str = reason.as_deref().unwrap_or("unknown");
+                // Bound the reason to the finite set the plan allows; unknown
+                // reasons are mapped to "unknown" so they don't create new series.
+                let bounded_reason = match reason_str {
+                    "timeout"
+                    | "no_runner"
+                    | "lease_expired"
+                    | "deaf_runner"
+                    | "startup_orphan"
+                    | "concurrency_cancelled"
+                    | "concurrency_pending"
+                    | "success"
+                    | "failure"
+                    | "cancelled"
+                    | "skipped" => reason_str,
+                    _ => "unknown",
+                };
+                self.observability
+                    .metrics()
+                    .lifecycle
+                    .record_job_completed(conclusion, bounded_reason);
+            }
+            NdjsonEvent::JobCompleted { status, .. } if status.is_terminal() => {
+                let conclusion = match status {
+                    preloop_gha_protocol::ExecutionStatus::Success => "success",
+                    preloop_gha_protocol::ExecutionStatus::Failure => "failure",
+                    preloop_gha_protocol::ExecutionStatus::Cancelled => "cancelled",
+                    preloop_gha_protocol::ExecutionStatus::Skipped => "skipped",
+                    _ => "unknown",
+                };
+                self.observability
+                    .metrics()
+                    .lifecycle
+                    .record_job_completed(conclusion, "completed");
+            }
+            _ => {}
+        }
         // Capture the projection under the lock, then persist after releasing
         // it: a slow or unavailable backend must not stall the control plane
         // (runner polling, heartbeats, other state mutations).

--- a/crates/preloop-runner-server/src/store.rs
+++ b/crates/preloop-runner-server/src/store.rs
@@ -19,7 +19,9 @@ use preloop_gha_protocol::SessionId;
 use rusqlite::{params, Connection, OptionalExtension, Transaction};
 use sha2::Digest;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
+use std::time::Instant;
 
 const DATABASE_FILE: &str = "preloop.db";
 pub(crate) const SNAPSHOT_FORMAT: u8 = 2;
@@ -58,6 +60,147 @@ pub(crate) trait Store: Send + Sync {
     ) -> anyhow::Result<()>;
     /// Append a control event (`run_accepted` / `run_status` / `job_status`).
     async fn append_event(&self, event: &NdjsonEvent) -> anyhow::Result<()>;
+}
+
+/// Decorator that records `preloop.store.operation.duration` for every
+/// `Store` method. One wrapper, not per-backend duplication.
+pub(crate) struct InstrumentedStore {
+    inner: Arc<dyn Store>,
+    observability: preloop_observability::Observability,
+    backend: String,
+}
+
+impl InstrumentedStore {
+    pub(crate) fn new(
+        inner: Arc<dyn Store>,
+        observability: preloop_observability::Observability,
+        backend: &str,
+    ) -> Self {
+        Self {
+            inner,
+            observability,
+            backend: backend.to_string(),
+        }
+    }
+
+    pub(crate) fn wrap(
+        inner: Arc<dyn Store>,
+        observability: preloop_observability::Observability,
+        backend: &str,
+    ) -> Arc<dyn Store> {
+        Arc::new(Self::new(inner, observability, backend))
+    }
+}
+
+#[async_trait]
+impl Store for InstrumentedStore {
+    async fn load_into(&self, inner: &mut InnerState) -> anyhow::Result<()> {
+        let start = Instant::now();
+        let res = self.inner.load_into(inner).await;
+        let outcome = if res.is_ok() { "ok" } else { "error" };
+        self.observability.metrics().store.observe(
+            &self.backend,
+            "load_into",
+            outcome,
+            start.elapsed(),
+        );
+        res
+    }
+
+    async fn store_inner(&self, snapshot: &StoreSnapshot) -> anyhow::Result<()> {
+        let start = Instant::now();
+        let res = self.inner.store_inner(snapshot).await;
+        let outcome = if res.is_ok() { "ok" } else { "error" };
+        self.observability.metrics().store.observe(
+            &self.backend,
+            "store_inner",
+            outcome,
+            start.elapsed(),
+        );
+        res
+    }
+
+    async fn store_meta_only(&self, meta: &MetaSnapshot) -> anyhow::Result<()> {
+        let start = Instant::now();
+        let res = self.inner.store_meta_only(meta).await;
+        let outcome = if res.is_ok() { "ok" } else { "error" };
+        self.observability.metrics().store.observe(
+            &self.backend,
+            "store_meta_only",
+            outcome,
+            start.elapsed(),
+        );
+        res
+    }
+
+    async fn store_run_event(&self, projection: RunProjection) -> anyhow::Result<()> {
+        let start = Instant::now();
+        let res = self.inner.store_run_event(projection).await;
+        let outcome = if res.is_ok() { "ok" } else { "error" };
+        self.observability.metrics().store.observe(
+            &self.backend,
+            "store_run_event",
+            outcome,
+            start.elapsed(),
+        );
+        res
+    }
+
+    async fn store_workflow_run_counter(
+        &self,
+        workflow_path: &str,
+        next_run_number: u64,
+    ) -> anyhow::Result<()> {
+        let start = Instant::now();
+        let res = self
+            .inner
+            .store_workflow_run_counter(workflow_path, next_run_number)
+            .await;
+        let outcome = if res.is_ok() { "ok" } else { "error" };
+        self.observability.metrics().store.observe(
+            &self.backend,
+            "store_workflow_run_counter",
+            outcome,
+            start.elapsed(),
+        );
+        res
+    }
+
+    async fn store_log_chunk(
+        &self,
+        key: &str,
+        chunk_index: i64,
+        payload: &[u8],
+        byte_count: i64,
+        line_count: i64,
+    ) -> anyhow::Result<()> {
+        let start = Instant::now();
+        let res = self
+            .inner
+            .store_log_chunk(key, chunk_index, payload, byte_count, line_count)
+            .await;
+        let outcome = if res.is_ok() { "ok" } else { "error" };
+        self.observability.metrics().store.observe(
+            &self.backend,
+            "store_log_chunk",
+            outcome,
+            start.elapsed(),
+        );
+        res
+    }
+
+    async fn append_event(&self, event: &NdjsonEvent) -> anyhow::Result<()> {
+        let start = Instant::now();
+        let res = self.inner.append_event(event).await;
+        let outcome = if res.is_ok() { "ok" } else { "error" };
+        self.observability.metrics().store.observe(
+            &self.backend,
+            "append_event",
+            outcome,
+            start.elapsed(),
+        );
+        res
+    }
 }
 
 /// Owned projection of the in-memory state that a full snapshot persists.


### PR DESCRIPTION
Bounded HTTP middleware (matched route template, finite surface, status class; live-log websocket excluded) replacing `TraceLayer`; `InstrumentedStore` decorator timing all seven store operations; lifecycle counters for job terminal transitions, queue wait, broker poll outcomes, session create/delete, and concurrency decisions; store always instrumented even without an explicit observability handle. Cardinality stays bounded by construction: every label derives from a finite set.

Part of a stacked series (merge bottom-up):
1. log hardening
2. foundation crate
3. status endpoints
4. this PR (metrics)
5. OTLP export
6. review-fix sweep

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Instruments HTTP and store with a bounded in-memory metrics registry and replaces `tower_http::trace::TraceLayer` with a safe middleware. This prevents high-cardinality labels, adds lifecycle counters, and appends these series to the existing `/metrics` output.

- HTTP: new middleware records method, normalized route template, finite surface, and status class; excludes `/ws/live-logs` from duration histograms; adds an active-requests gauge; never emits raw URIs or queries. Falls back to normalized templates when no matched route exists.
- Store: wraps the private `Store` once with `InstrumentedStore`, timing all seven operations and labeling by backend (`sqlite`|`postgres`) and outcome (`ok`|`error`). Tracks a consecutive-failures gauge. Store stays instrumented even when no explicit observability handle is passed.
- Lifecycle: counts job terminal transitions (bounded conclusion and reason), records queue wait on successful claims, broker poll outcomes, and session create/delete; adds a counter for concurrency decisions.
- `/metrics`: appends the registry’s HTTP, store, and lifecycle exposition after the snapshot-based gauges.

<sup>Written for commit e35589634695f5281dd15a1f034c041f7e65100a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add bounded in-memory metrics for HTTP, store, and lifecycle in runner server
> - Introduces `MetricsRegistry` in `preloop-observability` with bounded-label histograms and gauges for HTTP, store, and lifecycle metrics, rendered in Prometheus format
> - Wraps the server store in `InstrumentedStore` to record operation duration and consecutive failures keyed by backend and operation
> - Adds `http_metrics_middleware` to record active-request gauge and request-duration histogram; replaces the previous `TraceLayer::new_for_http()` layer
> - Records lifecycle counters for broker session transitions, job acquisition, and terminal job completions in [state.rs](https://github.com/preloopdev/preloop/pull/173/files#diff-c2bd4ecf09cb465e1785e470caa9aef7981a33adc29e223914ab769e4dcdfb6c) and [broker.rs](https://github.com/preloopdev/preloop/pull/173/files#diff-ab9b35995903f498c7375d06f0c2749322d9f3620100df45e33b2bc8eb01a991); appends the new series to `GET /metrics`
> - Risk: removing `TraceLayer` in [routes.rs](https://github.com/preloopdev/preloop/pull/173/files#diff-cddf0fa9f349c034a41884399628a23c7a10132a0a57b4e8787f4bb52a1edd48) drops automatic HTTP request/response tracing spans; the new middleware creates an info-level span but does not enter it
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e355896. 10 files reviewed, 14 issues evaluated, 6 issues filtered, 8 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>crates/preloop-observability/src/metrics.rs — 4 comments posted, 5 evaluated, 1 filtered</summary>
>
> - [line 78](https://github.com/preloopdev/preloop/blob/e35589634695f5281dd15a1f034c041f7e65100a/crates/preloop-observability/src/metrics.rs#L78): `dec_active` looks up the full `HttpLabels`, including `status_class`. The middleware increments with placeholder `status_class = "2xx"`, then replaces it with the response's actual class before calling this method. Every 4xx/5xx response therefore fails to decrement the original entry, so `http_server_active_requests` permanently accumulates completed error requests. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>crates/preloop-runner-server/src/bootstrap.rs — 0 comments posted, 2 evaluated, 2 filtered</summary>
>
> - [line 652](https://github.com/preloopdev/preloop/blob/e35589634695f5281dd15a1f034c041f7e65100a/crates/preloop-runner-server/src/bootstrap.rs#L652): The backend label consults `PRELOOP_STORE_URL` even when `config.store_url` is `Some`, although `AppState::new_with_store` gives the explicit argument precedence. For example, an explicit SQLite URL with a stale Postgres environment variable opens SQLite but labels every store metric as `backend="postgres"`, producing incorrect telemetry. <b>[ Out of scope (post-validation triage) ]</b>
> - [line 660](https://github.com/preloopdev/preloop/blob/e35589634695f5281dd15a1f034c041f7e65100a/crates/preloop-runner-server/src/bootstrap.rs#L660): `InstrumentedStore` is installed only after `AppState::new_with_store` returns, but that constructor has already made the sole `Store::load_into` call. Consequently `preloop.store.operation.duration` never records the `load_into` operation (including startup failures), despite the decorator implementing that metric; the store must be wrapped before state loading to instrument all operations. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
> <details>
> <summary>crates/preloop-runner-server/src/broker.rs — 1 comment posted, 3 evaluated, 2 filtered</summary>
>
> - [line 413](https://github.com/preloopdev/preloop/blob/e35589634695f5281dd15a1f034c041f7e65100a/crates/preloop-runner-server/src/broker.rs#L413): `broker_delete_session_root` records a successful delete even when neither `x-actions-session` nor the `sessionId` query parameter is present. In that case `remove_broker_session` is never called, yet the endpoint returns 204 and increments `preloop_runner_session_transition_total{operation="delete",reason="ok"}`, so malformed/no-op requests inflate the successful lifecycle metric. <b>[ Out of scope (post-validation triage) ]</b>
> - [line 850](https://github.com/preloopdev/preloop/blob/e35589634695f5281dd15a1f034c041f7e65100a/crates/preloop-runner-server/src/broker.rs#L850): Counting every terminal `NdjsonEvent::JobStatus` does not count terminal job transitions exactly once. `patch_timeline_records` projects each completed timeline record (including completed step records) into a terminal `JobStatus` using the logical job ID, and normal completion later emits another terminal `JobStatus`; repeated timeline PATCHes can add still more. Consequently `preloop_job_completed` overcounts a single job, potentially once per completed step plus completion, so alerts and job totals are incorrect. Deduplicate by job transition or record only at the authoritative completion mutation. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>crates/preloop-runner-server/src/routes.rs — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 815](https://github.com/preloopdev/preloop/blob/e35589634695f5281dd15a1f034c041f7e65100a/crates/preloop-runner-server/src/routes.rs#L815): Installing `http_metrics_middleware` exposes a label mismatch in its active-request accounting: it calls `inc_active` with `status_class = "2xx"` before dispatch, then changes that label to the actual response class before `dec_active`. Every 4xx/5xx request therefore permanently increments the `2xx` active series and decrements a different 4xx/5xx series below zero, so `/metrics` reports increasingly incorrect active-request gauges. <b>[ Cross-file consolidated ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->