### PR TITLE
fix(ci): keep pullfrog clones off the tmpfs

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -34,5 +34,18 @@ jobs:
           prompt: ${{ inputs.prompt || toJSON(github.event) }}
           model: openai/gpt-5.6-terra
         env:
+          # The action clones the repo into a `pullfrog-XXXXXX` directory under
+          # the system temp dir and never removes it. On the self-hosted host
+          # `/tmp` is a tmpfs sized at 50% of RAM, so every PR synchronize
+          # permanently consumed ~469 MB of memory. On 2026-08-28 that reached
+          # 58 leaked clones (12 GB, /tmp 100% full), leaving too little RAM for
+          # an 8 GB runner VM plus compilers: the kernel OOM-killed the runner
+          # VM and the preloop control plane four times, taking down the `rust`
+          # and `server-light` checks.
+          #
+          # RUNNER_TEMP is disk-backed and the runner clears it between jobs, so
+          # pointing the action there keeps the clones off RAM and makes cleanup
+          # someone else's job.
+          TMPDIR: ${{ runner.temp }}
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Problem

`pullfrog.yml` runs on the host runner (`aksh-golden-x64`), and the action clones the repo into a `pullfrog-XXXXXX` directory under the system temp dir, then never removes it.

On that host `/tmp` is a tmpfs sized at 50% of RAM, so **every PR synchronize permanently consumed ~469 MB of memory.**

## Impact

By 2026-08-28 this had reached **58 leaked clones — 12 GB, `/tmp` 100% full** — on a 23.3 GB box:

```
tmpfs  12G  12G  0  100% /tmp
```

That left too little RAM for an 8 GB runner VM plus the compilers running beside it. The kernel OOM-killed the runner VM and the preloop control plane four times (`NRestarts=4`):

```
22:05:58  oom-kill task=npm install   <- pullfrog itself
22:06:18  oom-kill task=libkrun VM    -> rust dies 22:06:32
22:23:55  oom-kill task=cc1           <- golden rebuild
22:24:04  oom-kill task=libkrun VM    -> server-light dies 22:24:23
```

Both failing checks on the v0.32.0 release commit `12721ff3` died at the instant their VM was killed — neither was a test failure.

## Change

One line: `TMPDIR: ${{ runner.temp }}`, plus a comment recording the incident.

`RUNNER_TEMP` resolves to `/opt/actions-runner/_work/_temp`, which is on `/dev/mapper/ubuntu--vg-ubuntu--lv` (disk, 609 GB free) and is cleared by the runner between jobs — so the clones stay off RAM and cleanup stops being anyone's problem.

## Validation

- YAML parses; `TMPDIR` resolves to `${{ runner.temp }}`
- `zizmor v1.29.0` -> `No findings to report. Good job! (10 suppressed)`
- Verified `workFolder: "_work"` in `/opt/actions-runner/.runner` and confirmed that path is disk-backed, **not** the tmpfs

## Root cause is an action bug

`utils/setup.ts:19` `mkdtempSync(join(tmpdir(), "pullfrog-"))` is never cleaned up: `entryPost.ts` (`post-if: always()`) contains no `rm`. The same codebase disposes its other temp dirs (`vertex.ts:73`, `codexAuth.ts:111`, `xrepo.ts:151`). It is invisible on GitHub-hosted runners because the VM is destroyed after each job, so it only bites self-hosted users — and it is worst when `/tmp` is a tmpfs, because then the leak is RAM.

Fixed separately in the action itself; this change is defense-in-depth that works today without an action release.

## Follow-ups

- Already applied on the host: reclaimed the 12 GB, added `pullfrog-tmp-reap.timer` (hourly, >2h age), and `OOMScoreAdjust=-500` on `preloop.service`
- Worth deciding whether pullfrog and `release-golden` should share the host runner with the VM pool at all


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps pullfrog clones off the tmpfs on the self-hosted runner so they stop leaking RAM and OOM-killing the runner VM.

The pullfrog action clones the repo into the system temp dir and never cleans it up. On the host `/tmp` is a tmpfs sized at 50% of RAM, so every PR synchronize permanently consumed ~469 MB — reaching 58 leaked clones (12 GB, `/tmp` 100% full) — and the kernel OOM-killed the runner VM and preloop control plane four times, taking down the `rust` and `server-light` checks. Setting `TMPDIR` to `${{ runner.temp }}` redirects the clones to disk-backed storage that the runner wipes between jobs, so the clones stay off RAM and cleanup is no longer our problem. The missing cleanup in the action itself is fixed upstream; this change works today without an action release.

<sup>Written for commit 27a301557137845828790ed0b4fb1be99e6ca9d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `TMPDIR` to `runner.temp` in Pullfrog workflow step
> Sets `TMPDIR` to `${{ runner.temp }}` in the env of the 'Run Pullfrog (via GHES-compatible fork)' step so clones land on the runner's temp directory instead of tmpfs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 27a3015.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow reliability by using a disk-backed temporary directory, reducing failures caused by temporary storage exhaustion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->