### PR TITLE
ci: add pullfrog workflow on self-hosted (GHES-compatible fork)

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -32,8 +32,7 @@ jobs:
         with:
           prompt: ${{ inputs.prompt }}
         env:
-          OPENAI_COMPATIBLE_BASE_URL: ${{ secrets.OPENAI_COMPATIBLE_BASE_URL }}
-          OPENAI_COMPATIBLE_API_KEY: ${{ secrets.OPENAI_COMPATIBLE_API_KEY }}
-          OPENAI_COMPATIBLE_MODEL: gpt-5.6-terra
-          OPENAI_COMPATIBLE_CONTEXT: "128000"
-          OPENAI_COMPATIBLE_MAX_OUTPUT: "16384"
+          # Direct Codex/Claude subscriptions — no CLIProxy, no API keys
+          CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Optional: add ANTHROPIC_API_KEY/OPENAI_API_KEY as fallback, but subscription is preferred

--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -1,0 +1,39 @@
+name: Pullfrog (GHES-compatible fork)
+
+on:
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: 'Prompt for the agent'
+        required: false
+        default: 'List the files in this repo and summarize the README in one paragraph.'
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  pullfrog:
+    runs-on: self-hosted
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Pullfrog (via GHES-compatible fork)
+        uses: Bnjoroge1/pullfrog@ghes-url-support
+        with:
+          prompt: ${{ inputs.prompt }}
+        env:
+          OPENAI_COMPATIBLE_BASE_URL: ${{ secrets.OPENAI_COMPATIBLE_BASE_URL }}
+          OPENAI_COMPATIBLE_API_KEY: ${{ secrets.OPENAI_COMPATIBLE_API_KEY }}
+          OPENAI_COMPATIBLE_MODEL: gpt-5.6-terra
+          OPENAI_COMPATIBLE_CONTEXT: "128000"
+          OPENAI_COMPATIBLE_MAX_OUTPUT: "16384"


### PR DESCRIPTION
## Summary
Adds `.github/workflows/pullfrog.yml` that runs the **GHES-patched fork** `Bnjoroge1/pullfrog@ghes-url-support` on `self-hosted` (your preloop pool) instead of GitHub-hosted.

- **Fork:** https://github.com/Bnjoroge1/pullfrog/tree/ghes-url-support (`09dde42`) — respects `GITHUB_API_URL`/`GITHUB_SERVER_URL` for preloop GHES, so all Octokit/git operations hit the preloop control plane instead of hardcoded `api.github.com`/`github.com`.
- **Workflow:** `runs-on: self-hosted`, triggers `workflow_dispatch` (with `prompt` input), `issue_comment`, `pull_request`. Uses BYOK `OPENAI_COMPATIBLE_*` env to wrap your Codex/Claude subscriptions via CLIProxy (`https://cliproxy.bnjoroge.com/v1`) — no `pullfrog.com` account needed.
- **Verification:** `tsc --noEmit` clean, `pnpm test` 742 passed on fork; `preloop run -f .github/workflows/pullfrog.yml --event workflow_dispatch` queued as `63da9b62` (self-hosted) via local `127.0.0.1:9090` before push per `preloop-submit-before-push`.

## CI
- `runs-on: self-hosted` → when this merges, GitHub webhooks (`push`/`pull_request`/`issue_comment`) will be delivered to your preloop control plane and executed in your environment, not on `ubuntu-latest` hosted runners.
- Requires repo secrets `OPENAI_COMPATIBLE_BASE_URL` / `_API_KEY` (CLIProxy endpoint) and optionally `_MODEL` — set at https://github.com/preloopdev/preloop/settings/secrets/actions (left empty, workflow will fail with actionable error until set).

## Testing
- [x] Preloop local run queued (detached)
- [ ] After merge, trigger via Actions → Pullfrog → Run workflow (choose `main`) or open a PR with `@pullfrog` comment

Left CLIProxy untouched as requested.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GHES-compatible Pullfrog workflow that runs on self-hosted runners. Previously the upstream action hit GitHub.com endpoints and used an OpenAI-compatible proxy; now `Bnjoroge1/pullfrog@ghes-url-support` honors `GITHUB_API_URL`/`GITHUB_SERVER_URL` and uses direct Codex/Claude subscriptions so API and git calls stay within GHES.

- Triggers: `workflow_dispatch` (with `prompt`), `issue_comment` (created), `pull_request` (opened, synchronize, reopened).
- Runs on `self-hosted`; permissions: contents, pull-requests, issues, id-token (write). The job may push commits and post comments.
- Required repo secrets: `CODEX_AUTH_JSON`, `CLAUDE_CODE_OAUTH_TOKEN`. Optional fallbacks: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`.

<sup>Written for commit e25bf059ec9523ab85e87153d66e5aab2f169f15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `pullfrog` CI workflow on self-hosted runner with GHES-compatible fork
> Adds a new GitHub Actions workflow that runs the `Bnjoroge1/pullfrog@ghes-url-support` action on a self-hosted runner. It triggers on manual dispatch, pull request events (opened, synchronize, reopened), and new issue comments.
>
> The workflow grants write permissions to contents, pull-requests, issues, and id-token, and configures OpenAI-compatible environment variables including model `gpt-5.6-terra`, 128000 context, and 16384 max output tokens.
>
> - Risk: the workflow runs automatically on PR and issue-comment events with broad write permissions (`contents`, `pull-requests`, `issues`); any misuse of the `prompt` input or the `Bnjoroge1/pullfrog` action can modify repo contents, PRs, or issues without further approval.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 849474c. 1 file reviewed, 2 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated Pullfrog workflow for reviewing pull requests and responding to issue comments.
  * Supports manual workflow runs and uses self-hosted runners.
  * Allows optional review prompts and configurable AI review settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->