### PR TITLE
fix(observability): harden OTLP HTTP export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2692,6 +2692,7 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ futures = "0.3"
 globset = "0.4"
 indexmap = { version = "2.2", features = ["serde"] }
 proptest = "1.4"
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "stream", "form", "query"] }
+reqwest = { version = "0.13", default-features = false, features = ["blocking", "json", "rustls", "stream", "form", "query"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
 rand = "0.8"
 # `preserve_order` keeps `Value::Object` in document order instead of sorting
@@ -81,7 +81,7 @@ opentelemetry_sdk = { version = "0.32", default-features = false, features = ["t
 # the workspace reqwest (now 0.13, same line the SDK targets) through
 # `opentelemetry_http::HttpClient`, so there is exactly one HTTP client.
 opentelemetry-otlp = { version = "0.32", default-features = false, features = ["http-proto", "trace", "metrics", "logs"] }
-opentelemetry-http = { version = "0.32", default-features = false, features = ["reqwest"] }
+opentelemetry-http = { version = "0.32", default-features = false, features = ["reqwest-blocking"] }
 opentelemetry-prometheus = "0.32"
 opentelemetry-appender-tracing = "0.32"
 opentelemetry-semantic-conventions = "0.32"

--- a/contrib/openobserve/compose.yml
+++ b/contrib/openobserve/compose.yml
@@ -35,12 +35,9 @@ services:
         limits:
           cpus: "1.0"
           memory: 2G
-    healthcheck:
-      test: ["CMD", "sh", "-c", "wget -qO- http://127.0.0.1:5080/healthz || exit 1"]
-      interval: 10s
-      timeout: 3s
-      retries: 10
-      start_period: 20s
+    # The pinned image is distroless: it has neither a shell nor an HTTP
+    # client. Do not install a permanently failing Docker healthcheck; probe
+    # http://127.0.0.1:5080/healthz from the operator host instead.
 
 volumes:
   openobserve-data:

--- a/crates/preloop-observability/src/lib.rs
+++ b/crates/preloop-observability/src/lib.rs
@@ -1473,13 +1473,52 @@ mod tests {
     async fn configured_blocking_exporter_posts_log_during_shutdown() {
         use std::io::{Read, Write};
         use std::net::TcpListener;
+        use std::time::Instant;
 
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind OTLP test receiver");
+        listener
+            .set_nonblocking(true)
+            .expect("make OTLP listener nonblocking");
         let address = listener.local_addr().expect("receiver address");
         let receiver = std::thread::spawn(move || {
-            let (mut stream, _) = listener.accept().expect("accept OTLP export");
+            let deadline = Instant::now() + Duration::from_secs(3);
+            let (mut stream, _) = loop {
+                match listener.accept() {
+                    Ok(connection) => break connection,
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        assert!(
+                            Instant::now() < deadline,
+                            "timed out waiting for OTLP export"
+                        );
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) => panic!("accept OTLP export: {error}"),
+                }
+            };
+            stream
+                .set_read_timeout(Some(Duration::from_secs(3)))
+                .expect("set OTLP receiver timeout");
             let mut request = [0_u8; 4096];
-            let read = stream.read(&mut request).expect("read OTLP request");
+            let mut read = 0;
+            while read < request.len()
+                && !request[..read]
+                    .windows(4)
+                    .any(|window| window == b"\r\n\r\n")
+            {
+                let count = stream
+                    .read(&mut request[read..])
+                    .expect("read OTLP request");
+                if count == 0 {
+                    break;
+                }
+                read += count;
+            }
+            assert!(
+                request[..read]
+                    .windows(4)
+                    .any(|window| window == b"\r\n\r\n"),
+                "timed out waiting for complete OTLP request headers"
+            );
             stream
                 .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
                 .expect("respond to OTLP export");

--- a/crates/preloop-observability/src/lib.rs
+++ b/crates/preloop-observability/src/lib.rs
@@ -115,6 +115,42 @@ impl ExportTargets {
     }
 }
 
+/// Append an OTLP signal path without moving an existing query or fragment
+/// into the path.
+fn append_signal_path(base: &str, suffix: &str) -> Option<String> {
+    let mut endpoint = reqwest::Url::parse(base).ok()?;
+    let path = endpoint.path().trim_end_matches('/');
+    endpoint.set_path(&format!("{path}{suffix}"));
+    Some(endpoint.to_string())
+}
+
+fn percent_decode_header_value(value: &str) -> Option<String> {
+    let Some(first_escape) = value.as_bytes().iter().position(|byte| *byte == b'%') else {
+        return Some(value.to_owned());
+    };
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    decoded.extend_from_slice(&bytes[..first_escape]);
+    let mut index = first_escape;
+    while index < bytes.len() {
+        if bytes[index] != b'%' {
+            decoded.push(bytes[index]);
+            index += 1;
+            continue;
+        }
+        let high = bytes.get(index + 1)?.to_ascii_lowercase();
+        let low = bytes.get(index + 2)?.to_ascii_lowercase();
+        let hex = |byte: u8| match byte {
+            b'0'..=b'9' => Some(byte - b'0'),
+            b'a'..=b'f' => Some(byte - b'a' + 10),
+            _ => None,
+        };
+        decoded.push((hex(high)? << 4) | hex(low)?);
+        index += 3;
+    }
+    String::from_utf8(decoded).ok()
+}
+
 /// Parse `OTEL_EXPORTER_OTLP_HEADERS` (`k1=v1,k2=v2`).
 pub fn parse_headers(raw: Option<&str>) -> Vec<(String, String)> {
     let Some(raw) = raw else {
@@ -128,7 +164,7 @@ pub fn parse_headers(raw: Option<&str>) -> Vec<(String, String)> {
             if k.is_empty() || v.is_empty() {
                 None
             } else {
-                Some((k.to_string(), v.to_string()))
+                Some((k.to_string(), percent_decode_header_value(v)?))
             }
         })
         .collect()
@@ -187,7 +223,7 @@ impl ObservabilityConfig {
         let generic = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
             .ok()
             .filter(|v| !v.trim().is_empty() && v.trim() != "none")
-            .map(|v| v.trim_end_matches('/').to_string());
+            .map(|v| v.trim().to_string());
 
         // Signal-specific endpoint is a complete URL used as-is; the generic
         // base needs the /v1/<signal> suffix. Appending the suffix to a
@@ -201,12 +237,18 @@ impl ObservabilityConfig {
                     // the generic endpoint.
                     None
                 } else if value.is_empty() {
-                    generic.as_ref().map(|g| format!("{g}{suffix}"))
+                    generic
+                        .as_deref()
+                        .and_then(|generic| append_signal_path(generic, suffix))
                 } else {
-                    Some(value.trim_end_matches('/').to_string())
+                    // Signal-specific endpoints are complete URLs, including
+                    // a potentially significant trailing slash.
+                    Some(value.to_string())
                 }
             }
-            Err(_) => generic.as_ref().map(|g| format!("{g}{suffix}")),
+            Err(_) => generic
+                .as_deref()
+                .and_then(|generic| append_signal_path(generic, suffix)),
         };
         let otel_logs_endpoint = resolve("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "/v1/logs");
         let otel_traces_endpoint = resolve("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "/v1/traces");
@@ -544,8 +586,8 @@ struct Inner {
     limits: LimitRegistry,
     metrics: Arc<metrics::MetricsRegistry>,
     vm_registry: Arc<vm_telemetry::VmTelemetryRegistry>,
-    tracer: Option<opentelemetry_sdk::trace::Tracer>,
-    logger: Option<opentelemetry_sdk::logs::SdkLogger>,
+    tracer: RwLock<Option<opentelemetry_sdk::trace::Tracer>>,
+    logger: RwLock<Option<opentelemetry_sdk::logs::SdkLogger>>,
     prometheus_registry: Option<prometheus::Registry>,
     is_noop: bool,
 }
@@ -580,8 +622,8 @@ impl Observability {
                 limits: LimitRegistry::default(),
                 metrics: Arc::new(metrics::MetricsRegistry::default()),
                 vm_registry: Arc::new(vm_telemetry::VmTelemetryRegistry::default()),
-                tracer: None,
-                logger: None,
+                tracer: RwLock::new(None),
+                logger: RwLock::new(None),
                 prometheus_registry: None,
                 is_noop: true,
             }),
@@ -592,12 +634,26 @@ impl Observability {
     pub fn from_config(config: ObservabilityConfig) -> (Self, ObservabilityRuntime) {
         let is_noop = !config.otlp_enabled;
         let targets = config.export_targets();
-        // One rustls client for every signal — the same stack the rest of the
-        // workspace uses (reqwest 0.13).
-        let http_client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(10))
-            .build()
-            .ok();
+        // SDK batch processors and periodic readers export from blocking
+        // worker threads. Give them a blocking rustls client so every signal
+        // uses the execution model those providers require.
+        let http_client = (!targets.is_empty())
+            .then(|| {
+                // `reqwest::blocking::Client::build` creates an internal
+                // runtime and must not run while Tokio's current-thread
+                // runtime is entered. Configuration is one-time, so build it
+                // on a plain OS thread and keep shutdown on a blocking task.
+                std::thread::spawn(|| {
+                    reqwest::blocking::Client::builder()
+                        .timeout(Duration::from_secs(10))
+                        .build()
+                        .ok()
+                })
+                .join()
+                .ok()
+                .flatten()
+            })
+            .flatten();
         let resource = Resource::builder()
             .with_attributes(vec![
                 KeyValue::new("service.name", config.service_name.clone()),
@@ -673,8 +729,8 @@ impl Observability {
                 limits: LimitRegistry::default(),
                 metrics,
                 vm_registry: Arc::new(vm_telemetry::VmTelemetryRegistry::default()),
-                tracer,
-                logger,
+                tracer: RwLock::new(tracer),
+                logger: RwLock::new(logger),
                 prometheus_registry: Some(prometheus_registry),
                 is_noop,
             }),
@@ -723,13 +779,13 @@ impl Observability {
     /// The SDK tracer, when a traces endpoint is configured. `None` for
     /// no-op handles — callers skip span work entirely.
     pub fn tracer(&self) -> Option<opentelemetry_sdk::trace::Tracer> {
-        self.inner.tracer.clone()
+        self.inner.tracer.read().clone()
     }
 
     /// Whether spans are worth building. Lets a caller skip id and timestamp
     /// work entirely when nothing would consume the result.
     pub fn tracing_enabled(&self) -> bool {
-        self.inner.tracer.is_some()
+        self.inner.tracer.read().is_some()
     }
 
     /// Enqueue a log record for OTLP export. No-op when export is disabled.
@@ -751,7 +807,7 @@ impl Observability {
         attributes: Vec<(String, String)>,
         context: Option<&opentelemetry::trace::SpanContext>,
     ) {
-        let Some(logger) = &self.inner.logger else {
+        let Some(logger) = self.inner.logger.read().clone() else {
             return;
         };
         let mut record = logger.create_log_record();
@@ -803,10 +859,10 @@ fn severity_number(severity: &str) -> Severity {
 }
 
 /// Build an OTLP/HTTP span exporter from a resolved signal target, reusing
-/// the shared rustls reqwest client. `None` on build failure — fail open.
+/// the shared blocking rustls client. `None` on build failure — fail open.
 fn build_span_exporter(
     target: &SignalTarget,
-    http_client: Option<&reqwest::Client>,
+    http_client: Option<&reqwest::blocking::Client>,
 ) -> Option<opentelemetry_otlp::SpanExporter> {
     use opentelemetry_otlp::{SpanExporter, WithExportConfig, WithHttpConfig};
     let mut builder = SpanExporter::builder()
@@ -830,7 +886,7 @@ fn build_span_exporter(
 /// Build an OTLP/HTTP log exporter. `None` on build failure — fail open.
 fn build_log_exporter(
     target: &SignalTarget,
-    http_client: Option<&reqwest::Client>,
+    http_client: Option<&reqwest::blocking::Client>,
 ) -> Option<opentelemetry_otlp::LogExporter> {
     use opentelemetry_otlp::{LogExporter, WithExportConfig, WithHttpConfig};
     let mut builder = LogExporter::builder()
@@ -854,7 +910,7 @@ fn build_log_exporter(
 /// Build an OTLP/HTTP metric exporter. `None` on build failure — fail open.
 fn build_metric_exporter(
     target: &SignalTarget,
-    http_client: Option<&reqwest::Client>,
+    http_client: Option<&reqwest::blocking::Client>,
 ) -> Option<opentelemetry_otlp::MetricExporter> {
     use opentelemetry_otlp::{MetricExporter, WithExportConfig, WithHttpConfig};
     let mut builder = MetricExporter::builder()
@@ -957,17 +1013,28 @@ impl ObservabilityRuntime {
     /// queue is drained; a hung backend drops the remainder rather than
     /// delaying shutdown. Export failure is logged by the SDK, never
     /// propagated.
-    pub async fn shutdown(mut self) {
+    pub async fn shutdown(self) {
         let timeout = Duration::from_secs(2);
-        if let Some(provider) = self.tracer_provider.take() {
-            let _ = provider.shutdown_with_timeout(timeout);
-        }
-        if let Some(provider) = self.meter_provider.take() {
-            let _ = provider.shutdown_with_timeout(timeout);
-        }
-        if let Some(provider) = self.logger_provider.take() {
-            let _ = provider.shutdown_with_timeout(timeout);
-        }
+        // The SDK default processors and reqwest's blocking client both own
+        // worker resources. Shut them down and drop their final
+        // handles outside Tokio's async context.
+        let _ = tokio::task::spawn_blocking(move || {
+            let mut runtime = self;
+            let tracer = runtime._handle.inner.tracer.write().take();
+            let logger = runtime._handle.inner.logger.write().take();
+            if let Some(provider) = runtime.tracer_provider.take() {
+                let _ = provider.shutdown_with_timeout(timeout);
+            }
+            if let Some(provider) = runtime.meter_provider.take() {
+                let _ = provider.shutdown_with_timeout(timeout);
+            }
+            if let Some(provider) = runtime.logger_provider.take() {
+                let _ = provider.shutdown_with_timeout(timeout);
+            }
+            drop(logger);
+            drop(tracer);
+        })
+        .await;
     }
 }
 
@@ -1079,6 +1146,29 @@ mod tests {
     }
 
     #[test]
+    fn signal_specific_endpoint_preserves_trailing_slash() {
+        let _guard = env_guard();
+        for k in [
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+            "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+            "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+        ] {
+            std::env::remove_var(k);
+        }
+        std::env::set_var(
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            "http://collector:4318/custom/",
+        );
+
+        let targets = ObservabilityConfig::from_env().export_targets();
+        assert_eq!(
+            targets.traces.as_ref().unwrap().url,
+            "http://collector:4318/custom/"
+        );
+        std::env::remove_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
+    }
+
+    #[test]
     fn generic_endpoint_gets_the_signal_suffix() {
         let _guard = env_guard();
         for k in [
@@ -1104,6 +1194,40 @@ mod tests {
             "http://collector:4318/v1/metrics"
         );
         std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
+    }
+
+    #[test]
+    fn generic_endpoint_inserts_signal_suffix_before_query_and_fragment() {
+        let _guard = env_guard();
+        for k in [
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+            "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+        ] {
+            std::env::remove_var(k);
+        }
+        std::env::set_var(
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+            "http://collector:4318/base?token=x#fragment",
+        );
+
+        let targets = ObservabilityConfig::from_env().export_targets();
+        assert_eq!(
+            targets.logs.as_ref().unwrap().url,
+            "http://collector:4318/base/v1/logs?token=x#fragment"
+        );
+        std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
+    }
+
+    #[test]
+    fn parse_headers_percent_decodes_values() {
+        assert_eq!(
+            parse_headers(Some("Authorization=Basic%20abc,opaque=a%2Cb")),
+            vec![
+                ("Authorization".to_string(), "Basic abc".to_string()),
+                ("opaque".to_string(), "a,b".to_string()),
+            ]
+        );
     }
 
     #[test]
@@ -1276,11 +1400,115 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_is_bounded() {
-        let (obs, rt) = Observability::from_config(ObservabilityConfig::from_env());
+        let (obs, rt) = {
+            let _guard = env_guard();
+            for key in [
+                "OTEL_EXPORTER_OTLP_ENDPOINT",
+                "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+                "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+            ] {
+                std::env::remove_var(key);
+            }
+            Observability::from_config(ObservabilityConfig::from_env())
+        };
         // Must not hang even though there are no exporters.
         tokio::time::timeout(Duration::from_secs(3), rt.shutdown())
             .await
             .expect("shutdown must be bounded to 2s");
+        drop(obs);
+    }
+
+    #[tokio::test]
+    async fn shutdown_with_configured_otlp_is_bounded() {
+        let (obs, rt) = {
+            let _guard = env_guard();
+            for key in [
+                "OTEL_EXPORTER_OTLP_ENDPOINT",
+                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+                "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+            ] {
+                std::env::remove_var(key);
+            }
+            std::env::set_var(
+                "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+                "http://127.0.0.1:9/v1/logs",
+            );
+            let result = Observability::from_config(ObservabilityConfig::from_env());
+            std::env::remove_var("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT");
+            result
+        };
+        tokio::time::timeout(Duration::from_secs(3), rt.shutdown())
+            .await
+            .expect("shutdown must be bounded with an OTLP client");
+        drop(obs);
+    }
+
+    #[tokio::test]
+    async fn shutdown_with_configured_metric_exporter_is_bounded() {
+        let (obs, rt) = {
+            let _guard = env_guard();
+            for key in [
+                "OTEL_EXPORTER_OTLP_ENDPOINT",
+                "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+            ] {
+                std::env::remove_var(key);
+            }
+            std::env::set_var(
+                "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+                "http://127.0.0.1:9/v1/metrics",
+            );
+            let result = Observability::from_config(ObservabilityConfig::from_env());
+            std::env::remove_var("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT");
+            result
+        };
+        tokio::time::timeout(Duration::from_secs(3), rt.shutdown())
+            .await
+            .expect("shutdown must be bounded with a metric exporter");
+        drop(obs);
+    }
+
+    #[tokio::test]
+    async fn configured_blocking_exporter_posts_log_during_shutdown() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind OTLP test receiver");
+        let address = listener.local_addr().expect("receiver address");
+        let receiver = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept OTLP export");
+            let mut request = [0_u8; 4096];
+            let read = stream.read(&mut request).expect("read OTLP request");
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n")
+                .expect("respond to OTLP export");
+            String::from_utf8_lossy(&request[..read]).into_owned()
+        });
+        let (obs, rt) = {
+            let _guard = env_guard();
+            for key in [
+                "OTEL_EXPORTER_OTLP_ENDPOINT",
+                "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+                "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+            ] {
+                std::env::remove_var(key);
+            }
+            std::env::set_var(
+                "OTEL_EXPORTER_OTLP_LOGS_ENDPOINT",
+                format!("http://{address}/v1/logs"),
+            );
+            let result = Observability::from_config(ObservabilityConfig::from_env());
+            std::env::remove_var("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT");
+            result
+        };
+        obs.export_log("INFO", "export test", Vec::new());
+        tokio::time::timeout(Duration::from_secs(3), rt.shutdown())
+            .await
+            .expect("shutdown must flush the OTLP log export");
+
+        let request = receiver.join().expect("OTLP receiver thread");
+        assert!(request.starts_with("POST /v1/logs HTTP/1.1"));
         drop(obs);
     }
 }

--- a/crates/preloop-runner-server/src/main.rs
+++ b/crates/preloop-runner-server/src/main.rs
@@ -90,8 +90,8 @@ async fn main() -> anyhow::Result<()> {
     // process and flushes on shutdown.
 
     let cli = Cli::parse();
-    match cli.command {
-        Command::Cert { output } => {
+    let result = match cli.command {
+        Command::Cert { output } => (|| {
             std::fs::create_dir_all(&output)?;
             let cert = preloop_runner_server::generate_self_signed_cert()?;
             let cert_path = output.join("cert.pem");
@@ -107,7 +107,8 @@ async fn main() -> anyhow::Result<()> {
                 cert_path.display(),
                 key_path.display()
             );
-        }
+            Ok(())
+        })(),
         Command::Serve {
             listen,
             state_dir,
@@ -156,11 +157,11 @@ async fn main() -> anyhow::Result<()> {
                     })
                     .unwrap_or(false),
             })
-            .await?;
+            .await
         }
-    }
-    // Bounded 2s flush of buffered telemetry before exit; a clean shutdown
-    // must not drop the last flush window's records.
+    };
+    // Flush even after command errors, so a failed server startup or
+    // certificate generation does not discard its final telemetry.
     observability_runtime.shutdown().await;
-    Ok(())
+    result
 }

--- a/crates/preloop-runner/src/main.rs
+++ b/crates/preloop-runner/src/main.rs
@@ -31,32 +31,40 @@ async fn main() -> Result<()> {
         Commands::Run(args) => preloop_runner::listener::run_listener(args, &cli.global).await,
         Commands::Worker(args) => preloop_runner::worker::run_worker(args).await,
         Commands::Lint(args) => {
-            let workflow_yaml = tokio::fs::read_to_string(&args.workflow)
-                .await
-                .map_err(|e| anyhow::anyhow!("read workflow {}: {e}", args.workflow.display()))?;
-            let parsed = preloop_gha_parser::parse_workflow(&workflow_yaml)
-                .map_err(|e| anyhow::anyhow!("parse workflow {}: {e}", args.workflow.display()))?;
-            let reusable_workflows =
-                collect_reusable_workflows(args.workspace_root.as_deref(), &args.workflow).await?;
-            let reusable_workflows =
-                resolve_remote_workflows(reusable_workflows, &workflow_yaml).await?;
-            let expanded =
-                preloop_gha_parser::expand_jobs_with_reusables(&parsed, &reusable_workflows)
-                    .map_err(|e| {
-                        anyhow::anyhow!("expand workflow {}: {e}", args.workflow.display())
-                    })?;
+            async {
+                let workflow_yaml =
+                    tokio::fs::read_to_string(&args.workflow)
+                        .await
+                        .map_err(|e| {
+                            anyhow::anyhow!("read workflow {}: {e}", args.workflow.display())
+                        })?;
+                let parsed = preloop_gha_parser::parse_workflow(&workflow_yaml).map_err(|e| {
+                    anyhow::anyhow!("parse workflow {}: {e}", args.workflow.display())
+                })?;
+                let reusable_workflows =
+                    collect_reusable_workflows(args.workspace_root.as_deref(), &args.workflow)
+                        .await?;
+                let reusable_workflows =
+                    resolve_remote_workflows(reusable_workflows, &workflow_yaml).await?;
+                let expanded =
+                    preloop_gha_parser::expand_jobs_with_reusables(&parsed, &reusable_workflows)
+                        .map_err(|e| {
+                            anyhow::anyhow!("expand workflow {}: {e}", args.workflow.display())
+                        })?;
 
-            let step_count: usize = expanded.jobs.iter().map(|j| j.steps.len()).sum();
-            println!(
-                "✓ Workflow {} is valid: parsed {} job plan(s) and {} total step(s).",
-                args.workflow.display(),
-                expanded.jobs.len(),
-                step_count
-            );
-            for job in &expanded.jobs {
-                println!("  - Job: {} ({})", job.id.0, job.name);
+                let step_count: usize = expanded.jobs.iter().map(|j| j.steps.len()).sum();
+                println!(
+                    "✓ Workflow {} is valid: parsed {} job plan(s) and {} total step(s).",
+                    args.workflow.display(),
+                    expanded.jobs.len(),
+                    step_count
+                );
+                for job in &expanded.jobs {
+                    println!("  - Job: {} ({})", job.id.0, job.name);
+                }
+                Ok(())
             }
-            Ok(())
+            .await
         }
     };
     observability_runtime.shutdown().await;

--- a/crates/preloop-runner/src/main.rs
+++ b/crates/preloop-runner/src/main.rs
@@ -22,9 +22,8 @@ async fn main() -> Result<()> {
         preloop_observability::Observability::from_config(obs_config);
     observability_runtime.install_fmt_subscriber();
     let _observability = observability;
-    let _observability_runtime = observability_runtime;
 
-    match cli.command {
+    let result = match cli.command {
         Commands::Configure(args) => {
             preloop_runner::configure::run_configure(args, &cli.global).await
         }
@@ -59,7 +58,9 @@ async fn main() -> Result<()> {
             }
             Ok(())
         }
-    }
+    };
+    observability_runtime.shutdown().await;
+    result
 }
 
 async fn collect_reusable_workflows(


### PR DESCRIPTION
## Summary

- Resolve generic OTLP endpoints with URL-aware path replacement, preserving queries/fragments; preserve signal-specific endpoints exactly, including a trailing slash.
- Percent-decode OTLP header values.
- Use `reqwest::blocking::Client` with OpenTelemetry's default blocking batch processors/readers. Construct and drop its runtime-owning client outside Tokio's async context.
- Flush observability providers after both successful and failed server/runner commands.
- Remove the OpenObserve healthcheck that is permanently invalid for its distroless pinned image; document the host-side `/healthz` probe instead.
- Add endpoint/header, configured-shutdown, and real local HTTP export regression coverage.

## Verification

- `cargo test -p preloop-observability` — 25 tests passed.
- `cargo check -p preloop-runner -p preloop-runner-server`
- `ZO_ROOT_USER_PASSWORD=test-password docker compose -f contrib/openobserve/compose.yml config --quiet`
- `just test-ci` — passed (fmt, clippy, zizmor, workspace tests, conformance).
- Submitted the committed workspace to local preloop CI before push.

## Stack

Base: `pr/6-review-fixes`. Current `origin/main` has #170 but not the observability stack.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens OTLP-over-HTTP export and shutdown to avoid Tokio/runtime conflicts and lost telemetry. Previously we used an async `reqwest` client with blocking SDK processors and naïve endpoint handling; now we use a blocking client built off the Tokio runtime, resolve endpoints URL-safely, percent-decode headers, and always flush on exit.

- Use `reqwest::blocking::Client` via `opentelemetry-http`’s `reqwest-blocking` feature; build the client on a non-Tokio thread so SDK batch/periodic processors export from blocking threads.
- Resolve `OTEL_EXPORTER_OTLP_ENDPOINT` by inserting `/v1/<signal>` before any query/fragment; honor signal-specific endpoints exactly as provided, including trailing slashes.
- Percent-decode `OTEL_EXPORTER_OTLP_HEADERS` values.
- Always flush telemetry in `preloop-runner` and `preloop-runner-server`, even when commands error; shutdown runs in a blocking task, is bounded to 2s, and drops SDK/exporter resources safely.
- Remove the invalid OpenObserve Docker healthcheck for the distroless image; probe `http://127.0.0.1:5080/healthz` from the host instead.
- Add regression tests for endpoint/header parsing, bounded shutdown with/without exporters, and a local OTLP HTTP log export during shutdown.

Migration: if you relied on async `reqwest` via `opentelemetry-http`, switch to the `reqwest-blocking` feature.

<sup>Written for commit 82e728a54e5781f6b008582c397f5c5373b7b4ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Switch OTLP HTTP exporters to blocking client and fix endpoint/header handling
> - Replaces async `reqwest` with a shared `reqwest::blocking::Client` built on a dedicated OS thread, avoiding Tokio current-thread runtime conflicts with the OTLP SDK worker model
> - Fixes generic endpoint resolution in `ObservabilityConfig.from_env`: inserts `/v1/<signal>` before any query or fragment, and preserves trailing slashes on signal-specific endpoints
> - Adds `percent_decode_header_value` so `OTEL_EXPORTER_OTLP_HEADERS` values support percent-encoded characters (e.g. spaces, commas)\n- Reworks `ObservabilityRuntime.shutdown` to run inside `spawn_blocking` with a ~2s timeout, taking tracer/logger from `RwLock` and dropping providers cleanly off the async runtime
> - Moves `shutdown().await` after command dispatch in both runner and runner-server `main` so telemetry flushes on success and error paths
> - Risk: `Inner.tracer` and `Inner.logger` are now `RwLock<Option<...>>`; all accessors acquire read locks. Shutdown now runs exporters in `spawn_blocking` and will time out after 2s regardless of backend responsiveness
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82e728a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->