### PR TITLE
ci: pin pullfrog fork to SHA 09dde42 (was branch)

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Pullfrog (via GHES-compatible fork)
-        uses: Bnjoroge1/pullfrog@ghes-url-support
+        uses: Bnjoroge1/pullfrog@09dde428a88245ab3c448ff3dcadb8325e4e1d05 # ghes-url-support
         with:
           prompt: ${{ inputs.prompt }}
         env:


### PR DESCRIPTION
## Summary
Pins `Bnjoroge1/pullfrog@ghes-url-support` to `09dde428a88245ab3c448ff3dcadb8325e4e1d05` (was mutable branch).

- `pull` for job failed due to unpinned action (zizmor `unpinned-uses` / supply-chain)
- GHES fork is mutable `ghes-url-support` branch — pin ensures reproducible runs on `self-hosted` pool

## Change
```yaml
- uses: Bnjoroge1/pullfrog@ghes-url-support
+ uses: Bnjoroge1/pullfrog@09dde428a88245ab3c448ff3dcadb8325e4e1d05 # ghes-url-support
```

## Verification
- Branch `fix/pullfrog-pin-sha` (`f27ac5be`) pushed
- Fork SHA `09dde42` is GHES patch (`GITHUB_API_URL`/`SERVER_URL`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `Bnjoroge1/pullfrog` from the mutable `ghes-url-support` branch to a fixed commit in the `pullfrog` workflow. This satisfies `zizmor` unpinned-uses policy, unblocks GHES self-hosted runs, and makes workflow executions reproducible.

- Confirm the pinned commit includes the GHES URL support patch (uses GITHUB_API_URL/SERVER_URL).
- No migration required.

<sup>Written for commit f27ac5be2d181ee4766d96c251b7a056a58265d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated review workflow to use a fixed, GHES-compatible version for more consistent execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->