### PR TITLE
fix(ci): keep pullfrog clones off the tmpfs

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -34,5 +34,18 @@ jobs:
           prompt: ${{ inputs.prompt || toJSON(github.event) }}
           model: openai/gpt-5.6-terra
         env:
+          # The action clones the repo into a `pullfrog-XXXXXX` directory under
+          # the system temp dir and never removes it. On the self-hosted host
+          # `/tmp` is a tmpfs sized at 50% of RAM, so every PR synchronize
+          # permanently consumed ~469 MB of memory. On 2026-08-28 that reached
+          # 58 leaked clones (12 GB, /tmp 100% full), leaving too little RAM for
+          # an 8 GB runner VM plus compilers: the kernel OOM-killed the runner
+          # VM and the preloop control plane four times, taking down the `rust`
+          # and `server-light` checks.
+          #
+          # RUNNER_TEMP is disk-backed and the runner clears it between jobs, so
+          # pointing the action there keeps the clones off RAM and makes cleanup
+          # someone else's job.
+          TMPDIR: ${{ runner.temp }}
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
The action clones the repo into pullfrog-XXXXXX under the system temp dir and never removes it. On the self-hosted host /tmp is a tmpfs sized at 50% of RAM, so every PR synchronize permanently consumed ~469 MB of memory.

By 2026-08-28 this reached 58 leaked clones -- 12 GB, /tmp 100% full -- on a 23.3 GB box. That left too little RAM for an 8 GB runner VM plus the compilers running beside it: the kernel OOM-killed the runner VM and the preloop control plane four times (NRestarts=4), taking down the rust and server-light checks on the v0.32.0 release commit.

Point the action at RUNNER_TEMP, which is disk-backed (/opt/actions-runner/_work/_temp) and cleared by the runner between jobs.

Entire-Checkpoint: 01M15T0PFTJZ6C6RDQQ99VH1MZ

## What & why

<!-- What this change does and the problem it solves. Link the issue if there is one. -->

## Protocol surface

<!--
Check whether this change touches the core runner protocol interface:
  - registration / `/_apis/...` request and response shapes
  - broker messages (job request, complete, renew) and NDJSON event shapes
  - Twirp results-service / artifact-service payloads
  - check-run or OAuth wire behavior

If it does, the gates below are REQUIRED before merge — preloop's compatibility
contract is byte-for-byte fidelity with the official runner (v2.336.0).
-->

- [ ] I confirm this change touches the runner protocol interface: **YES / NO**

## Required gates

- [ ] `just test-ci` passes locally (fmt-check + clippy `-D` + full test suite + runner-watch conformance)
- [ ] If protocol/wire shapes changed: the change is validated against the official runner (golden replay via `runner-watch`, or a live capture showing the official bytes), not only unit tests
- [ ] If the touched subsystem has property tests (`concurrency_properties`, scheduling, matrix expansion, …): they are extended for the changed contract and pass (`PROPTEST_CASES=256 cargo test -p preloop-runner-server`)
- [ ] New wire fields/events are additive and serde-defaulted where the official runner would not send them
- [ ] No secrets, credentials, or internal/deployment-specific paths are introduced (captures with live tokens must be redacted or excluded)

## Verification performed

<!-- Concrete evidence: commands run, test names, capture outputs. -->

## Checklist

- [ ] Tests added/updated for any new observable contract
- [ ] Docs updated (`docs/`, `CONTRIBUTING.md`) where behavior changed
- [ ] Changelog-worthy user-facing change described in the PR body


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the pullfrog action leaking repo clones into the system tmpfs, which exhausted memory and OOM-killed the runner VM and preloop control plane during the v0.32.0 release checks.

- Points the action at `RUNNER_TEMP` (via `TMPDIR`), which is disk-backed and cleared by the runner between jobs.
- Prevents future clones from accumulating in `/tmp`, where 58 leaked clones consumed 12 GB and filled the tmpfs completely.

<sup>Written for commit 27a301557137845828790ed0b4fb1be99e6ca9d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temporary file handling during automated repository analysis.
  * Prevented temporary data from accumulating across runs on self-hosted environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->