### PR TITLE
fix(orchestrator): pause starvation sweep while warm-pool runners boot

### DIFF
--- a/crates/preloop-orchestrator/src/lib.rs
+++ b/crates/preloop-orchestrator/src/lib.rs
@@ -3375,6 +3375,19 @@ async fn run_slot<P: VmProvider + 'static>(
     let mut spare: Option<ReadyRunner> = None;
 
     while !shutdown.is_cancelled() {
+        // Warm mode cleared the pool's preparing flag once the golden bake
+        // finished, but this slot still has to resolve (and possibly bake)
+        // the golden for the queued job's environment and then
+        // fork+boot+register its first runner -- minutes with no runner
+        // registered. Hold the shared provisioning guard across that whole
+        // window, golden preparation included, so the server's starvation
+        // sweep keeps the queued-job grace clock paused; drop it once a
+        // registered runner is in hand.
+        let preparing = PreparingGuard::enter(
+            provisioning.clone(),
+            config.preparing_signal.clone(),
+            config.pool_status.clone(),
+        );
         let (golden, environment) = if config.use_fork {
             // Read the `runs-on` labels of the next queued job so the pool
             // can select the correct base-image golden before forking.
@@ -3468,18 +3481,6 @@ async fn run_slot<P: VmProvider + 'static>(
             Some(runner) => runner,
             None => {
                 generation += 1;
-                // Warm mode cleared the preparing flag when the golden bake
-                // finished, but this slot's fork+boot+register still takes
-                // minutes. Raise the shared provisioning guard for the
-                // duration so the server's starvation sweep does not fail a
-                // job queued during that window: `provision_slot` returns
-                // only after the runner has registered, at which point a
-                // matching runner is directly visible to the sweep.
-                let preparing = PreparingGuard::enter(
-                    provisioning.clone(),
-                    config.preparing_signal.clone(),
-                    config.pool_status.clone(),
-                );
                 match provision_slot(
                     &provider,
                     &config,
@@ -3491,12 +3492,8 @@ async fn run_slot<P: VmProvider + 'static>(
                 )
                 .await
                 {
-                    Ok(runner) => {
-                        drop(preparing);
-                        runner
-                    }
+                    Ok(runner) => runner,
                     Err(error) => {
-                        drop(preparing);
                         warn!(slot, %error, "provisioning runner failed; retrying");
                         tokio::select! {
                             _ = shutdown.cancelled() => break,
@@ -3507,6 +3504,10 @@ async fn run_slot<P: VmProvider + 'static>(
                 }
             }
         };
+
+        // Runner is registered (or an already-registered spare); the sweep
+        // can see a matching runner directly now, so resume its grace clock.
+        drop(preparing);
 
         generation += 1;
         let successor = run_one_runner(

--- a/crates/preloop-orchestrator/src/lib.rs
+++ b/crates/preloop-orchestrator/src/lib.rs
@@ -2472,6 +2472,14 @@ impl<P: VmProvider + 'static> RunnerPool<P> {
             );
         }
 
+        // Warm slots boot their first runners *after* the warm completes and
+        // the preparing flag clears, so those boots must raise the shared
+        // provisioning guard or a job queued during the ~minutes-long boot
+        // window would starve (the server's sweep fails jobs queued 120s
+        // with no matching runner). One counter for the whole pool: the
+        // first completed slot must not clear the signal while its siblings
+        // are still bootstrapping.
+        let provisioning = Arc::new(std::sync::Mutex::new(0));
         for slot in 0..warm_size {
             let provider = self.provider.clone();
             let config = self.config.clone();
@@ -2481,6 +2489,7 @@ impl<P: VmProvider + 'static> RunnerPool<P> {
                 idle: idle.clone(),
                 keys: keys.clone(),
                 building: building.clone(),
+                provisioning: provisioning.clone(),
             };
             slots.spawn(async move {
                 run_slot(
@@ -2609,6 +2618,7 @@ impl<P: VmProvider + 'static> RunnerPool<P> {
                 idle: idle.clone(),
                 keys: keys.clone(),
                 building: building.clone(),
+                provisioning: provisioning.clone(),
             };
             let slot_provisioning = provisioning.clone();
             // Shared with the slot's pause watcher: a job parked in a debug
@@ -2917,6 +2927,10 @@ struct PoolHandles {
     keys: Arc<KeyPool>,
     /// Replacements currently being built across the whole pool.
     building: Arc<AtomicUsize>,
+    /// Provisions in flight across the whole pool. Raised so the server's
+    /// starvation sweep keeps the queued-job grace clock paused while any
+    /// warm-mode slot is still booting its runner.
+    provisioning: Arc<std::sync::Mutex<usize>>,
 }
 
 /// What a slot needs in order to build its next runner.
@@ -2935,6 +2949,8 @@ struct SlotPlan<'a> {
     keys: &'a Arc<KeyPool>,
     /// Replacements currently being built across the whole pool.
     building: &'a AtomicUsize,
+    /// Provisions in flight across the whole pool (see `PoolHandles`).
+    provisioning: &'a Arc<std::sync::Mutex<usize>>,
     /// Whether this slot keeps a warm successor after the current job.
     prebuild_successor: bool,
 }
@@ -3312,6 +3328,7 @@ async fn run_on_demand_slot<P: VmProvider + 'static>(
             idle: &handles.idle,
             keys: &handles.keys,
             building: &handles.building,
+            provisioning: &handles.provisioning,
             prebuild_successor: false,
         },
     )
@@ -3352,6 +3369,7 @@ async fn run_slot<P: VmProvider + 'static>(
         idle,
         keys,
         building,
+        provisioning,
     } = handles;
     let mut generation: u64 = 0;
     let mut spare: Option<ReadyRunner> = None;
