### PR TITLE
fix(observability): enforce logging policy across OTLP

### DIFF
--- a/crates/preloop-observability/src/lib.rs
+++ b/crates/preloop-observability/src/lib.rs
@@ -938,9 +938,12 @@ impl ObservabilityRuntime {
         // be appended without naming the concrete `Layered` type, then wrap it
         // in the registry. The tracing-opentelemetry layer requires
         // `LookupSpan`, which the registry provides.
+        // Every output must observe the same `RUST_LOG` policy. Applying the
+        // filter only to fmt would suppress an event locally while still
+        // exporting it through OTLP.
         let mut chain: Box<
             dyn tracing_subscriber::Layer<tracing_subscriber::registry::Registry> + Send + Sync,
-        > = Box::new(fmt_layer.with_filter(filter));
+        > = Box::new(fmt_layer);
         if let Some(provider) = &self.tracer_provider {
             let tracer = provider.tracer("preloop");
             let layer = tracing_opentelemetry::layer().with_tracer(tracer);
@@ -950,7 +953,9 @@ impl ObservabilityRuntime {
             let layer = OpenTelemetryTracingBridge::new(provider);
             chain = Box::new(chain.and_then(layer));
         }
-        let _ = tracing::subscriber::set_global_default(Registry::default().with(chain));
+        let _ = tracing::subscriber::set_global_default(
+            Registry::default().with(chain.with_filter(filter)),
+        );
     }
 
     /// Flush exporters for at most 2s, then exit. Each provider's bounded
@@ -984,6 +989,23 @@ impl fmt::Debug for ObservabilityRuntime {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::AtomicUsize;
+
+    #[derive(Clone)]
+    struct CountingLayer(Arc<AtomicUsize>);
+
+    impl<S> tracing_subscriber::Layer<S> for CountingLayer
+    where
+        S: tracing::Subscriber,
+    {
+        fn on_event(
+            &self,
+            _event: &tracing::Event<'_>,
+            _context: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
 
     /// `ObservabilityConfig::from_env` reads process-global `OTEL_*`
     /// variables, and several tests mutate them. Cargo runs unit tests on
@@ -1004,6 +1026,20 @@ mod tests {
         assert!(!obs.instance_id().is_empty());
         assert!(obs.tracer().is_none());
         assert!(!obs.tracing_enabled());
+    }
+
+    #[test]
+    fn rust_log_filter_gates_a_complete_layer_chain() {
+        let observed = Arc::new(AtomicUsize::new(0));
+        let subscriber = Registry::default()
+            .with(CountingLayer(Arc::clone(&observed)).with_filter(EnvFilter::new("warn")));
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!("must not reach an OTLP layer");
+            tracing::warn!("must reach an OTLP layer");
+        });
+
+        assert_eq!(observed.load(Ordering::Relaxed), 1);
     }
 
     #[test]

--- a/rules/no-sensitive-log-fields.yml
+++ b/rules/no-sensitive-log-fields.yml
@@ -1,84 +1,61 @@
 id: no-sensitive-log-fields
 message: |
   INFO/WARN/ERROR tracing fields must not carry capability material: token,
-  authorization, cookie, headers, body, payload, or signed_url. These leak
+  authorization, cookie, headers, signed_url, body, or payload. These leak
   bearer material into journald and OTLP. Use operation/kind/size/result
   fields instead. The conformance flow recorder (recording.rs) is exempt.
 severity: error
 language: rust
 # recording.rs deliberately captures every header and body for conformance.
 ignores:
-  - "**/recording.rs"
+  - "crates/preloop-runner-server/src/recording.rs"
 rule:
-  any:
-    # info!(token, …) / warn!(authorization = …, …)
-    - pattern: info!($$$ARGS, token, $$$REST)
-    - pattern: warn!($$$ARGS, token, $$$REST)
-    - pattern: error!($$$ARGS, token, $$$REST)
-    - pattern: info!(token, $$$REST)
-    - pattern: warn!(token, $$$REST)
-    - pattern: error!(token, $$$REST)
-    - pattern: info!($$$ARGS, authorization, $$$REST)
-    - pattern: warn!($$$ARGS, authorization, $$$REST)
-    - pattern: error!($$$ARGS, authorization, $$$REST)
-    - pattern: info!($$$ARGS, cookie, $$$REST)
-    - pattern: warn!($$$ARGS, cookie, $$$REST)
-    - pattern: error!($$$ARGS, cookie, $$$REST)
-    - pattern: info!($$$ARGS, headers, $$$REST)
-    - pattern: warn!($$$ARGS, headers, $$$REST)
-    - pattern: error!($$$ARGS, headers, $$$REST)
-    - pattern: info!($$$ARGS, signed_url, $$$REST)
-    - pattern: warn!($$$ARGS, signed_url, $$$REST)
-    - pattern: error!($$$ARGS, signed_url, $$$REST)
-    # Assigned form: info!(token = value, …) — the shorthand patterns above
-    # do not match it, so a sensitive field could bypass the rule.
-    - pattern: info!($$$ARGS, token = $$$VALUE, $$$REST)
-    - pattern: warn!($$$ARGS, token = $$$VALUE, $$$REST)
-    - pattern: error!($$$ARGS, token = $$$VALUE, $$$REST)
-    - pattern: info!($$$ARGS, authorization = $$$VALUE, $$$REST)
-    - pattern: warn!($$$ARGS, authorization = $$$VALUE, $$$REST)
-    - pattern: error!($$$ARGS, authorization = $$$VALUE, $$$REST)
-    - pattern: info!($$$ARGS, cookie = $$$VALUE, $$$REST)
-    - pattern: warn!($$$ARGS, cookie = $$$VALUE, $$$REST)
-    - pattern: error!($$$ARGS, cookie = $$$VALUE, $$$REST)
-    - pattern: info!($$$ARGS, headers = $$$VALUE, $$$REST)
-    - pattern: warn!($$$ARGS, headers = $$$VALUE, $$$REST)
-    - pattern: error!($$$ARGS, headers = $$$VALUE, $$$REST)
-    - pattern: info!($$$ARGS, signed_url = $$$VALUE, $$$REST)
-    - pattern: warn!($$$ARGS, signed_url = $$$VALUE, $$$REST)
-    - pattern: error!($$$ARGS, signed_url = $$$VALUE, $$$REST)
-    # Assigned body/payload in plain, ?-debug and %-display forms.
-    - pattern: info!($$$ARGS, body = $$$VALUE, $$$REST)
-    - pattern: warn!($$$ARGS, body = $$$VALUE, $$$REST)
-    - pattern: error!($$$ARGS, body = $$$VALUE, $$$REST)
-    - pattern: info!($$$ARGS, ?body = $$$VALUE, $$$REST)
-    - pattern: warn!($$$ARGS, ?body = $$$VALUE, $$$REST)
-    - pattern: error!($$$ARGS, ?body = $$$VALUE, $$$REST)
-    - pattern: info!($$$ARGS, %body = $$$VALUE, $$$REST)
-    - pattern: warn!($$$ARGS, %body = $$$VALUE, $$$REST)
-    - pattern: error!($$$ARGS, %body = $$$VALUE, $$$REST)
-    - pattern: info!($$$ARGS, payload = $$$VALUE, $$$REST)
-    - pattern: warn!($$$ARGS, payload = $$$VALUE, $$$REST)
-    - pattern: error!($$$ARGS, payload = $$$VALUE, $$$REST)
-    - pattern: info!($$$ARGS, ?payload = $$$VALUE, $$$REST)
-    - pattern: warn!($$$ARGS, ?payload = $$$VALUE, $$$REST)
-    - pattern: error!($$$ARGS, ?payload = $$$VALUE, $$$REST)
-    - pattern: info!($$$ARGS, %payload = $$$VALUE, $$$REST)
-    - pattern: warn!($$$ARGS, %payload = $$$VALUE, $$$REST)
-    - pattern: error!($$$ARGS, %payload = $$$VALUE, $$$REST)
-    # ?body / body = … inside the macro
-    - pattern: info!(?body, $$$REST)
-    - pattern: warn!(?body, $$$REST)
-    - pattern: error!(?body, $$$REST)
-    - pattern: info!(body, $$$REST)
-    - pattern: warn!(body, $$$REST)
-    - pattern: error!(body, $$$REST)
-    - pattern: info!(%body, $$$REST)
-    - pattern: warn!(%body, $$$REST)
-    - pattern: error!(%body, $$$REST)
-    - pattern: info!(payload, $$$REST)
-    - pattern: warn!(payload, $$$REST)
-    - pattern: error!(payload, $$$REST)
-    - pattern: info!(?payload, $$$REST)
-    - pattern: warn!(?payload, $$$REST)
-    - pattern: error!(?payload, $$$REST)
+  all:
+    # Restrict generic macro matching to the tracing macros, in bare,
+    # `tracing::`, or `::tracing::` form.
+    - regex: '^(?:::)?(?:tracing::)?(?:info|warn|error)!'
+    - any:
+        # Shorthand fields in any argument position — plain, ?-debug, %-display.
+        - pattern: $MACRO!($$$ARGS, token, $$$REST)
+        - pattern: $MACRO!($$$ARGS, ?token, $$$REST)
+        - pattern: $MACRO!($$$ARGS, %token, $$$REST)
+        - pattern: $MACRO!($$$ARGS, authorization, $$$REST)
+        - pattern: $MACRO!($$$ARGS, ?authorization, $$$REST)
+        - pattern: $MACRO!($$$ARGS, %authorization, $$$REST)
+        - pattern: $MACRO!($$$ARGS, cookie, $$$REST)
+        - pattern: $MACRO!($$$ARGS, ?cookie, $$$REST)
+        - pattern: $MACRO!($$$ARGS, %cookie, $$$REST)
+        - pattern: $MACRO!($$$ARGS, headers, $$$REST)
+        - pattern: $MACRO!($$$ARGS, ?headers, $$$REST)
+        - pattern: $MACRO!($$$ARGS, %headers, $$$REST)
+        - pattern: $MACRO!($$$ARGS, signed_url, $$$REST)
+        - pattern: $MACRO!($$$ARGS, ?signed_url, $$$REST)
+        - pattern: $MACRO!($$$ARGS, %signed_url, $$$REST)
+        - pattern: $MACRO!($$$ARGS, body, $$$REST)
+        - pattern: $MACRO!($$$ARGS, ?body, $$$REST)
+        - pattern: $MACRO!($$$ARGS, %body, $$$REST)
+        - pattern: $MACRO!($$$ARGS, payload, $$$REST)
+        - pattern: $MACRO!($$$ARGS, ?payload, $$$REST)
+        - pattern: $MACRO!($$$ARGS, %payload, $$$REST)
+        # Assigned fields in any argument position — plain, ?-debug, %-display.
+        - pattern: $MACRO!($$$ARGS, token = $$$VALUE, $$$REST)
+        - pattern: $MACRO!($$$ARGS, ?token = $$$VALUE, $$$REST)
+        - pattern: $MACRO!($$$ARGS, %token = $$$VALUE, $$$REST)
+        - pattern: $MACRO!($$$ARGS, authorization = $$$VALUE, $$$REST)
+        - pattern: $MACRO!($$$ARGS, ?authorization = $$$VALUE, $$$REST)
+        - pattern: $MACRO!($$$ARGS, %authorization = $$$VALUE, $$$REST)
+        - pattern: $MACRO!($$$ARGS, cookie = $$$VALUE, $$$REST)
+        - pattern: $MACRO!($$$ARGS, ?cookie = $$$VALUE, $$$REST)
+        - pattern: $MACRO!($$$ARGS, %cookie = $$$VALUE, $$$REST)
+        - pattern: $MACRO!($$$ARGS, headers = $$$VALUE, $$$REST)
+        - pattern: $MACRO!($$$ARGS, ?headers = $$$VALUE, $$$REST)
+        - pattern: $MACRO!($$$ARGS, %headers = $$$VALUE, $$$REST)
+        - pattern: $MACRO!($$$ARGS, signed_url = $$$VALUE, $$$REST)
+        - pattern: $MACRO!($$$ARGS, ?signed_url = $$$VALUE, $$$REST)
+        - pattern: $MACRO!($$$ARGS, %signed_url = $$$VALUE, $$$REST)
+        - pattern: $MACRO!($$$ARGS, body = $$$VALUE, $$$REST)
+        - pattern: $MACRO!($$$ARGS, ?body = $$$VALUE, $$$REST)
+        - pattern: $MACRO!($$$ARGS, %body = $$$VALUE, $$$REST)
+        - pattern: $MACRO!($$$ARGS, payload = $$$VALUE, $$$REST)
+        - pattern: $MACRO!($$$ARGS, ?payload = $$$VALUE, $$$REST)
+        - pattern: $MACRO!($$$ARGS, %payload = $$$VALUE, $$$REST)


### PR DESCRIPTION
## Summary

- Extend `no-sensitive-log-fields` to reject sensitive fields in bare, `tracing::`, and `::tracing::` `info!`, `warn!`, and `error!` macros.
- Restore complete shorthand and assigned-field coverage for plain, `?`, and `%` formatting forms; narrow the recorder exemption to its exact path.
- Apply `RUST_LOG` around the complete tracing subscriber chain, so terminal, OTLP trace, and OTLP log outputs obey one policy.
- Add a regression test proving a complete filtered layer chain rejects `info!` under `RUST_LOG=warn` while accepting `warn!`.

## Verification

- 378-case ast-grep probe: all bare and qualified sensitive-field forms detected; safe controls were not flagged.
- `cargo test -p preloop-observability rust_log_filter_gates_a_complete_layer_chain -- --exact`
- `just sg-scan-strict`
- `just test-ci` — passed (fmt, clippy, zizmor, workspace tests, conformance).
- Submitted the committed workspace to local preloop CI before push.

## Stack

Base: `pr/6-review-fixes`. This remains a stack follow-up because `origin/main` contains #170 but not the later observability PR content.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a single `RUST_LOG` policy across the full `tracing_subscriber` chain so OTLP logs and traces follow the same filter; previously only the fmt layer was filtered, allowing suppressed terminal events to still export via OTLP. Tightens `no-sensitive-log-fields` to catch sensitive fields in bare and qualified `tracing` `info!`, `warn!`, and `error!` macros, in both shorthand and assigned forms.

**Review notes**
- Moves the `EnvFilter` from `fmt_layer.with_filter(filter)` to `Registry::default().with(chain.with_filter(filter))`, covering terminal output, the OTLP trace bridge, and OTLP log export. Includes a regression test that gates `info!` under `warn`.
- Refactors the ast-grep rule to match `^(?:::)?(?:tracing::)?(?:info|warn|error)!` and to detect `token`, `authorization`, `cookie`, `headers`, `signed_url`, `body`, and `payload` in plain, `?`, and `%` formatting, for both shorthand and `field = value` forms.
- Narrows the recorder exemption to `crates/preloop-runner-server/src/recording.rs`.

**Migration**
- Update log sites flagged by `no-sensitive-log-fields` to remove sensitive fields; expect new lint failures in CI.

<sup>Written for commit a5ef2334bfa45bb699620005e6be575f614cf543. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply `EnvFilter` to full observability layer chain and rewrite `no-sensitive-log-fields` lint rule
> - Moves the `EnvFilter` from the `fmt` layer alone to the entire composed subscriber chain in `ObservabilityRuntime.install_fmt_subscriber`, so OTLP and OTel log bridge outputs are gated by the same `RUST_LOG` policy as the fmt output.
> - Adds a `CountingLayer` test helper and a `rust_log_filter_gates_a_complete_layer_chain` unit test that verifies a `warn`-level filter suppresses `info!` events across the whole chain.
> - Rewrites [no-sensitive-log-fields.yml](https://github.com/preloopdev/preloop/pull/183/files#diff-2a379d0d71107c7925b75189ec06417319326b5b43ea19f8bd6422bb3e5956bf) from a flat `any:` list of hardcoded macro patterns to an `all:` structure using a regex-restricted `$MACRO` placeholder, matching both shorthand and assigned sensitive fields (`token`, `authorization`, `cookie`, `headers`, `signed_url`, `body`, `payload`) in plain, `?`-debug, and `%`-display forms.
> - Risk: the filter now suppresses events below the `RUST_LOG` threshold for all outputs including OTLP; if a deployment relied on OTLP receiving events that the fmt layer previously filtered out, those events will no longer be exported.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a5ef233.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->