### PR TITLE
fix(snapshot): support Git partial-clone filters

### DIFF
--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -16057,41 +16057,43 @@ jobs:
         String::from_utf8_lossy(&index_result.stderr)
     );
 
-    let mut protocol_v2_request = pkt_line(b"command=fetch\n");
-    protocol_v2_request.extend_from_slice(&pkt_line(b"agent=git/2.43.0\n"));
-    protocol_v2_request.extend_from_slice(&pkt_line(b"object-format=sha1\n"));
-    protocol_v2_request.extend_from_slice(b"0001");
-    protocol_v2_request.extend_from_slice(&pkt_line(format!("want {commit}\n").as_bytes()));
-    protocol_v2_request.extend_from_slice(&pkt_line(b"filter blob:none\n"));
-    protocol_v2_request.extend_from_slice(&pkt_line(b"done\n"));
-    protocol_v2_request.extend_from_slice(b"0000");
-    let protocol_v2_upload = app
-        .clone()
-        .oneshot(
-            Request::builder()
-                .method(Method::POST)
-                .uri(format!("/snapshots/{run_id}/git-upload-pack"))
-                .header(header::AUTHORIZATION, format!("Bearer {runtime_token}"))
-                .header(
-                    header::CONTENT_TYPE,
-                    "application/x-git-upload-pack-request",
-                )
-                .header("Git-Protocol", "version=2")
-                .body(Body::from(protocol_v2_request))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(protocol_v2_upload.status(), StatusCode::OK);
-    let protocol_v2_body = to_bytes(protocol_v2_upload.into_body(), usize::MAX)
-        .await
-        .unwrap();
-    assert!(
-        protocol_v2_body.starts_with(b"0008NAK\n")
-            || protocol_v2_body.windows(4).any(|window| window == b"PACK"),
-        "protocol v2 upload-pack response should remain pkt-line or pack framed: {:?}",
-        &protocol_v2_body[..protocol_v2_body.len().min(128)]
-    );
+    for filter in ["blob:none", "tree:0", "combine:blob:none+tree:0"] {
+        let mut protocol_v2_request = pkt_line(b"command=fetch\n");
+        protocol_v2_request.extend_from_slice(&pkt_line(b"agent=git/2.43.0\n"));
+        protocol_v2_request.extend_from_slice(&pkt_line(b"object-format=sha1\n"));
+        protocol_v2_request.extend_from_slice(b"0001");
+        protocol_v2_request.extend_from_slice(&pkt_line(format!("want {commit}\n").as_bytes()));
+        protocol_v2_request.extend_from_slice(&pkt_line(format!("filter {filter}\n").as_bytes()));
+        protocol_v2_request.extend_from_slice(&pkt_line(b"done\n"));
+        protocol_v2_request.extend_from_slice(b"0000");
+        let protocol_v2_upload = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(format!("/snapshots/{run_id}/git-upload-pack"))
+                    .header(header::AUTHORIZATION, format!("Bearer {runtime_token}"))
+                    .header(
+                        header::CONTENT_TYPE,
+                        "application/x-git-upload-pack-request",
+                    )
+                    .header("Git-Protocol", "version=2")
+                    .body(Body::from(protocol_v2_request))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(protocol_v2_upload.status(), StatusCode::OK);
+        let protocol_v2_body = to_bytes(protocol_v2_upload.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(
+            protocol_v2_body.starts_with(b"0008NAK\n")
+                || protocol_v2_body.windows(4).any(|window| window == b"PACK"),
+            "protocol v2 {filter} response should remain pkt-line or pack framed: {:?}",
+            &protocol_v2_body[..protocol_v2_body.len().min(128)]
+        );
+    }
 
     let bare_repository = state_dir.join(repository);
     assert!(


### PR DESCRIPTION
## Summary

Enable Git smart-HTTP partial-clone filters for immutable workspace snapshots.

Before this change, Grafana's large checkout with `filter: blob:none` failed with `bad line length character` / `expected packfile`. The synthetic bare repository enabled SHA wants but omitted `uploadpack.allowFilter`.

## Changes

- Enable `uploadpack.allowFilter=true` when creating snapshot repositories.
- Extend `local_workspace_checkout_acquires_synthetic_repository_and_serves_git_http` to cover:
  - protocol v2 + `blob:none`
  - protocol v2 + `tree:0`
  - combined `blob:none` + `tree:0`

## Verification

- Targeted snapshot filter test passed.
- `preloop-runner-server`: 592 passed, 3 ignored.
- `just test-ci`: passed, including 39/39 conformance scenarios.
- Canonical snapshot CI submission completed successfully: `83532456-29ab-4d56-b3b8-e29fb78c9012`.

Fixes the large-repository snapshot checkout failure without changing fallback behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Git smart-HTTP partial clones for snapshot repositories. Previously, protocol v2 fetches with filters like blob:none failed with “bad line length character” / “expected packfile”; now the server accepts filters and returns pkt-line or pack-framed responses.

- Set `uploadpack.allowFilter=true` when creating snapshot synthetic bare repositories.
- Extend the protocol v2 upload-pack test to cover `blob:none`, `tree:0`, and `combine:blob:none+tree:0`, and assert valid framing.
- Preserve behavior for full clones and unfiltered fetches.

<sup>Written for commit 5d045f056516d529cb3e4a6edcaff0fd6a7ae1c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Test Git partial-clone filters `blob:none`, `tree:0`, and `combine` in upload-pack
> Updates the protocol v2 upload-pack test in [lib_tests.rs](https://github.com/preloopdev/preloop/pull/186/files#diff-f2ac4bf4ed94dbd3d5588b9e55f75bf58237d755f1bb267b14991dffefb9ea3d) to loop over three partial-clone filter variants (`blob:none`, `tree:0`, `combine:blob:none+tree:0`) instead of testing only `blob:none`. Each variant sends a `filter {filter}` line and validates the response framing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b38497a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded Git upload support validation to cover additional filtering modes.
  * Added independent checks for successful responses across packet-line and pack-formatted data.
  * Improved confidence in filtered repository transfers without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->