### PR TITLE
ci: fix zizmor artipacked + unpinned-uses for pullfrog workflow

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -23,8 +23,9 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Run Pullfrog (via GHES-compatible fork)


### PR DESCRIPTION
## Summary
Fixes `zizmor` failure on `main` (`c864949`) — `pullfrog.yml` had two findings:

- `error[unpinned-uses]` at `pullfrog.yml:26` `actions/checkout@v4` → pinned to `08c6903cd8c0fde910a37f88322edcfb5dd907a8` (v5.0.0)
- `warning[artipacked]` at `pullfrog.yml:26` missing `persist-credentials: false` → added

Previous pin of `Bnjoroge1/pullfrog@ghes-url-support` to `09dde42` fixed the other `unpinned-uses`; this completes it. Next `zizmor` on `self-hosted` should pass (0 high, 0 medium).

## Change
```yaml
- uses: actions/checkout@v4
+ - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
    with:
+     persist-credentials: false
      fetch-depth: 0
```

## Verification
- Branch `fix/pullfrog-zizmor` (`d13bd6a2`) pushed
- Prior `zizmor` log `32525074882` showed 1 medium + 1 high after pin fix; this addresses both

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `zizmor` findings in `pullfrog.yml` by pinning `actions/checkout` and disabling credential persistence. This removes the unpinned-uses error and artipacked warning and reduces default token exposure.

- Pin `actions/checkout` to `08c6903cd8c0fde910a37f88322edcfb5dd907a8` (v5.0.0) and set `persist-credentials: false`; `zizmor` on self-hosted should now pass (0 high, 0 medium).
- If any step needs to push to the repo, provide an explicit token or re-authenticate since checkout no longer persists credentials.

<sup>Written for commit d13bd6a254d6f6bebc8f89294c830b3f7eeea447. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

