### PR TITLE
ci: run zizmor on self-hosted (was ubuntu-latest)

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   zizmor:
     name: GitHub Actions Security Analysis with zizmor
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary
Moves `zizmor` (GitHub Actions Security Analysis) from `ubuntu-latest` (GitHub-hosted) to `self-hosted` (your preloop pool at `aksh.preloop.dev`).

- `zizmor.yml:12` `runs-on: self-hosted` — was `ubuntu-latest` → scheduled on hosted
- `zizmor` only needs `uv` + `uvx zizmor .github/workflows/` — works on your `ubuntu-22.04` VMs, no hosted needed
- Matches `pullfrog.yml` now on `self-hosted`

## Verification
- Branch `fix/zizmor-self-hosted` (`8188b7ed`) pushed, `preloop run` not needed (static analysis, no GHES)
- Next PR will show `zizmor` check as `aksh.preloop.dev/runs/...` instead of `github.com/actions/runs/...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the `zizmor` workflow on self-hosted runners instead of `ubuntu-latest` to align with our CI pool and reduce reliance on GitHub-hosted capacity. Previously the job ran on GitHub-hosted; now it schedules on self-hosted with no change to analysis behavior.

- Only change: `runs-on: self-hosted` for the `zizmor` job; it still runs `uvx zizmor .github/workflows/`.
- Self-hosted runners must have `uv` available and outbound network access.
- Expect the check to report from the self-hosted environment; no contributor actions required.

<sup>Written for commit 8188b7edde3344e8721e1369c072e2caebd053c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

