### PR TITLE
feat(cli): make `logs --job/--step` work and add `--follow`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           toolchain: "1.97"
           components: rustfmt,clippy
 
-      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Install lld linker
         run: apt-get update && apt-get install -y --no-install-recommends lld

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
           lfs: true
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-      - uses: Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Replay official runner flows
         run: bash ./benchmarks/conformance/run.sh
       - name: Upload light report

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -4382,15 +4382,10 @@ mod tests {
     fn live_log_frame_prints_only_console_lines() {
         let frame = "event: live-log\ndata: {\"stepId\":\"s1\",\"startLine\":1,\"count\":2,\
                      \"value\":[\"first\",\"second\"]}";
-        // Captured behavior: the payload's `value` lines are the output, and the
-        // `event:` name is not.
-        let wrapper: preloop_gha_protocol::LiveLogFeedLinesWrapper = frame
-            .lines()
-            .find_map(|line| line.strip_prefix("data:"))
-            .map(|payload| serde_json::from_str(payload.trim_start()).unwrap())
-            .expect("frame carries a data payload");
-        assert_eq!(wrapper.value, vec!["first", "second"]);
-        assert_eq!(wrapper.step_id, "s1");
+        // The production parser reports whether this frame emitted console
+        // lines; the `event:` line itself carries no output.
+        assert!(print_live_log_frame_bytes(frame.as_bytes()).unwrap());
+        assert!(!print_live_log_frame_bytes(b"event: live-log").unwrap());
     }
 
     #[test]

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -3532,7 +3532,7 @@ async fn cmd_logs(args: LogsArgs) -> anyhow::Result<()> {
 
 /// Fetch a run's overall execution status.
 ///
-/// `None` when the field is absent or unrecognized, which the caller treats as
+/// `None` when the field is absent or unrecognized, which callers treat as
 /// "keep following" rather than a reason to stop.
 async fn run_status(
     client: &reqwest::Client,
@@ -3553,13 +3553,54 @@ async fn run_status(
     Ok(serde_json::from_value(record["status"].clone()).ok())
 }
 
-/// Stream one job's live console feed until the run reaches a terminal state.
+/// Fetch one job's durable log through the native logs endpoint.
+async fn fetch_run_job_logs(
+    client: &reqwest::Client,
+    url: &str,
+    run_id: &str,
+    job: Option<&str>,
+) -> anyhow::Result<String> {
+    let mut request = client.get(format!("{url}/api/v1/runs/{run_id}/logs"));
+    if let Some(job) = job {
+        request = request.query(&[("job", job)]);
+    }
+    if let Some(token) = api_token() {
+        request = request.bearer_auth(token);
+    }
+    let response = request.send().await?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!("server returned {status}: {body}");
+    }
+    Ok(response.text().await?)
+}
+
+/// Wait for the selected run to reach a terminal state after its job feed
+/// closes. A job can finish before a sibling, so SSE EOF alone is not enough.
+async fn wait_for_run_terminal(
+    client: &reqwest::Client,
+    url: &str,
+    run_id: &str,
+) -> anyhow::Result<()> {
+    loop {
+        if run_status(client, url, run_id)
+            .await?
+            .is_some_and(|status| status.is_terminal())
+        {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+/// Stream one job's live console feed, then wait for the run to finish.
 ///
-/// Consumes the server's SSE feed rather than polling the whole log and
-/// diffing: the feed replays the retained snapshot before going live, so a late
-/// follower still sees earlier output. Job selection is the server's job — it
-/// defaults a single-job run and names the candidates otherwise, so the rule
-/// matches the one behind `?job=` on the non-streaming route.
+/// The server closes the selected job's feed when that job completes. The
+/// client therefore drains every queued SSE frame before checking run status;
+/// if a sibling is still active, it waits rather than returning early. When a
+/// completed job has no retained in-memory snapshot (for example after a
+/// server restart), the durable job-log endpoint supplies the missing output.
 async fn follow_run_logs(
     client: &reqwest::Client,
     url: &str,
@@ -3583,57 +3624,83 @@ async fn follow_run_logs(
     }
 
     let mut stream = response.bytes_stream();
-    let mut buffer = String::new();
-    // The feed stays open with keep-alive comments after a job ends, so the
-    // run's own status is what decides when following is done.
-    let mut status_poll = tokio::time::interval(Duration::from_secs(3));
-    status_poll.tick().await;
-
-    loop {
-        tokio::select! {
-            chunk = stream.next() => match chunk {
-                Some(Ok(bytes)) => {
-                    buffer.push_str(&String::from_utf8_lossy(&bytes));
-                    // SSE frames are separated by a blank line.
-                    while let Some(split) = buffer.find("\n\n") {
-                        let frame = buffer[..split].to_owned();
-                        buffer.drain(..split + 2);
-                        print_live_log_frame(&frame);
-                    }
-                }
-                Some(Err(error)) => anyhow::bail!("live log stream failed: {error}"),
-                None => break,
-            },
-            _ = status_poll.tick() => {
-                if let Ok(Some(status)) = run_status(client, url, run_id).await {
-                    if status.is_terminal() {
-                        break;
-                    }
-                }
-            }
+    let mut buffer = Vec::new();
+    let mut emitted_data = false;
+    while let Some(chunk) = stream.next().await {
+        let bytes = chunk.map_err(|error| anyhow::anyhow!("live log stream failed: {error}"))?;
+        buffer.extend_from_slice(&bytes);
+        while let Some((frame_end, delimiter_len)) = next_sse_frame(&buffer) {
+            let frame: Vec<u8> = buffer.drain(..frame_end).collect();
+            buffer.drain(..delimiter_len);
+            emitted_data |= print_live_log_frame_bytes(&frame)?;
         }
     }
-    Ok(())
+    // A well-formed SSE server terminates every event with a blank line, but
+    // process a final complete-looking frame rather than silently dropping it.
+    if !buffer.is_empty() {
+        emitted_data |= print_live_log_frame_bytes(&buffer)?;
+    }
+
+    if !emitted_data {
+        // The live buffer is intentionally in-memory. A late follower after a
+        // restart still gets the durable output instead of a successful empty
+        // follow.
+        let body = fetch_run_job_logs(client, url, run_id, job).await?;
+        print!("{body}");
+    }
+    wait_for_run_terminal(client, url, run_id).await
 }
 
-/// Print the console lines carried by one SSE frame.
+/// Return the first complete SSE frame delimiter and its byte length.
+fn next_sse_frame(buffer: &[u8]) -> Option<(usize, usize)> {
+    for index in 0..buffer.len().saturating_sub(1) {
+        if buffer[index..].starts_with(b"\n\n") {
+            return Some((index, 2));
+        }
+        if index + 4 <= buffer.len() && buffer[index..].starts_with(b"\r\n\r\n") {
+            return Some((index, 4));
+        }
+        if buffer[index..].starts_with(b"\r\r") {
+            return Some((index, 2));
+        }
+    }
+    None
+}
+
+/// Print console lines carried by one complete, UTF-8 SSE frame.
 ///
-/// Non-`data:` lines (keep-alive comments, the `event:` name) carry no output.
-/// An unparseable payload is skipped rather than aborting a long follow.
-fn print_live_log_frame(frame: &str) {
-    for line in frame.lines() {
+/// Raw bytes are decoded only after the frame boundary is known, so an HTTP
+/// chunk split in the middle of a multibyte character cannot corrupt JSON.
+/// Keep-alive/comment frames and malformed JSON remain non-fatal.
+fn print_live_log_frame_bytes(frame: &[u8]) -> anyhow::Result<bool> {
+    let frame = std::str::from_utf8(frame).context("live log SSE frame was not UTF-8")?;
+    let mut data_lines = Vec::new();
+    for line in frame.split('\n') {
+        let line = line.strip_suffix('\r').unwrap_or(line);
         let Some(payload) = line.strip_prefix("data:") else {
             continue;
         };
-        let payload = payload.trim_start();
-        if let Ok(wrapper) =
-            serde_json::from_str::<preloop_gha_protocol::LiveLogFeedLinesWrapper>(payload)
-        {
-            for console_line in wrapper.value {
-                println!("{console_line}");
-            }
-        }
+        data_lines.push(payload.strip_prefix(' ').unwrap_or(payload));
     }
+    if data_lines.is_empty() {
+        return Ok(false);
+    }
+    let payload = data_lines.join("\n");
+    let Ok(wrapper) =
+        serde_json::from_str::<preloop_gha_protocol::LiveLogFeedLinesWrapper>(&payload)
+    else {
+        return Ok(false);
+    };
+    for console_line in &wrapper.value {
+        println!("{console_line}");
+    }
+    Ok(!wrapper.value.is_empty())
+}
+
+/// Print one SSE frame for callers/tests that already have valid UTF-8 text.
+#[cfg(test)]
+fn print_live_log_frame(frame: &str) {
+    let _ = print_live_log_frame_bytes(frame.as_bytes());
 }
 
 async fn cmd_cancel(args: CancelArgs) -> anyhow::Result<()> {

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -726,13 +726,24 @@ struct LogsArgs {
     /// Run ID. Defaults to the most recent run.
     run_id: Option<String>,
 
-    /// Filter by job ID.
+    /// Filter by job: the workflow job key (`build`) or its agent job UUID.
     #[arg(long)]
     job: Option<String>,
 
-    /// Filter by step number.
+    /// Filter by 1-based step number within the job, in execution order.
+    ///
+    /// Needs `--job` when the run has more than one job, because step
+    /// numbering restarts per job.
     #[arg(long)]
-    step: Option<u32>,
+    step: Option<usize>,
+
+    /// Stream output as it arrives, like `tail -f`, and exit when the run
+    /// reaches a terminal state.
+    ///
+    /// Follows one job's live console feed, so it needs `--job` unless the run
+    /// has exactly one job. Cannot be combined with `--step`.
+    #[arg(short = 'f', long)]
+    follow: bool,
 }
 
 #[derive(Debug, Parser)]
@@ -3463,6 +3474,21 @@ fn condition_action(code: &str) -> &'static str {
     }
 }
 
+/// Build the `?job=&step=` pairs for a filtered log request.
+///
+/// Split out so a test can assert the wire query without a live server: these
+/// pairs silently going missing is exactly the bug this replaced.
+fn logs_query(job: Option<&str>, step: Option<usize>) -> Vec<(&'static str, String)> {
+    let mut query = Vec::new();
+    if let Some(job) = job {
+        query.push(("job", job.to_owned()));
+    }
+    if let Some(step) = step {
+        query.push(("step", step.to_string()));
+    }
+    query
+}
+
 async fn cmd_logs(args: LogsArgs) -> anyhow::Result<()> {
     let client = build_client();
     let url = server_url();
@@ -3472,7 +3498,24 @@ async fn cmd_logs(args: LogsArgs) -> anyhow::Result<()> {
             .await?
             .ok_or_else(|| anyhow::anyhow!("no runs found"))?,
     };
+
+    if args.follow {
+        // The live feed carries whole steps as they stream; it has no notion of
+        // "just step N". Refuse instead of quietly ignoring one of the flags.
+        if args.step.is_some() {
+            anyhow::bail!(
+                "`--step` cannot be combined with `--follow`: the live feed is per job, not \
+                 per step. Follow the job, or drop `--follow` to read one finished step."
+            );
+        }
+        return follow_run_logs(&client, &url, &run_id, args.job.as_deref()).await;
+    }
+
     let mut request = client.get(format!("{url}/api/v1/runs/{run_id}/logs"));
+    let query = logs_query(args.job.as_deref(), args.step);
+    if !query.is_empty() {
+        request = request.query(&query);
+    }
     if let Some(token) = api_token() {
         request = request.bearer_auth(token);
     }
@@ -3485,6 +3528,112 @@ async fn cmd_logs(args: LogsArgs) -> anyhow::Result<()> {
     let body = response.text().await?;
     print!("{body}");
     Ok(())
+}
+
+/// Fetch a run's overall execution status.
+///
+/// `None` when the field is absent or unrecognized, which the caller treats as
+/// "keep following" rather than a reason to stop.
+async fn run_status(
+    client: &reqwest::Client,
+    url: &str,
+    run_id: &str,
+) -> anyhow::Result<Option<preloop_gha_protocol::ExecutionStatus>> {
+    let mut request = client.get(format!("{url}/api/v1/runs/{run_id}"));
+    if let Some(token) = api_token() {
+        request = request.bearer_auth(token);
+    }
+    let response = request.send().await?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!("server returned {status}: {body}");
+    }
+    let record: serde_json::Value = response.json().await?;
+    Ok(serde_json::from_value(record["status"].clone()).ok())
+}
+
+/// Stream one job's live console feed until the run reaches a terminal state.
+///
+/// Consumes the server's SSE feed rather than polling the whole log and
+/// diffing: the feed replays the retained snapshot before going live, so a late
+/// follower still sees earlier output. Job selection is the server's job — it
+/// defaults a single-job run and names the candidates otherwise, so the rule
+/// matches the one behind `?job=` on the non-streaming route.
+async fn follow_run_logs(
+    client: &reqwest::Client,
+    url: &str,
+    run_id: &str,
+    job: Option<&str>,
+) -> anyhow::Result<()> {
+    use futures_util::StreamExt as _;
+
+    let mut request = client.get(format!("{url}/api/v1/runs/{run_id}/logs/live"));
+    if let Some(job) = job {
+        request = request.query(&[("job", job)]);
+    }
+    if let Some(token) = api_token() {
+        request = request.bearer_auth(token);
+    }
+    let response = request.send().await?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!("server returned {status}: {body}");
+    }
+
+    let mut stream = response.bytes_stream();
+    let mut buffer = String::new();
+    // The feed stays open with keep-alive comments after a job ends, so the
+    // run's own status is what decides when following is done.
+    let mut status_poll = tokio::time::interval(Duration::from_secs(3));
+    status_poll.tick().await;
+
+    loop {
+        tokio::select! {
+            chunk = stream.next() => match chunk {
+                Some(Ok(bytes)) => {
+                    buffer.push_str(&String::from_utf8_lossy(&bytes));
+                    // SSE frames are separated by a blank line.
+                    while let Some(split) = buffer.find("\n\n") {
+                        let frame = buffer[..split].to_owned();
+                        buffer.drain(..split + 2);
+                        print_live_log_frame(&frame);
+                    }
+                }
+                Some(Err(error)) => anyhow::bail!("live log stream failed: {error}"),
+                None => break,
+            },
+            _ = status_poll.tick() => {
+                if let Ok(Some(status)) = run_status(client, url, run_id).await {
+                    if status.is_terminal() {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Print the console lines carried by one SSE frame.
+///
+/// Non-`data:` lines (keep-alive comments, the `event:` name) carry no output.
+/// An unparseable payload is skipped rather than aborting a long follow.
+fn print_live_log_frame(frame: &str) {
+    for line in frame.lines() {
+        let Some(payload) = line.strip_prefix("data:") else {
+            continue;
+        };
+        let payload = payload.trim_start();
+        if let Ok(wrapper) =
+            serde_json::from_str::<preloop_gha_protocol::LiveLogFeedLinesWrapper>(payload)
+        {
+            for console_line in wrapper.value {
+                println!("{console_line}");
+            }
+        }
+    }
 }
 
 async fn cmd_cancel(args: CancelArgs) -> anyhow::Result<()> {
@@ -4118,6 +4267,71 @@ mod tests {
         };
         assert_eq!(args.job.unwrap(), "build");
         assert_eq!(args.step.unwrap(), 3);
+    }
+
+    /// The flags used to parse and then be dropped on the floor. Assert the
+    /// wire query itself, not just that clap accepted the argument.
+    #[test]
+    fn logs_filters_reach_the_query_string() {
+        assert_eq!(
+            logs_query(Some("build"), Some(3)),
+            vec![("job", "build".to_owned()), ("step", "3".to_owned())]
+        );
+    }
+
+    #[test]
+    fn logs_query_omits_absent_filters() {
+        assert!(logs_query(None, None).is_empty());
+        assert_eq!(
+            logs_query(Some("test"), None),
+            vec![("job", "test".to_owned())]
+        );
+        assert_eq!(logs_query(None, Some(2)), vec![("step", "2".to_owned())]);
+    }
+
+    #[test]
+    fn logs_follow_flag_parses_short_and_long() {
+        for argv in [vec!["logs", "-f"], vec!["logs", "--follow"]] {
+            let cli = parse(&argv).unwrap();
+            let Command::Logs(args) = cli.command else {
+                panic!("expected Logs");
+            };
+            assert!(args.follow, "{argv:?} should enable follow");
+        }
+    }
+
+    #[test]
+    fn logs_defaults_to_no_follow_and_no_filters() {
+        let cli = parse(&["logs"]).unwrap();
+        let Command::Logs(args) = cli.command else {
+            panic!("expected Logs");
+        };
+        assert!(!args.follow);
+        assert!(args.job.is_none());
+        assert!(args.step.is_none());
+    }
+
+    #[test]
+    fn live_log_frame_prints_only_console_lines() {
+        let frame = "event: live-log\ndata: {\"stepId\":\"s1\",\"startLine\":1,\"count\":2,\
+                     \"value\":[\"first\",\"second\"]}";
+        // Captured behavior: the payload's `value` lines are the output, and the
+        // `event:` name is not.
+        let wrapper: preloop_gha_protocol::LiveLogFeedLinesWrapper = frame
+            .lines()
+            .find_map(|line| line.strip_prefix("data:"))
+            .map(|payload| serde_json::from_str(payload.trim_start()).unwrap())
+            .expect("frame carries a data payload");
+        assert_eq!(wrapper.value, vec!["first", "second"]);
+        assert_eq!(wrapper.step_id, "s1");
+    }
+
+    #[test]
+    fn live_log_frame_tolerates_keepalive_and_garbage() {
+        // Keep-alive comments and unparseable payloads must not abort a follow.
+        print_live_log_frame(":");
+        print_live_log_frame("event: live-log\ndata: not-json");
+        print_live_log_frame("");
     }
 
     #[test]

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -3530,29 +3530,6 @@ async fn cmd_logs(args: LogsArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Fetch a run's overall execution status.
-///
-/// `None` when the field is absent or unrecognized, which callers treat as
-/// "keep following" rather than a reason to stop.
-async fn run_status(
-    client: &reqwest::Client,
-    url: &str,
-    run_id: &str,
-) -> anyhow::Result<Option<preloop_gha_protocol::ExecutionStatus>> {
-    let mut request = client.get(format!("{url}/api/v1/runs/{run_id}"));
-    if let Some(token) = api_token() {
-        request = request.bearer_auth(token);
-    }
-    let response = request.send().await?;
-    if !response.status().is_success() {
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        anyhow::bail!("server returned {status}: {body}");
-    }
-    let record: serde_json::Value = response.json().await?;
-    Ok(serde_json::from_value(record["status"].clone()).ok())
-}
-
 /// Fetch one job's durable log through the native logs endpoint.
 async fn fetch_run_job_logs(
     client: &reqwest::Client,
@@ -3576,31 +3553,12 @@ async fn fetch_run_job_logs(
     Ok(response.text().await?)
 }
 
-/// Wait for the selected run to reach a terminal state after its job feed
-/// closes. A job can finish before a sibling, so SSE EOF alone is not enough.
-async fn wait_for_run_terminal(
-    client: &reqwest::Client,
-    url: &str,
-    run_id: &str,
-) -> anyhow::Result<()> {
-    loop {
-        if run_status(client, url, run_id)
-            .await?
-            .is_some_and(|status| status.is_terminal())
-        {
-            return Ok(());
-        }
-        tokio::time::sleep(Duration::from_secs(1)).await;
-    }
-}
-
-/// Stream one job's live console feed, then wait for the run to finish.
+/// Stream one job's live console feed and exit when that job finishes.
 ///
 /// The server closes the selected job's feed when that job completes. The
-/// client therefore drains every queued SSE frame before checking run status;
-/// if a sibling is still active, it waits rather than returning early. When a
-/// completed job has no retained in-memory snapshot (for example after a
-/// server restart), the durable job-log endpoint supplies the missing output.
+/// client drains every queued SSE frame before returning; if a completed job
+/// has no retained in-memory snapshot (for example after a server restart),
+/// the durable job-log endpoint supplies the missing output.
 async fn follow_run_logs(
     client: &reqwest::Client,
     url: &str,
@@ -3648,7 +3606,7 @@ async fn follow_run_logs(
         let body = fetch_run_job_logs(client, url, run_id, job).await?;
         print!("{body}");
     }
-    wait_for_run_terminal(client, url, run_id).await
+    Ok(())
 }
 
 /// Return the first complete SSE frame delimiter and its byte length.

--- a/crates/preloop-orchestrator/src/lib.rs
+++ b/crates/preloop-orchestrator/src/lib.rs
@@ -5134,7 +5134,7 @@ while [ "$#" -gt 0 ]; do
     *) url="$1"; shift;;
   esac
 done
-case "$url" in *SHASUMS256.txt*) printf "618e4294602b78e97118a39050116b70d088b16197cd3819bba1fc18b473dfc4  node-v20.19.0-linux-arm64.tar.gz\n371fc060d5dd4de565586c3cc70034956db67a8f3dae0f0e5724fa56147c472a  node-v24.3.0-linux-arm64.tar.gz\n8a4dbcdd8bccef3132d21e8543940557e55dcf44f00f0a99ba8a062f4552e722  node-v20.19.0-linux-x64.tar.gz\nbbeb5fb8113b44fc30f5a5887dbc0ab66af8e56139f5f9fbe7c7a1aa056246dc  node-v24.3.0-linux-x64.tar.gz\n" > "$out"; exit 0;; esac
+case "$url" in *SHASUMS256.txt*) printf "47ef73d543ecf6eb19435f6c03a0ac4809b3bf0dd6b26c7c571efc2a6572a74d  node-v20.20.2-linux-arm64.tar.gz\nd28c8a5bf0a808f0ed434a1dce8c54ae98f0371c0bd86ac58abc613f73e6643f  node-v24.19.0-linux-arm64.tar.gz\n19e56f0825510207dd904f087fe52faa0a4eb6b2aab5f0ea7a33830d04888b8b  node-v20.20.2-linux-x64.tar.gz\nf625d97cd707df4ff96254916fbc5ff014f09c09effe5a1e0ca8f6d41a8789d4  node-v24.19.0-linux-x64.tar.gz\n" > "$out"; exit 0;; esac
 printf archive > "$out"
 "#,
         )
@@ -5151,13 +5151,13 @@ case "$*" in
     if [ "$arch" = "x86_64" ]; then
       printf "bbeb5fb8113b44fc30f5a5887dbc0ab66af8e56139f5f9fbe7c7a1aa056246dc  dummy\n"
     else
-      printf "371fc060d5dd4de565586c3cc70034956db67a8f3dae0f0e5724fa56147c472a  dummy\n"
+      printf "d28c8a5bf0a808f0ed434a1dce8c54ae98f0371c0bd86ac58abc613f73e6643f  dummy\n"
     fi;;
   *)
     if [ "$arch" = "x86_64" ]; then
-      printf "8a4dbcdd8bccef3132d21e8543940557e55dcf44f00f0a99ba8a062f4552e722  dummy\n"
+      printf "19e56f0825510207dd904f087fe52faa0a4eb6b2aab5f0ea7a33830d04888b8b  dummy\n"
     else
-      printf "618e4294602b78e97118a39050116b70d088b16197cd3819bba1fc18b473dfc4  dummy\n"
+      printf "47ef73d543ecf6eb19435f6c03a0ac4809b3bf0dd6b26c7c571efc2a6572a74d  dummy\n"
     fi;;
 esac
 "#,
@@ -5175,13 +5175,13 @@ case "$*" in
     if [ "$arch" = "x86_64" ]; then
       printf "bbeb5fb8113b44fc30f5a5887dbc0ab66af8e56139f5f9fbe7c7a1aa056246dc  dummy\n"
     else
-      printf "371fc060d5dd4de565586c3cc70034956db67a8f3dae0f0e5724fa56147c472a  dummy\n"
+      printf "d28c8a5bf0a808f0ed434a1dce8c54ae98f0371c0bd86ac58abc613f73e6643f  dummy\n"
     fi;;
   *)
     if [ "$arch" = "x86_64" ]; then
-      printf "8a4dbcdd8bccef3132d21e8543940557e55dcf44f00f0a99ba8a062f4552e722  dummy\n"
+      printf "19e56f0825510207dd904f087fe52faa0a4eb6b2aab5f0ea7a33830d04888b8b  dummy\n"
     else
-      printf "618e4294602b78e97118a39050116b70d088b16197cd3819bba1fc18b473dfc4  dummy\n"
+      printf "47ef73d543ecf6eb19435f6c03a0ac4809b3bf0dd6b26c7c571efc2a6572a74d  dummy\n"
     fi;;
 esac
 "#,
@@ -5241,13 +5241,13 @@ chmod +x "$dest/bin/node"
                 if cfg!(target_arch = "x86_64") {
                     "8a4dbcdd"
                 } else {
-                    "618e4294"
+                    "47ef73d5"
                 }
             } else {
                 if cfg!(target_arch = "x86_64") {
                     "bbeb5fb8"
                 } else {
-                    "371fc060"
+                    "d28c8a5b"
                 }
             };
             assert!(manifest.contains(expected_sha), "{manifest}");
@@ -5278,7 +5278,7 @@ while [ "$#" -gt 0 ]; do
     *) url="$1"; shift;;
   esac
 done
-case "$url" in *SHASUMS256.txt*) printf "618e4294602b78e97118a39050116b70d088b16197cd3819bba1fc18b473dfc4  node-v20.19.0-linux-arm64.tar.gz\n371fc060d5dd4de565586c3cc70034956db67a8f3dae0f0e5724fa56147c472a  node-v24.3.0-linux-arm64.tar.gz\n8a4dbcdd8bccef3132d21e8543940557e55dcf44f00f0a99ba8a062f4552e722  node-v20.19.0-linux-x64.tar.gz\nbbeb5fb8113b44fc30f5a5887dbc0ab66af8e56139f5f9fbe7c7a1aa056246dc  node-v24.3.0-linux-x64.tar.gz\n" > "$out"; exit 0;; esac
+case "$url" in *SHASUMS256.txt*) printf "47ef73d543ecf6eb19435f6c03a0ac4809b3bf0dd6b26c7c571efc2a6572a74d  node-v20.20.2-linux-arm64.tar.gz\nd28c8a5bf0a808f0ed434a1dce8c54ae98f0371c0bd86ac58abc613f73e6643f  node-v24.19.0-linux-arm64.tar.gz\n19e56f0825510207dd904f087fe52faa0a4eb6b2aab5f0ea7a33830d04888b8b  node-v20.20.2-linux-x64.tar.gz\nf625d97cd707df4ff96254916fbc5ff014f09c09effe5a1e0ca8f6d41a8789d4  node-v24.19.0-linux-x64.tar.gz\n" > "$out"; exit 0;; esac
 printf archive > "$out"
 "#,
         )
@@ -5294,13 +5294,13 @@ case "$*" in
     if [ "$arch" = "x86_64" ]; then
       printf "bbeb5fb8113b44fc30f5a5887dbc0ab66af8e56139f5f9fbe7c7a1aa056246dc  dummy\n"
     else
-      printf "371fc060d5dd4de565586c3cc70034956db67a8f3dae0f0e5724fa56147c472a  dummy\n"
+      printf "d28c8a5bf0a808f0ed434a1dce8c54ae98f0371c0bd86ac58abc613f73e6643f  dummy\n"
     fi;;
   *)
     if [ "$arch" = "x86_64" ]; then
-      printf "8a4dbcdd8bccef3132d21e8543940557e55dcf44f00f0a99ba8a062f4552e722  dummy\n"
+      printf "19e56f0825510207dd904f087fe52faa0a4eb6b2aab5f0ea7a33830d04888b8b  dummy\n"
     else
-      printf "618e4294602b78e97118a39050116b70d088b16197cd3819bba1fc18b473dfc4  dummy\n"
+      printf "47ef73d543ecf6eb19435f6c03a0ac4809b3bf0dd6b26c7c571efc2a6572a74d  dummy\n"
     fi;;
 esac
 "#,
@@ -5318,13 +5318,13 @@ case "$*" in
     if [ "$arch" = "x86_64" ]; then
       printf "bbeb5fb8113b44fc30f5a5887dbc0ab66af8e56139f5f9fbe7c7a1aa056246dc  dummy\n"
     else
-      printf "371fc060d5dd4de565586c3cc70034956db67a8f3dae0f0e5724fa56147c472a  dummy\n"
+      printf "d28c8a5bf0a808f0ed434a1dce8c54ae98f0371c0bd86ac58abc613f73e6643f  dummy\n"
     fi;;
   *)
     if [ "$arch" = "x86_64" ]; then
-      printf "8a4dbcdd8bccef3132d21e8543940557e55dcf44f00f0a99ba8a062f4552e722  dummy\n"
+      printf "19e56f0825510207dd904f087fe52faa0a4eb6b2aab5f0ea7a33830d04888b8b  dummy\n"
     else
-      printf "618e4294602b78e97118a39050116b70d088b16197cd3819bba1fc18b473dfc4  dummy\n"
+      printf "47ef73d543ecf6eb19435f6c03a0ac4809b3bf0dd6b26c7c571efc2a6572a74d  dummy\n"
     fi;;
 esac
 "#,

--- a/crates/preloop-runner-server/src/distributed_task.rs
+++ b/crates/preloop-runner-server/src/distributed_task.rs
@@ -710,6 +710,15 @@ pub(crate) async fn complete_job_inner(
             newly_terminal_success = run.status == ExecutionStatus::Success;
         }
     }
+    // Close only after the run and job were validated and the completion was
+    // projected. Invalid callbacks must not terminate another job's feed.
+    let live_log_key = inner
+        .job_requests
+        .values()
+        .find(|record| record.run_id == completion.run_id && record.job_id == completion.job_id)
+        .map(|record| record.agent_job_id.to_string())
+        .unwrap_or_else(|| completion.job_id.0.clone());
+    crate::live_logs::close_live_log(&mut inner, &live_log_key);
     // Use the status actually stored (may differ from completion if terminal-locked).
     let effective_status = inner
         .runs
@@ -782,17 +791,6 @@ pub(crate) async fn complete_job_inner(
         // terminal without reaching either site; the record leaks but is
         // unreachable — the job is out of every dispatchable collection.
         inner.github_token_requests.remove(request_id);
-    }
-    // Evict live-log state for this job to prevent unbounded memory growth.
-    // The durable step-log blob has already been uploaded by the runner.
-    if let Some(agent_key) = inner
-        .job_requests
-        .values()
-        .find(|r| r.run_id == completion.run_id && r.job_id == completion.job_id)
-        .map(|r| r.agent_job_id.to_string())
-    {
-        inner.live_log_lines.remove(&agent_key);
-        inner.live_log_tx.remove(&agent_key);
     }
     inner.dap_ports.remove(&completion.run_id);
     let queue_nonempty = !inner.queue.is_empty() || !inner.cancellation_queue.is_empty();

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -2601,6 +2601,408 @@ async fn log_get_run_logs_returns_404_for_unknown_run() {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
+/// Build a two-job run and return `(run_id, [(job_id, plan_id, agent_job_id)])`
+/// ordered by request id, so filter tests can address either job.
+async fn two_job_run_for_log_filters(
+    app: &axum::Router,
+    state: &AppState,
+) -> (RunId, Vec<(String, String, String)>) {
+    let accepted = submit_yaml(
+        app,
+        r#"
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo test
+"#,
+        "owner/repo",
+    )
+    .await;
+    let run_id: RunId = accepted["run_id"].as_str().unwrap().parse().unwrap();
+    let jobs = {
+        let inner = state.inner.lock().await;
+        let mut requests: Vec<_> = inner
+            .job_requests
+            .values()
+            .filter(|request| request.run_id == run_id)
+            .collect();
+        requests.sort_by_key(|request| request.request_id);
+        requests
+            .into_iter()
+            .map(|request| {
+                (
+                    request.job_id.0.clone(),
+                    request.plan_id.clone(),
+                    request.agent_job_id.to_string(),
+                )
+            })
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(jobs.len(), 2, "fixture must produce two jobs");
+    (run_id, jobs)
+}
+
+async fn get_logs(app: &axum::Router, uri: String) -> (StatusCode, Vec<u8>) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri(uri)
+                .header(header::AUTHORIZATION, "Bearer preloop-system-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    (status, body.to_vec())
+}
+
+/// Write `job-logs.txt` for one job.
+async fn write_merged_job_log(temp: &tempfile::TempDir, plan: &str, agent: &str, body: &str) {
+    let dir = temp
+        .path()
+        .join("replay")
+        .join("results")
+        .join(plan)
+        .join(agent);
+    tokio::fs::create_dir_all(&dir).await.unwrap();
+    tokio::fs::write(dir.join("job-logs.txt"), body.as_bytes())
+        .await
+        .unwrap();
+}
+
+/// Write ordered per-step logs for one job. Mtimes are spaced so the handler's
+/// (mtime, name) ordering is deterministic.
+async fn write_step_job_logs(
+    temp: &tempfile::TempDir,
+    plan: &str,
+    agent: &str,
+    steps: &[(&str, &str)],
+) {
+    let dir = temp
+        .path()
+        .join("replay")
+        .join("results")
+        .join(plan)
+        .join(agent);
+    tokio::fs::create_dir_all(&dir).await.unwrap();
+    for (name, body) in steps {
+        tokio::fs::write(dir.join(format!("step-{name}.txt")), body.as_bytes())
+            .await
+            .unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test]
+async fn log_run_logs_job_filter_returns_only_that_job() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, jobs) = two_job_run_for_log_filters(&app, &state).await;
+    write_merged_job_log(&temp, &jobs[0].1, &jobs[0].2, "build output\n").await;
+    write_merged_job_log(&temp, &jobs[1].1, &jobs[1].2, "test output\n").await;
+
+    // Unfiltered still merges every job, in request order.
+    let (status, body) = get_logs(&app, format!("/api/v1/runs/{run_id}/logs")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, b"build output\ntest output\n");
+
+    // Filtering by the workflow job key returns only that job.
+    let (status, body) = get_logs(&app, format!("/api/v1/runs/{run_id}/logs?job=test")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body, b"test output\n",
+        "job filter must exclude the other job"
+    );
+
+    let (status, body) = get_logs(&app, format!("/api/v1/runs/{run_id}/logs?job=build")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, b"build output\n");
+}
+
+#[tokio::test]
+async fn log_run_logs_job_filter_accepts_agent_job_uuid() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, jobs) = two_job_run_for_log_filters(&app, &state).await;
+    write_merged_job_log(&temp, &jobs[0].1, &jobs[0].2, "build output\n").await;
+    write_merged_job_log(&temp, &jobs[1].1, &jobs[1].2, "test output\n").await;
+
+    // The live-log feed accepts either identifier; so must this.
+    let agent_uuid = &jobs[1].2;
+    let (status, body) =
+        get_logs(&app, format!("/api/v1/runs/{run_id}/logs?job={agent_uuid}")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, b"test output\n");
+}
+
+#[tokio::test]
+async fn log_run_logs_unknown_job_is_404_not_whole_run() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, jobs) = two_job_run_for_log_filters(&app, &state).await;
+    write_merged_job_log(&temp, &jobs[0].1, &jobs[0].2, "build output\n").await;
+
+    let (status, body) = get_logs(
+        &app,
+        format!("/api/v1/runs/{run_id}/logs?job=does-not-exist"),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "a bogus job must fail loudly, never fall back to the full run"
+    );
+    assert!(
+        !String::from_utf8_lossy(&body).contains("build output"),
+        "404 body must not leak the unfiltered log"
+    );
+}
+
+#[tokio::test]
+async fn log_run_logs_step_filter_selects_one_step() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, jobs) = two_job_run_for_log_filters(&app, &state).await;
+    write_step_job_logs(
+        &temp,
+        &jobs[0].1,
+        &jobs[0].2,
+        &[
+            ("a", "step one\n"),
+            ("b", "step two\n"),
+            ("c", "step three\n"),
+        ],
+    )
+    .await;
+
+    for (step, expected) in [(1, "step one\n"), (2, "step two\n"), (3, "step three\n")] {
+        let (status, body) = get_logs(
+            &app,
+            format!("/api/v1/runs/{run_id}/logs?job=build&step={step}"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "step {step}");
+        assert_eq!(body, expected.as_bytes(), "step {step} content");
+    }
+}
+
+#[tokio::test]
+async fn log_run_logs_step_out_of_range_is_404() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, jobs) = two_job_run_for_log_filters(&app, &state).await;
+    write_step_job_logs(
+        &temp,
+        &jobs[0].1,
+        &jobs[0].2,
+        &[("a", "step one\n"), ("b", "step two\n")],
+    )
+    .await;
+
+    let (status, body) =
+        get_logs(&app, format!("/api/v1/runs/{run_id}/logs?job=build&step=9")).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    let message = String::from_utf8_lossy(&body);
+    assert!(
+        message.contains('2'),
+        "error should report how many steps exist: {message}"
+    );
+}
+
+#[tokio::test]
+async fn log_run_logs_step_zero_is_rejected_as_one_based() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, jobs) = two_job_run_for_log_filters(&app, &state).await;
+    write_step_job_logs(&temp, &jobs[0].1, &jobs[0].2, &[("a", "step one\n")]).await;
+
+    let (status, _) = get_logs(&app, format!("/api/v1/runs/{run_id}/logs?job=build&step=0")).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn log_run_logs_step_on_merged_upload_is_conflict() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, jobs) = two_job_run_for_log_filters(&app, &state).await;
+    // A merged job log carries no step boundaries.
+    write_merged_job_log(&temp, &jobs[0].1, &jobs[0].2, "everything\n").await;
+
+    let (status, body) =
+        get_logs(&app, format!("/api/v1/runs/{run_id}/logs?job=build&step=1")).await;
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "must refuse rather than pass the whole job off as one step"
+    );
+    assert!(
+        !String::from_utf8_lossy(&body).contains("everything"),
+        "conflict body must not return the unsplit log"
+    );
+}
+
+#[tokio::test]
+async fn log_run_logs_step_without_job_in_multi_job_run_is_ambiguous() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, jobs) = two_job_run_for_log_filters(&app, &state).await;
+    write_step_job_logs(&temp, &jobs[0].1, &jobs[0].2, &[("a", "step one\n")]).await;
+
+    let (status, body) = get_logs(&app, format!("/api/v1/runs/{run_id}/logs?step=1")).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "step numbering restarts per job, so this names two things"
+    );
+    let message = String::from_utf8_lossy(&body);
+    assert!(
+        message.contains("build") && message.contains("test"),
+        "error should name the candidate jobs: {message}"
+    );
+}
+
+#[tokio::test]
+async fn log_run_logs_step_filter_works_on_live_console_blocks() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, jobs) = two_job_run_for_log_filters(&app, &state).await;
+
+    // Nothing on disk yet — a job still in flight streams numbered console
+    // blocks, one per step, and `--step` must work against those too.
+    for (log_id, body) in [("2", "live step two\n"), ("10", "live step ten\n")] {
+        let plan = &jobs[0].1;
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri(format!("/_apis/v1/Logfiles/scope/actions/{plan}/{log_id}"))
+                    .header(header::AUTHORIZATION, "Bearer preloop-system-token")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+    }
+
+    // Numeric console-log order, not lexicographic: 2 precedes 10.
+    let (status, body) =
+        get_logs(&app, format!("/api/v1/runs/{run_id}/logs?job=build&step=1")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, b"live step two\n");
+
+    let (status, body) =
+        get_logs(&app, format!("/api/v1/runs/{run_id}/logs?job=build&step=2")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, b"live step ten\n");
+}
+
+#[tokio::test]
+async fn live_run_logs_native_route_requires_job_when_ambiguous() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, _jobs) = two_job_run_for_log_filters(&app, &state).await;
+
+    let (status, body) = get_logs(&app, format!("/api/v1/runs/{run_id}/logs/live")).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "two jobs cannot be followed on one stream"
+    );
+    let message = String::from_utf8_lossy(&body);
+    assert!(
+        message.contains("build") && message.contains("test"),
+        "error should name the candidate jobs: {message}"
+    );
+}
+
+#[tokio::test]
+async fn live_run_logs_native_route_rejects_unknown_job() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, _jobs) = two_job_run_for_log_filters(&app, &state).await;
+
+    let (status, _) = get_logs(&app, format!("/api/v1/runs/{run_id}/logs/live?job=nope")).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn live_run_logs_native_route_defaults_single_job_run() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let accepted = submit_yaml(
+        &app,
+        "on: push\njobs:\n  only:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n",
+        "owner/repo",
+    )
+    .await;
+    let run_id: RunId = accepted["run_id"].as_str().unwrap().parse().unwrap();
+
+    // One job means no ambiguity, so omitting `job` must stream rather than 400.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri(format!("/api/v1/runs/{run_id}/logs/live"))
+                .header(header::AUTHORIZATION, "Bearer preloop-system-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers()[header::CONTENT_TYPE],
+        "text/event-stream"
+    );
+}
+
+#[tokio::test]
+async fn live_run_logs_native_route_rejects_unauthenticated() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, _jobs) = two_job_run_for_log_filters(&app, &state).await;
+
+    // The runner-protocol twin of this route is unreachable with a native
+    // bearer; this one must still refuse an anonymous caller.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri(format!("/api/v1/runs/{run_id}/logs/live?job=build"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
 #[tokio::test]
 async fn log_append_masks_submitted_secrets() {
     let temp = tempfile::tempdir().unwrap();

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -13035,6 +13035,98 @@ async fn workflow_steps_update_prefers_runner_reported_step_names() {
 }
 
 #[tokio::test]
+async fn workflow_steps_update_preserves_duplicate_names_after_restart() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+
+    let accepted = submit_yaml(
+        &app,
+        "on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - name: Test\n        run: cargo test --lib\n      - name: Test\n        run: cargo test --integration\n",
+        "local/preloop",
+    )
+    .await;
+    let run_id = accepted["run_id"].as_str().unwrap().to_owned();
+    let (plan_id, agent_job_id, request_id) = {
+        let inner = state.inner.lock().await;
+        let request = inner
+            .job_requests
+            .values()
+            .find(|request| request.run_id.0.to_string() == run_id)
+            .expect("submitted run must have a job request");
+        (
+            request.plan_id.clone(),
+            request.agent_job_id.to_string(),
+            request.request_id,
+        )
+    };
+    let first_id = uuid::Uuid::new_v4().to_string();
+    let second_id = uuid::Uuid::new_v4().to_string();
+
+    let response = request_json(
+        &app,
+        Method::POST,
+        "/twirp/github.actions.results.api.v1.WorkflowStepUpdateService/WorkflowStepsUpdate",
+        json!({
+            "workflow_run_backend_id": plan_id,
+            "workflow_job_run_backend_id": agent_job_id,
+            "steps": [
+                {
+                    "external_id": first_id,
+                    "number": 1,
+                    "name": "Test",
+                    "status": 6,
+                    "conclusion": 2
+                },
+                {
+                    "external_id": second_id,
+                    "number": 2,
+                    "name": "Test",
+                    "status": 6,
+                    "conclusion": 2
+                }
+            ]
+        }),
+    )
+    .await;
+    assert_eq!(response["ok"], true);
+
+    {
+        let mut inner = state.inner.lock().await;
+        inner.broker_messages.remove(&request_id);
+    }
+    let run = get_run_json(&app, &run_id).await;
+    let steps = run["jobs_list"][0]["steps"].as_array().unwrap();
+    assert_eq!(
+        steps.len(),
+        2,
+        "duplicate names must remain separate: {steps:?}"
+    );
+    assert_eq!(steps[0]["id"], first_id);
+    assert_eq!(steps[1]["id"], second_id);
+
+    write_step_job_logs(
+        &temp,
+        &plan_id,
+        &agent_job_id,
+        &[
+            (&first_id, "first duplicate\n"),
+            (&second_id, "second duplicate\n"),
+        ],
+    )
+    .await;
+    for (step, expected) in [(1, "first duplicate\n"), (2, "second duplicate\n")] {
+        let (status, body) = get_logs(
+            &app,
+            format!("/api/v1/runs/{run_id}/logs?job=build&step={step}"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, expected.as_bytes());
+    }
+}
+
+#[tokio::test]
 async fn workflow_steps_update_terminal_first_sighting_does_not_fake_zero_duration() {
     let temp = tempfile::tempdir().unwrap();
     let state = AppState::new(temp.path().to_path_buf()).await.unwrap();

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -747,6 +747,8 @@ async fn openapi_document_lists_native_surface_and_excludes_runner_protocol() {
     let document: serde_json::Value = serde_json::from_slice(&body).unwrap();
     let paths = document["paths"].as_object().unwrap();
     assert!(paths.contains_key("/api/v1/runs"));
+    assert!(paths.contains_key("/api/v1/runs/{run_id}/logs"));
+    assert!(paths.contains_key("/api/v1/runs/{run_id}/logs/live"));
     assert!(paths.contains_key("/api/v1/debug/sessions"));
     assert!(!paths.keys().any(|path| path.starts_with("/_apis/")));
     assert!(!paths.keys().any(|path| path.starts_with("/broker/")));
@@ -2801,6 +2803,54 @@ async fn log_run_logs_step_filter_selects_one_step() {
 }
 
 #[tokio::test]
+async fn log_run_logs_step_filter_uses_workflow_step_ids() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, jobs) = two_job_run_for_log_filters(&app, &state).await;
+    let workflow_step_id = {
+        let mut inner = state.inner.lock().await;
+        let message = inner
+            .queue
+            .iter()
+            .find(|job| job.run_id == run_id && job.job_id.0 == "build")
+            .or_else(|| {
+                inner
+                    .pending_jobs
+                    .iter()
+                    .find(|job| job.run_id == run_id && job.job_id.0 == "build")
+            })
+            .map(|job| job.message.clone())
+            .expect("fixture must carry a queued build job");
+        let step_id = message
+            .steps
+            .first()
+            .map(|step| step.id.to_string())
+            .expect("fixture must carry a broker step id");
+        inner.broker_messages.insert(message.request_id, message);
+        step_id
+    };
+
+    // The synthetic file sorts first by upload time, but `step=1` must follow
+    // the workflow metadata and select the user step's external id.
+    write_step_job_logs(
+        &temp,
+        &jobs[0].1,
+        &jobs[0].2,
+        &[
+            ("synthetic-setup", "setup output\n"),
+            (&workflow_step_id, "user step output\n"),
+        ],
+    )
+    .await;
+
+    let (status, body) =
+        get_logs(&app, format!("/api/v1/runs/{run_id}/logs?job=build&step=1")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, b"user step output\n");
+}
+
+#[tokio::test]
 async fn log_run_logs_step_out_of_range_is_404() {
     let temp = tempfile::tempdir().unwrap();
     let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
@@ -2949,6 +2999,42 @@ async fn live_run_logs_native_route_rejects_unknown_job() {
 }
 
 #[tokio::test]
+async fn live_run_logs_native_route_rejects_uuid_from_other_run() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (_foreign_run_id, foreign_jobs) = two_job_run_for_log_filters(&app, &state).await;
+    let (run_id, _jobs) = two_job_run_for_log_filters(&app, &state).await;
+    let foreign_job_uuid = foreign_jobs[0].2.clone();
+
+    // Leave a globally keyed buffer behind, then ask for that UUID through a
+    // different run. A live-log key is not a sufficient authorization to read
+    // another run's output.
+    crate::live_logs::record_live_log_wrapper(
+        &state.shared(),
+        &foreign_job_uuid,
+        preloop_gha_protocol::LiveLogFeedLinesWrapper {
+            step_id: "foreign".into(),
+            start_line: 1,
+            count: 1,
+            value: vec!["must stay private".into()],
+        },
+    )
+    .await;
+
+    let (status, body) = get_logs(
+        &app,
+        format!("/api/v1/runs/{run_id}/logs/live?job={foreign_job_uuid}"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert!(
+        !String::from_utf8_lossy(&body).contains("must stay private"),
+        "cross-run UUID lookup must not expose the foreign buffer"
+    );
+}
+
+#[tokio::test]
 async fn live_run_logs_native_route_defaults_single_job_run() {
     let temp = tempfile::tempdir().unwrap();
     let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
@@ -3001,6 +3087,179 @@ async fn live_run_logs_native_route_rejects_unauthenticated() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// Drive one job of a run to a terminal status through the same path every
+/// completion funnels through (`complete_job_inner`).
+async fn complete_job(state: &AppState, run_id: RunId, job_id: &str, status: ExecutionStatus) {
+    let _ = crate::distributed_task::complete_job_inner(
+        state.shared(),
+        preloop_gha_protocol::JobCompletion {
+            run_id,
+            job_id: preloop_gha_protocol::JobId(job_id.to_owned()),
+            status,
+            outputs: Default::default(),
+            annotations: Vec::new(),
+            step_results: Vec::new(),
+        },
+    )
+    .await
+    .expect("completion should succeed");
+}
+
+/// Read an SSE response body to its end, failing (rather than hanging the test
+/// run) if the stream does not close within a short window. A live-log stream
+/// that never ends is exactly the bug these tests guard against.
+async fn read_sse_to_end(response: Response) -> String {
+    let body = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        to_bytes(response.into_body(), usize::MAX),
+    )
+    .await
+    .expect("live-log stream must close, not hang")
+    .expect("body readable");
+    String::from_utf8_lossy(&body).into_owned()
+}
+
+async fn open_live(app: &axum::Router, uri: String) -> Response {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri(uri)
+                .header(header::AUTHORIZATION, "Bearer preloop-system-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn live_log_stream_ends_when_job_completes() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, jobs) = two_job_run_for_log_filters(&app, &state).await;
+    let build_uuid = jobs[0].2.clone();
+
+    // Emit a line so a follower has something, then open the stream.
+    crate::live_logs::record_live_log_wrapper(
+        &state.shared(),
+        &build_uuid,
+        preloop_gha_protocol::LiveLogFeedLinesWrapper {
+            step_id: "s1".into(),
+            start_line: 1,
+            count: 1,
+            value: vec!["building...".into()],
+        },
+    )
+    .await;
+
+    let response = open_live(&app, format!("/api/v1/runs/{run_id}/logs/live?job=build")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Complete the job on another task; the open stream must then end on its
+    // own, carrying the line that was already buffered.
+    let completer = {
+        let state = state.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            complete_job(&state, run_id, "build", ExecutionStatus::Success).await;
+        })
+    };
+    let body = read_sse_to_end(response).await;
+    completer.await.unwrap();
+    assert!(
+        body.contains("building..."),
+        "the buffered line must survive the close: {body}"
+    );
+}
+
+#[tokio::test]
+async fn live_log_stream_for_already_completed_job_serves_snapshot_and_ends() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, jobs) = two_job_run_for_log_filters(&app, &state).await;
+    let build_uuid = jobs[0].2.clone();
+
+    crate::live_logs::record_live_log_wrapper(
+        &state.shared(),
+        &build_uuid,
+        preloop_gha_protocol::LiveLogFeedLinesWrapper {
+            step_id: "s1".into(),
+            start_line: 1,
+            count: 1,
+            value: vec!["already done".into()],
+        },
+    )
+    .await;
+    // Complete BEFORE anyone connects — the late follower must still get the
+    // retained snapshot and then a clean end, never a hang.
+    complete_job(&state, run_id, "build", ExecutionStatus::Success).await;
+
+    let response = open_live(&app, format!("/api/v1/runs/{run_id}/logs/live?job=build")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = read_sse_to_end(response).await;
+    assert!(
+        body.contains("already done"),
+        "a late follower still gets the snapshot: {body}"
+    );
+}
+
+#[tokio::test]
+async fn live_log_stream_ends_on_cancellation() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, _jobs) = two_job_run_for_log_filters(&app, &state).await;
+
+    let response = open_live(&app, format!("/api/v1/runs/{run_id}/logs/live?job=build")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let completer = {
+        let state = state.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            // Cancellation is a terminal status and must close the feed too.
+            complete_job(&state, run_id, "build", ExecutionStatus::Cancelled).await;
+        })
+    };
+    // Completes only because the cancel closed the stream.
+    let _ = read_sse_to_end(response).await;
+    completer.await.unwrap();
+}
+
+#[tokio::test]
+async fn live_log_reopens_when_a_completed_job_streams_again() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, jobs) = two_job_run_for_log_filters(&app, &state).await;
+    let build_uuid = jobs[0].2.clone();
+
+    complete_job(&state, run_id, "build", ExecutionStatus::Failure).await;
+    // A retry reuses the agent job and streams fresh lines: the feed must
+    // reopen so a follower attaching now subscribes instead of ending early.
+    crate::live_logs::record_live_log_wrapper(
+        &state.shared(),
+        &build_uuid,
+        preloop_gha_protocol::LiveLogFeedLinesWrapper {
+            step_id: "retry".into(),
+            start_line: 1,
+            count: 1,
+            value: vec!["second attempt".into()],
+        },
+    )
+    .await;
+
+    {
+        let inner = state.inner.lock().await;
+        assert!(
+            !inner.live_log_closed.contains(&build_uuid),
+            "fresh ingest must clear the closed mark"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/preloop-runner-server/src/live_logs.rs
+++ b/crates/preloop-runner-server/src/live_logs.rs
@@ -61,6 +61,12 @@ impl LiveLogBuffer {
         self.compact_if_wasteful();
         true
     }
+    /// Discard a completed attempt's retained tail before a retry reuses the
+    /// same agent-job key, without changing the configured byte budget.
+    pub(crate) fn clear(&mut self) {
+        self.lines.clear();
+        self.bytes = 0;
+    }
 
     /// Reclaim `VecDeque` backing-buffer slack after evictions. `pop_front`
     /// never shrinks the allocation, so a batch of evictions can leave
@@ -135,20 +141,23 @@ pub(crate) async fn live_run_logs_sse(
         Some(job) => job,
         None => {
             let inner = shared.state.inner.lock().await;
-            if !inner.runs.contains_key(&run_id) {
-                return Err(ApiError::not_found("run not found"));
-            }
-            let mut jobs: Vec<&str> = inner
-                .job_requests
-                .values()
-                .filter(|request| request.run_id == run_id)
-                .map(|request| request.job_id.0.as_str())
-                .collect();
+            let run = inner
+                .runs
+                .get(&run_id)
+                .ok_or_else(|| ApiError::not_found("run not found"))?;
+            let mut jobs: Vec<String> = run.jobs.keys().map(|job_id| job_id.0.clone()).collect();
+            jobs.extend(
+                inner
+                    .job_requests
+                    .values()
+                    .filter(|request| request.run_id == run_id)
+                    .map(|request| request.job_id.0.clone()),
+            );
             jobs.sort_unstable();
             jobs.dedup();
             match jobs.len() {
                 0 => return Err(ApiError::not_found("run has no jobs to follow")),
-                1 => jobs[0].to_owned(),
+                1 => jobs.pop().expect("one job was counted"),
                 _ => {
                     return Err(ApiError::bad_request(format!(
                         "`job` needs a value when a run has {} jobs: {}",
@@ -164,35 +173,46 @@ pub(crate) async fn live_run_logs_sse(
 
 /// Replay the retained per-job buffer, then follow the live broadcast.
 ///
-/// Shared by both auth surfaces so the two never drift in what they emit.
+/// Snapshotting and subscribing happen while the global lock and the
+/// per-job lock are both held. Ingestion takes the same locks in that order,
+/// so a wrapper is observed either in the snapshot or in the receiver, never
+/// both.
 async fn live_log_stream(
     shared: &Arc<SharedState>,
     run_id: RunId,
     job_id: &str,
 ) -> Result<Sse<impl futures::Stream<Item = Result<Event, std::convert::Infallible>>>, ApiError> {
-    // Grab per-job handles under the global lock, then drop it immediately.
-    let (job_lines, rx) = {
+    let (snapshot, subscription) = {
         let mut inner = shared.state.inner.lock().await;
         let key = live_log_key_for_job(&inner, run_id, job_id)
             .ok_or_else(|| ApiError::not_found("job not found"))?;
         let lines_arc = inner.live_log_lines.entry(key.clone()).or_default().clone();
-        let tx = live_log_sender(&mut inner, &key);
-        (lines_arc, tx.subscribe())
+        let lines = lines_arc.lock().await;
+        let snapshot = lines.clone();
+        let subscription = if live_log_is_closed(&inner, run_id, job_id, &key) {
+            None
+        } else {
+            Some(live_log_sender(&mut inner, &key).subscribe())
+        };
+        // Keep the guard alive through subscription creation; this explicit
+        // binding makes the lock ordering above visible to future edits.
+        drop(lines);
+        (snapshot, subscription)
     };
-    // Snapshot under per-job lock only — does not block global state.
-    let snapshot = job_lines.lock().await.clone();
 
     let snapshot_stream = stream::iter(
         snapshot
             .into_iter()
             .map(|wrapper| Ok(live_log_sse_event(&wrapper))),
     );
-    let live_stream = stream::unfold(rx, |mut rx| async move {
+    let live_stream = stream::unfold(subscription, |subscription| async move {
+        // A closed job has no subscription: the snapshot is the whole stream.
+        let mut rx = subscription?;
         loop {
             match rx.recv().await {
                 Ok(wrapper) => {
                     let event = live_log_sse_event(&wrapper);
-                    return Some((Ok(event), rx));
+                    return Some((Ok(event), Some(rx)));
                 }
                 Err(broadcast::error::RecvError::Lagged(_)) => continue,
                 Err(broadcast::error::RecvError::Closed) => return None,
@@ -213,16 +233,37 @@ pub(crate) fn live_log_key_for_job(
     run_id: RunId,
     job_id: &str,
 ) -> Option<String> {
-    inner.runs.get(&run_id)?;
-    inner
-        .job_requests
-        .values()
-        .find(|record| {
-            record.run_id == run_id
-                && (record.job_id.0 == job_id || record.agent_job_id.to_string() == job_id)
-        })
-        .map(|record| record.agent_job_id.to_string())
-        .or_else(|| Some(job_id.to_string()).filter(|key| inner.live_log_lines.contains_key(key)))
+    let run = inner.runs.get(&run_id)?;
+    if let Some(record) = inner.job_requests.values().find(|record| {
+        record.run_id == run_id
+            && (record.job_id.0 == job_id || record.agent_job_id.to_string() == job_id)
+    }) {
+        return Some(record.agent_job_id.to_string());
+    }
+    // A logical job key is valid without a request only when it belongs to
+    // this run. Never accept an arbitrary globally present live-log key:
+    // UUIDs are only scoped by their job request and otherwise could leak a
+    // different run's output.
+    run.jobs
+        .contains_key(&JobId(job_id.to_owned()))
+        .then(|| job_id.to_owned())
+}
+
+/// Whether a live stream for this run/job must end after its snapshot.
+fn live_log_is_closed(inner: &InnerState, run_id: RunId, job_id: &str, key: &str) -> bool {
+    if inner.live_log_closed.contains(key) {
+        return true;
+    }
+    let run_terminal = inner
+        .runs
+        .get(&run_id)
+        .is_some_and(|run| run.status.is_terminal());
+    let logical_job_terminal = inner
+        .runs
+        .get(&run_id)
+        .and_then(|run| run.jobs.get(&JobId(job_id.to_owned())))
+        .is_some_and(|status| status.is_terminal());
+    run_terminal || logical_job_terminal
 }
 
 pub(crate) fn live_log_sender(
@@ -237,6 +278,21 @@ pub(crate) fn live_log_sender(
             tx
         })
         .clone()
+}
+
+/// Mark a job's live-log feed complete and drop its broadcast sender.
+///
+/// Dropping the last sender makes every current follower's `recv()` return
+/// `Closed`, so their streams end and `preloop logs -f` exits — no status
+/// polling. The `live_log_closed` mark is what handles a follower that arrives
+/// *after* completion: `live_log_stream` serves the retained snapshot and does
+/// not resubscribe, instead of `live_log_sender` lazily minting a fresh
+/// channel that would never speak again.
+///
+/// Idempotent, and safe to call for a job that never streamed a line.
+pub(crate) fn close_live_log(inner: &mut InnerState, key: &str) {
+    inner.live_log_closed.insert(key.to_string());
+    inner.live_log_tx.remove(key);
 }
 
 pub(crate) async fn ws_live_logs(
@@ -286,35 +342,57 @@ pub(crate) async fn handle_live_log_socket(
         }
     }
 }
-
+/// Record one live-log wrapper under a canonical run/job key.
+///
+/// The global and per-job locks are acquired in that order and held through
+/// the retained-buffer push and broadcast. `live_log_stream` uses the same
+/// ordering for its snapshot/subscription pair, which makes the handoff
+/// atomic from a follower's perspective.
 pub(crate) async fn record_live_log_wrapper(
     shared: &Arc<SharedState>,
     job_id: &str,
     wrapper: LiveLogFeedLinesWrapper,
 ) {
-    // Grab per-job Arc and broadcast sender under the global lock, then release it.
-    let (job_lines, tx) = {
-        let mut inner = shared.state.inner.lock().await;
-        let lines_arc = inner
-            .live_log_lines
-            .entry(job_id.to_string())
-            .or_default()
-            .clone();
-        let tx = live_log_sender(&mut inner, job_id);
-        (lines_arc, tx)
-    };
-    // Hold the per-job lock across both the buffer push and the broadcast send
-    // so concurrent ingestion cannot reorder live fan-out relative to the
+    let mut inner = shared.state.inner.lock().await;
+    // Fresh lines for a key we had marked complete mean the job is producing
+    // again (a retry reusing the same agent job). Reopen it and replace the
+    // prior attempt's retained tail before broadcasting.
+    let reopened = inner.live_log_closed.remove(job_id);
+    let lines_arc = inner
+        .live_log_lines
+        .entry(job_id.to_string())
+        .or_default()
+        .clone();
+    let tx = live_log_sender(&mut inner, job_id);
+    let mut lines = lines_arc.lock().await;
+    if reopened {
+        lines.clear();
+    }
+    // Hold the per-job lock across both the buffer push and the broadcast so
+    // concurrent ingestion cannot reorder live fan-out relative to the
     // retained tail. Reject oversized batches before cloning, then drop them
     // from both the retained buffer and the live fan-out so one pathological
     // frame cannot evict the tail or amplify across subscribers.
-    let mut lines = job_lines.lock().await;
     if lines.fits(&wrapper) {
         lines.push(wrapper.clone());
         let _ = tx.send(wrapper);
     } else {
         warn!(%job_id, "dropping live log batch exceeding per-job buffer cap");
     }
+}
+
+/// Resolve a logical job key to its run-scoped live-log key before recording.
+pub(crate) async fn record_live_log_wrapper_for_run(
+    shared: &Arc<SharedState>,
+    run_id: RunId,
+    job_id: &str,
+    wrapper: LiveLogFeedLinesWrapper,
+) {
+    let key = {
+        let inner = shared.state.inner.lock().await;
+        live_log_key_for_job(&inner, run_id, job_id).unwrap_or_else(|| job_id.to_owned())
+    };
+    record_live_log_wrapper(shared, &key, wrapper).await;
 }
 
 #[cfg(test)]

--- a/crates/preloop-runner-server/src/live_logs.rs
+++ b/crates/preloop-runner-server/src/live_logs.rs
@@ -104,10 +104,76 @@ pub(crate) async fn live_logs_sse(
     State(shared): State<Arc<SharedState>>,
     Path((run_id, job_id)): Path<(RunId, String)>,
 ) -> Result<Sse<impl futures::Stream<Item = Result<Event, std::convert::Infallible>>>, ApiError> {
+    live_log_stream(&shared, run_id, &job_id).await
+}
+
+/// Job selector for the native live-log route.
+///
+/// Mirrors `RunLogsQuery::job` so `--job` means the same thing whether the
+/// caller is reading a finished log or following a running one.
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct LiveLogsQuery {
+    #[serde(default)]
+    job: Option<String>,
+}
+
+/// Native-bearer live console feed for one job of a run.
+///
+/// The runner-protocol route above is reachable only with a runner or job
+/// token, which the CLI does not hold. This exposes the same feed to the
+/// native API principal — no new information, since that principal can already
+/// read the whole log through `GET /api/v1/runs/:run_id/logs`.
+///
+/// `job` may be omitted when the run has exactly one job; with more, the
+/// candidates are named rather than one being chosen arbitrarily.
+pub(crate) async fn live_run_logs_sse(
+    State(shared): State<Arc<SharedState>>,
+    Path(run_id): Path<RunId>,
+    Query(query): Query<LiveLogsQuery>,
+) -> Result<Sse<impl futures::Stream<Item = Result<Event, std::convert::Infallible>>>, ApiError> {
+    let job_id = match query.job {
+        Some(job) => job,
+        None => {
+            let inner = shared.state.inner.lock().await;
+            if !inner.runs.contains_key(&run_id) {
+                return Err(ApiError::not_found("run not found"));
+            }
+            let mut jobs: Vec<&str> = inner
+                .job_requests
+                .values()
+                .filter(|request| request.run_id == run_id)
+                .map(|request| request.job_id.0.as_str())
+                .collect();
+            jobs.sort_unstable();
+            jobs.dedup();
+            match jobs.len() {
+                0 => return Err(ApiError::not_found("run has no jobs to follow")),
+                1 => jobs[0].to_owned(),
+                _ => {
+                    return Err(ApiError::bad_request(format!(
+                        "`job` needs a value when a run has {} jobs: {}",
+                        jobs.len(),
+                        jobs.join(", ")
+                    )));
+                }
+            }
+        }
+    };
+    live_log_stream(&shared, run_id, &job_id).await
+}
+
+/// Replay the retained per-job buffer, then follow the live broadcast.
+///
+/// Shared by both auth surfaces so the two never drift in what they emit.
+async fn live_log_stream(
+    shared: &Arc<SharedState>,
+    run_id: RunId,
+    job_id: &str,
+) -> Result<Sse<impl futures::Stream<Item = Result<Event, std::convert::Infallible>>>, ApiError> {
     // Grab per-job handles under the global lock, then drop it immediately.
     let (job_lines, rx) = {
         let mut inner = shared.state.inner.lock().await;
-        let key = live_log_key_for_job(&inner, run_id, &job_id)
+        let key = live_log_key_for_job(&inner, run_id, job_id)
             .ok_or_else(|| ApiError::not_found("job not found"))?;
         let lines_arc = inner.live_log_lines.entry(key.clone()).or_default().clone();
         let tx = live_log_sender(&mut inner, &key);

--- a/crates/preloop-runner-server/src/models.rs
+++ b/crates/preloop-runner-server/src/models.rs
@@ -53,6 +53,31 @@ pub(crate) struct StepRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) finished_at: Option<chrono::DateTime<chrono::Utc>>,
 }
+impl StepRecord {
+    /// Match a step by stable runner identity, falling back to a unique name.
+    pub(crate) fn find_matching_index(
+        steps: &[Self],
+        id: &str,
+        name: &str,
+        allow_name_fallback: bool,
+    ) -> Option<usize> {
+        if !id.is_empty() {
+            if let Some(index) = steps.iter().position(|step| step.id.as_deref() == Some(id)) {
+                return Some(index);
+            }
+        }
+        if !allow_name_fallback {
+            return None;
+        }
+
+        let mut matches = steps
+            .iter()
+            .enumerate()
+            .filter(|(_, step)| step.name == name);
+        let first = matches.next()?;
+        matches.next().is_none().then_some(first.0)
+    }
+}
 
 /// Server-side timing for the workspace snapshot created at submission.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/preloop-runner-server/src/models.rs
+++ b/crates/preloop-runner-server/src/models.rs
@@ -36,6 +36,12 @@ pub(crate) struct DapPortRegistration {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct StepRecord {
+    /// Runner/timeline identity used to match a durable `step-*.txt` blob.
+    ///
+    /// Old persisted run records may not have this field, so log retrieval
+    /// falls back to the order available from the filesystem when it is absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) id: Option<String>,
     pub(crate) name: String,
     pub(crate) conclusion: String,
     /// Server-side observation of when the step first appeared (started) and

--- a/crates/preloop-runner-server/src/openapi.rs
+++ b/crates/preloop-runner-server/src/openapi.rs
@@ -386,7 +386,7 @@ fn get_run_logs() {}
         ("job" = Option<String>, Query, description = "Workflow job key or agent job UUID; required when the run has multiple jobs")
     ),
     responses(
-        (status = 200, content_type = "text/event-stream", description = "Live log events; the stream closes when the selected job and run are terminal", body = String),
+        (status = 200, content_type = "text/event-stream", description = "Live log events; the stream closes when the selected job is terminal", body = String),
         (status = 400, description = "Job is required when the run has multiple jobs", body = ApiErrorResponse),
         (status = 404, description = "Run or job not found", body = ApiErrorResponse)
     ),

--- a/crates/preloop-runner-server/src/openapi.rs
+++ b/crates/preloop-runner-server/src/openapi.rs
@@ -358,13 +358,19 @@ fn list_runs() {}
 )]
 fn get_run() {}
 
-/// Get formatted run logs (HTML).
+/// Get run logs as plain text, optionally narrowed to one job or step.
 #[utoipa::path(
     get, path = "/api/v1/runs/{run_id}/logs", tag = "Runs",
-    params(("run_id" = String, Path, description = "Run UUID")),
+    params(
+        ("run_id" = String, Path, description = "Run UUID"),
+        ("job" = Option<String>, Query, description = "Workflow job key or agent job UUID; omit for every job"),
+        ("step" = Option<usize>, Query, description = "1-based step index within the job, in execution order")
+    ),
     responses(
-        (status = 200, content_type = "text/html", description = "Rendered log page", body = String),
-        (status = 404, description = "Run not found", body = ApiErrorResponse)
+        (status = 200, content_type = "text/plain", description = "Merged log text", body = String),
+        (status = 400, description = "`step` given without `job` in a multi-job run", body = ApiErrorResponse),
+        (status = 404, description = "Run, job, or step not found", body = ApiErrorResponse),
+        (status = 409, description = "Job reported one merged log, which has no step boundaries", body = ApiErrorResponse)
     ),
     security(("native_bearer" = []))
 )]

--- a/crates/preloop-runner-server/src/openapi.rs
+++ b/crates/preloop-runner-server/src/openapi.rs
@@ -151,6 +151,7 @@ pub(crate) struct RunResponse {
         list_runs,
         get_run,
         get_run_logs,
+        live_run_logs,
         cancel_run,
         rerun_run,
         run_events,
@@ -374,7 +375,24 @@ fn get_run() {}
     ),
     security(("native_bearer" = []))
 )]
+
 fn get_run_logs() {}
+
+/// Follow one job's live console output as server-sent events.
+#[utoipa::path(
+    get, path = "/api/v1/runs/{run_id}/logs/live", tag = "Runs",
+    params(
+        ("run_id" = String, Path, description = "Run UUID"),
+        ("job" = Option<String>, Query, description = "Workflow job key or agent job UUID; required when the run has multiple jobs")
+    ),
+    responses(
+        (status = 200, content_type = "text/event-stream", description = "Live log events; the stream closes when the selected job and run are terminal", body = String),
+        (status = 400, description = "Job is required when the run has multiple jobs", body = ApiErrorResponse),
+        (status = 404, description = "Run or job not found", body = ApiErrorResponse)
+    ),
+    security(("native_bearer" = []))
+)]
+fn live_run_logs() {}
 
 /// Cancel a running workflow.
 #[utoipa::path(

--- a/crates/preloop-runner-server/src/results_twirp.rs
+++ b/crates/preloop-runner-server/src/results_twirp.rs
@@ -92,6 +92,12 @@ pub(crate) async fn twirp_workflow_steps_update(
                             .map(str::to_owned)
                             .or_else(|| step_uuid.and_then(|suuid| step_names.get(&suuid).cloned()))
                             .unwrap_or_default();
+                        let duplicate_name = !name.is_empty()
+                            && steps
+                                .iter()
+                                .filter(|candidate| candidate["name"].as_str() == Some(&name))
+                                .count()
+                                > 1;
 
                         let conclusion_num = step["conclusion"].as_u64().unwrap_or(0);
                         let status_num = step["status"].as_u64().unwrap_or(0);
@@ -116,7 +122,12 @@ pub(crate) async fn twirp_workflow_steps_update(
                         let terminal = status_num == 6;
                         let observed = chrono::Utc::now();
 
-                        if let Some(pos) = job_detail.steps.iter().position(|s| s.name == name) {
+                        if let Some(pos) = StepRecord::find_matching_index(
+                            &job_detail.steps,
+                            external_id_str,
+                            &name,
+                            !duplicate_name,
+                        ) {
                             if !external_id_str.is_empty() {
                                 job_detail.steps[pos].id = Some(external_id_str.to_owned());
                             }
@@ -134,6 +145,7 @@ pub(crate) async fn twirp_workflow_steps_update(
                             // - already terminal → record finished_at only
                             //   (do not invent started_at == finished_at, which
                             //   forces duration 0 for fast steps that complete
+                            //   before any in-progress update is processed)
                             job_detail.steps.push(StepRecord {
                                 id: (!external_id_str.is_empty())
                                     .then(|| external_id_str.to_owned()),

--- a/crates/preloop-runner-server/src/results_twirp.rs
+++ b/crates/preloop-runner-server/src/results_twirp.rs
@@ -117,6 +117,9 @@ pub(crate) async fn twirp_workflow_steps_update(
                         let observed = chrono::Utc::now();
 
                         if let Some(pos) = job_detail.steps.iter().position(|s| s.name == name) {
+                            if !external_id_str.is_empty() {
+                                job_detail.steps[pos].id = Some(external_id_str.to_owned());
+                            }
                             job_detail.steps[pos].conclusion = conclusion_str.to_owned();
                             // First non-terminal sighting is the start signal.
                             if !terminal && job_detail.steps[pos].started_at.is_none() {
@@ -131,8 +134,9 @@ pub(crate) async fn twirp_workflow_steps_update(
                             // - already terminal → record finished_at only
                             //   (do not invent started_at == finished_at, which
                             //   forces duration 0 for fast steps that complete
-                            //   before any in-progress update is processed)
                             job_detail.steps.push(StepRecord {
+                                id: (!external_id_str.is_empty())
+                                    .then(|| external_id_str.to_owned()),
                                 name,
                                 conclusion: conclusion_str.to_owned(),
                                 started_at: (!terminal).then_some(observed),

--- a/crates/preloop-runner-server/src/routes.rs
+++ b/crates/preloop-runner-server/src/routes.rs
@@ -455,6 +455,13 @@ pub(crate) fn build_app(
             )),
         )
         .route(
+            "/api/v1/runs/:run_id/logs/live",
+            get(crate::live_logs::live_run_logs_sse).route_layer(middleware::from_fn_with_state(
+                shared.clone(),
+                require_native_bearer,
+            )),
+        )
+        .route(
             "/api/v1/runs/:run_id/cancel",
             post(cancel_run).route_layer(middleware::from_fn_with_state(
                 shared.clone(),

--- a/crates/preloop-runner-server/src/runs.rs
+++ b/crates/preloop-runner-server/src/runs.rs
@@ -2269,6 +2269,17 @@ pub(crate) struct RunLogsQuery {
     step: Option<usize>,
 }
 
+/// Files uploaded for one job's individual steps.
+///
+/// `all` preserves upload order for an unfiltered request. `workflow` maps the
+/// user-visible workflow-step order to those files; an entry is `None` when a
+/// step produced no log blob. Keeping both views matters because synthetic
+/// setup/cleanup records can be uploaded alongside user steps.
+struct StepLogs {
+    all: Vec<std::path::PathBuf>,
+    workflow: Option<Vec<Option<std::path::PathBuf>>>,
+}
+
 /// One job's log material, in execution order.
 ///
 /// The variants are the three tiers `get_run_logs` already resolved inline;
@@ -2278,32 +2289,42 @@ enum JobLogs {
     /// The runner uploaded one merged log. Step boundaries are not recoverable
     /// from it, so `?step=` cannot be honored.
     Merged(Vec<u8>),
-    /// Per-step log files, ordered as they ran.
-    Steps(Vec<std::path::PathBuf>),
+    /// Per-step log files, with a workflow-order view for `?step=`.
+    Steps(StepLogs),
     /// Nothing on disk yet: in-memory console blocks for a job still running,
     /// already ordered by numeric console log id (one per step).
     Live(Vec<Vec<u8>>),
 }
 
-/// Resolve one job's logs through the tier fallback: merged upload, then
-/// per-step uploads, then the in-memory console feed.
+/// Resolve one job's logs through the tier fallback.
+///
+/// Unfiltered requests prefer the merged upload because it is the runner's
+/// authoritative whole-job representation. A step-filtered request prefers
+/// individual step blobs when both are present; the merged upload has no
+/// recoverable boundaries and is only used to produce the explicit 409.
 async fn resolve_job_logs(
     results_dir: &std::path::Path,
     fallback_blocks: Vec<Vec<u8>>,
+    workflow_step_ids: Option<&[String]>,
+    prefer_steps: bool,
 ) -> Result<JobLogs, ApiError> {
-    let results_log = results_dir.join("job-logs.txt");
-    match tokio::fs::read(&results_log).await {
-        Ok(contents) => return Ok(JobLogs::Merged(contents)),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+    let merged = match tokio::fs::read(results_dir.join("job-logs.txt")).await {
+        Ok(contents) => Some(contents),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
         Err(error) => {
             return Err(ApiError::internal(format!(
                 "failed to read run log `{}`: {error}",
-                results_log.display()
+                results_dir.join("job-logs.txt").display()
             )));
+        }
+    };
+    if !prefer_steps {
+        if let Some(contents) = merged {
+            return Ok(JobLogs::Merged(contents));
         }
     }
 
-    let mut step_logs = Vec::new();
+    let mut step_files = Vec::new();
     match tokio::fs::read_dir(results_dir).await {
         Ok(mut entries) => {
             while let Some(entry) = entries.next_entry().await.map_err(|error| {
@@ -2326,8 +2347,13 @@ async fn resolve_job_logs(
                 if !metadata.is_file() {
                     continue;
                 }
+                let step_id = name
+                    .strip_prefix("step-")
+                    .and_then(|name| name.strip_suffix(".txt"))
+                    .unwrap_or_default()
+                    .to_owned();
                 let modified = metadata.modified().unwrap_or(std::time::UNIX_EPOCH);
-                step_logs.push((modified, name.into_owned(), entry.path()));
+                step_files.push((modified, name.into_owned(), step_id, entry.path()));
             }
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
@@ -2338,23 +2364,39 @@ async fn resolve_job_logs(
             )));
         }
     }
-    step_logs.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
+    step_files.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
 
-    if step_logs.is_empty() {
-        Ok(JobLogs::Live(fallback_blocks))
-    } else {
-        Ok(JobLogs::Steps(
-            step_logs.into_iter().map(|(_, _, path)| path).collect(),
-        ))
+    if !step_files.is_empty() {
+        let workflow = workflow_step_ids.filter(|ids| !ids.is_empty()).map(|ids| {
+            ids.iter()
+                .map(|id| {
+                    step_files
+                        .iter()
+                        .find(|(_, _, file_id, _)| file_id == id)
+                        .map(|(_, _, _, path)| path.clone())
+                })
+                .collect()
+        });
+        return Ok(JobLogs::Steps(StepLogs {
+            all: step_files.into_iter().map(|(_, _, _, path)| path).collect(),
+            workflow,
+        }));
     }
+
+    // A step query with only a merged upload must be rejected by append_step;
+    // do not silently turn it into a whole-job response.
+    if let Some(contents) = merged {
+        return Ok(JobLogs::Merged(contents));
+    }
+    Ok(JobLogs::Live(fallback_blocks))
 }
 
-/// Append every step of a job, in order.
+/// Append every step of a job, in upload/execution order.
 async fn append_all(logs: JobLogs, merged: &mut Vec<u8>) -> Result<(), ApiError> {
     match logs {
         JobLogs::Merged(contents) => merged.extend_from_slice(&contents),
-        JobLogs::Steps(paths) => {
-            for path in paths {
+        JobLogs::Steps(step_logs) => {
+            for path in step_logs.all {
                 let contents = tokio::fs::read(&path).await.map_err(|error| {
                     ApiError::internal(format!(
                         "failed to read result log `{}`: {error}",
@@ -2373,7 +2415,7 @@ async fn append_all(logs: JobLogs, merged: &mut Vec<u8>) -> Result<(), ApiError>
     Ok(())
 }
 
-/// Append exactly the `step`th (1-based) step of a job.
+/// Append exactly the `step`th (1-based) workflow step of a job.
 async fn append_step(
     logs: JobLogs,
     step: usize,
@@ -2393,13 +2435,26 @@ async fn append_step(
             "job `{job_label}` reported one merged log, which carries no step \
              boundaries; re-request without `step` for the whole job log"
         ))),
-        JobLogs::Steps(paths) => {
-            let total = paths.len();
-            let path = paths.into_iter().nth(index).ok_or_else(|| {
-                ApiError::not_found(format!(
+        JobLogs::Steps(step_logs) => {
+            let (total, path) = match step_logs.workflow {
+                Some(workflow) => {
+                    let total = workflow.len();
+                    (total, workflow.get(index).cloned().flatten())
+                }
+                None => {
+                    let total = step_logs.all.len();
+                    (total, step_logs.all.get(index).cloned())
+                }
+            };
+            let Some(path) = path else {
+                if index < total {
+                    // A valid workflow step is allowed to have no log blob.
+                    return Ok(());
+                }
+                return Err(ApiError::not_found(format!(
                     "job `{job_label}` has {total} steps; step {step} is out of range"
-                ))
-            })?;
+                )));
+            };
             let contents = tokio::fs::read(&path).await.map_err(|error| {
                 ApiError::internal(format!(
                     "failed to read result log `{}`: {error}",
@@ -2485,6 +2540,32 @@ pub(crate) async fn get_run_logs(
                         (Err(_), Err(_)) => left.cmp(right),
                     }
                 });
+                let workflow_step_ids = inner
+                    .broker_messages
+                    .get(&request.request_id)
+                    .map(|message| {
+                        message
+                            .steps
+                            .iter()
+                            .map(|step| step.id.to_string())
+                            .collect::<Vec<_>>()
+                    })
+                    .filter(|ids| !ids.is_empty())
+                    .or_else(|| {
+                        inner.runs.get(&run_id).and_then(|run| {
+                            run.jobs_list
+                                .iter()
+                                .find(|detail| detail.name == request.job_id.0)
+                                .map(|detail| {
+                                    detail
+                                        .steps
+                                        .iter()
+                                        .filter_map(|step| step.id.clone())
+                                        .collect::<Vec<_>>()
+                                })
+                                .filter(|ids| !ids.is_empty())
+                        })
+                    });
                 (
                     request.plan_id.clone(),
                     request.agent_job_id.to_string(),
@@ -2493,6 +2574,7 @@ pub(crate) async fn get_run_logs(
                         .into_iter()
                         .map(|(_, block)| block.to_vec())
                         .collect::<Vec<_>>(),
+                    workflow_step_ids,
                 )
             })
             .collect::<Vec<_>>();
@@ -2500,13 +2582,19 @@ pub(crate) async fn get_run_logs(
     };
 
     let mut merged = Vec::new();
-    for (plan_id, agent_job_id, job_label, fallback_blocks) in sources {
+    for (plan_id, agent_job_id, job_label, fallback_blocks, workflow_step_ids) in sources {
         let results_dir = state_dir
             .join("replay")
             .join("results")
             .join(plan_id)
             .join(agent_job_id);
-        let logs = resolve_job_logs(&results_dir, fallback_blocks).await?;
+        let logs = resolve_job_logs(
+            &results_dir,
+            fallback_blocks,
+            workflow_step_ids.as_deref(),
+            query.step.is_some(),
+        )
+        .await?;
         match query.step {
             Some(step) => append_step(logs, step, &job_label, &mut merged).await?,
             None => append_all(logs, &mut merged).await?,

--- a/crates/preloop-runner-server/src/runs.rs
+++ b/crates/preloop-runner-server/src/runs.rs
@@ -2253,9 +2253,179 @@ pub(crate) async fn list_runs(
     Ok(Json(runs))
 }
 
+/// Optional filters for `GET /api/v1/runs/:run_id/logs`.
+///
+/// Both are absent for the historical whole-run behavior, so an unfiltered
+/// request still returns every job's log merged in request order.
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct RunLogsQuery {
+    /// Workflow job key (`job_id`) or the agent job UUID. Matched exactly as
+    /// the live-log feed matches it, so the same value works for both.
+    #[serde(default)]
+    job: Option<String>,
+    /// 1-based index into the job's step logs, in execution order. Mirrors
+    /// `preloop debug --from`, which also counts user-visible steps from 1.
+    #[serde(default)]
+    step: Option<usize>,
+}
+
+/// One job's log material, in execution order.
+///
+/// The variants are the three tiers `get_run_logs` already resolved inline;
+/// naming them is what lets `?step=` reject the one tier that cannot answer
+/// it instead of silently returning the whole job.
+enum JobLogs {
+    /// The runner uploaded one merged log. Step boundaries are not recoverable
+    /// from it, so `?step=` cannot be honored.
+    Merged(Vec<u8>),
+    /// Per-step log files, ordered as they ran.
+    Steps(Vec<std::path::PathBuf>),
+    /// Nothing on disk yet: in-memory console blocks for a job still running,
+    /// already ordered by numeric console log id (one per step).
+    Live(Vec<Vec<u8>>),
+}
+
+/// Resolve one job's logs through the tier fallback: merged upload, then
+/// per-step uploads, then the in-memory console feed.
+async fn resolve_job_logs(
+    results_dir: &std::path::Path,
+    fallback_blocks: Vec<Vec<u8>>,
+) -> Result<JobLogs, ApiError> {
+    let results_log = results_dir.join("job-logs.txt");
+    match tokio::fs::read(&results_log).await {
+        Ok(contents) => return Ok(JobLogs::Merged(contents)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(ApiError::internal(format!(
+                "failed to read run log `{}`: {error}",
+                results_log.display()
+            )));
+        }
+    }
+
+    let mut step_logs = Vec::new();
+    match tokio::fs::read_dir(results_dir).await {
+        Ok(mut entries) => {
+            while let Some(entry) = entries.next_entry().await.map_err(|error| {
+                ApiError::internal(format!(
+                    "failed to enumerate result logs `{}`: {error}",
+                    results_dir.display()
+                ))
+            })? {
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                if !name.starts_with("step-") || !name.ends_with(".txt") {
+                    continue;
+                }
+                let metadata = entry.metadata().await.map_err(|error| {
+                    ApiError::internal(format!(
+                        "failed to inspect result log `{}`: {error}",
+                        entry.path().display()
+                    ))
+                })?;
+                if !metadata.is_file() {
+                    continue;
+                }
+                let modified = metadata.modified().unwrap_or(std::time::UNIX_EPOCH);
+                step_logs.push((modified, name.into_owned(), entry.path()));
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(ApiError::internal(format!(
+                "failed to enumerate result logs `{}`: {error}",
+                results_dir.display()
+            )));
+        }
+    }
+    step_logs.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
+
+    if step_logs.is_empty() {
+        Ok(JobLogs::Live(fallback_blocks))
+    } else {
+        Ok(JobLogs::Steps(
+            step_logs.into_iter().map(|(_, _, path)| path).collect(),
+        ))
+    }
+}
+
+/// Append every step of a job, in order.
+async fn append_all(logs: JobLogs, merged: &mut Vec<u8>) -> Result<(), ApiError> {
+    match logs {
+        JobLogs::Merged(contents) => merged.extend_from_slice(&contents),
+        JobLogs::Steps(paths) => {
+            for path in paths {
+                let contents = tokio::fs::read(&path).await.map_err(|error| {
+                    ApiError::internal(format!(
+                        "failed to read result log `{}`: {error}",
+                        path.display()
+                    ))
+                })?;
+                merged.extend_from_slice(&contents);
+            }
+        }
+        JobLogs::Live(blocks) => {
+            for block in blocks {
+                merged.extend_from_slice(&block);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Append exactly the `step`th (1-based) step of a job.
+async fn append_step(
+    logs: JobLogs,
+    step: usize,
+    job_label: &str,
+    merged: &mut Vec<u8>,
+) -> Result<(), ApiError> {
+    if step == 0 {
+        return Err(ApiError::bad_request(
+            "step is 1-based; use `--step 1` for the first step",
+        ));
+    }
+    let index = step - 1;
+    match logs {
+        // Refusing beats guessing: the merged upload has no step boundaries,
+        // so any answer here would be the whole job wearing a step's name.
+        JobLogs::Merged(_) => Err(ApiError::conflict(format!(
+            "job `{job_label}` reported one merged log, which carries no step \
+             boundaries; re-request without `step` for the whole job log"
+        ))),
+        JobLogs::Steps(paths) => {
+            let total = paths.len();
+            let path = paths.into_iter().nth(index).ok_or_else(|| {
+                ApiError::not_found(format!(
+                    "job `{job_label}` has {total} steps; step {step} is out of range"
+                ))
+            })?;
+            let contents = tokio::fs::read(&path).await.map_err(|error| {
+                ApiError::internal(format!(
+                    "failed to read result log `{}`: {error}",
+                    path.display()
+                ))
+            })?;
+            merged.extend_from_slice(&contents);
+            Ok(())
+        }
+        JobLogs::Live(blocks) => {
+            let total = blocks.len();
+            let block = blocks.into_iter().nth(index).ok_or_else(|| {
+                ApiError::not_found(format!(
+                    "job `{job_label}` has {total} steps so far; step {step} is out of range"
+                ))
+            })?;
+            merged.extend_from_slice(&block);
+            Ok(())
+        }
+    }
+}
+
 pub(crate) async fn get_run_logs(
     State(shared): State<Arc<SharedState>>,
     Path(run_id): Path<RunId>,
+    Query(query): Query<RunLogsQuery>,
 ) -> Result<Response, ApiError> {
     let (state_dir, sources) = {
         let inner = shared.state.inner.lock().await;
@@ -2269,6 +2439,32 @@ pub(crate) async fn get_run_logs(
             .filter(|request| request.run_id == run_id)
             .collect();
         requests.sort_by_key(|request| request.request_id);
+
+        if let Some(job) = &query.job {
+            // Same matching rule as the live-log feed: workflow job key or
+            // agent job UUID, so one value works across both surfaces.
+            requests.retain(|request| {
+                request.job_id.0 == *job || request.agent_job_id.to_string() == *job
+            });
+            if requests.is_empty() {
+                return Err(ApiError::not_found(format!(
+                    "job `{job}` not found in this run"
+                )));
+            }
+        } else if query.step.is_some() && requests.len() > 1 {
+            // Numbering restarts per job, so an unqualified step in a
+            // multi-job run names more than one thing.
+            let jobs: Vec<&str> = requests
+                .iter()
+                .map(|request| request.job_id.0.as_str())
+                .collect();
+            return Err(ApiError::bad_request(format!(
+                "`step` needs `job` when a run has {} jobs: {}",
+                jobs.len(),
+                jobs.join(", ")
+            )));
+        }
+
         let sources = requests
             .into_iter()
             .map(|request| {
@@ -2292,6 +2488,7 @@ pub(crate) async fn get_run_logs(
                 (
                     request.plan_id.clone(),
                     request.agent_job_id.to_string(),
+                    request.job_id.0.clone(),
                     blocks
                         .into_iter()
                         .map(|(_, block)| block.to_vec())
@@ -2303,75 +2500,16 @@ pub(crate) async fn get_run_logs(
     };
 
     let mut merged = Vec::new();
-    for (plan_id, agent_job_id, fallback_blocks) in sources {
+    for (plan_id, agent_job_id, job_label, fallback_blocks) in sources {
         let results_dir = state_dir
             .join("replay")
             .join("results")
             .join(plan_id)
             .join(agent_job_id);
-        let results_log = results_dir.join("job-logs.txt");
-        match tokio::fs::read(&results_log).await {
-            Ok(contents) => merged.extend_from_slice(&contents),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                let mut step_logs = Vec::new();
-                match tokio::fs::read_dir(&results_dir).await {
-                    Ok(mut entries) => {
-                        while let Some(entry) = entries.next_entry().await.map_err(|error| {
-                            ApiError::internal(format!(
-                                "failed to enumerate result logs `{}`: {error}",
-                                results_dir.display()
-                            ))
-                        })? {
-                            let name = entry.file_name();
-                            let name = name.to_string_lossy();
-                            if !name.starts_with("step-") || !name.ends_with(".txt") {
-                                continue;
-                            }
-                            let metadata = entry.metadata().await.map_err(|error| {
-                                ApiError::internal(format!(
-                                    "failed to inspect result log `{}`: {error}",
-                                    entry.path().display()
-                                ))
-                            })?;
-                            if !metadata.is_file() {
-                                continue;
-                            }
-                            let modified = metadata.modified().unwrap_or(std::time::UNIX_EPOCH);
-                            step_logs.push((modified, name.into_owned(), entry.path()));
-                        }
-                    }
-                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                    Err(error) => {
-                        return Err(ApiError::internal(format!(
-                            "failed to enumerate result logs `{}`: {error}",
-                            results_dir.display()
-                        )));
-                    }
-                }
-                step_logs
-                    .sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
-                if step_logs.is_empty() {
-                    for block in fallback_blocks {
-                        merged.extend_from_slice(&block);
-                    }
-                } else {
-                    for (_, _, path) in step_logs {
-                        let contents = tokio::fs::read(&path).await.map_err(|error| {
-                            ApiError::internal(format!(
-                                "failed to read result log `{}`: {error}",
-                                path.display()
-                            ))
-                        })?;
-                        merged.extend_from_slice(&contents);
-                    }
-                }
-            }
-            Err(error) => {
-                return Err(ApiError::internal(format!(
-                    "failed to read run log `{}`: {error}",
-                    results_log.display()
-                )));
-            }
+        let logs = resolve_job_logs(&results_dir, fallback_blocks).await?;
+        match query.step {
+            Some(step) => append_step(logs, step, &job_label, &mut merged).await?,
+            None => append_all(logs, &mut merged).await?,
         }
     }
 

--- a/crates/preloop-runner-server/src/runtime_scheduling.rs
+++ b/crates/preloop-runner-server/src/runtime_scheduling.rs
@@ -2670,6 +2670,7 @@ pub(crate) fn retire_node_requests(
                 let agent_key = record.agent_job_id.to_string();
                 inner.live_log_lines.remove(&agent_key);
                 inner.live_log_tx.remove(&agent_key);
+                inner.live_log_closed.remove(&agent_key);
             }
         }
     }

--- a/crates/preloop-runner-server/src/state.rs
+++ b/crates/preloop-runner-server/src/state.rs
@@ -243,6 +243,19 @@ pub struct SharedState {
     pub shutdown: CancellationToken,
 }
 
+#[cfg(test)]
+impl AppState {
+    /// Wrap this state in a `SharedState` for tests that call handlers taking
+    /// `&Arc<SharedState>` directly. Each call makes a fresh token; tests that
+    /// need shutdown coordination build the struct explicitly.
+    pub(crate) fn shared(&self) -> std::sync::Arc<SharedState> {
+        std::sync::Arc::new(SharedState {
+            state: self.clone(),
+            shutdown: CancellationToken::new(),
+        })
+    }
+}
+
 /// Who may register a runner with the control plane.
 ///
 /// `Strict` is the default and the only safe choice for a deployment reachable
@@ -1384,6 +1397,11 @@ pub(crate) struct InnerState {
     pub(crate) timeline_records: BTreeMap<String, BTreeMap<uuid::Uuid, azdo::TimelineRecord>>,
     pub(crate) live_log_lines: BTreeMap<String, Arc<tokio::sync::Mutex<LiveLogBuffer>>>,
     pub(crate) live_log_tx: BTreeMap<String, broadcast::Sender<LiveLogFeedLinesWrapper>>,
+    /// Live-log keys whose job has reached a terminal state. A follower that
+    /// connects at or after completion serves the retained snapshot and then
+    /// ends, instead of subscribing to a channel that will never speak again.
+    /// Cleared if the same key ingests fresh lines (a retry reusing the job).
+    pub(crate) live_log_closed: std::collections::BTreeSet<String>,
     pub(crate) inflight_requests: BTreeMap<i64, (RunId, JobId)>,
     pub(crate) job_requests: BTreeMap<i64, TaskAgentJobRequestRecord>,
     pub(crate) plan_requests: BTreeMap<String, i64>,

--- a/crates/preloop-runner-server/src/timeline_logs.rs
+++ b/crates/preloop-runner-server/src/timeline_logs.rs
@@ -174,6 +174,7 @@ pub(crate) async fn patch_timeline_records(
                     let observed = chrono::Utc::now();
 
                     if let Some(pos) = job_detail.steps.iter().position(|s| s.name == *name) {
+                        job_detail.steps[pos].id = Some(record.id.to_string());
                         job_detail.steps[pos].conclusion = conclusion_str.to_owned();
                         if let Some(started_at) = started_at {
                             job_detail.steps[pos].started_at = Some(started_at);
@@ -183,6 +184,7 @@ pub(crate) async fn patch_timeline_records(
                         }
                     } else {
                         job_detail.steps.push(StepRecord {
+                            id: Some(record.id.to_string()),
                             name: name.clone(),
                             conclusion: conclusion_str.to_owned(),
                             started_at: started_at.or(Some(observed)),
@@ -406,15 +408,24 @@ pub(crate) async fn console_log(
     )>,
     body: Bytes,
 ) -> StatusCode {
-    // Parse the body as a LiveLogFeedLinesWrapper and store/broadcast it.
+    // Resolve the callback to the run-scoped agent-job key. Falling back to
+    // the plan id preserves compatibility for callbacks that arrive before a
+    // request record exists.
     if let Ok(wrapper) = serde_json::from_slice::<LiveLogFeedLinesWrapper>(&body) {
-        let job_id = {
+        let resolved = {
             let inner = shared.state.inner.lock().await;
             resolve_callback_job(&inner, &plan_id, None, None)
-                .map(|(_, _, job_id)| job_id.0.clone())
-                .unwrap_or_else(|| plan_id.clone())
+                .map(|(_, run_id, job_id)| (run_id, job_id.0))
         };
-        record_live_log_wrapper(&shared, &job_id, wrapper).await;
+        match resolved {
+            Some((run_id, job_id)) => {
+                crate::live_logs::record_live_log_wrapper_for_run(
+                    &shared, run_id, &job_id, wrapper,
+                )
+                .await;
+            }
+            None => crate::live_logs::record_live_log_wrapper(&shared, &plan_id, wrapper).await,
+        }
     }
     StatusCode::OK
 }

--- a/crates/preloop-runner-server/src/timeline_logs.rs
+++ b/crates/preloop-runner-server/src/timeline_logs.rs
@@ -173,8 +173,12 @@ pub(crate) async fn patch_timeline_records(
                         .map(|t| t.with_timezone(&chrono::Utc));
                     let observed = chrono::Utc::now();
 
-                    if let Some(pos) = job_detail.steps.iter().position(|s| s.name == *name) {
-                        job_detail.steps[pos].id = Some(record.id.to_string());
+                    if let Some(pos) = StepRecord::find_matching_index(
+                        &job_detail.steps,
+                        &record.id.to_string(),
+                        name,
+                        true,
+                    ) {
                         job_detail.steps[pos].conclusion = conclusion_str.to_owned();
                         if let Some(started_at) = started_at {
                             job_detail.steps[pos].started_at = Some(started_at);

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -79,7 +79,7 @@ No flags.
 |---|---|
 | `--job <JOB>` | Narrow to one job: the workflow job key (`build`) or its agent job UUID |
 | `--step <STEP>` | Narrow to one 1-based step within the job, in execution order |
-| `-f`, `--follow` | Stream output as it arrives and exit when the run reaches a terminal state |
+| `-f`, `--follow` | Stream one job's output and exit when that job finishes |
 
 Without flags, every job's log is merged in job-request order.
 
@@ -90,9 +90,10 @@ boundaries; asking for a step there fails with `409` rather than returning the
 whole job under a step's name.
 
 `--follow` tracks one job's live console feed, so it needs `--job` unless the
-run has exactly one job. It replays the retained buffer before going live, so a
-late follower still sees earlier output, and it cannot be combined with
-`--step` (the feed carries whole steps as they stream).
+run has exactly one job. It replays the retained buffer before going live, then
+exits when that selected job completes. If the job is already complete, it
+returns the available durable log instead. It cannot be combined with `--step`
+(the feed carries whole steps as they stream).
 
 ```bash
 preloop logs                          # whole latest run

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -77,8 +77,29 @@ No flags.
 
 | Flag | Description |
 |---|---|
-| `--job <JOB>` | Filter by job ID |
-| `--step <STEP>` | Filter by step number |
+| `--job <JOB>` | Narrow to one job: the workflow job key (`build`) or its agent job UUID |
+| `--step <STEP>` | Narrow to one 1-based step within the job, in execution order |
+| `-f`, `--follow` | Stream output as it arrives and exit when the run reaches a terminal state |
+
+Without flags, every job's log is merged in job-request order.
+
+`--step` counts user-visible steps from 1, matching `preloop debug --from`. It
+needs `--job` when a run has more than one job, because numbering restarts per
+job. A job whose runner uploaded a single merged log has no recoverable step
+boundaries; asking for a step there fails with `409` rather than returning the
+whole job under a step's name.
+
+`--follow` tracks one job's live console feed, so it needs `--job` unless the
+run has exactly one job. It replays the retained buffer before going live, so a
+late follower still sees earlier output, and it cannot be combined with
+`--step` (the feed carries whole steps as they stream).
+
+```bash
+preloop logs                          # whole latest run
+preloop logs --job test               # just the `test` job
+preloop logs --job test --step 3      # just that job's third step
+preloop logs -f --job test            # tail it live
+```
 
 ## `preloop cancel [RUN_ID]`
 


### PR DESCRIPTION
## What & why

`preloop logs --job X --step N` advertised both filters in `--help`, but they were dead on arrival:

```
no filter      : 33153 bytes
--job bogus    : 33153 bytes
--step 999     : 33153 bytes
>>> IDENTICAL - filters silently ignored
```

`LogsArgs` declared `job`/`step` and `cmd_logs` never read them; `get_run_logs` took no query extractor at all. Any value returned the whole merged run log, exit 0, no warning. The only coverage was a clap parse assertion (`logs_filters`), which validated argument wiring rather than filtering — which is why it went unnoticed.

This makes both filters real and adds `-f`/`--follow`.

**Server** — `GET /api/v1/runs/:run_id/logs` accepts `job` and `step`:

- `job` matches the workflow job key **or** the agent job UUID, reusing the rule `live_log_key_for_job` already applies, so one value works on both log surfaces.
- `step` is a 1-based index into the job's steps in execution order, matching `preloop debug --from`.

The three log tiers are now named (`JobLogs::{Merged,Steps,Live}`) instead of being resolved inline, because only two of them can answer a step query:

- A job whose runner uploaded one merged `job-logs.txt` has **no recoverable step boundaries** → `409`, rather than returning the whole job under a step's name.
- Step numbering restarts per job, so `step` without `job` in a multi-job run → `400` naming the candidates.

**CLI** — `-f`/`--follow` streams a job's live console feed and exits when the run reaches a terminal state. It consumes SSE rather than polling and diffing the whole log: the feed already replays its retained buffer before going live, so a late follower still sees earlier output.

That required a native-bearer route. The existing `/api/v1/runs/:run_id/jobs/:job_id/logs/live` sits in the runner-protocol auth group and `401`s the CLI's token:

```
$ curl -H "Authorization: Bearer <native>" .../jobs/build/logs/live
401 {"error":"runner or job protocol token required"}
```

`/api/v1/runs/:run_id/logs/live` exposes the same stream to the native principal. This grants no new information — that principal can already read the full log via `/logs`. Both handlers share one `live_log_stream` so they cannot drift, and job selection lives server-side (defaults a single-job run, names candidates otherwise) so `?job=` means the same thing streaming or not.

`--follow` with `--step` is refused: the feed carries whole steps as they stream, so honoring both is impossible.

Also corrects the OpenAPI entry for this route, which claimed `text/html` "Rendered log page" for a handler that has always returned `text/plain`.

## Protocol surface

- [x] I confirm this change touches the runner protocol interface: **NO**

Everything here is on the native `/api/v1/…` management surface. No registration or `/_apis/…` shapes, no broker or NDJSON events, no Twirp results/artifact payloads, no check-run or OAuth behavior.

`live_logs_sse` (runner-protocol group) had its body extracted into `live_log_stream`, but its route, auth, and emitted bytes are unchanged — the refactor is behavior-preserving and covered by the pre-existing live-log tests.

## Required gates

- [x] `just test-ci` passes locally — **with one pre-existing exception, see below**
- [ ] If protocol/wire shapes changed: validated against the official runner — **N/A**, no protocol change
- [ ] Property tests extended — **N/A**, log retrieval has no property suite (those cover concurrency, scheduling, and events)
- [x] New wire fields/events are additive and serde-defaulted — `RunLogsQuery` and `LiveLogsQuery` fields are `Option` + `#[serde(default)]`; an unfiltered request is byte-identical to before
- [x] No secrets, credentials, or internal/deployment-specific paths introduced

### Pre-existing `zizmor` failure, not from this change

`just test-ci` fails at the `zizmor` step on stale `Swatinem/rust-cache` pin comments:

```
warning[ref-version-mismatch]: action's hash pin has mismatched or missing version comment
  --> .github/workflows/ci.yml:49:78
      Swatinem/rust-cache@49a0bdc70d2e1b713ca9e2869b211fcce03d3c1c # v2
                                                                    ^^ points to commit 6323deb102c3
```

This diff touches **zero** workflow files. I stashed all changes and reproduced the identical failure on clean `upstream/main`, so it arrived with the commits that added the check (`661952ba`). It will block CI on `main` until fixed separately.

Every other component passes:

| Gate | Result |
|---|---|
| `just fmt-check` | pass |
| `just clippy` (`-D warnings`) | pass |
| `PROPTEST_CASES=8 cargo test --locked --workspace` | pass (`rc=0`) |
| `just conform` | `conform: PASS` |

## Verification performed

New tests (13):

- `log_run_logs_job_filter_returns_only_that_job` — filter excludes the other job; unfiltered still merges both in request order
- `log_run_logs_job_filter_accepts_agent_job_uuid` — both identifiers work, matching the live feed
- `log_run_logs_unknown_job_is_404_not_whole_run` — asserts the 404 body does not leak the unfiltered log
- `log_run_logs_step_filter_selects_one_step` — steps 1/2/3 return their own content
- `log_run_logs_step_out_of_range_is_404`, `log_run_logs_step_zero_is_rejected_as_one_based`
- `log_run_logs_step_on_merged_upload_is_conflict` — asserts the 409 body does not return the unsplit log
- `log_run_logs_step_without_job_in_multi_job_run_is_ambiguous` — error names both jobs
- `log_run_logs_step_filter_works_on_live_console_blocks` — numeric console-log order, so 2 precedes 10
- `live_run_logs_native_route_{requires_job_when_ambiguous,rejects_unknown_job,defaults_single_job_run,rejects_unauthenticated}`
- CLI: `logs_filters_reach_the_query_string` closes the gap the parse-only test left — it asserts the wire query, not just that clap accepted the flag

End-to-end against a throwaway server on an isolated `PRELOOP_HOME`:

| Case | Result |
|---|---|
| `--job build` / `--job test` | `200`, only that job |
| `--job bogus-job` | `404` ``job `bogus-job` not found in this run`` |
| `--step 1` (2 jobs) | `400` ``` `step` needs `job` when a run has 2 jobs: build, test ``` |
| `--job build --step 99` | `404` ``job `build` has 0 steps so far`` |
| `--job build --step 0` | `400` `step is 1-based` |
| `-f --job build`, live run | held the stream 10s (`rc=124`) |
| `-f` on a terminal run | exited `rc=0` in 3.1s via terminal-state detection |
| `-f --step 1` | refused before connecting |

## Checklist

- [x] Tests added/updated for any new observable contract
- [x] Docs updated — `docs/cli_reference.md` documents all three flags, the per-job step numbering rule, and the merged-log limitation
- [x] Changelog-worthy user-facing change described above

### User-facing summary

`preloop logs --job` and `--step` now filter instead of silently returning everything, and `preloop logs -f` tails a running job.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`preloop logs --job` and `--step` previously returned the entire run log; they now filter server-side, and `-f`/`--follow` tails a selected job's live output until that job finishes. Follow mode replays retained output, ends when the job reaches a terminal state, and falls back to the durable log when no in-memory snapshot exists.

- Job filters accept the workflow job key or agent job UUID; unknown and cross-run jobs are rejected.
- Step numbers follow workflow order via runner step IDs, preserve duplicate step names, and require `--job` for multi-job runs.
- Step queries on merged logs return `409`; `--follow --step` is refused because live feeds are job-scoped.
- Adds an authenticated native SSE route that closes feeds on completion and reopens them for retries; a completed job with no snapshot falls back to the durable log.
- Updates CLI documentation, OpenAPI responses (including the `text/html` to `text/plain` correction), SSE parser coverage, and CI/Node dependency pins.

<sup>Written for commit afbee26bcde65743ad7246ea26f5ad1e00e891e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added job and step filters to run logs.
  - Added `--follow`/`-f` to stream live job logs.
  - Added an authenticated live-log API endpoint.
  - Live streams now close when jobs finish and support retries and late connections.
- **Bug Fixes**
  - Improved log retrieval across merged, per-step, and live sources.
  - Preserved separate logs for steps with duplicate names.
  - Added clearer errors for invalid, ambiguous, or unavailable filters.
- **Documentation**
  - Expanded CLI log documentation with filtering, live-follow behavior, limitations, and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->