@@ -3450,6 +3468,18 @@ async fn run_slot<P: VmProvider + 'static>(
             Some(runner) => runner,
             None => {
                 generation += 1;
+                // Warm mode cleared the preparing flag when the golden bake
+                // finished, but this slot's fork+boot+register still takes
+                // minutes. Raise the shared provisioning guard for the
+                // duration so the server's starvation sweep does not fail a
+                // job queued during that window: `provision_slot` returns
+                // only after the runner has registered, at which point a
+                // matching runner is directly visible to the sweep.
+                let preparing = PreparingGuard::enter(
+                    provisioning.clone(),
+                    config.preparing_signal.clone(),
+                    config.pool_status.clone(),
+                );
                 match provision_slot(
                     &provider,
                     &config,
@@ -3461,8 +3491,12 @@ async fn run_slot<P: VmProvider + 'static>(
                 )
                 .await
                 {
-                    Ok(runner) => runner,
+                    Ok(runner) => {
+                        drop(preparing);
+                        runner
+                    }
                     Err(error) => {
+                        drop(preparing);
                         warn!(slot, %error, "provisioning runner failed; retrying");
                         tokio::select! {
                             _ = shutdown.cancelled() => break,
@@ -3488,6 +3522,7 @@ async fn run_slot<P: VmProvider + 'static>(
                 idle: &idle,
                 keys: &keys,
                 building: &building,
+                provisioning: &provisioning,
                 prebuild_successor: true,
             },
         )
@@ -3638,6 +3673,7 @@ async fn run_one_runner<P: VmProvider + 'static>(
         idle,
         keys,
         building,
+        provisioning,
         prebuild_successor,
     } = plan;
 
@@ -3711,6 +3747,15 @@ async fn run_one_runner<P: VmProvider + 'static>(
             .saturating_sub(idle_after)
             .max(usize::from(idle_after == 0));
         let _reservation = Reservation::take(building, wanted, config.pool_status.clone())?;
+        // The successor boot runs alongside the job; while it is in flight a
+        // matching runner may not be registered yet (all slots busy). Hold
+        // the shared provisioning guard so the server's starvation sweep
+        // keeps the queued-job grace clock paused for the boot duration.
+        let preparing = PreparingGuard::enter(
+            provisioning.clone(),
+            config.preparing_signal.clone(),
+            config.pool_status.clone(),
+        );
         match provision_slot(
             &provider,
             config,
@@ -3722,8 +3767,12 @@ async fn run_one_runner<P: VmProvider + 'static>(
         )
         .await
         {
-            Ok(successor) => Some(successor),
+            Ok(successor) => {
+                drop(preparing);
+                Some(successor)
+            }
             Err(error) => {
+                drop(preparing);
                 warn!(slot, %error, "pre-provisioning the replacement runner failed");
                 None
             }
@@ -4758,6 +4807,9 @@ mod lifecycle_tests {
         fail_run: bool,
         fail_delete: bool,
         announce_busy: bool,
+        /// When set, `exec_with_secret_env` (the configure step) blocks until
+        /// notified, so a test can observe the pool mid-provision.
+        configure_gate: Option<Arc<tokio::sync::Notify>>,
         /// Binary that `command -v` cannot find until its toolchain installs.
         absent_binary: Mutex<Option<&'static str>>,
         /// Guest pause marker state: when set, the exec probe for the debug
@@ -4791,10 +4843,16 @@ mod lifecycle_tests {
                 fail_run,
                 fail_delete,
                 announce_busy: false,
+                configure_gate: None,
                 absent_binary: Mutex::new(None),
                 pause_marker: std::sync::atomic::AtomicBool::new(false),
                 probe_transport_error: std::sync::atomic::AtomicBool::new(false),
             }
+        }
+
+        fn with_configure_gate(mut self, gate: Arc<tokio::sync::Notify>) -> Self {
+            self.configure_gate = Some(gate);
+            self
         }
 
         fn announcing_busy(mut self) -> Self {
@@ -5373,6 +5431,69 @@ chmod +x "$destination/bin/node"
         assert!(!signal.load(Ordering::Acquire));
     }
 
+    #[tokio::test]
+    async fn warm_slot_raises_preparing_signal_while_provisioning() {
+        // A warm slot clears the pool's preparing flag at the end of the
+        // golden bake, then boots its first runner minutes later. The boot
+        // must re-raise the shared signal, or the server's starvation sweep
+        // fails a job queued during that window ("starving queued job failed
+        // after 120s") even though a runner is on the way.
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let provider = Arc::new(
+            TestProvider::new(false, false, false, false, false).with_configure_gate(gate.clone()),
+        );
+        let mut config = test_config(false);
+        config.size = 1;
+        let signal = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        config.preparing_signal = Some(signal.clone());
+
+        let handles = PoolHandles {
+            idle: Arc::new(std::sync::Mutex::new(0)),
+            keys: Arc::new(KeyPool::new()),
+            building: Arc::new(AtomicUsize::new(0)),
+            provisioning: Arc::new(std::sync::Mutex::new(0)),
+        };
+        let shutdown = CancellationToken::new();
+        let slot = tokio::spawn(run_slot(
+            provider.clone(),
+            config.clone(),
+            0,
+            shutdown.clone(),
+            Arc::new(GoldenRegistry::new(config.name_prefix.clone())),
+            handles,
+        ));
+
+        // Wait until the slot's first provision reaches configure (i.e. the
+        // runner is mid-boot, before registration).
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(5);
+        loop {
+            if provider
+                .events()
+                .await
+                .iter()
+                .any(|event| event.starts_with("configure:"))
+            {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "slot never reached the configure step"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        assert!(
+            signal.load(Ordering::Acquire),
+            "warm-mode provisioning must raise the preparing signal"
+        );
+
+        // Release the gate, then stop the slot.
+        gate.notify_waiters();
+        shutdown.cancel();
+        slot.abort();
+        let _ = slot.await;
+    }
+
     fn test_config(control_socket: bool) -> RunnerPoolConfig {
         RunnerPoolConfig {
             size: 1,
@@ -5626,6 +5747,9 @@ chmod +x "$destination/bin/node"
                 .lock()
                 .await
                 .push(format!("configure:{}", name.as_str()));
+            if let Some(gate) = &self.configure_gate {
+                gate.notified().await;
+            }
             if self.fail_configure {
                 return Err(test_error("configure-failure"));
             }
@@ -6399,6 +6523,7 @@ chmod +x "$destination/bin/node"
                 idle: &idle,
                 keys: &Arc::new(KeyPool::new()),
                 building: &AtomicUsize::new(0),
+                provisioning: &Arc::new(std::sync::Mutex::new(0)),
                 prebuild_successor: true,
             },
         )
@@ -6418,6 +6543,7 @@ chmod +x "$destination/bin/node"
             idle: Arc::new(std::sync::Mutex::new(0)),
             keys: Arc::new(KeyPool::new()),
             building: Arc::new(AtomicUsize::new(0)),
+            provisioning: Arc::new(std::sync::Mutex::new(0)),
         };
 
         run_on_demand_slot(

--- a/crates/preloop-runner-server/src/bootstrap.rs
+++ b/crates/preloop-runner-server/src/bootstrap.rs
@@ -181,16 +181,31 @@ pub(crate) async fn reap_once(shared: &Arc<SharedState>) {
     // left the queue drop their entry, so no enqueue-site coordination is
     // needed and the map cannot go stale. While a co-hosted pool is still
     // preparing its machine image (artifact download or build, golden prep)
-    // it cannot register a runner no matter how long the job waits, so the
-    // clock is reset for the whole warm: a job queued mid-warm gets a full
-    // grace window once provisioning actually starts.
+    // or booting a runner it cannot register a runner no matter how long the
+    // job waits, so the clock is reset for the whole warm: a job queued
+    // mid-warm gets a full grace window once provisioning actually starts.
+    // The reset is bounded by MAX_QUEUED_GRACE (see below) so continuous
+    // provisioning cannot pause the clock forever.
     const QUEUED_JOB_GRACE: Duration = Duration::from_secs(120);
+    // Absolute backstop, measured from ready-enqueue, on how long
+    // provisioning/preparing may pause a job's starvation clock. It protects
+    // a job whose runner is genuinely on the way, but keeps continuous
+    // successor prebuilds or a provision that fails and retries forever from
+    // masking an unschedulable job (bad `runs-on`, or a persistently broken
+    // provision) indefinitely.
+    const MAX_QUEUED_GRACE: Duration = Duration::from_secs(600);
+    let pool_status = shared.state.pool_status.snapshot();
     let pool_preparing = shared
         .state
         .pool_preparing
         .as_ref()
         .is_some_and(|flag| flag.load(std::sync::atomic::Ordering::Acquire))
-        || shared.state.pool_status.snapshot().preparing;
+        || pool_status.preparing
+        // A consolidated-handle embedding may drive only `pool_status` (no
+        // legacy `preparing_signal`). Warm-slot and successor provisioning
+        // raise `provisioning`, not `preparing`, so treat an in-flight
+        // provision as preparing or those boots would go unprotected here.
+        || pool_status.provisioning > 0;
     let queued_jobs: Vec<_> = inner.queue.iter().cloned().collect();
     let in_queue: std::collections::BTreeSet<(RunId, JobId)> = queued_jobs
         .iter()
@@ -218,29 +233,42 @@ pub(crate) async fn reap_once(shared: &Arc<SharedState>) {
             inner.queued_at.remove(&key);
             continue;
         }
-        if pool_preparing {
-            // The pool is warming and cannot register a runner yet; do not
-            // let the grace window expire while the first machine image is
-            // still being produced.
-            inner.queued_at.remove(&key);
-            continue;
-        }
-        let first_seen = *inner.queued_at.entry(key.clone()).or_insert(now);
-        if now.duration_since(first_seen).unwrap_or_default() < QUEUED_JOB_GRACE {
-            continue;
-        }
+        let grace = if pool_preparing {
+            // The pool is warming or booting a runner that may serve this
+            // job, so hold the grace window rather than failing a job whose
+            // runner is genuinely on the way. Bound the hold by
+            // MAX_QUEUED_GRACE measured from ready-enqueue: once a job has
+            // waited that long it starves even while the pool is still
+            // preparing, so sustained provisioning cannot mask it forever.
+            let enqueued = if job.enqueued_at_unix_nanos > 0 {
+                SystemTime::UNIX_EPOCH + Duration::from_nanos(job.enqueued_at_unix_nanos as u64)
+            } else {
+                now
+            };
+            if now.duration_since(enqueued).unwrap_or_default() < MAX_QUEUED_GRACE {
+                inner.queued_at.remove(&key);
+                continue;
+            }
+            MAX_QUEUED_GRACE
+        } else {
+            let first_seen = *inner.queued_at.entry(key.clone()).or_insert(now);
+            if now.duration_since(first_seen).unwrap_or_default() < QUEUED_JOB_GRACE {
+                continue;
+            }
+            QUEUED_JOB_GRACE
+        };
         let reason = format!(
             "no runner is registered for `runs-on: {}` and none appeared \
              within {}s, so the job cannot be scheduled",
             job.runs_on.join(", "),
-            QUEUED_JOB_GRACE.as_secs()
+            grace.as_secs()
         );
         tracing::warn!(
             run_id = %job.run_id,
             job_id = %job.job_id.0,
             labels = ?job.runs_on,
             "starving queued job failed after {}s without a matching runner",
-            QUEUED_JOB_GRACE.as_secs()
+            grace.as_secs()
         );
         starved_keys.push((job.run_id, job.job_id.clone(), reason));
     }

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -8015,6 +8015,59 @@ async fn queued_job_survives_the_grace_window_while_the_pool_is_preparing() {
 }
 
 #[tokio::test]
+async fn queued_job_starves_past_the_ceiling_even_while_the_pool_is_preparing() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let shutdown = CancellationToken::new();
+    let app = app(state.clone(), shutdown.clone());
+
+    // The pool signals "preparing" indefinitely -- e.g. a provision that
+    // keeps failing and retrying, or continuous successor prebuilds under
+    // sustained load -- so the signal never clears. A job this pool can
+    // never serve must still hit the bounded starvation failure path
+    // instead of being masked forever.
+    state.pool_preparing = Some(std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
+        true,
+    )));
+    let shared = Arc::new(SharedState {
+        state: state.clone(),
+        shutdown,
+    });
+
+    let accepted = submit_simple_run(&app).await;
+    let run_id: RunId = accepted["run_id"].as_str().unwrap().parse().unwrap();
+
+    // Age the job's ready-enqueue past the absolute ceiling.
+    {
+        let mut inner = state.inner.lock().await;
+        let cutoff = (SystemTime::now() - Duration::from_secs(700))
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as i64;
+        for job in inner.queue.iter_mut() {
+            if job.run_id == run_id {
+                job.enqueued_at_unix_nanos = cutoff;
+            }
+        }
+    }
+    reap_once(&shared).await;
+    {
+        let inner = state.inner.lock().await;
+        assert!(
+            inner.queue.is_empty(),
+            "a job past the ceiling must starve even while the pool is preparing"
+        );
+        let run = inner.runs.get(&run_id).expect("run record must survive");
+        assert_eq!(
+            run.jobs.get(&JobId("build".to_owned())),
+            Some(&ExecutionStatus::Failure),
+            "the unschedulable job must fail, not queue forever"
+        );
+        assert_eq!(run.status, ExecutionStatus::Failure);
+    }
+}
+
+#[tokio::test]
 async fn job_timeout_enforcement_cancels_job() {
     let temp = tempfile::tempdir().unwrap();
     let state = AppState::new(temp.path().to_path_buf()).await.unwrap();


### PR DESCRIPTION
## What

Warm mode cleared the pool's preparing flag when the golden bake finished, then slots spent minutes booting their first runners with the signal down. Jobs queued during that window hit the 120s starvation sweep — `starving queued job failed after 120s without a matching runner` — even though a runner was on the way.

Reproduced under POOL_SIZE=4 on the conformance host: zoxide and fzf both failed at cold start (queued 15:08:23, starved 15:10:23, first runner registered 15:12:01 — 98s too late). Measured queue→first-runner-ready ≈ 218s.

## Fix

Hold the shared `PreparingGuard` (the same counter-based guard on-demand mode already uses around `provision_slot`) around every warm-slot provision and successor prebuild, so the grace clock stays paused until the runner has actually registered. One counter per pool: the first completed slot cannot clear the signal while its siblings are still bootstrapping.

- `PoolHandles` / `SlotPlan` gain a shared `provisioning` counter
- `run_slot` wraps `provision_slot` in the guard
- `run_one_runner` successor prebuilds hold the guard too
- regression test `warm_slot_raises_preparing_signal_while_provisioning` gates configure mid-provision and asserts the signal is raised

## Verification

- `cargo test -p preloop-orchestrator --lib`: 70/70 pass
- `just test-ci`: fmt, clippy -D warnings, tests, MITM conformance — all pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes warm-pool starvation where jobs queued while slots booted their first runners failed after 120s despite a runner being on the way.

- Holds the shared `PreparingGuard` across golden resolution, provision, and successor prebuild; the grace clock stays paused until a runner registers, with one counter per pool so the first completed slot doesn't clear the signal while siblings are booting.
- Treats in-flight provisioning (`pool_status.provisioning > 0`) as preparing, covering embeddings that drive only the consolidated `pool_status` handle.
- Bounds the preparing pause at 600s from ready-enqueue so continuous successor prebuilds or a permanently failing provision can't mask an unschedulable job forever; starvation messages now report the effective grace period.
- Adds regression tests for the mid-provision signal and for starving a job past the ceiling while the pool stays preparing.

<sup>Written for commit 1f1f5213d84f684286d8267b9ea3885889cca503. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep `preparing` signal asserted during warm-pool runner boot in `RunnerPool`
> - Adds a shared `provisioning: Arc<Mutex<usize>>` counter to `PoolHandles`, propagated through `SlotPlan`, that pauses the queued-job grace clock while any slot is provisioning a runner
> - Wraps the initial `provision_slot` call in `run_slot` and the successor prebuild in `run_one_runner` with `PreparingGuard::enter`, which increments the counter on entry and drops it on success or error
> - Extends the test VM double with an optional `configure_gate: Notify` to block at the configure step, plus assertions that `preparing` stays asserted during warm-mode provisioning
> - Risk: if `PreparingGuard` is not dropped on an error path, the provisioning counter stays elevated indefinitely and the grace clock never resumes — verify all drop sites in [lib.rs](https://github.com/preloopdev/preloop/pull/198/files#diff-2d8f260146e957e725ce81cc61c0dd0be728bdb14854ddce65993faab9a7015c) `run_slot` and `run_one_runner`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 879c8ff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job handling while runners are provisioning.
  * Prevented queued jobs from expiring prematurely during warm runner startup or successor provisioning.
  * Ensured provisioning status remains active until runner registration succeeds or fails.
  * Added an absolute wait limit so queued jobs eventually fail if provisioning remains stalled indefinitely.
  * Updated starvation messages to report the effective grace period.
* **Tests**
  * Expanded coverage for blocked runner registration, warm-mode provisioning, and prolonged pool preparation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->