### PR TITLE
fix(server): publish replay logs atomically

### DIFF
--- a/crates/preloop-runner-server/src/blob_store.rs
+++ b/crates/preloop-runner-server/src/blob_store.rs
@@ -314,12 +314,19 @@ pub(crate) async fn replay_results_put(
     if let Some(parent) = dest.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    match std::fs::write(&dest, &body) {
+
+    // Publish the completed blob with a same-filesystem rename. A direct
+    // write exposes a growing file to GET /api/v1/runs/:run_id/logs, which
+    // can observe a prefix while the runner is still uploading the body.
+    let temp = dest.with_extension(format!("{}.tmp", uuid::Uuid::new_v4()));
+    let result = std::fs::write(&temp, &body).and_then(|()| std::fs::rename(&temp, &dest));
+    match result {
         Ok(()) => {
             tracing::info!("Stored {} bytes at replay/results/{path}", body.len());
             StatusCode::CREATED
         }
         Err(e) => {
+            let _ = std::fs::remove_file(&temp);
             tracing::warn!("Failed to store replay/results/{path}: {e}");
             StatusCode::INTERNAL_SERVER_ERROR
         }

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -17324,44 +17324,97 @@ async fn replay_job_log_upload_is_published_as_one_complete_file() {
     let temp = tempfile::tempdir().unwrap();
     let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
     let app = app(state.clone(), CancellationToken::new());
-    let plan = uuid::Uuid::new_v4().to_string();
-    let job = uuid::Uuid::new_v4().to_string();
-    let path = format!("/replay/results/{plan}/{job}/job-logs.txt");
-    let sig = crate::auth::sign_replay_upload_ticket(&state, &path);
-    let expected = "log line\n".repeat(1024);
+    let accepted = submit_yaml(
+        &app,
+        r#"
+on: push
+jobs:
+  first:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo first
+  second:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo second
+"#,
+        "owner/repo",
+    )
+    .await;
+    let run_id: RunId = accepted["run_id"].as_str().unwrap().parse().unwrap();
+    let requests = {
+        let inner = state.inner.lock().await;
+        let mut requests = inner
+            .job_requests
+            .values()
+            .filter(|request| request.run_id == run_id)
+            .map(|request| {
+                (
+                    request.request_id,
+                    request.plan_id.clone(),
+                    request.agent_job_id.to_string(),
+                )
+            })
+            .collect::<Vec<_>>();
+        requests.sort_by_key(|(request_id, _, _)| *request_id);
+        requests
+    };
+    assert_eq!(requests.len(), 2);
+
+    let first_log = "first job line\n".repeat(4096);
+    let second_log = "second job line\n".repeat(4096);
+    for ((_, plan, job), body) in requests
+        .iter()
+        .zip([first_log.as_str(), second_log.as_str()])
+    {
+        let path = format!("/replay/results/{plan}/{job}/job-logs.txt");
+        let sig = crate::auth::sign_replay_upload_ticket(&state, &path);
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::PUT)
+                    .uri(format!(
+                        "{path}?sv=2021-08-06&se=2028-01-01T00%3A00%3A00Z&sr=c&sp=rw&sig={sig}"
+                    ))
+                    .body(Body::from(body.to_owned()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+    }
 
     let response = app
         .oneshot(
             Request::builder()
-                .method(Method::PUT)
-                .uri(format!(
-                    "{path}?sv=2021-08-06&se=2028-01-01T00%3A00%3A00Z&sr=c&sp=rw&sig={sig}"
-                ))
-                .body(Body::from(expected.clone()))
+                .method(Method::GET)
+                .uri(format!("/api/v1/runs/{run_id}/logs"))
+                .header(header::AUTHORIZATION, "Bearer preloop-system-token")
+                .body(Body::empty())
                 .unwrap(),
         )
         .await
         .unwrap();
-    assert_eq!(response.status(), StatusCode::CREATED);
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let expected = [first_log.as_bytes(), second_log.as_bytes()].concat();
+    assert_eq!(body.as_ref(), expected);
 
-    let results_dir = temp
-        .path()
-        .join("replay")
-        .join("results")
-        .join(&plan)
-        .join(&job);
-    assert_eq!(
-        tokio::fs::read(results_dir.join("job-logs.txt"))
-            .await
-            .unwrap(),
-        expected.as_bytes()
-    );
-    let mut entries = tokio::fs::read_dir(results_dir).await.unwrap();
-    let mut names = Vec::new();
-    while let Some(entry) = entries.next_entry().await.unwrap() {
-        names.push(entry.file_name());
+    for (_, plan, job) in &requests {
+        let results_dir = temp
+            .path()
+            .join("replay")
+            .join("results")
+            .join(plan)
+            .join(job);
+        let mut entries = tokio::fs::read_dir(results_dir).await.unwrap();
+        let mut names = Vec::new();
+        while let Some(entry) = entries.next_entry().await.unwrap() {
+            names.push(entry.file_name());
+        }
+        assert_eq!(names, vec![std::ffi::OsString::from("job-logs.txt")]);
     }
-    assert_eq!(names, vec![std::ffi::OsString::from("job-logs.txt")]);
 }
 
 #[tokio::test]

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -17319,6 +17319,50 @@ async fn replay_blob_uploads_require_a_ticket_bound_to_the_exact_path() {
         .unwrap();
     assert_eq!(forged.status(), StatusCode::UNAUTHORIZED);
 }
+#[tokio::test]
+async fn replay_job_log_upload_is_published_as_one_complete_file() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let plan = uuid::Uuid::new_v4().to_string();
+    let job = uuid::Uuid::new_v4().to_string();
+    let path = format!("/replay/results/{plan}/{job}/job-logs.txt");
+    let sig = crate::auth::sign_replay_upload_ticket(&state, &path);
+    let expected = "log line\n".repeat(1024);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::PUT)
+                .uri(format!(
+                    "{path}?sv=2021-08-06&se=2028-01-01T00%3A00%3A00Z&sr=c&sp=rw&sig={sig}"
+                ))
+                .body(Body::from(expected.clone()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let results_dir = temp
+        .path()
+        .join("replay")
+        .join("results")
+        .join(&plan)
+        .join(&job);
+    assert_eq!(
+        tokio::fs::read(results_dir.join("job-logs.txt"))
+            .await
+            .unwrap(),
+        expected.as_bytes()
+    );
+    let mut entries = tokio::fs::read_dir(results_dir).await.unwrap();
+    let mut names = Vec::new();
+    while let Some(entry) = entries.next_entry().await.unwrap() {
+        names.push(entry.file_name());
+    }
+    assert_eq!(names, vec![std::ffi::OsString::from("job-logs.txt")]);
+}
 
 #[tokio::test]
 async fn replay_blob_urls_are_minted_only_for_the_callers_own_job() {


### PR DESCRIPTION
## Summary\n- publish replay result blobs through a same-filesystem temp-file rename\n- prevent GET /api/v1/runs/:run_id/logs from observing a partially written job log\n- add coverage for complete job-log publication with no temp-file residue\n\n## Verification\n- cargo fmt --all -- --check\n- cargo test -p preloop-runner-server log_get_run_logs -- --nocapture\n- cargo test -p preloop-runner-server replay_job_log_upload_is_published_as_one_complete_file -- --nocapture\n- cargo test -p preloop-runner-server\n\nFixes #134

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes replay job logs atomically so GET /api/v1/runs/:run_id/logs never reads a prefix. Previously we wrote directly to the destination; now we write to a temp file in the same directory and rename it into place. This requires writable space in the results directory and a same-filesystem rename.

- On write or rename failure, delete the temp file and return 500.
- Add a test that uploads logs for two jobs, verifies GET aggregates complete content, and asserts no temp files remain.

<sup>Written for commit c9751be2653754c002e738c3081421b1daecdcb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish replay logs atomically via temp file and rename in `blob_store::replay_results_put`
> - Replaces the direct write to the destination path with a two-phase publish: write the full body to a temp file (dest + UUID + `.tmp`) then rename it to the final destination. On failure, the temp file is removed when possible.
> - Adds a test that uploads large `job-logs.txt` blobs for two jobs, then fetches `/api/v1/runs/{run_id}/logs` to confirm the full concatenated content is returned and no temp files remain in the job results directories.
> - Risk: none; readers no longer observe partially written files, and the error path cleans up the temp file created by `replay_results_put`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c2d4edc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Replay uploads are now saved atomically, preventing incomplete or corrupted result files.
  * Failed uploads are cleaned up automatically without leaving temporary files behind.
  * Ensured uploaded job logs retain their complete contents.

* **Tests**
  * Added coverage verifying successful authenticated uploads and clean results directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->