### PR TITLE
ci: set pullfrog model to openai/gpt-5.6-terra for BYOK Codex

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -32,6 +32,7 @@ jobs:
         uses: Bnjoroge1/pullfrog@09dde428a88245ab3c448ff3dcadb8325e4e1d05 # ghes-url-support
         with:
           prompt: ${{ inputs.prompt || toJSON(github.event) }}
+          model: openai/gpt-5.6-terra
         env:
           # Direct Codex/Claude subscriptions — no CLIProxy, no API keys
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}


### PR DESCRIPTION
Fixes `Pullfrog` `32545649002` failure on `main` (`OpenRouter API key is missing`).

- `opencode has 20 models but none match curated aliases — letting OpenCode auto-select` → auto tries `openrouter` which needs `OPENROUTER_API_KEY`/card
- BYOK Codex auth enables 13 `openai/gpt-*` models (`ghes-url-support` fork), pin to `openai/gpt-5.6-terra` for Codex subscription (`CODEX_AUTH_JSON` via 30m `launchd` cron)
- `model: openai/gpt-5.6-terra` in `with:` fixes auto-select

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `model` input to `openai/gpt-5.6-terra` in Pullfrog workflow
> Adds an explicit `model` field to the 'Run Pullfrog' step in [pullfrog.yml](https://github.com/preloopdev/preloop/pull/181/files#diff-16673329c9565ebf552bf50c97d69e4f4203029869537fec18848d4bc0cb7ec8) for BYOK Codex usage. The Pullfrog action now receives `openai/gpt-5.6-terra` as its model parameter.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9d5a006.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the `Pullfrog` workflow model to `openai/gpt-5.6-terra` to align with BYOK Codex and prevent OpenRouter auto-selection failures. Old behavior: auto-selected an `openrouter` model that required `OPENROUTER_API_KEY`. New behavior: always uses a Codex-backed OpenAI GPT model via `CODEX_AUTH_JSON`. Side effects: none in Codex environments.

- No migration for Codex users; outside Codex, either provide `OPENROUTER_API_KEY` or change the model.

<sup>Written for commit 9d5a006d7d8351f36662093766cb1dab2c94827d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the automated workflow to use the configured GPT-5.6 Terra agent model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->