### PR TITLE
fix(ci): make release golden rebuilds opt-in

### DIFF
--- a/.github/workflows/release-golden.yml
+++ b/.github/workflows/release-golden.yml
@@ -1,5 +1,23 @@
 name: release-golden
 
+# Golden rebuilds on a `release` event are OPT-IN via a
+# `<!-- preloop:build-golden -->` marker in the release body.
+#
+# They used to be opt-OUT via `<!-- preloop:skip-golden -->`, which never
+# worked: cargo-dist owns the release body (see release.yml) and generates
+# install/download instructions from scratch, so a marker written into
+# CHANGELOG.md never reached `github.event.release.body` and the guard was
+# always true. Every release therefore rebuilt the golden, even when the bake
+# content (packages, install script) had not changed.
+#
+# That is not free: `build-and-publish-golden` runs on the [self-hosted, Linux,
+# X64] box that also hosts the runner pool. On v0.32.0 it compiled alongside a
+# `cargo test --workspace` job and triggered a host-wide OOM that killed the
+# runner VM (anon-rss 8 GiB) and preloop.service with it, failing CI on a
+# release commit whose tree passed `just test-ci` locally.
+#
+# Deliberate golden builds still run via workflow_dispatch, which is how they
+# have actually been produced in practice.
 on:
   release:
     types: [published]
@@ -120,7 +138,7 @@ jobs:
 
   build-and-publish-golden:
     name: Build & Publish Golden MicroVM Artifact
-    if: (github.event_name == 'workflow_dispatch' && !inputs.reuse_previous_goldens) || (github.event_name == 'release' && !contains(github.event.release.body, '<!-- preloop:skip-golden -->'))
+    if: (github.event_name == 'workflow_dispatch' && !inputs.reuse_previous_goldens) || (github.event_name == 'release' && contains(github.event.release.body, '<!-- preloop:build-golden -->'))
     runs-on: [self-hosted, Linux, X64]
     env:
       CARGO_BUILD_JOBS: "1"
@@ -344,7 +362,7 @@ jobs:
 
   build-and-publish-golden-macos:
     name: Build & Publish aarch64 Golden (macOS)
-    if: (github.event_name == 'workflow_dispatch' && !inputs.reuse_previous_goldens) || (github.event_name == 'release' && !contains(github.event.release.body, '<!-- preloop:skip-golden -->'))
+    if: (github.event_name == 'workflow_dispatch' && !inputs.reuse_previous_goldens) || (github.event_name == 'release' && contains(github.event.release.body, '<!-- preloop:build-golden -->'))
     runs-on: [self-hosted, macOS, ARM64]
     permissions:
       contents: write


### PR DESCRIPTION
## Problem

The `skip-golden` guard never worked. `release.yml` is cargo-dist generated and **owns the release body** — it writes install/download instructions from scratch — so the `<!-- preloop:skip-golden -->` marker placed in `CHANGELOG.md` never reached `github.event.release.body`. The guard

```yaml
if: ... || (github.event_name == 'release' && !contains(github.event.release.body, '<!-- preloop:skip-golden -->'))
```

was therefore always true, and **every** release rebuilt the golden — including releases whose bake content (packages, install script) had not changed.

Verified on v0.32.0: the marker was in the changelog section, and the published release body still reported `skip-golden marker present: false`.

## Why it matters

`build-and-publish-golden` runs on `[self-hosted, Linux, X64]` — the same host as the runner pool. On v0.32.0 it compiled (`cc1`) alongside a `cargo test --workspace` job and triggered a host-wide OOM:

```
oom-kill:constraint=CONSTRAINT_NONE ... global_oom, task=cc1
Out of memory: Killed process (libkrun VM) anon-rss:8073908kB
preloop.service: Failed with result 'oom-kill'
```

That killed the 8 GiB runner VM and took `preloop.service` with it, orphaning the in-flight job (`failed job claims orphaned by a control-plane restart`). `rust` and `server-light` failed on a release commit whose tree had passed `just test-ci` locally. It happened twice (22:06 and 22:24); unit `MemoryPeak` hit 18.1 GiB on a 23.3 GiB host.

## Change

Invert both guards to opt **in** on `<!-- preloop:build-golden -->`, so a release no longer rebuilds the golden unless explicitly asked. Deliberate golden builds keep running via `workflow_dispatch`, which is how they have actually been produced in practice (the last successful golden build was a manual dispatch on Aug 24).

A comment records why, so the broken opt-out marker is not reintroduced.

## Validation

YAML parses; `zizmor` reports `No findings to report` on the changed file — the same linter CI runs.

Note: `preloop-runner-client submit --event workflow_dispatch` cannot validate this repo's `ci.yml`, because `events/workflow_dispatch.rs` sets `sha: None`, so `actions/checkout` fetches `0000000000000000000000000000000000000000` and fails with `upload-pack: not our ref`. Worth fixing separately — it makes the submit-before-push path unusable for any checkout-based workflow.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release golden rebuilds are now opt-in via a `<!-- preloop:build-golden -->` marker in the release body, instead of the previous opt-out `<!-- preloop:skip-golden -->` marker that never worked because cargo-dist rewrites the release body. Every release previously rebuilt the golden, which caused an OOM on the self-hosted runner on v0.32.0; now only deliberate rebuilds (via workflow_dispatch or the new marker) run.

<sup>Written for commit 85e3e20ea2cb78503d758751b544baa4caff41f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make release golden rebuilds opt-in via `preloop:build-golden` marker
> The `build-and-publish-golden` and `build-and-publish-golden-macos` jobs in [release-golden.yml](https://github.com/preloopdev/preloop/pull/193/files#diff-8a72c5d3a3ca0128bddb5eef1f052010982727c54632512ef2e883dd5ca5da35) now only run on release events when the release body contains `<!-- preloop:build-golden -->`. Previously they ran by default unless the body contained `<!-- preloop:skip-golden -->`.
> - Behavioral Change: releases without the marker will no longer produce golden builds; teams must add the marker to the release body to trigger them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 85e3e20.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Golden MicroVM rebuilds for releases are now opt-in.
  * Release builds run only when the release description includes the designated build marker.
  * Added documentation clarifying how to enable golden rebuilds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->