### PR TITLE
ci: fix pullfrog prompt for issue_comment/pr (was empty)

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run Pullfrog (via GHES-compatible fork)
         uses: Bnjoroge1/pullfrog@09dde428a88245ab3c448ff3dcadb8325e4e1d05 # ghes-url-support
         with:
-          prompt: ${{ inputs.prompt }}
+          prompt: ${{ inputs.prompt || toJSON(github.event) }}
         env:
           # Direct Codex/Claude subscriptions — no CLIProxy, no API keys
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}


### PR DESCRIPTION
Fixes `Pullfrog` `issue_comment` failures on `main` `63fd800` (`one of prompt or prompt_file is required`).

- `prompt: ${{ inputs.prompt }}` empty for `issue_comment`/`pull_request` events → `prompt: ${{ inputs.prompt || toJSON(github.event) }}` so those events get event JSON, `workflow_dispatch` keeps `inputs.prompt`
- Next `issue_comment` on `main` will pass (currently `zizmor` already green on `63fd800` after pin fix)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failures in the `pullfrog` workflow for `issue_comment` and `pull_request` events by providing a default prompt. Previously the `prompt` input was empty and runs failed with "one of prompt or prompt_file is required"; now the workflow falls back to the GitHub event JSON, while `workflow_dispatch` continues to use `inputs.prompt`.

- Sets `prompt` to `${{ inputs.prompt || toJSON(github.event) }}` in `.github/workflows/pullfrog.yml`.
- No behavior change for `workflow_dispatch`; `issue_comment`/`pull_request` runs now have a non-empty prompt and should pass.

<sup>Written for commit fb089bd906d69f9a684fa5aca3f8f09505b8b42b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

