### PR TITLE
fix(github): fetch webhook workflows from event SHA instead of branch ref

### DIFF
--- a/crates/preloop-runner-server/src/dispatch_tests.rs
+++ b/crates/preloop-runner-server/src/dispatch_tests.rs
@@ -120,6 +120,21 @@ fn git_ok(ws: &std::path::Path, args: &[&str]) {
     );
 }
 
+fn git_head(ws: &std::path::Path) -> String {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(ws)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git rev-parse failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap().trim().to_owned()
+}
+
 /// POST a raw JSON body to `uri` with `bearer` (defaults to the system
 /// token). Returns (status, parsed body).
 async fn post_json(
@@ -1024,6 +1039,7 @@ async fn webhook_receiver_accepts_any_registered_app_secret() {
     )
     .unwrap();
     init_git_repo(&ws);
+    let event_sha = git_head(&ws);
     let mut state = AppState::new(temp.path().join("state").to_path_buf())
         .await
         .unwrap();
@@ -1035,7 +1051,7 @@ async fn webhook_receiver_accepts_any_registered_app_secret() {
 
     let payload = json!({
         "ref": "refs/heads/main",
-        "after": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        "after": event_sha,
         "repository": {"full_name": "octocat/repo", "default_branch": "main"},
         "commits": [],
     });

--- a/crates/preloop-runner-server/src/events/pull_request.rs
+++ b/crates/preloop-runner-server/src/events/pull_request.rs
@@ -5,7 +5,7 @@
 //! Pull request webhook always emits `pull_request_target` AND conditionally
 //! emits `pull_request` (gated on AllowPullRequests / non-fork).
 //!
-//! - pull_request_target: ref = refs/heads/{base.ref}, sha = head.sha
+//! - pull_request_target: ref = refs/heads/{base.ref}, sha = base.sha (required)
 //! - pull_request: ref = refs/pull/{n}/merge, sha = merge_commit_sha
 //!   (or refs/pull/{n}/head if no merge pseudo-branch)
 
@@ -104,7 +104,7 @@ impl EventAdapter for Adapter {
         events.push(EffectiveEvent {
             event: "pull_request_target".to_owned(),
             git_ref: format!("refs/heads/{base}"),
-            sha: base_checkout.or_else(|| Some(head.to_owned())),
+            sha: base_checkout,
             status_check_sha: Some(head.to_owned()),
             activity_type: act.clone(),
             trust_tier: Some(TrustTier::PullRequestTarget),
@@ -187,6 +187,11 @@ mod tests {
         });
         let events = Adapter.project(&payload);
         assert_eq!(events.len(), 2);
+        let target = events
+            .iter()
+            .find(|event| event.event == "pull_request_target")
+            .unwrap();
+        assert_eq!(target.sha, None);
         let pr = events
             .iter()
             .find(|event| event.event == "pull_request")

--- a/crates/preloop-runner-server/src/events/pull_request_target.rs
+++ b/crates/preloop-runner-server/src/events/pull_request_target.rs
@@ -52,7 +52,7 @@ impl EventAdapter for Adapter {
         vec![EffectiveEvent {
             event: "pull_request_target".to_owned(),
             git_ref: format!("refs/heads/{base_ref}"),
-            sha: base_sha.or(head_sha).map(|s| s.to_owned()),
+            sha: base_sha.map(|s| s.to_owned()),
             status_check_sha: head_sha.map(|s| s.to_owned()),
             activity_type,
             trust_tier: Some(TrustTier::PullRequestTarget),
@@ -85,7 +85,7 @@ mod tests {
     }
 
     #[test]
-    fn falls_back_to_head_when_base_sha_missing() {
+    fn leaves_checkout_sha_missing_when_base_sha_missing() {
         let payload = serde_json::json!({
             "action": "opened",
             "pull_request": {
@@ -95,6 +95,6 @@ mod tests {
             "repository": { "default_branch": "main" }
         });
         let events = Adapter.project(&payload);
-        assert_eq!(events[0].sha, Some("head-sha-789".to_owned()));
+        assert_eq!(events[0].sha, None);
     }
 }

--- a/crates/preloop-runner-server/src/github.rs
+++ b/crates/preloop-runner-server/src/github.rs
@@ -1284,36 +1284,46 @@ async fn process_github_webhook(
         } else {
             &effective.git_ref
         };
-        let workflows = fetch_workflows(shared, &repo_full_name, workflow_ref)
-            .await
-            .map_err(|error| {
-                error!(
-                    event = %effective.event,
-                    ?error,
-                    "Failed to fetch workflows — delivery failed, will be redelivered"
-                );
-                StatusCode::BAD_GATEWAY
-            })?;
+
+        // The event ref is mutable: another push can move it while this
+        // delivery is in flight, and GitHub's webhook/API views may briefly
+        // converge at different times. Keep it for github.ref and trigger
+        // semantics, but resolve the workflow definition from the immutable
+        // commit that the event identifies.
         let resolved_sha = match &effective.sha {
             Some(sha) => sha.clone(),
-            None => match resolve_ref_sha(shared, &repo_full_name, &effective.git_ref).await {
+            None => match resolve_ref_sha(shared, &repo_full_name, workflow_ref).await {
                 Ok(Some(sha)) => sha,
                 Ok(None) => {
                     error!(
-                        ref_name = %effective.git_ref,
-                        "webhook ref has no resolvable commit SHA — delivery failed, will be redelivered"
+                        ref_name = %workflow_ref,
+                        "webhook workflow ref has no resolvable commit SHA — delivery failed, will be redelivered"
                     );
                     return Err(StatusCode::BAD_GATEWAY);
                 }
                 Err(error) => {
                     error!(
                         ?error,
-                        "failed to resolve webhook ref SHA — delivery failed, will be redelivered"
+                        ref_name = %workflow_ref,
+                        "failed to resolve webhook workflow ref SHA — delivery failed, will be redelivered"
                     );
                     return Err(StatusCode::BAD_GATEWAY);
                 }
             },
         };
+
+        let workflows = fetch_workflows(shared, &repo_full_name, &resolved_sha)
+            .await
+            .map_err(|error| {
+                error!(
+                    event = %effective.event,
+                    sha = %resolved_sha,
+                    source_ref = %workflow_ref,
+                    ?error,
+                    "Failed to fetch workflows at the event commit — delivery failed, will be redelivered"
+                );
+                StatusCode::BAD_GATEWAY
+            })?;
         if effective.event == "push" && effective.git_ref == ref_default {
             if let Some(scheduler) = &shared.state.scheduler {
                 scheduler

--- a/crates/preloop-runner-server/src/github.rs
+++ b/crates/preloop-runner-server/src/github.rs
@@ -1333,47 +1333,52 @@ async fn process_github_webhook(
                 // the current default-branch head rather than this delivery's
                 // possibly stale event commit. Triggered runs still use the
                 // event-pinned `workflows` above.
-                let scheduler_sha = match resolve_ref_sha(shared, &repo_full_name, &ref_default)
+                let scheduler_source = match resolve_ref_sha(shared, &repo_full_name, &ref_default)
                     .await
                 {
-                    Ok(Some(sha)) => sha,
+                    Ok(Some(scheduler_sha)) => {
+                        let scheduler_workflows = if scheduler_sha == resolved_sha {
+                            Some(workflows.clone())
+                        } else {
+                            match fetch_workflows(shared, &repo_full_name, &scheduler_sha).await {
+                                Ok(workflows) => Some(workflows),
+                                Err(error) => {
+                                    warn!(
+                                        sha = %scheduler_sha,
+                                        ?error,
+                                        "failed to fetch current default-branch workflows — skipping cron reconciliation"
+                                    );
+                                    None
+                                }
+                            }
+                        };
+                        scheduler_workflows.map(|workflows| (scheduler_sha, workflows))
+                    }
                     Ok(None) => {
-                        error!(
+                        warn!(
                             ref_name = %ref_default,
-                            "current default branch has no resolvable commit SHA — delivery failed, will be redelivered"
+                            "current default branch has no resolvable commit SHA — skipping cron reconciliation"
                         );
-                        return Err(StatusCode::BAD_GATEWAY);
+                        None
                     }
                     Err(error) => {
-                        error!(
+                        warn!(
                             ?error,
                             ref_name = %ref_default,
-                            "failed to resolve current default branch SHA — delivery failed, will be redelivered"
+                            "failed to resolve current default branch SHA — skipping cron reconciliation"
                         );
-                        return Err(StatusCode::BAD_GATEWAY);
+                        None
                     }
                 };
-                let scheduler_workflows = if scheduler_sha == resolved_sha {
-                    workflows.clone()
-                } else {
-                    fetch_workflows(shared, &repo_full_name, &scheduler_sha)
-                        .await
-                        .map_err(|error| {
-                            error!(
-                                sha = %scheduler_sha,
-                                ?error,
-                                "failed to fetch current default-branch workflows — delivery failed, will be redelivered"
-                            );
-                            StatusCode::BAD_GATEWAY
-                        })?
-                };
-                let mut scheduler_payload = payload_val.clone();
-                if let Some(object) = scheduler_payload.as_object_mut() {
-                    object.insert("after".to_owned(), Value::String(scheduler_sha));
+                if let Some((scheduler_sha, scheduler_workflows)) = scheduler_source {
+                    let mut scheduler_payload = payload_val.clone();
+                    if let Some(object) = scheduler_payload.as_object_mut() {
+                        object.insert("after".to_owned(), Value::String(scheduler_sha));
+                    }
+                    scheduler
+                        .reconcile_all(&scheduler_workflows, scheduler_payload, shared.clone())
+                        .await;
                 }
-                scheduler
-                    .reconcile_all(&scheduler_workflows, scheduler_payload, shared.clone())
-                    .await;
             }
         }
 

--- a/crates/preloop-runner-server/src/github.rs
+++ b/crates/preloop-runner-server/src/github.rs
@@ -668,7 +668,7 @@ pub(crate) async fn fetch_workflows_at(
             let permissions = BTreeMap::from([("contents".to_owned(), "read".to_owned())]);
             Some(crate::github_app::get_or_mint_token_at(api_base, &app, repo, &permissions).await?)
         } else {
-            std::env::var("PRELOOP_GITHUB_TOKEN").ok()
+            shared.state.static_github_pat()
         };
         if let Some(token) = &token {
             fetch_remote_workflows(token, repo, git_ref, api_base).await

--- a/crates/preloop-runner-server/src/github.rs
+++ b/crates/preloop-runner-server/src/github.rs
@@ -579,79 +579,71 @@ pub(crate) async fn fetch_workflows_at(
         // A dispatch for a branch other than the checked-out tree must read
         // the workflow definitions from that ref, not from the working tree.
         if !git_ref.is_empty() {
-            // A ref beginning with '-' would be parsed by git as an option
-            // (e.g. `git rev-parse --verify -x^{commit}`); treat it as
-            // unresolvable and fall back to the checked-out tree.
             if git_ref.starts_with('-') {
-                warn!(
-                    %git_ref,
-                    workspace = %base_path.display(),
-                    "git_ref starts with '-' and is not a valid ref; falling back to the checked-out tree",
-                );
-            } else {
-                let commitish: &str = &format!("{git_ref}^{{commit}}");
-                let resolved = tokio::process::Command::new("git")
-                    .arg("-C")
-                    .arg(base_path)
-                    .args(["rev-parse", "--verify", commitish])
-                    .output()
-                    .await?;
-                if resolved.status.success() {
-                    let listing = tokio::process::Command::new("git")
-                        .arg("-C")
-                        .arg(base_path)
-                        .args([
-                            "ls-tree",
-                            "-r",
-                            "--name-only",
-                            git_ref,
-                            "--",
-                            ".github/workflows",
-                        ])
-                        .output()
-                        .await?;
-                    if !listing.status.success() {
-                        anyhow::bail!(
-                            "git ls-tree for ref {git_ref:?} in {} failed: {}",
-                            base_path.display(),
-                            String::from_utf8_lossy(&listing.stderr),
-                        );
-                    }
-                    for line in String::from_utf8_lossy(&listing.stdout).lines() {
-                        let path = line.trim();
-                        if path.is_empty() {
-                            continue;
-                        }
-                        let name = path.rsplit('/').next().unwrap_or(path);
-                        if name.ends_with(".yml") || name.ends_with(".yaml") {
-                            let path_ref: &str = &format!("{git_ref}:{path}");
-                            let content = tokio::process::Command::new("git")
-                                .arg("-C")
-                                .arg(base_path)
-                                .args(["show", path_ref])
-                                .output()
-                                .await?;
-                            if !content.status.success() {
-                                anyhow::bail!(
-                                    "git show {path_ref:?} in {} failed: {}",
-                                    base_path.display(),
-                                    String::from_utf8_lossy(&content.stderr),
-                                );
-                            }
-                            workflows.insert(
-                                name.to_owned(),
-                                String::from_utf8_lossy(&content.stdout).into_owned(),
-                            );
-                        }
-                    }
-                    return Ok(workflows);
-                }
-                warn!(
-                    %git_ref,
-                    workspace = %base_path.display(),
-                    "git_ref does not resolve in the local workspace; falling back to the checked-out tree",
+                anyhow::bail!("workflow revision {git_ref:?} is not a valid Git ref");
+            }
+            let commitish = format!("{git_ref}^{{commit}}");
+            let resolved = tokio::process::Command::new("git")
+                .arg("-C")
+                .arg(base_path)
+                .args(["rev-parse", "--verify", &commitish])
+                .output()
+                .await?;
+            if !resolved.status.success() {
+                anyhow::bail!(
+                    "workflow revision {git_ref:?} is unavailable in local workspace {}: {}",
+                    base_path.display(),
+                    String::from_utf8_lossy(&resolved.stderr),
                 );
             }
+            let listing = tokio::process::Command::new("git")
+                .arg("-C")
+                .arg(base_path)
+                .args([
+                    "ls-tree",
+                    "-r",
+                    "--name-only",
+                    git_ref,
+                    "--",
+                    ".github/workflows",
+                ])
+                .output()
+                .await?;
+            if !listing.status.success() {
+                anyhow::bail!(
+                    "git ls-tree for ref {git_ref:?} in {} failed: {}",
+                    base_path.display(),
+                    String::from_utf8_lossy(&listing.stderr),
+                );
+            }
+            for line in String::from_utf8_lossy(&listing.stdout).lines() {
+                let path = line.trim();
+                if path.is_empty() {
+                    continue;
+                }
+                let name = path.rsplit('/').next().unwrap_or(path);
+                if name.ends_with(".yml") || name.ends_with(".yaml") {
+                    let path_ref = format!("{git_ref}:{path}");
+                    let content = tokio::process::Command::new("git")
+                        .arg("-C")
+                        .arg(base_path)
+                        .args(["show", &path_ref])
+                        .output()
+                        .await?;
+                    if !content.status.success() {
+                        anyhow::bail!(
+                            "git show {path_ref:?} in {} failed: {}",
+                            base_path.display(),
+                            String::from_utf8_lossy(&content.stderr),
+                        );
+                    }
+                    workflows.insert(
+                        name.to_owned(),
+                        String::from_utf8_lossy(&content.stdout).into_owned(),
+                    );
+                }
+            }
+            return Ok(workflows);
         }
         let workflows_dir = base_path.join(".github/workflows");
         if workflows_dir.exists() {
@@ -680,8 +672,11 @@ pub(crate) async fn fetch_workflows_at(
         };
         if let Some(token) = &token {
             fetch_remote_workflows(token, repo, git_ref, api_base).await
+        } else if !git_ref.is_empty() {
+            anyhow::bail!(
+                "cannot fetch workflow revision {git_ref:?} without a local workspace or GitHub credentials"
+            );
         } else {
-            // Default fallback to current workspace root if nothing is configured
             let workflows_dir = PathBuf::from(".").join(".github/workflows");
             let mut workflows = BTreeMap::new();
             if workflows_dir.exists() {
@@ -1292,6 +1287,14 @@ async fn process_github_webhook(
         // commit that the event identifies.
         let resolved_sha = match &effective.sha {
             Some(sha) => sha.clone(),
+            None if effective.event == "pull_request_target" => {
+                error!(
+                    event = %effective.event,
+                    ref_name = %workflow_ref,
+                    "pull_request_target has no base commit SHA — delivery failed, will be redelivered"
+                );
+                return Err(StatusCode::BAD_GATEWAY);
+            }
             None => match resolve_ref_sha(shared, &repo_full_name, workflow_ref).await {
                 Ok(Some(sha)) => sha,
                 Ok(None) => {
@@ -1326,8 +1329,50 @@ async fn process_github_webhook(
             })?;
         if effective.event == "push" && effective.git_ref == ref_default {
             if let Some(scheduler) = &shared.state.scheduler {
+                // Cron definitions are global state, so reconcile them from
+                // the current default-branch head rather than this delivery's
+                // possibly stale event commit. Triggered runs still use the
+                // event-pinned `workflows` above.
+                let scheduler_sha = match resolve_ref_sha(shared, &repo_full_name, &ref_default)
+                    .await
+                {
+                    Ok(Some(sha)) => sha,
+                    Ok(None) => {
+                        error!(
+                            ref_name = %ref_default,
+                            "current default branch has no resolvable commit SHA — delivery failed, will be redelivered"
+                        );
+                        return Err(StatusCode::BAD_GATEWAY);
+                    }
+                    Err(error) => {
+                        error!(
+                            ?error,
+                            ref_name = %ref_default,
+                            "failed to resolve current default branch SHA — delivery failed, will be redelivered"
+                        );
+                        return Err(StatusCode::BAD_GATEWAY);
+                    }
+                };
+                let scheduler_workflows = if scheduler_sha == resolved_sha {
+                    workflows.clone()
+                } else {
+                    fetch_workflows(shared, &repo_full_name, &scheduler_sha)
+                        .await
+                        .map_err(|error| {
+                            error!(
+                                sha = %scheduler_sha,
+                                ?error,
+                                "failed to fetch current default-branch workflows — delivery failed, will be redelivered"
+                            );
+                            StatusCode::BAD_GATEWAY
+                        })?
+                };
+                let mut scheduler_payload = payload_val.clone();
+                if let Some(object) = scheduler_payload.as_object_mut() {
+                    object.insert("after".to_owned(), Value::String(scheduler_sha));
+                }
                 scheduler
-                    .reconcile_all(&workflows, payload_val.clone(), shared.clone())
+                    .reconcile_all(&scheduler_workflows, scheduler_payload, shared.clone())
                     .await;
             }
         }
@@ -1745,6 +1790,34 @@ mod tests {
         format!("sha256={hex}")
     }
 
+    fn git_output(workspace: &std::path::Path, args: &[&str]) -> String {
+        let output = std::process::Command::new("git")
+            .arg("-C")
+            .arg(workspace)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).unwrap().trim().to_owned()
+    }
+
+    fn commit_workspace(workspace: &std::path::Path) -> String {
+        for args in [
+            &["init", "-q", "-b", "main"][..],
+            &["config", "user.email", "github-tests@example.invalid"][..],
+            &["config", "user.name", "GitHub Tests"][..],
+        ] {
+            git_output(workspace, args);
+        }
+        git_output(workspace, &["add", "-A"]);
+        git_output(workspace, &["commit", "-qm", "test workflow"]);
+        git_output(workspace, &["rev-parse", "HEAD"])
+    }
+
     #[test]
     fn github_owned_workflow_filter_matches_filename_or_path() {
         let configured =
@@ -1791,14 +1864,14 @@ mod tests {
     }
 
     /// The signed push payload GitHub would deliver for `owner/repo`.
-    fn signed_push_payload() -> (Vec<u8>, String) {
+    fn signed_push_payload(after: &str) -> (Vec<u8>, String) {
         let payload = serde_json::json!({
             "ref": "refs/heads/main",
             "before": "0000000000000000000000000000000000000000",
-            "after": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            "after": after,
             "repository": {"full_name": "owner/repo", "default_branch": "main"},
             "commits": [{
-                "id": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                "id": after,
                 "added": ["src/main.rs"],
                 "modified": [],
                 "removed": []
@@ -1815,6 +1888,7 @@ mod tests {
     struct WebhookFixture {
         state: AppState,
         app: axum::Router,
+        workspace: std::path::PathBuf,
         payload_bytes: Vec<u8>,
         signature_header: String,
     }
@@ -1833,20 +1907,33 @@ mod tests {
         }
 
         async fn with_workspace(temp: &tempfile::TempDir, ws_dir: std::path::PathBuf) -> Self {
+            let event_sha = if ws_dir.join(".github/workflows").is_dir() {
+                commit_workspace(&ws_dir)
+            } else {
+                "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_owned()
+            };
             let mut state = AppState::new(temp.path().join("state").to_path_buf())
                 .await
                 .unwrap();
             state.webhook_secret = Some("super-secret".to_owned());
-            state.local_workspace = Some(ws_dir);
+            state.local_workspace = Some(ws_dir.clone());
             let app =
                 crate::app_with_test_api(state.clone(), CancellationToken::new(), "test-token");
-            let (payload_bytes, signature_header) = signed_push_payload();
+            let (payload_bytes, signature_header) = signed_push_payload(&event_sha);
             Self {
                 state,
                 app,
+                workspace: ws_dir,
                 payload_bytes,
                 signature_header,
             }
+        }
+
+        fn refresh_payload_from_head(&mut self) {
+            let event_sha = git_output(&self.workspace, &["rev-parse", "HEAD"]);
+            let (payload_bytes, signature_header) = signed_push_payload(&event_sha);
+            self.payload_bytes = payload_bytes;
+            self.signature_header = signature_header;
         }
 
         /// Deliver the signed standard payload under `delivery`.
@@ -1889,11 +1976,10 @@ mod tests {
         let ws_dir = temp.path().join("ws");
         std::fs::create_dir_all(&ws_dir).unwrap();
         std::fs::create_dir_all(ws_dir.join(".github")).unwrap();
-        // `.github/workflows` exists but is a regular file: the inventory read
-        // fails deterministically (read_dir on a non-directory errors), so the
-        // delivery cannot be processed.
+        // The initial workspace has no Git object for the immutable payload
+        // SHA, so processing fails before the delivery can be acknowledged.
         std::fs::write(ws_dir.join(".github/workflows"), "not a directory").unwrap();
-        let fixture = WebhookFixture::with_workspace(&temp, ws_dir.clone()).await;
+        let mut fixture = WebhookFixture::with_workspace(&temp, ws_dir.clone()).await;
 
         let status = fixture.post("delivery-fetch-fail", Some("push")).await;
         assert_eq!(
@@ -1925,6 +2011,8 @@ mod tests {
             "on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hello\n",
         )
         .unwrap();
+        commit_workspace(&ws_dir);
+        fixture.refresh_payload_from_head();
 
         assert_eq!(
             fixture.post("delivery-fetch-fail", Some("push")).await,
@@ -1946,12 +2034,14 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let fixture = WebhookFixture::new(&temp).await;
 
-        // A push without `after` leaves the effective SHA unresolved, and the
-        // local workspace is not a Git repository, so no SHA can be resolved:
-        // the delivery's work cannot be done.
+        // A push that names a commit absent from the local repository must
+        // fail rather than execute workflow YAML from the current checkout.
+        // The delivery's work cannot be done until that immutable commit is
+        // available.
         let payload = serde_json::json!({
             "ref": "refs/heads/main",
             "before": "0000000000000000000000000000000000000000",
+            "after": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
             "repository": {"full_name": "owner/repo", "default_branch": "main"},
             "commits": [{
                 "id": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -9304,6 +9304,129 @@ jobs:
     assert!(*check_run_id > 0);
 }
 
+#[tokio::test]
+async fn github_webhook_fetches_workflow_from_event_sha_not_current_branch() {
+    // This is a local-workspace reproduction of the same race as the remote
+    // App path: the webhook names an older commit while the branch has already
+    // advanced to a different workflow definition.
+    let _env = crate::state::GITHUB_ENV_LOCK.lock().await;
+    let _no_token = crate::state::TestEnvVar::unset("PRELOOP_GITHUB_TOKEN");
+    let _no_api_url = crate::state::TestEnvVar::unset("PRELOOP_GITHUB_API_URL");
+
+    let temp = tempfile::tempdir().unwrap();
+    let ws_dir = temp.path().join("workspace");
+    std::fs::create_dir_all(ws_dir.join(".github/workflows")).unwrap();
+
+    let old_workflow = r#"
+name: old
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo old-workflow
+"#;
+    let new_workflow = r#"
+name: new
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo new-workflow
+"#;
+    std::fs::write(ws_dir.join(".github/workflows/build.yml"), old_workflow).unwrap();
+
+    let git = |args: &[&str]| -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(&ws_dir)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).unwrap().trim().to_owned()
+    };
+    git(&["init", "-b", "main"]);
+    git(&["config", "user.email", "preloop-tests@example.invalid"]);
+    git(&["config", "user.name", "Preloop Tests"]);
+    git(&["add", ".github/workflows/build.yml"]);
+    git(&["commit", "-m", "old workflow"]);
+    let event_sha = git(&["rev-parse", "HEAD"]);
+
+    std::fs::write(ws_dir.join(".github/workflows/build.yml"), new_workflow).unwrap();
+    git(&["add", ".github/workflows/build.yml"]);
+    git(&["commit", "-m", "new workflow"]);
+    let branch_sha = git(&["rev-parse", "HEAD"]);
+    assert_ne!(event_sha, branch_sha);
+
+    let mut state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    state.webhook_secret = Some("super-secret".to_owned());
+    state.local_workspace = Some(ws_dir);
+    let app = app(state.clone(), CancellationToken::new());
+
+    let payload = serde_json::json!({
+        "ref": "refs/heads/main",
+        "before": "0000000000000000000000000000000000000000",
+        "after": event_sha,
+        "repository": {
+            "full_name": "owner/repo",
+            "default_branch": "main"
+        },
+        "commits": [{
+            "id": event_sha,
+            "added": [".github/workflows/build.yml"],
+            "modified": [],
+            "removed": []
+        }]
+    });
+    let payload_bytes = serde_json::to_vec(&payload).unwrap();
+
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+    type HmacSha256 = Hmac<Sha256>;
+    let mut mac = HmacSha256::new_from_slice(b"super-secret").unwrap();
+    mac.update(&payload_bytes);
+    let signature = mac
+        .finalize()
+        .into_bytes()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/v1/github/webhooks")
+                .header("x-github-event", "push")
+                .header("x-github-delivery", "sha-pinned-workflow")
+                .header("x-hub-signature-256", format!("sha256={signature}"))
+                .header("content-type", "application/json")
+                .body(Body::from(payload_bytes))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let inner = state.inner.lock().await;
+    let run = inner.runs.values().next().expect("webhook created a run");
+    assert_eq!(
+        run.submission.resolved_sha.as_deref(),
+        Some(event_sha.as_str())
+    );
+    assert!(
+        run.submission.workflow_yaml.contains("old-workflow"),
+        "workflow must be loaded from the webhook commit, not current main"
+    );
+    assert!(!run.submission.workflow_yaml.contains("new-workflow"));
+}
+
 /// Check-run ids must survive a restart even when no job status event ever
 /// fired — a long queue can sit between check-run creation and the job's
 /// first status event, and a deploy in that window used to restore the run

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -7126,6 +7126,27 @@ async fn fork_pull_request_webhook_jobs_are_downgraded_and_secrets_denied() {
     .await
     .unwrap();
 
+    let git = |args: &[&str]| -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(&ws_dir)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).unwrap().trim().to_owned()
+    };
+    git(&["init", "-b", "main"]);
+    git(&["config", "user.email", "preloop-tests@example.invalid"]);
+    git(&["config", "user.name", "Preloop Tests"]);
+    git(&["add", ".github/workflows/test.yml"]);
+    git(&["commit", "-m", "test workflow"]);
+    let base_sha = git(&["rev-parse", "HEAD"]);
+
     let mut state = AppState::new(temp.path().to_path_buf()).await.unwrap();
     state.webhook_secret = Some("super-secret".to_owned());
     state.local_workspace = Some(ws_dir);
@@ -7150,8 +7171,9 @@ async fn fork_pull_request_webhook_jobs_are_downgraded_and_secrets_denied() {
             },
             "base": {
                 "ref": "main",
-                "sha": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
-            }
+                "sha": base_sha.clone()
+            },
+            "merge_commit_sha": base_sha
         },
         "repository": {
             "full_name": "owner/repo",
@@ -9208,6 +9230,27 @@ jobs:
         .await
         .unwrap();
 
+    let git = |args: &[&str]| -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(&ws_dir)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).unwrap().trim().to_owned()
+    };
+    git(&["init", "-b", "main"]);
+    git(&["config", "user.email", "preloop-tests@example.invalid"]);
+    git(&["config", "user.name", "Preloop Tests"]);
+    git(&["add", ".github/workflows/build.yml"]);
+    git(&["commit", "-m", "test workflow"]);
+    let event_sha = git(&["rev-parse", "HEAD"]);
+
     let mut state = AppState::new(temp.path().to_path_buf()).await.unwrap();
     state.webhook_secret = Some("super-secret".to_owned());
     state.local_workspace = Some(ws_dir.clone());
@@ -9221,14 +9264,14 @@ jobs:
     let payload = serde_json::json!({
         "ref": "refs/heads/main",
         "before": "0000000000000000000000000000000000000000",
-        "after": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+        "after": event_sha.clone(),
         "repository": {
             "full_name": "owner/repo",
             "default_branch": "main"
         },
         "commits": [
             {
-                "id": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+                "id": event_sha,
                 "added": ["src/main.rs"],
                 "modified": [],
                 "removed": []
@@ -9427,6 +9470,205 @@ jobs:
     assert!(!run.submission.workflow_yaml.contains("new-workflow"));
 }
 
+#[tokio::test]
+async fn github_webhook_rejects_missing_event_sha_without_workspace_fallback() {
+    let _env = crate::state::GITHUB_ENV_LOCK.lock().await;
+    let _no_token = crate::state::TestEnvVar::unset("PRELOOP_GITHUB_TOKEN");
+    let _no_api_url = crate::state::TestEnvVar::unset("PRELOOP_GITHUB_API_URL");
+
+    let temp = tempfile::tempdir().unwrap();
+    let ws_dir = temp.path().join("workspace");
+    fs::create_dir_all(ws_dir.join(".github/workflows")).unwrap();
+    fs::write(
+        ws_dir.join(".github/workflows/build.yml"),
+        r#"
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo current-worktree
+"#,
+    )
+    .unwrap();
+
+    let git = |args: &[&str]| {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(&ws_dir)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+    git(&["init", "-b", "main"]);
+    git(&["config", "user.email", "preloop-tests@example.invalid"]);
+    git(&["config", "user.name", "Preloop Tests"]);
+    git(&["add", ".github/workflows/build.yml"]);
+    git(&["commit", "-m", "current workflow"]);
+
+    let missing_sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_owned();
+    let mut state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    state.webhook_secret = Some("super-secret".to_owned());
+    state.local_workspace = Some(ws_dir);
+    let app = app(state.clone(), CancellationToken::new());
+
+    let payload = serde_json::json!({
+        "ref": "refs/heads/main",
+        "before": "0000000000000000000000000000000000000000",
+        "after": missing_sha,
+        "repository": {
+            "full_name": "owner/repo",
+            "default_branch": "main"
+        },
+        "commits": [{
+            "id": missing_sha,
+            "added": [".github/workflows/build.yml"],
+            "modified": [],
+            "removed": []
+        }]
+    });
+    let payload_bytes = serde_json::to_vec(&payload).unwrap();
+
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+    type HmacSha256 = Hmac<Sha256>;
+    let mut mac = HmacSha256::new_from_slice(b"super-secret").unwrap();
+    mac.update(&payload_bytes);
+    let signature = mac
+        .finalize()
+        .into_bytes()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/v1/github/webhooks")
+                .header("x-github-event", "push")
+                .header("x-github-delivery", "missing-event-sha")
+                .header("x-hub-signature-256", format!("sha256={signature}"))
+                .header("content-type", "application/json")
+                .body(Body::from(payload_bytes))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+
+    let inner = state.inner.lock().await;
+    assert!(
+        inner.runs.is_empty(),
+        "missing event SHA must not execute current-worktree YAML"
+    );
+}
+
+#[tokio::test]
+async fn github_webhook_rejects_pull_request_target_without_base_sha() {
+    let _env = crate::state::GITHUB_ENV_LOCK.lock().await;
+    let _no_token = crate::state::TestEnvVar::unset("PRELOOP_GITHUB_TOKEN");
+    let _no_api_url = crate::state::TestEnvVar::unset("PRELOOP_GITHUB_API_URL");
+
+    let temp = tempfile::tempdir().unwrap();
+    let ws_dir = temp.path().join("workspace");
+    fs::create_dir_all(ws_dir.join(".github/workflows")).unwrap();
+    fs::write(
+        ws_dir.join(".github/workflows/build.yml"),
+        r#"
+on: pull_request_target
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo base-workflow
+"#,
+    )
+    .unwrap();
+
+    let git = |args: &[&str]| {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(&ws_dir)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+    git(&["init", "-b", "main"]);
+    git(&["config", "user.email", "preloop-tests@example.invalid"]);
+    git(&["config", "user.name", "Preloop Tests"]);
+    git(&["add", ".github/workflows/build.yml"]);
+    git(&["commit", "-m", "base workflow"]);
+
+    let mut state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    state.webhook_secret = Some("super-secret".to_owned());
+    state.local_workspace = Some(ws_dir);
+    let app = app(state.clone(), CancellationToken::new());
+
+    let payload = serde_json::json!({
+        "action": "opened",
+        "number": 42,
+        "pull_request": {
+            "number": 42,
+            "base": { "ref": "main" },
+            "head": {
+                "ref": "feature/fork",
+                "sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "repo": { "fork": true }
+            }
+        },
+        "repository": {
+            "full_name": "owner/repo",
+            "default_branch": "main"
+        }
+    });
+    let payload_bytes = serde_json::to_vec(&payload).unwrap();
+
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+    type HmacSha256 = Hmac<Sha256>;
+    let mut mac = HmacSha256::new_from_slice(b"super-secret").unwrap();
+    mac.update(&payload_bytes);
+    let signature = mac
+        .finalize()
+        .into_bytes()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/v1/github/webhooks")
+                .header("x-github-event", "pull_request")
+                .header("x-github-delivery", "missing-base-sha")
+                .header("x-hub-signature-256", format!("sha256={signature}"))
+                .header("content-type", "application/json")
+                .body(Body::from(payload_bytes))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+
+    let inner = state.inner.lock().await;
+    assert!(
+        inner.runs.is_empty(),
+        "pull_request_target must not execute head-controlled YAML"
+    );
+}
+
 /// Check-run ids must survive a restart even when no job status event ever
 /// fired — a long queue can sit between check-run creation and the job's
 /// first status event, and a deploy in that window used to restore the run
@@ -9457,6 +9699,27 @@ jobs:
         .await
         .unwrap();
 
+    let git = |args: &[&str]| -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(&ws_dir)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).unwrap().trim().to_owned()
+    };
+    git(&["init", "-b", "main"]);
+    git(&["config", "user.email", "preloop-tests@example.invalid"]);
+    git(&["config", "user.name", "Preloop Tests"]);
+    git(&["add", ".github/workflows/build.yml"]);
+    git(&["commit", "-m", "test workflow"]);
+    let event_sha = git(&["rev-parse", "HEAD"]);
+
     let run_id = {
         let mut state = AppState::new(temp.path().to_path_buf()).await.unwrap();
         state.webhook_secret = Some("super-secret".to_owned());
@@ -9466,14 +9729,14 @@ jobs:
         let payload = serde_json::json!({
             "ref": "refs/heads/main",
             "before": "0000000000000000000000000000000000000000",
-            "after": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+            "after": event_sha.clone(),
             "repository": {
                 "full_name": "owner/repo",
                 "default_branch": "main"
             },
             "commits": [
                 {
-                    "id": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+                    "id": event_sha,
                     "added": ["src/main.rs"],
                     "modified": [],
                     "removed": []
@@ -9635,6 +9898,27 @@ impl WebhookDedupFixture {
         )
         .unwrap();
 
+        let git = |args: &[&str]| -> String {
+            let output = Command::new("git")
+                .args(args)
+                .current_dir(&ws_dir)
+                .output()
+                .unwrap();
+            assert!(
+                output.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&output.stderr)
+            );
+            String::from_utf8(output.stdout).unwrap().trim().to_owned()
+        };
+        git(&["init", "-b", "main"]);
+        git(&["config", "user.email", "preloop-tests@example.invalid"]);
+        git(&["config", "user.name", "Preloop Tests"]);
+        git(&["add", ".github/workflows/build.yml"]);
+        git(&["commit", "-m", "test workflow"]);
+        let event_sha = git(&["rev-parse", "HEAD"]);
+
         let mut state = AppState::new(temp.path().join("state").to_path_buf())
             .await
             .unwrap();
@@ -9645,10 +9929,10 @@ impl WebhookDedupFixture {
         let payload = serde_json::json!({
             "ref": "refs/heads/main",
             "before": "0000000000000000000000000000000000000000",
-            "after": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            "after": event_sha.clone(),
             "repository": {"full_name": "owner/repo", "default_branch": "main"},
             "commits": [{
-                "id": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                "id": event_sha,
                 "added": ["src/main.rs"],
                 "modified": [],
                 "removed": []
@@ -9809,6 +10093,29 @@ jobs:
         .await
         .unwrap();
 
+    let git = |args: &[&str]| -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(&ws_dir)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).unwrap().trim().to_owned()
+    };
+    git(&["init", "-b", "main"]);
+    git(&["config", "user.email", "preloop-tests@example.invalid"]);
+    git(&["config", "user.name", "Preloop Tests"]);
+    git(&["add", ".github/workflows/test.yml"]);
+    git(&["commit", "-m", "test workflow"]);
+    let base_sha = git(&["rev-parse", "HEAD"]);
+    git(&["commit", "--allow-empty", "-m", "head commit"]);
+    let head_sha = git(&["rev-parse", "HEAD"]);
+
     let mut state = AppState::new(temp.path().to_path_buf()).await.unwrap();
     state.webhook_secret = Some("super-secret".to_owned());
     state.local_workspace = Some(ws_dir.clone());
@@ -9822,12 +10129,12 @@ jobs:
         "pull_request": {
             "head": {
                 "ref": "feature-branch",
-                "sha": "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3"
+                "sha": head_sha
             },
             "base": {
                 "ref": "main",
-                "sha": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
-            }
+                "sha": base_sha.clone()
+            },
         },
         "repository": {
             "full_name": "owner/repo",
@@ -9876,7 +10183,7 @@ jobs:
     // the job. Falling through to all-zeros makes every checkout ask the
     // server for `0000…` and fail as "not our ref".
     assert_eq!(
-        run_record.head_sha, "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+        run_record.head_sha, head_sha,
         "pull_request head sha must drive github.sha"
     );
 }
@@ -10795,6 +11102,27 @@ async fn config_webhook_secret_verifies_signed_deliveries() {
     )
     .await
     .unwrap();
+
+    let git = |args: &[&str]| -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(&ws_dir)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+        String::from_utf8(output.stdout).unwrap().trim().to_owned()
+    };
+    git(&["init", "-b", "main"]);
+    git(&["config", "user.email", "preloop-tests@example.invalid"]);
+    git(&["config", "user.name", "Preloop Tests"]);
+    git(&["add", ".github/workflows/build.yml"]);
+    git(&["commit", "-m", "test workflow"]);
+    let event_sha = git(&["rev-parse", "HEAD"]);
     let config_path = temp.path().join("config.toml");
     std::fs::write(
         &config_path,
@@ -10818,10 +11146,10 @@ async fn config_webhook_secret_verifies_signed_deliveries() {
     let payload = serde_json::json!({
         "ref": "refs/heads/main",
         "before": "0000000000000000000000000000000000000000",
-        "after": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+        "after": event_sha.clone(),
         "repository": {"full_name": "owner/repo", "default_branch": "main"},
         "commits": [{
-            "id": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+            "id": event_sha,
             "added": ["src/main.rs"],
             "modified": [],
             "removed": []

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -7542,6 +7542,78 @@ async fn app_only_server_fetches_webhook_workflows_with_installation_token() {
 }
 
 #[tokio::test]
+async fn pat_only_server_fetches_webhook_workflows_with_configured_pat() {
+    use axum::http::HeaderMap;
+    use axum::routing::get;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let api_base = format!("http://{}", listener.local_addr().unwrap());
+    let download_url = format!("{api_base}/raw/ci.yml");
+    let stub = Router::new()
+        .route(
+            "/repos/preloopdev/preloop/contents/.github/workflows",
+            get(move |headers: HeaderMap| {
+                let download_url = download_url.clone();
+                async move {
+                    assert_eq!(
+                        headers
+                            .get("authorization")
+                            .and_then(|value| value.to_str().ok()),
+                        Some("Bearer ghp_config_workflow_token")
+                    );
+                    Json(json!([{
+                        "name": "ci.yml",
+                        "type": "file",
+                        "download_url": download_url
+                    }]))
+                }
+            }),
+        )
+        .route(
+            "/raw/ci.yml",
+            get(|headers: HeaderMap| async move {
+                assert_eq!(
+                    headers
+                        .get("authorization")
+                        .and_then(|value| value.to_str().ok()),
+                    Some("Bearer ghp_config_workflow_token")
+                );
+                "on: push\njobs:\n  test:\n    runs-on: self-hosted\n    steps:\n      - run: true\n"
+            }),
+        );
+    tokio::spawn(async move { axum::serve(listener, stub).await.unwrap() });
+
+    let temp = tempfile::tempdir().unwrap();
+    let config_path = temp.path().join("config.toml");
+    std::fs::write(
+        &config_path,
+        "[github]\npat = \"ghp_config_workflow_token\"\n",
+    )
+    .unwrap();
+    let mut state = AppState::new_with_config(temp.path().join("state"), config_path)
+        .await
+        .unwrap();
+    state.local_workspace = None;
+    assert!(state.github_app.is_none());
+    let shared = Arc::new(SharedState {
+        state,
+        shutdown: CancellationToken::new(),
+    });
+
+    let workflows = crate::github::fetch_workflows_at(
+        &shared,
+        "preloopdev/preloop",
+        "refs/heads/main",
+        &api_base,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(workflows.len(), 1);
+    assert!(workflows["ci.yml"].contains("runs-on: self-hosted"));
+}
+
+#[tokio::test]
 async fn app_only_server_resolves_pull_request_changed_files_with_installation_token() {
     use crate::github_app::{GitHubAppCredentials, MintFailurePolicy};
     use axum::extract::{Path, Query};

--- a/docs/github-app-webhook.md
+++ b/docs/github-app-webhook.md
@@ -66,7 +66,7 @@ The system is configured using the following environment variables:
 | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
 | `PRELOOP_WEBHOOK_SECRET`            | Secret key configured on the GitHub App to verify payload signatures.                                                                        | `my-secure-webhook-secret`                 |
 | `PRELOOP_LOCAL_WORKSPACE`           | Path to a local Git worktree used for offline workflow loading and immutable local-source checkouts.                                         | `/path/to/my-repo`                         |
-| `PRELOOP_GITHUB_TOKEN`              | GitHub Personal Access Token or App Installation Token to fetch workflows and update check runs.                                             | `ghp_...` or `ghs_...`                     |
+| `PRELOOP_GITHUB_TOKEN`              | Fallback GitHub Personal Access Token for workflow retrieval and Check Run updates when no configured GitHub App is available.                  | `ghp_...`                                  |
 | `PRELOOP_GITHUB_APPS_JSON`          | JSON array of additional registered Apps overriding `github.apps`; each entry: `app_id`, `pem`, optional `webhook_secret`/`installation_id`. | `[{"app_id":12345,"pem":"-----BEGIN..."}]` |
 | `PRELOOP_GITHUB_APP_DEFAULT_EVENTS` | Comma-separated creation-time event list for the App-manifest flow; defaults to `push,pull_request`.                                         | `push,pull_request`                        |
 
@@ -108,7 +108,9 @@ different workflow during delivery.
 1. **Local Filesystem (Offline/Dev Mode)**:
  If `PRELOOP_LOCAL_WORKSPACE` is configured, `preloop` reads the
  `.github/workflows/` directory from the event's commit when that commit is
- present in the local repository. For a default
+ present in the local repository. If an immutable event SHA is unavailable,
+ delivery fails so GitHub can redeliver it; the current worktree is never used
+ as a substitute. For a default
  `uses: actions/checkout@v4` step, submission also captures the worktree as
  an immutable synthetic Git commit and redirects the compiled checkout inputs
  to preloop's authenticated smart-HTTP endpoint. Tracked modifications,
@@ -122,8 +124,10 @@ different workflow during delivery.
  `GET /repos/{owner}/{repo}/contents/.github/workflows?ref={commit_sha}`
  and downloads files from that immutable ref.
 3. **Current Directory Fallback**:
- If neither is set, it defaults to looking in the local
- `.github/workflows/` directory of the current running workspace.
+If neither is set and no immutable workflow revision was requested, it defaults
+to looking in the local `.github/workflows/` directory of the current running
+workspace. A webhook delivery with an event SHA fails instead of reading the
+current worktree.
 
 ---
 
@@ -135,7 +139,9 @@ The system maps the lifecycle of each job to a GitHub Check Run:
 2. **In Progress**: When the runner fetches and starts the job, the status is updated to `in_progress`.
 3. **Completed**: When the runner finishes (or `preloop` reaps it due to timeout/lease expiration), the check run is updated to `completed` with the corresponding conclusion (`success`, `failure`, or `cancelled`).
 
-If `PRELOOP_GITHUB_TOKEN` is not configured, these requests are simulated in-memory and logged to the console, allowing fully offline execution.
+If neither a configured GitHub App nor `PRELOOP_GITHUB_TOKEN` is available,
+these requests are simulated in-memory and logged to the console, allowing
+fully offline execution.
 
 ---
 
@@ -144,12 +150,14 @@ If `PRELOOP_GITHUB_TOKEN` is not configured, these requests are simulated in-mem
 ### Step 1: Set up Webhook in GitHub
 
 1. Go to your GitHub App settings.
-2. Set the payload URL to `http://<your--url>/api/v1/github/webhooks`.
+2. Set the payload URL to `https://<your-url>/api/v1/github/webhooks`.
 3. Set the content type to `application/json`.
 4. Enter a secure Webhook Secret (e.g. `super-secret`).
-5. Select the events preloop should turn into runs. For the full surface,
- tick every event in the table above; the manifest flow
- (`GET /api/v1/github/register`) does this automatically for new Apps.
+5. Select the events preloop should turn into runs. The manifest defaults to
+   `push` and `pull_request`. Before registering a new App, set
+   `PRELOOP_GITHUB_APP_DEFAULT_EVENTS` to a comma-separated list when additional
+   events are required. For an existing App, tick additional events manually
+   under the App's settings → Webhooks → Edit.
  At minimum, tick the trigger events: `push`, `pull_request`,
  `pull_request_target`, `pull_request_review`, `workflow_dispatch`,
  `workflow_run`, `repository_dispatch`, `issue_comment`, `issues`,
@@ -220,7 +228,7 @@ or trigger any other subscribed event. `preloop` will:
 
    When these values are set, preloop signs a GitHub App JWT and exchanges it for a per-job installation access token scoped to the run's repository and to that job's effective `permissions:`. A job declaring no `permissions:` gets GitHub's restricted default (`contents`, `metadata`, `packages` at `read`), never the installation's full grant. If no App configuration is present at all, `PRELOOP_GITHUB_TOKEN` is the job token. If an App *is* configured but minting fails, `PRELOOP_GITHUB_APP_MINT_FAILURE` decides — `local` (the default) keeps the job on the local HMAC JWT rather than silently widening its authority to the PAT. See [GitHub Tokens](./github-tokens.md).
 6. **Confirm delivery and job credential use**:
- Push a commit or open a pull request. preloop verifies the webhook and queues matching jobs. The installed App's scoped token is supplied to the runner job. Remote workflow retrieval and GitHub Check Run reporting currently continue to use `PRELOOP_GITHUB_TOKEN`; configure `PRELOOP_LOCAL_WORKSPACE` for offline workflow loading, or provide that token for those server-side GitHub API calls.
+Push a commit or open a pull request. preloop verifies the webhook and queues matching jobs. The installed App's scoped token is supplied to the runner job. For remote workflow retrieval and GitHub Check Run reporting, preloop selects the configured GitHub App credentials; `PRELOOP_GITHUB_TOKEN` is used only as the fallback when no App is available. App-only deployments do not need to provide a PAT for these server-side calls.
 
 ---
 

--- a/docs/github-app-webhook.md
+++ b/docs/github-app-webhook.md
@@ -1,4 +1,4 @@
-# GitHub App Webhook Integration Log & User Guide
+# GitHub App Webhook Integration Log &amp; User Guide
 
 This document records the design, build log, and interaction guide for the end-to-end GitHub App Webhook receiver and Checks API status reporting system in `preloop`.
 
@@ -16,12 +16,14 @@ status back to the repository.
 The webhook receiver understands every event the `EventAdapter` registry
 supports (`src/events/mod.rs`, `all_event_names()`):
 
-| Tier | Events |
-|---|---|
-| A — CI-critical | `push`, `pull_request`, `pull_request_target`, `pull_request_review`, `workflow_dispatch`, `workflow_run`, `check_run`, `check_suite`, `repository_dispatch`, `create`, `delete`, `release` |
-| B — issue/PR/social | `issues`, `issue_comment`, `discussion`, `discussion_comment`, `label`, `milestone` |
-| C — release/admin/fork/wiki | `watch`, `fork`, `deployment`, `deployment_status`, `member`, `public`, `gollum`, `page_build` |
-| Internal | `schedule` (synthesized by the cron scheduler, never delivered as a webhook) |
+
+| Tier                        | Events                                                                                                                                                                                      |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A — CI-critical             | `push`, `pull_request`, `pull_request_target`, `pull_request_review`, `workflow_dispatch`, `workflow_run`, `check_run`, `check_suite`, `repository_dispatch`, `create`, `delete`, `release` |
+| B — issue/PR/social         | `issues`, `issue_comment`, `discussion`, `discussion_comment`, `label`, `milestone`                                                                                                         |
+| C — release/admin/fork/wiki | `watch`, `fork`, `deployment`, `deployment_status`, `member`, `public`, `gollum`, `page_build`                                                                                              |
+| Internal                    | `schedule` (synthesized by the cron scheduler, never delivered as a webhook)                                                                                                                |
+
 
 The App-manifest flow (`GET /api/v1/github/register`) defaults to the minimal
 CI event set: `push` and `pull_request`. Override the creation-time event list
@@ -59,21 +61,22 @@ graph TD
 
 The system is configured using the following environment variables:
 
-| Variable | Description | Example |
-|---|---|---|
-| `PRELOOP_WEBHOOK_SECRET` | Secret key configured on the GitHub App to verify payload signatures. | `my-secure-webhook-secret` |
-| `PRELOOP_LOCAL_WORKSPACE` | Path to a local Git worktree used for offline workflow loading and immutable local-source checkouts. | `/path/to/my-repo` |
-| `PRELOOP_GITHUB_TOKEN` | GitHub Personal Access Token or App Installation Token to fetch workflows and update check runs. | `ghp_...` or `ghs_...` |
-| `PRELOOP_GITHUB_APPS_JSON` | JSON array of additional registered Apps overriding `github.apps`; each entry: `app_id`, `pem`, optional `webhook_secret`/`installation_id`. | `[{"app_id":12345,"pem":"-----BEGIN..."}]` |
-| `PRELOOP_GITHUB_APP_DEFAULT_EVENTS` | Comma-separated creation-time event list for the App-manifest flow; defaults to `push,pull_request`. | `push,pull_request` |
+
+| Variable                            | Description                                                                                                                                  | Example                                    |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| `PRELOOP_WEBHOOK_SECRET`            | Secret key configured on the GitHub App to verify payload signatures.                                                                        | `my-secure-webhook-secret`                 |
+| `PRELOOP_LOCAL_WORKSPACE`           | Path to a local Git worktree used for offline workflow loading and immutable local-source checkouts.                                         | `/path/to/my-repo`                         |
+| `PRELOOP_GITHUB_TOKEN`              | GitHub Personal Access Token or App Installation Token to fetch workflows and update check runs.                                             | `ghp_...` or `ghs_...`                     |
+| `PRELOOP_GITHUB_APPS_JSON`          | JSON array of additional registered Apps overriding `github.apps`; each entry: `app_id`, `pem`, optional `webhook_secret`/`installation_id`. | `[{"app_id":12345,"pem":"-----BEGIN..."}]` |
+| `PRELOOP_GITHUB_APP_DEFAULT_EVENTS` | Comma-separated creation-time event list for the App-manifest flow; defaults to `push,pull_request`.                                         | `push,pull_request`                        |
+
 
 ### Security Best Practices
 
-*   **Git-Ignore Credentials**: Never check `.env`, `*.pem`, or `*.key` files into Git. These files are excluded in the root `.gitignore`.
-   
-*   **Production Key Management**: In production, do not write private keys or secrets to plaintext files on the server disk. Instead:
-    - Load them directly into memory at runtime using a Secrets Manager (e.g. HashiCorp Vault, AWS Secrets Manager, or Kubernetes Secrets).
-    - Inject the configuration as environment variables directly to the running process without file-based middleware.
+- **Git-Ignore Credentials**: Never check `.env`, `*.pem`, or `*.key` files into Git. These files are excluded in the root `.gitignore`.
+- **Production Key Management**: In production, do not write private keys or secrets to plaintext files on the server disk. Instead:
+  - Load them directly into memory at runtime using a Secrets Manager (e.g. HashiCorp Vault, AWS Secrets Manager, or Kubernetes Secrets).
+  - Inject the configuration as environment variables directly to the running process without file-based middleware.
 
 ---
 
@@ -82,41 +85,52 @@ The system is configured using the following environment variables:
 <!-- Trigger Webhook Event Test 2026-07-01 13:38 -->
 
 `preloop` verifies that incoming webhooks are authentic:
+
 - When `PRELOOP_WEBHOOK_SECRET` is set, `preloop` computes the HMAC-SHA256 signature of the raw request body and verifies it against the `x-hub-signature-256` header.
 - If verification fails, the header is missing, or no secret is configured at
-  all, the endpoint returns `401 Unauthorized` — signature verification is
-  mandatory, never skipped.
+all, the endpoint returns `401 Unauthorized` — signature verification is
+mandatory, never skipped.
 - With multiple registered Apps (`github.apps`, see
-  [GitHub Tokens](./github-tokens.md)), the signature is verified against
-  **each** App's webhook secret; a payload signed by any registered App is
-  accepted, and one signed by none is rejected.
+[GitHub Tokens](./github-tokens.md)), the signature is verified against
+**each** App's webhook secret; a payload signed by any registered App is
+accepted, and one signed by none is rejected.
 
 ---
 
 ## 4. Workflow Fetching Strategies
 
-When a webhook event is received, `preloop` retrieves the workflow definitions:
+When a webhook event is received, `preloop` resolves the event's immutable
+commit SHA before retrieving workflow definitions. The branch ref remains in
+the submission for GitHub event context (`github.ref` and trigger filters), but
+the YAML is fetched from the commit SHA so a branch update cannot select a
+different workflow during delivery.
+
 1. **Local Filesystem (Offline/Dev Mode)**:
-   If `PRELOOP_LOCAL_WORKSPACE` is configured, `preloop` reads the `.github/workflows/`
-   directory directly from that local path. For a default
-   `uses: actions/checkout@v4` step, submission also captures the worktree as an
-   immutable synthetic Git commit and redirects the compiled checkout inputs to
-   preloop's authenticated smart-HTTP endpoint. Tracked modifications, deletions,
-   and untracked non-ignored files are included without modifying the user's
-   index or workflow YAML. Explicit repository/ref/token/server checkout inputs
-   retain their original remote behavior.
+ If `PRELOOP_LOCAL_WORKSPACE` is configured, `preloop` reads the
+ `.github/workflows/` directory from the event's commit when that commit is
+ present in the local repository. For a default
+ `uses: actions/checkout@v4` step, submission also captures the worktree as
+ an immutable synthetic Git commit and redirects the compiled checkout inputs
+ to preloop's authenticated smart-HTTP endpoint. Tracked modifications,
+ deletions, and untracked non-ignored files are included without modifying
+ the user's index or workflow YAML. Explicit repository/ref/token/server
+ checkout inputs retain their original remote behavior.
 2. **GitHub API (Remote/Production Mode)**:
-   If `PRELOOP_LOCAL_WORKSPACE` is not configured, but `PRELOOP_GITHUB_TOKEN` is set, `preloop` queries:
-   `GET /repos/{owner}/{repo}/contents/.github/workflows?ref={git_ref}`
-   And downloads files dynamically.
+ If `PRELOOP_LOCAL_WORKSPACE` is not configured, but
+ `PRELOOP_GITHUB_TOKEN` or a configured GitHub App is available, `preloop`
+ queries:
+ `GET /repos/{owner}/{repo}/contents/.github/workflows?ref={commit_sha}`
+ and downloads files from that immutable ref.
 3. **Current Directory Fallback**:
-   If neither is set, it defaults to looking in the local `.github/workflows/` directory of the current running workspace.
+ If neither is set, it defaults to looking in the local
+ `.github/workflows/` directory of the current running workspace.
 
 ---
 
 ## 5. GitHub Checks API Reporting
 
 The system maps the lifecycle of each job to a GitHub Check Run:
+
 1. **Queued**: When a run is accepted, a check run is created via `POST /repos/{owner}/{repo}/check-runs` with status `queued`. The check run ID is recorded in `RunRecord.job_check_run_ids`.
 2. **In Progress**: When the runner fetches and starts the job, the status is updated to `in_progress`.
 3. **Completed**: When the runner finishes (or `preloop` reaps it due to timeout/lease expiration), the check run is updated to `completed` with the corresponding conclusion (`success`, `failure`, or `cancelled`).
@@ -128,20 +142,23 @@ If `PRELOOP_GITHUB_TOKEN` is not configured, these requests are simulated in-mem
 ## 6. How Users Interact with it
 
 ### Step 1: Set up Webhook in GitHub
+
 1. Go to your GitHub App settings.
-2. Set the payload URL to `http://<your-preloop-url>/api/v1/github/webhooks`.
+2. Set the payload URL to `http://<your--url>/api/v1/github/webhooks`.
 3. Set the content type to `application/json`.
 4. Enter a secure Webhook Secret (e.g. `super-secret`).
 5. Select the events preloop should turn into runs. For the full surface,
-   tick every event in the table above; the manifest flow
-   (`GET /api/v1/github/register`) does this automatically for new Apps.
-   At minimum, tick the trigger events: `push`, `pull_request`,
-   `pull_request_target`, `pull_request_review`, `workflow_dispatch`,
-   `workflow_run`, `repository_dispatch`, `issue_comment`, `issues`,
-   `check_run`, `check_suite`, `create`, `delete`, `release`.
+ tick every event in the table above; the manifest flow
+ (`GET /api/v1/github/register`) does this automatically for new Apps.
+ At minimum, tick the trigger events: `push`, `pull_request`,
+ `pull_request_target`, `pull_request_review`, `workflow_dispatch`,
+ `workflow_run`, `repository_dispatch`, `issue_comment`, `issues`,
+ `check_run`, `check_suite`, `create`, `delete`, `release`.
 
 ### Step 2: Start `preloop-runner-server`
+
 Run the server with the environment variables set:
+
 ```sh
 export PRELOOP_WEBHOOK_SECRET="super-secret"
 export PRELOOP_LOCAL_WORKSPACE="/path/to/runner-watcher"
@@ -151,8 +168,10 @@ just serve
 ```
 
 ### Step 3: Trigger workflows
+
 Push a commit, open a pull request, dispatch a workflow through the REST API,
 or trigger any other subscribed event. `preloop` will:
+
 - Receive the webhook event.
 - Fetch the workflows.
 - Match filters (branches, tags, paths).
@@ -166,31 +185,30 @@ or trigger any other subscribed event. `preloop` will:
 `preloop` supports the official **GitHub App Manifest** flow to create an App. Creating the App and installing it are separate GitHub operations.
 
 1. **Expose preloop at its final public HTTPS URL**:
-   Start `preloop-runner-server` behind a publicly reachable HTTPS address, then open:
-   ```text
+ Start `preloop-runner-server` behind a publicly reachable HTTPS address, then open:
+  ```text
    https://preloop.example.com/api/v1/github/register
-   ```
+  ```
+
    `localhost` is suitable for viewing the form, but GitHub cannot deliver webhook events or callback redirects to it. The manifest only includes webhook settings for non-local hosts.
-
 2. **Create the App from the manifest**:
-   Click **Register App on GitHub**. GitHub opens its App-creation flow with preloop's redirect URL, webhook URL, default events, and default permissions pre-filled.
-
+ Click **Register App on GitHub**. GitHub opens its App-creation flow with preloop's redirect URL, webhook URL, default events, and default permissions pre-filled.
 3. **Capture the callback credentials**:
-   After GitHub creates the App, it redirects to:
-   ```text
+ After GitHub creates the App, it redirects to:
+  ```text
    https://preloop.example.com/api/v1/github/callback?code=...
-   ```
+  ```
+
    preloop exchanges the one-time code for an App ID, webhook secret, and private-key PEM, then displays them. Treat the PEM and webhook secret as credentials: store them in a secret manager and do not commit them.
-
 4. **Install the App**:
-   In GitHub's App settings, install the newly created App on the target account or repository. Copy the installation ID from its installation settings URL, for example:
-   ```text
+ In GitHub's App settings, install the newly created App on the target account or repository. Copy the installation ID from its installation settings URL, for example:
+  ```text
    https://github.com/settings/installations/INSTALLATION_ID
-   ```
-   The App cannot mint an installation access token until this step is complete.
+  ```
 
+   The App cannot mint an installation access token until this step is complete.
 5. **Configure preloop and restart it**:
-   ```sh
+  ```sh
    export PRELOOP_WEBHOOK_SECRET="your-new-webhook-secret"
    export PRELOOP_GITHUB_APP_ID="your-new-app-id"
    export PRELOOP_GITHUB_APP_INSTALLATION_ID="your-installation-id"
@@ -198,30 +216,31 @@ or trigger any other subscribed event. `preloop` will:
    ...
    -----END PRIVATE KEY-----'
    # Or: export PRELOOP_GITHUB_APP_PRIVATE_KEY_PATH=/secure/path/preloop-app.pem
-   ```
+  ```
 
    When these values are set, preloop signs a GitHub App JWT and exchanges it for a per-job installation access token scoped to the run's repository and to that job's effective `permissions:`. A job declaring no `permissions:` gets GitHub's restricted default (`contents`, `metadata`, `packages` at `read`), never the installation's full grant. If no App configuration is present at all, `PRELOOP_GITHUB_TOKEN` is the job token. If an App *is* configured but minting fails, `PRELOOP_GITHUB_APP_MINT_FAILURE` decides — `local` (the default) keeps the job on the local HMAC JWT rather than silently widening its authority to the PAT. See [GitHub Tokens](./github-tokens.md).
-
 6. **Confirm delivery and job credential use**:
-   Push a commit or open a pull request. preloop verifies the webhook and queues matching jobs. The installed App's scoped token is supplied to the runner job. Remote workflow retrieval and GitHub Check Run reporting currently continue to use `PRELOOP_GITHUB_TOKEN`; configure `PRELOOP_LOCAL_WORKSPACE` for offline workflow loading, or provide that token for those server-side GitHub API calls.
+ Push a commit or open a pull request. preloop verifies the webhook and queues matching jobs. The installed App's scoped token is supplied to the runner job. Remote workflow retrieval and GitHub Check Run reporting currently continue to use `PRELOOP_GITHUB_TOKEN`; configure `PRELOOP_LOCAL_WORKSPACE` for offline workflow loading, or provide that token for those server-side GitHub API calls.
 
 ---
 
-## 8. Operational Deployment & Troubleshooting Guide
+## 8. Operational Deployment &amp; Troubleshooting Guide
 
 This section documents operational best practices, lessons learned, and real-world failure modes encountered during live deployments.
 
 ### 8.1 `--public-url` Dual Purpose
 
 The `--public-url` parameter supplied to `preloop serve` serves two distinct purposes:
+
 1. **In-VM Control Plane Endpoint**: Tells the ephemeral runner microVM inside SmolVM where to connect back to the control plane.
 2. **GitHub Check Run Links**: Forms the base URL for the `details_url` field sent to GitHub when registering check runs on PRs and commits (e.g. `https://preloop.preloop.dev/runs/<run_id>`).
 
 **Pitfall**: Setting `--public-url` to a local LAN IP (e.g. `http://192.168.1.221:9090`) during local testing will cause GitHub check runs to be registered with non-routable local IP links on GitHub PRs. Always keep `--public-url https://preloop.preloop.dev` in production deployments.
 
-### 8.2 Cloudflare Tunnel Configuration & Error 1033
+### 8.2 Cloudflare Tunnel Configuration &amp; Error 1033
 
 When routing public webhooks and check status requests through Cloudflare Tunnels (`preloop.preloop.dev`):
+
 - **Error 1033 (`Argo Tunnel error`)**: Occurs when Cloudflare's edge cannot communicate with the local `cloudflared` process, or when port `9090` is down or un-routable.
 - **Correct Tunnel Target**: The production named tunnel `preloop-prod` (`16cc97ea-e9d5-4723-875a-6de90f880b07`) must be run with explicit local target port 9090:
   ```sh
@@ -229,16 +248,18 @@ When routing public webhooks and check status requests through Cloudflare Tunnel
   ```
 - **Port Mismatches**: Running an unconfigured token or pointing `cloudflared` to a different port (e.g., `8787` or `8080`) breaks webhook delivery and causes in-VM runner artifact uploads to time out with HTTP 530.
 
-### 8.3 GitHub App Scope Clamping & HTTP 422 Handling
+### 8.3 GitHub App Scope Clamping &amp; HTTP 422 Handling
 
 GitHub App token minting is strictly all-or-nothing:
+
 - Requesting any scope ungranted by the GitHub App installation causes GitHub's API to return `HTTP 422 Unprocessable Entity`.
 - **Automatic Clamping**: For unrequested default scopes (e.g. `packages: read`), `preloop` automatically clamps token requests to the installation's granted intersection (`contents: read`, `metadata: read`).
 - **Explicit Permissions**: Workflows declaring explicit `permissions:` blocks that exceed installation grants will intentionally fail loudly so missing permissions are never silently ignored.
 
-### 8.4 Cross-Compiled Runner Bundle & `cargo clean`
+### 8.4 Cross-Compiled Runner Bundle &amp; `cargo clean`
 
 The microVM orchestrator requires the cross-compiled Linux ARM64 runner binary at `target/aarch64-unknown-linux-gnu/debug/preloop-runner`:
+
 - Running `cargo clean` removes this binary, causing `preloop serve` to log:
   ```text
   WARN preloop: local runner provisioning unavailable; jobs queue until a runner is available error=Linux runner bundle unavailable...
@@ -247,7 +268,8 @@ The microVM orchestrator requires the cross-compiled Linux ARM64 runner binary a
   ```sh
   cargo zigbuild -p preloop-runner --target aarch64-unknown-linux-gnu
   ```
--
+- 
+
 ### 8.5 Skipping CI Runs
 
 To suppress CI for a push, include any of these labels anywhere in a commit message within the push batch (not just the head commit):
@@ -260,6 +282,7 @@ To suppress CI for a push, include any of these labels anywhere in a commit mess
 - `***NO_CI***`
 
 Example:
+
 ```sh
 git commit -m "docs: update readme [skip ci]"
 git push
@@ -267,7 +290,7 @@ git push
 
 If **any** commit in a push batch contains a skip label, the entire push is suppressed — no jobs are queued and no check runs are created. This matches official GitHub Actions behavior.
 
-### 8.6 Guest Network Isolation, Origin Routing & the Tunnel Hairpin
+### 8.6 Guest Network Isolation, Origin Routing &amp; the Tunnel Hairpin
 
 Runner VMs run under `NetworkPolicy::PublicOnly` — guest egress can reach the public internet but the hypervisor's egress floor deliberately refuses guest→host private addresses (loopback or LAN IP; verified: guest curl domehan the host LAN URL hangs indefinitely). Guests reach the control plane through exactly one sanctioned path:
 
@@ -278,11 +301,13 @@ Runner VMs run under `NetworkPolicy::PublicOnly` — guest egress can reach the 
 
 The bridge only binds when the advertised origin is a loopback address the guest can bind. This makes `--public-url` carry a third, hidden role beyond in-VM runner config and GitHub check-run `details_url`: it selects the transport for *all* guest-side traffic.
 
-| `--public-url` | Runner transport | Job-side traffic | Tunnel dependency |
-|---|---|---|---|
-| `http://127.0.0.1:9090` (dev) | socket | loopback bridge → socket | none |
-| `http://<lan-ip>:9090` | socket | **blackholes** (LAN IP refused by egress floor) | — |
-| `https://preloop.preloop.dev` (prod) | **public internet → Cloudflare → argo tunnel → host** | same hairpin | **hard dependency** |
+
+| `--public-url`                       | Runner transport                                      | Job-side traffic                                | Tunnel dependency   |
+| ------------------------------------ | ----------------------------------------------------- | ----------------------------------------------- | ------------------- |
+| `http://127.0.0.1:9090` (dev)        | socket                                                | loopback bridge → socket                        | none                |
+| `http://<lan-ip>:9090`               | socket                                                | **blackholes** (LAN IP refused by egress floor) | —                   |
+| `https://preloop.preloop.dev` (prod) | **public internet → Cloudflare → argo tunnel → host** | same hairpin                                    | **hard dependency** |
+
 
 Consequences:
 
@@ -293,8 +318,8 @@ Consequences:
 
 `preloop serve` now publishes two origins:
 
-- **`PRELOOP_PUBLIC_URL`** (`--public-url`) — GitHub-facing only. Used for check-run `details_url` links and anything GitHub must reach. No guest ever dials it.
-- **`PRELOOP_RUNNER_URL`** — every URL handed to runners and their jobs (connectionData `brokerUrl`, endpoint data `ResultsServiceUrl`/`CacheServerUrl`, Twirp signed blob/cache URLs, `system.github.launch_endpoint`, OIDC issuer, live-log ws feed). `serve` pins it to `http://127.0.0.1:<port>` by default, which routes over the mounted unix socket (`PRELOOP_CONTROL_SOCKET`) for the runner itself and via the in-guest loopback bridge (`control_bridge.rs`) for job-side TCP programs.
+- `**PRELOOP_PUBLIC_URL**` (`--public-url`) — GitHub-facing only. Used for check-run `details_url` links and anything GitHub must reach. No guest ever dials it.
+- `**PRELOOP_RUNNER_URL**` — every URL handed to runners and their jobs (connectionData `brokerUrl`, endpoint data `ResultsServiceUrl`/`CacheServerUrl`, Twirp signed blob/cache URLs, `system.github.launch_endpoint`, OIDC issuer, live-log ws feed). `serve` pins it to `http://127.0.0.1:<port>` by default, which routes over the mounted unix socket (`PRELOOP_CONTROL_SOCKET`) for the runner itself and via the in-guest loopback bridge (`control_bridge.rs`) for job-side TCP programs.
 
 Consequences:
 


### PR DESCRIPTION
## Summary

Pin workflow YAML retrieval during GitHub webhook processing to the immutable event commit SHA (`effective.sha`) rather than the mutable branch ref (`effective.git_ref`).

## Details

- Resolves a race condition where a subsequent push to the same branch while a webhook is in flight could cause the webhook handler to fetch and execute updated workflow definitions from the branch head instead of the workflow state at the time of the event.
- Retains the branch/tag ref for `github.ref` event context and trigger filtering.
- Adds an integration test (`github_webhook_fetches_workflow_from_event_sha_not_current_branch`) verifying that workflow resolution picks the event commit SHA even when the branch head has advanced.
- Updates Section 4 of `docs/github-app-webhook.md` to reflect SHA-pinned workflow fetching.

## Verification
- Unit and integration tests in `preloop-runner-server` pass (`cargo test -p preloop-runner-server --lib github::tests`).
- `github_webhook_fetches_workflow_from_event_sha_not_current_branch` passes end-to-end.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetches workflow YAML for GitHub webhooks from the event’s immutable commit SHA instead of the branch ref to eliminate race conditions. Previously we read from the branch head (`effective.git_ref`); now we resolve and use `effective.sha`. This ensures the workflow matches the state at event time while preserving `github.ref` for filters.

- Resolves the SHA from the event (or via ref lookup) and passes it to workflow fetching; keeps the ref for context and trigger matching.
- Improves logging around ref/SHA resolution failures; preserves redelivery behavior on errors.
- Adds an integration test (`github_webhook_fetches_workflow_from_event_sha_not_current_branch`) covering the branch-advance race.
- Updates Section 4 of `docs/github-app-webhook.md` to document SHA-pinned fetching.
- No configuration or migration changes required; verify both local workspace and GitHub API fetch paths.

<sup>Written for commit 39084ef273775655c27a18eb6c4fdac587a0dd20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fetch GitHub webhook workflows from event commit SHA instead of branch ref
> - `process_github_webhook` now resolves an immutable commit SHA before fetching workflow YAML, using `effective.sha` or resolving the event's `git_ref`; deliveries without a resolvable SHA fail and trigger redelivery
> - `fetch_workflows_at` strictly reads workflows from the resolved Git commit via `git ls-tree`/`git show` and errors if the ref cannot be resolved — it no longer falls back to the current worktree or process CWD
> - `pull_request_target` and `pull_request` adapters set `sha` only from `base.sha`; the fallback to `head.sha` is removed, so `sha` is `None` when `base.sha` is absent
> - Cron reconciliation for default-branch push events fetches workflows separately at the current branch head, injecting that SHA into a cloned payload's `after` field
> - Risk: webhook deliveries that previously fell back to worktree/CWD workflows or head SHA will now fail and redeliver; remote fetches without App or PAT credentials and a non-empty `git_ref` now error instead of reading from CWD
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5cd2c6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Webhook-triggered runs now use workflows from the event’s exact commit, preventing newer branch changes from affecting historical events.
  - Invalid or unavailable refs no longer fall back to the checked-out tree.
  - Configured personal access tokens can authenticate workflow retrieval when App credentials are unavailable.
  - Missing credentials and unresolved workflow lookups now return retryable `502 Bad Gateway` responses.
  - Pull request target runs no longer use a head commit when the required base commit is missing.
  - Default-branch scheduled runs now track the current branch commit accurately; reconciliation is skipped safely when resolution fails.

- **Documentation**
  - Expanded GitHub App webhook setup, configuration, verification, networking, recovery, and multi-App guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->