### PR TITLE
feat(runner): capability-based action archive extraction using cap-std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,6 +369,36 @@ name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
+name = "cap-primitives"
+version = "3.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e0bf07d379916947be6c4a07f43684153d710a2896c31f9e97781362895596c"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys 0.59.0",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "3.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a59e59fa26472d29680ece6a9f8ee8b0551a719a33df2f5240bde065ecbddfd7"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes",
+ "rustix",
+]
 
 [[package]]
 name = "cbc"
@@ -825,6 +861,17 @@ checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
 dependencies = [
  "autocfg",
  "tokio",
+]
+
+[[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1343,6 +1390,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
+dependencies = [
+ "io-lifetimes",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1527,6 +1590,12 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "md-5"
@@ -2226,6 +2295,7 @@ dependencies = [
  "axum",
  "base64",
  "bytes",
+ "cap-std",
  "chrono",
  "clap",
  "command-group",
@@ -2802,6 +2872,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2866,7 +2946,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4364,6 +4444,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ cron = "0.12"
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"
 utoipa = { version = "5", features = ["uuid", "chrono"] }
+cap-std = "3.4"
 
 command-group = { version = "5", features = ["with-tokio"] }
 flate2 = "1"

--- a/crates/preloop-runner/Cargo.toml
+++ b/crates/preloop-runner/Cargo.toml
@@ -21,6 +21,7 @@ preloop-gha-expressions = { path = "../preloop-gha-expressions" }
 preloop-gha-parser = { path = "../preloop-gha-parser" }
 preloop-dap = { path = "../preloop-dap" }
 
+cap-std = { workspace = true }
 anyhow.workspace = true
 base64.workspace = true
 clap.workspace = true

--- a/crates/preloop-runner/src/worker/actions/manager.rs
+++ b/crates/preloop-runner/src/worker/actions/manager.rs
@@ -88,6 +88,9 @@ pub fn extract_tarball(bytes: &[u8], dest: &Path) -> Result<()> {
     let dest_dir = cap_std::fs::Dir::open_ambient_dir(dest, cap_std::ambient_authority())
         .with_context(|| format!("opening capability sandbox for {}", dest.display()))?;
 
+    #[cfg(unix)]
+    use cap_std::fs::PermissionsExt;
+
     let decoder = flate2::read::GzDecoder::new(bytes);
     let mut archive = tar::Archive::new(decoder);
 
@@ -111,13 +114,49 @@ pub fn extract_tarball(bytes: &[u8], dest: &Path) -> Result<()> {
                 path.display()
             );
         }
-        if let Some(parent) = stripped.parent() {
-            if parent.components().count() > 0 {
-                dest_dir.create_dir_all(parent)?;
+
+        let entry_type = entry.header().entry_type();
+        if entry_type.is_dir() {
+            dest_dir.create_dir_all(&stripped)?;
+        } else if entry_type.is_file() {
+            if let Some(parent) = stripped.parent() {
+                if parent.components().count() > 0 {
+                    dest_dir.create_dir_all(parent)?;
+                }
             }
+            let mut outfile = dest_dir.create(&stripped)?;
+            std::io::copy(&mut entry, &mut outfile)?;
+
+            #[cfg(unix)]
+            if let Ok(mode) = entry.header().mode() {
+                let perms = cap_std::fs::Permissions::from_mode(mode);
+                let _ = outfile.set_permissions(perms);
+            }
+        } else if entry_type.is_symlink() {
+            if let Some(link_target) = entry.link_name()? {
+                if link_target.is_absolute()
+                    || link_target.starts_with("/")
+                    || link_target.starts_with("\\")
+                {
+                    anyhow::bail!(
+                        "symlink with absolute target rejected: {}",
+                        link_target.display()
+                    );
+                }
+                if let Some(parent) = stripped.parent() {
+                    if parent.components().count() > 0 {
+                        dest_dir.create_dir_all(parent)?;
+                    }
+                }
+                dest_dir.symlink(&link_target, &stripped)?;
+            }
+        } else {
+            anyhow::bail!(
+                "unsupported or dangerous archive entry type {:?} for {}",
+                entry_type,
+                path.display()
+            );
         }
-        let target = dest.join(&stripped);
-        entry.unpack(&target)?;
     }
 
     Ok(())
@@ -171,6 +210,30 @@ mod tests {
         enc.finish().unwrap()
     }
 
+    fn create_test_tarball_with_custom_entry(
+        path: &str,
+        entry_type: tar::EntryType,
+        link_name: Option<&str>,
+        content: &[u8],
+    ) -> Vec<u8> {
+        let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        {
+            let mut tar = tar::Builder::new(&mut enc);
+            let mut header = tar::Header::new_gnu();
+            header.set_size(content.len() as u64);
+            header.set_mode(0o644);
+            header.set_entry_type(entry_type);
+            header.as_mut_bytes()[..path.len()].copy_from_slice(path.as_bytes());
+            if let Some(target) = link_name {
+                header.set_link_name(target).unwrap();
+            }
+            header.set_cksum();
+            tar.append(&header, content).unwrap();
+            tar.finish().unwrap();
+        }
+        enc.finish().unwrap()
+    }
+
     #[test]
     fn extract_tarball_unpacks_safely_inside_sandbox() {
         let temp = TempDir::new().unwrap();
@@ -200,5 +263,83 @@ mod tests {
         let tar_bytes = create_test_tarball(&[("root/../../escape.txt", b"evil")]);
         let result = extract_tarball(&tar_bytes, &dest);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn extract_tarball_rejects_hard_links() {
+        let temp = TempDir::new().unwrap();
+        let dest = temp.path().join("action_dest");
+
+        let tar_bytes = create_test_tarball_with_custom_entry(
+            "root/evil_hardlink",
+            tar::EntryType::Link,
+            Some("/etc/passwd"),
+            b"",
+        );
+        let result = extract_tarball(&tar_bytes, &dest);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("unsupported or dangerous"));
+    }
+
+    #[test]
+    fn extract_tarball_rejects_absolute_symlinks() {
+        let temp = TempDir::new().unwrap();
+        let dest = temp.path().join("action_dest");
+
+        let tar_bytes = create_test_tarball_with_custom_entry(
+            "root/evil_symlink",
+            tar::EntryType::Symlink,
+            Some("/etc/shadow"),
+            b"",
+        );
+        let result = extract_tarball(&tar_bytes, &dest);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("symlink with absolute target rejected"));
+    }
+
+    #[test]
+    fn extract_tarball_rejects_escaping_symlink_traversal() {
+        let temp = TempDir::new().unwrap();
+        let dest = temp.path().join("action_dest");
+        let outside_file = temp.path().join("escaped_target.txt");
+        std::fs::write(&outside_file, b"initial").unwrap();
+
+        // Archive has:
+        // 1. symlink `sub/evil_link` -> `../../escaped_target.txt`
+        // 2. file `sub/evil_link` trying to overwrite through it or traverse it
+        let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        {
+            let mut tar = tar::Builder::new(&mut enc);
+            let mut header = tar::Header::new_gnu();
+            header.set_size(0);
+            header.set_mode(0o777);
+            header.set_entry_type(tar::EntryType::Symlink);
+            header.as_mut_bytes()[.."root/sub/evil_link".len()]
+                .copy_from_slice(b"root/sub/evil_link");
+            header.set_link_name("../../escaped_target.txt").unwrap();
+            header.set_cksum();
+            tar.append(&header, &b""[..]).unwrap();
+
+            let mut file_header = tar::Header::new_gnu();
+            file_header.set_size(7);
+            file_header.set_mode(0o644);
+            file_header.set_entry_type(tar::EntryType::Regular);
+            file_header.as_mut_bytes()[.."root/sub/evil_link/pwn".len()]
+                .copy_from_slice(b"root/sub/evil_link/pwn");
+            file_header.set_cksum();
+            tar.append(&file_header, &b"hacked!"[..]).unwrap();
+            tar.finish().unwrap();
+        }
+        let tar_bytes = enc.finish().unwrap();
+        let result = extract_tarball(&tar_bytes, &dest);
+        assert!(result.is_err());
+        // Verify outside file was untouched
+        assert_eq!(std::fs::read_to_string(&outside_file).unwrap(), "initial");
     }
 }

--- a/crates/preloop-runner/src/worker/actions/manager.rs
+++ b/crates/preloop-runner/src/worker/actions/manager.rs
@@ -78,9 +78,15 @@ pub async fn download_action(
 }
 
 /// Extract a `.tar.gz` tarball to `dest`, stripping the top-level directory.
+///
+/// Uses `cap_std` capability-based filesystem sandboxing to ensure extracted entries
+/// cannot escape `dest` via path traversal (`..`), absolute paths, or malicious symlinks.
 pub fn extract_tarball(bytes: &[u8], dest: &Path) -> Result<()> {
     std::fs::create_dir_all(dest)
         .with_context(|| format!("creating action dir {}", dest.display()))?;
+
+    let dest_dir = cap_std::fs::Dir::open_ambient_dir(dest, cap_std::ambient_authority())
+        .with_context(|| format!("opening capability sandbox for {}", dest.display()))?;
 
     let decoder = flate2::read::GzDecoder::new(bytes);
     let mut archive = tar::Archive::new(decoder);
@@ -92,10 +98,25 @@ pub fn extract_tarball(bytes: &[u8], dest: &Path) -> Result<()> {
         if stripped.components().count() == 0 {
             continue;
         }
-        let target = dest.join(&stripped);
-        if let Some(parent) = target.parent() {
-            std::fs::create_dir_all(parent)?;
+        if stripped.components().any(|c| {
+            matches!(
+                c,
+                std::path::Component::ParentDir
+                    | std::path::Component::RootDir
+                    | std::path::Component::Prefix(_)
+            )
+        }) {
+            anyhow::bail!(
+                "malicious archive entry escapes sandbox: {}",
+                path.display()
+            );
         }
+        if let Some(parent) = stripped.parent() {
+            if parent.components().count() > 0 {
+                dest_dir.create_dir_all(parent)?;
+            }
+        }
+        let target = dest.join(&stripped);
         entry.unpack(&target)?;
     }
 
@@ -126,4 +147,58 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn create_test_tarball(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        {
+            let mut tar = tar::Builder::new(&mut enc);
+            for (path, content) in entries {
+                let mut header = tar::Header::new_gnu();
+                header.set_size(content.len() as u64);
+                header.set_mode(0o644);
+                header.as_mut_bytes()[..path.len()].copy_from_slice(path.as_bytes());
+                header.set_cksum();
+                tar.append(&header, *content).unwrap();
+            }
+            tar.finish().unwrap();
+        }
+        enc.finish().unwrap()
+    }
+
+    #[test]
+    fn extract_tarball_unpacks_safely_inside_sandbox() {
+        let temp = TempDir::new().unwrap();
+        let dest = temp.path().join("action_dest");
+
+        let tar_bytes = create_test_tarball(&[
+            ("checkout-v4/action.yml", b"name: Checkout\n"),
+            ("checkout-v4/dist/index.js", b"console.log('hello');\n"),
+        ]);
+
+        extract_tarball(&tar_bytes, &dest).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dest.join("action.yml")).unwrap(),
+            "name: Checkout\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dest.join("dist/index.js")).unwrap(),
+            "console.log('hello');\n"
+        );
+    }
+
+    #[test]
+    fn extract_tarball_rejects_path_traversal() {
+        let temp = TempDir::new().unwrap();
+        let dest = temp.path().join("action_dest");
+
+        let tar_bytes = create_test_tarball(&[("root/../../escape.txt", b"evil")]);
+        let result = extract_tarball(&tar_bytes, &dest);
+        assert!(result.is_err());
+    }
 }

--- a/crates/preloop-runner/src/worker/actions/manager.rs
+++ b/crates/preloop-runner/src/worker/actions/manager.rs
@@ -71,7 +71,32 @@ pub async fn download_action(
         "Action archive {owner}/{repo}@{git_ref}: {} bytes",
         bytes.len()
     );
-    extract_tarball(&bytes, &dest)?;
+
+    let parent_dir = dest
+        .parent()
+        .context("action destination must have parent directory")?;
+    std::fs::create_dir_all(parent_dir)
+        .with_context(|| format!("creating parent dir {}", parent_dir.display()))?;
+
+    let staging = tempfile::Builder::new()
+        .prefix(".action_tmp_")
+        .tempdir_in(parent_dir)
+        .with_context(|| format!("creating staging dir in {}", parent_dir.display()))?;
+
+    extract_tarball(&bytes, staging.path())?;
+
+    let staging_path = staging.keep();
+    if !dest.exists() {
+        if let Err(err) = std::fs::rename(&staging_path, &dest) {
+            let _ = std::fs::remove_dir_all(&staging_path);
+            if !dest.exists() {
+                return Err(err)
+                    .with_context(|| format!("moving extracted action to {}", dest.display()));
+            }
+        }
+    } else {
+        let _ = std::fs::remove_dir_all(&staging_path);
+    }
 
     info!("Extracted action to {}", dest.display());
     Ok(dest)
@@ -341,5 +366,71 @@ mod tests {
         assert!(result.is_err());
         // Verify outside file was untouched
         assert_eq!(std::fs::read_to_string(&outside_file).unwrap(), "initial");
+    }
+
+    #[tokio::test]
+    async fn download_action_atomic_cleanup_on_error() {
+        use axum::{routing::get, Router};
+        let evil_tar = create_test_tarball(&[("root/../../escape.txt", b"evil")]);
+
+        let app = Router::new().route("/tarball", get(|| async move { evil_tar }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let temp = TempDir::new().unwrap();
+        let actions_dir = temp.path().join("actions");
+
+        let url = format!("http://{addr}/tarball");
+        let result = download_action("owner", "repo", "v1", &actions_dir, Some(&url), None).await;
+
+        assert!(result.is_err());
+        let dest = actions_dir.join("owner").join("repo").join("v1");
+        assert!(
+            !dest.exists(),
+            "failed download must not leave dest directory behind"
+        );
+    }
+
+    #[tokio::test]
+    async fn download_action_atomic_success_and_cache_hit() {
+        use axum::{routing::get, Router};
+        let valid_tar = create_test_tarball(&[("checkout-v4/action.yml", b"name: Checkout\n")]);
+
+        let app = Router::new().route("/tarball", get(|| async move { valid_tar }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let temp = TempDir::new().unwrap();
+        let actions_dir = temp.path().join("actions");
+
+        let url = format!("http://{addr}/tarball");
+        let res = download_action("owner", "repo", "v1", &actions_dir, Some(&url), None)
+            .await
+            .unwrap();
+
+        assert!(res.exists());
+        assert_eq!(
+            std::fs::read_to_string(res.join("action.yml")).unwrap(),
+            "name: Checkout\n"
+        );
+
+        // Second call hits the cache without reaching the server
+        let cached_res = download_action(
+            "owner",
+            "repo",
+            "v1",
+            &actions_dir,
+            Some("http://127.0.0.1:1/unreachable"),
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(cached_res, res);
     }
 }

--- a/crates/preloop-runner/src/worker/actions/manager.rs
+++ b/crates/preloop-runner/src/worker/actions/manager.rs
@@ -204,16 +204,40 @@ pub fn extract_tarball(bytes: &[u8], dest: &Path) -> Result<()> {
         } else if entry_type.is_symlink() {
             if let Some(link_target) = entry.link_name()? {
                 let parent = stripped.parent();
-                if !is_safe_relative_symlink(parent, &link_target) {
-                    anyhow::bail!(
-                        "symlink with escaping or absolute target rejected: {}",
-                        link_target.display()
-                    );
-                }
                 if let Some(parent) = parent {
                     if parent.components().count() > 0 {
                         dest_dir.create_dir_all(parent)?;
                     }
+                }
+
+                // Resolve physical parent directory relative to dest to account for
+                // preceding symlinks that shift the physical parent depth.
+                let canonical_dest = dest.canonicalize()?;
+                let physical_parent = if let Some(parent) = parent {
+                    let parent_path = dest.join(parent);
+                    if let Ok(canonical_parent) = parent_path.canonicalize() {
+                        if !canonical_parent.starts_with(&canonical_dest) {
+                            anyhow::bail!(
+                                "symlink parent directory escapes destination root: {}",
+                                parent.display()
+                            );
+                        }
+                        canonical_parent
+                            .strip_prefix(&canonical_dest)
+                            .ok()
+                            .map(Path::to_path_buf)
+                    } else {
+                        Some(parent.to_path_buf())
+                    }
+                } else {
+                    None
+                };
+
+                if !is_safe_relative_symlink(physical_parent.as_deref(), &link_target) {
+                    anyhow::bail!(
+                        "symlink with escaping or absolute target rejected: {}",
+                        link_target.display()
+                    );
                 }
                 dest_dir.symlink(&link_target, &stripped)?;
             }
@@ -278,11 +302,31 @@ fn copy_dir_recursive_inner(src: &Path, dst: &Path, root_src: &Path) -> Result<(
             let entry_path = entry.path();
             let target = std::fs::read_link(&entry_path)
                 .with_context(|| format!("reading symlink {}", entry_path.display()))?;
-            let rel_parent = entry_path
-                .strip_prefix(root_src)
-                .ok()
-                .and_then(|p| p.parent());
-            if !is_safe_relative_symlink(rel_parent, &target) {
+            let canonical_root = root_src.canonicalize()?;
+            let physical_parent = if let Some(parent) = entry_path.parent() {
+                if let Ok(canonical_parent) = parent.canonicalize() {
+                    if !canonical_parent.starts_with(&canonical_root) {
+                        anyhow::bail!(
+                            "symlink parent directory escapes source root: {}",
+                            parent.display()
+                        );
+                    }
+                    canonical_parent
+                        .strip_prefix(&canonical_root)
+                        .ok()
+                        .map(Path::to_path_buf)
+                } else {
+                    entry_path
+                        .strip_prefix(root_src)
+                        .ok()
+                        .and_then(|p| p.parent())
+                        .map(Path::to_path_buf)
+                }
+            } else {
+                None
+            };
+
+            if !is_safe_relative_symlink(physical_parent.as_deref(), &target) {
                 anyhow::bail!(
                     "local action contains escaping or absolute symlink: {} -> {}",
                     entry.path().display(),
@@ -293,10 +337,17 @@ fn copy_dir_recursive_inner(src: &Path, dst: &Path, root_src: &Path) -> Result<(
             std::os::unix::fs::symlink(&target, &dest)
                 .with_context(|| format!("creating symlink {}", dest.display()))?;
             #[cfg(windows)]
-            if target.is_dir() {
-                std::os::windows::fs::symlink_dir(&target, &dest)?;
-            } else {
-                std::os::windows::fs::symlink_file(&target, &dest)?;
+            {
+                let is_dir = if let Some(parent) = entry_path.parent() {
+                    parent.join(&target).is_dir()
+                } else {
+                    target.is_dir()
+                };
+                if is_dir {
+                    std::os::windows::fs::symlink_dir(&target, &dest)?;
+                } else {
+                    std::os::windows::fs::symlink_file(&target, &dest)?;
+                }
             }
         } else if ty.is_dir() {
             copy_dir_recursive_inner(&entry.path(), &dest, root_src)?;
@@ -470,6 +521,56 @@ mod tests {
         assert!(result.is_err());
         // Verify outside file was untouched
         assert_eq!(std::fs::read_to_string(&outside_file).unwrap(), "initial");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extract_tarball_rejects_chained_symlink_escape() {
+        let temp = TempDir::new().unwrap();
+        let dest = temp.path().join("action_dest");
+
+        // Archive has:
+        // 1. directory `root/b`
+        // 2. symlink `root/a/deep` -> `../b`
+        // 3. symlink `root/a/deep/link` -> `../../outside` (lexically looks like depth 2 with 2 '..' = 0, but physically is depth 1 with 2 '..' = -1!)
+        let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        {
+            let mut tar = tar::Builder::new(&mut enc);
+            let mut dir_header = tar::Header::new_gnu();
+            dir_header.set_size(0);
+            dir_header.set_mode(0o755);
+            dir_header.set_entry_type(tar::EntryType::Directory);
+            dir_header.as_mut_bytes()[.."root/b/".len()].copy_from_slice(b"root/b/");
+            dir_header.set_cksum();
+            tar.append(&dir_header, &b""[..]).unwrap();
+
+            let mut link1_header = tar::Header::new_gnu();
+            link1_header.set_size(0);
+            link1_header.set_mode(0o777);
+            link1_header.set_entry_type(tar::EntryType::Symlink);
+            link1_header.as_mut_bytes()[.."root/a/deep".len()].copy_from_slice(b"root/a/deep");
+            link1_header.set_link_name("../b").unwrap();
+            link1_header.set_cksum();
+            tar.append(&link1_header, &b""[..]).unwrap();
+
+            let mut link2_header = tar::Header::new_gnu();
+            link2_header.set_size(0);
+            link2_header.set_mode(0o777);
+            link2_header.set_entry_type(tar::EntryType::Symlink);
+            link2_header.as_mut_bytes()[.."root/a/deep/link".len()]
+                .copy_from_slice(b"root/a/deep/link");
+            link2_header.set_link_name("../../outside").unwrap();
+            link2_header.set_cksum();
+            tar.append(&link2_header, &b""[..]).unwrap();
+            tar.finish().unwrap();
+        }
+        let tar_bytes = enc.finish().unwrap();
+        let result = extract_tarball(&tar_bytes, &dest);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("symlink with escaping or absolute target rejected"));
     }
 
     #[cfg(unix)]

--- a/crates/preloop-runner/src/worker/actions/manager.rs
+++ b/crates/preloop-runner/src/worker/actions/manager.rs
@@ -202,7 +202,31 @@ pub fn copy_local_action(source: &Path, actions_dir: &Path, action_name: &str) -
     if dest.exists() {
         return Ok(dest);
     }
-    copy_dir_recursive(source, &dest)?;
+    let parent_dir = dest
+        .parent()
+        .context("destination must have parent directory")?;
+    std::fs::create_dir_all(parent_dir)?;
+    let staging = tempfile::Builder::new()
+        .prefix(".local_action_tmp_")
+        .tempdir_in(parent_dir)?;
+    copy_dir_recursive(source, staging.path())?;
+    let staging_path = staging.keep();
+    if !dest.exists() {
+        if let Err(err) = std::fs::rename(&staging_path, &dest) {
+            let _ = std::fs::remove_dir_all(&staging_path);
+            if !dest.exists() {
+                return Err(err).with_context(|| {
+                    format!(
+                        "moving copied local action from {} to {}",
+                        staging_path.display(),
+                        dest.display()
+                    )
+                });
+            }
+        }
+    } else {
+        let _ = std::fs::remove_dir_all(&staging_path);
+    }
     Ok(dest)
 }
 
@@ -213,7 +237,35 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
         let entry = entry?;
         let ty = entry.file_type()?;
         let dest = dst.join(entry.file_name());
-        if ty.is_dir() {
+        if ty.is_symlink() {
+            let target = std::fs::read_link(entry.path())
+                .with_context(|| format!("reading symlink {}", entry.path().display()))?;
+            if target.is_absolute()
+                || target.components().any(|c| {
+                    matches!(
+                        c,
+                        std::path::Component::ParentDir
+                            | std::path::Component::RootDir
+                            | std::path::Component::Prefix(_)
+                    )
+                })
+            {
+                anyhow::bail!(
+                    "local action contains escaping or absolute symlink: {} -> {}",
+                    entry.path().display(),
+                    target.display()
+                );
+            }
+            #[cfg(unix)]
+            std::os::unix::fs::symlink(&target, &dest)
+                .with_context(|| format!("creating symlink {}", dest.display()))?;
+            #[cfg(windows)]
+            if target.is_dir() {
+                std::os::windows::fs::symlink_dir(&target, &dest)?;
+            } else {
+                std::os::windows::fs::symlink_file(&target, &dest)?;
+            }
+        } else if ty.is_dir() {
             copy_dir_recursive(&entry.path(), &dest)?;
         } else {
             std::fs::copy(entry.path(), &dest)?;
@@ -481,5 +533,50 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(cached_res, res);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_local_action_rejects_escaping_symlinks() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("source_action");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::write(source.join("action.yml"), "name: Local\n").unwrap();
+
+        // Create escaping symlink pointing outside action
+        let outside = temp.path().join("secret.txt");
+        std::fs::write(&outside, "secret").unwrap();
+        std::os::unix::fs::symlink("../secret.txt", source.join("escape_link")).unwrap();
+
+        let actions_dir = temp.path().join("actions");
+        let result = copy_local_action(&source, &actions_dir, "my-local-action");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("escaping or absolute symlink"));
+        assert!(!actions_dir.join("my-local-action").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_local_action_allows_safe_internal_symlinks() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("source_action");
+        std::fs::create_dir_all(source.join("dist")).unwrap();
+        std::fs::create_dir_all(source.join("bin")).unwrap();
+        std::fs::write(source.join("action.yml"), "name: Local\n").unwrap();
+        std::fs::write(source.join("dist/index.js"), "console.log('hi');\n").unwrap();
+
+        // Create safe internal symlink
+        std::os::unix::fs::symlink("dist/index.js", source.join("main.js")).unwrap();
+
+        let actions_dir = temp.path().join("actions");
+        let dest = copy_local_action(&source, &actions_dir, "my-local-action").unwrap();
+        assert!(dest.exists());
+        assert_eq!(
+            std::fs::read_to_string(dest.join("main.js")).unwrap(),
+            "console.log('hi');\n"
+        );
     }
 }

--- a/crates/preloop-runner/src/worker/actions/manager.rs
+++ b/crates/preloop-runner/src/worker/actions/manager.rs
@@ -102,6 +102,45 @@ pub async fn download_action(
     Ok(dest)
 }
 
+/// Check whether a relative symlink target, resolved against the symlink's parent directory,
+/// normalizes safely within the root directory (never escapes above root).
+fn is_safe_relative_symlink(link_parent: Option<&Path>, link_target: &Path) -> bool {
+    if link_target.is_absolute() || link_target.starts_with("/") || link_target.starts_with("\\") {
+        return false;
+    }
+
+    let mut stack: Vec<&std::ffi::OsStr> = Vec::new();
+    if let Some(parent) = link_parent {
+        for component in parent.components() {
+            match component {
+                std::path::Component::Normal(c) => stack.push(c),
+                std::path::Component::ParentDir => {
+                    if stack.pop().is_none() {
+                        return false;
+                    }
+                }
+                std::path::Component::CurDir => {}
+                _ => return false,
+            }
+        }
+    }
+
+    for component in link_target.components() {
+        match component {
+            std::path::Component::Normal(c) => stack.push(c),
+            std::path::Component::ParentDir => {
+                if stack.pop().is_none() {
+                    return false;
+                }
+            }
+            std::path::Component::CurDir => {}
+            _ => return false,
+        }
+    }
+
+    true
+}
+
 /// Extract a `.tar.gz` tarball to `dest`, stripping the top-level directory.
 ///
 /// Uses `cap_std` capability-based filesystem sandboxing to ensure extracted entries
@@ -164,20 +203,14 @@ pub fn extract_tarball(bytes: &[u8], dest: &Path) -> Result<()> {
             }
         } else if entry_type.is_symlink() {
             if let Some(link_target) = entry.link_name()? {
-                if link_target.components().any(|c| {
-                    matches!(
-                        c,
-                        std::path::Component::ParentDir
-                            | std::path::Component::RootDir
-                            | std::path::Component::Prefix(_)
-                    )
-                }) {
+                let parent = stripped.parent();
+                if !is_safe_relative_symlink(parent, &link_target) {
                     anyhow::bail!(
                         "symlink with escaping or absolute target rejected: {}",
                         link_target.display()
                     );
                 }
-                if let Some(parent) = stripped.parent() {
+                if let Some(parent) = parent {
                     if parent.components().count() > 0 {
                         dest_dir.create_dir_all(parent)?;
                     }
@@ -232,24 +265,24 @@ pub fn copy_local_action(source: &Path, actions_dir: &Path, action_name: &str) -
 
 /// Recursively copy a directory.
 fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
+    copy_dir_recursive_inner(src, dst, src)
+}
+
+fn copy_dir_recursive_inner(src: &Path, dst: &Path, root_src: &Path) -> Result<()> {
     std::fs::create_dir_all(dst)?;
     for entry in std::fs::read_dir(src)? {
         let entry = entry?;
         let ty = entry.file_type()?;
         let dest = dst.join(entry.file_name());
         if ty.is_symlink() {
-            let target = std::fs::read_link(entry.path())
-                .with_context(|| format!("reading symlink {}", entry.path().display()))?;
-            if target.is_absolute()
-                || target.components().any(|c| {
-                    matches!(
-                        c,
-                        std::path::Component::ParentDir
-                            | std::path::Component::RootDir
-                            | std::path::Component::Prefix(_)
-                    )
-                })
-            {
+            let entry_path = entry.path();
+            let target = std::fs::read_link(&entry_path)
+                .with_context(|| format!("reading symlink {}", entry_path.display()))?;
+            let rel_parent = entry_path
+                .strip_prefix(root_src)
+                .ok()
+                .and_then(|p| p.parent());
+            if !is_safe_relative_symlink(rel_parent, &target) {
                 anyhow::bail!(
                     "local action contains escaping or absolute symlink: {} -> {}",
                     entry.path().display(),
@@ -266,7 +299,7 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
                 std::os::windows::fs::symlink_file(&target, &dest)?;
             }
         } else if ty.is_dir() {
-            copy_dir_recursive(&entry.path(), &dest)?;
+            copy_dir_recursive_inner(&entry.path(), &dest, root_src)?;
         } else {
             std::fs::copy(entry.path(), &dest)?;
         }
@@ -441,6 +474,46 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn extract_tarball_allows_in_root_relative_symlinks() {
+        let temp = TempDir::new().unwrap();
+        let dest = temp.path().join("action_dest");
+
+        // Archive has:
+        // 1. regular file `lib/tool.js`
+        // 2. in-root relative symlink `bin/tool` -> `../lib/tool.js`
+        let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        {
+            let mut tar = tar::Builder::new(&mut enc);
+            let mut file_header = tar::Header::new_gnu();
+            file_header.set_size(19);
+            file_header.set_mode(0o644);
+            file_header.set_entry_type(tar::EntryType::Regular);
+            file_header.as_mut_bytes()[.."root/lib/tool.js".len()]
+                .copy_from_slice(b"root/lib/tool.js");
+            file_header.set_cksum();
+            tar.append(&file_header, &b"console.log('tool')"[..])
+                .unwrap();
+
+            let mut link_header = tar::Header::new_gnu();
+            link_header.set_size(0);
+            link_header.set_mode(0o777);
+            link_header.set_entry_type(tar::EntryType::Symlink);
+            link_header.as_mut_bytes()[.."root/bin/tool".len()].copy_from_slice(b"root/bin/tool");
+            link_header.set_link_name("../lib/tool.js").unwrap();
+            link_header.set_cksum();
+            tar.append(&link_header, &b""[..]).unwrap();
+            tar.finish().unwrap();
+        }
+        let tar_bytes = enc.finish().unwrap();
+        extract_tarball(&tar_bytes, &dest).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dest.join("bin/tool")).unwrap(),
+            "console.log('tool')"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn extract_tarball_masks_special_permission_bits() {
         use std::os::unix::fs::PermissionsExt;
 
@@ -570,6 +643,9 @@ mod tests {
 
         // Create safe internal symlink
         std::os::unix::fs::symlink("dist/index.js", source.join("main.js")).unwrap();
+        // Create safe in-root relative symlink spanning subdirectories
+        std::fs::write(source.join("dist/tool.js"), "tool_content").unwrap();
+        std::os::unix::fs::symlink("../dist/tool.js", source.join("bin/tool")).unwrap();
 
         let actions_dir = temp.path().join("actions");
         let dest = copy_local_action(&source, &actions_dir, "my-local-action").unwrap();
@@ -577,6 +653,10 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(dest.join("main.js")).unwrap(),
             "console.log('hi');\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dest.join("bin/tool")).unwrap(),
+            "tool_content"
         );
     }
 }

--- a/crates/preloop-runner/src/worker/actions/manager.rs
+++ b/crates/preloop-runner/src/worker/actions/manager.rs
@@ -122,11 +122,7 @@ pub fn extract_tarball(bytes: &[u8], dest: &Path) -> Result<()> {
     for entry in archive.entries()? {
         let mut entry = entry?;
         let path = entry.path()?.into_owned();
-        let stripped: PathBuf = path.components().skip(1).collect();
-        if stripped.components().count() == 0 {
-            continue;
-        }
-        if stripped.components().any(|c| {
+        if path.components().any(|c| {
             matches!(
                 c,
                 std::path::Component::ParentDir
@@ -138,6 +134,11 @@ pub fn extract_tarball(bytes: &[u8], dest: &Path) -> Result<()> {
                 "malicious archive entry escapes sandbox: {}",
                 path.display()
             );
+        }
+
+        let stripped: PathBuf = path.components().skip(1).collect();
+        if stripped.components().count() == 0 {
+            continue;
         }
 
         let entry_type = entry.header().entry_type();
@@ -154,17 +155,25 @@ pub fn extract_tarball(bytes: &[u8], dest: &Path) -> Result<()> {
 
             #[cfg(unix)]
             if let Ok(mode) = entry.header().mode() {
-                let perms = cap_std::fs::Permissions::from_mode(mode);
-                let _ = outfile.set_permissions(perms);
+                // Mask to standard rwx permissions (0o777), stripping setuid (0o4000), setgid (0o2000), and sticky (0o1000) bits
+                let safe_mode = mode & 0o777;
+                let perms = cap_std::fs::Permissions::from_mode(safe_mode);
+                outfile
+                    .set_permissions(perms)
+                    .with_context(|| format!("setting permissions on {}", stripped.display()))?;
             }
         } else if entry_type.is_symlink() {
             if let Some(link_target) = entry.link_name()? {
-                if link_target.is_absolute()
-                    || link_target.starts_with("/")
-                    || link_target.starts_with("\\")
-                {
+                if link_target.components().any(|c| {
+                    matches!(
+                        c,
+                        std::path::Component::ParentDir
+                            | std::path::Component::RootDir
+                            | std::path::Component::Prefix(_)
+                    )
+                }) {
                     anyhow::bail!(
-                        "symlink with absolute target rejected: {}",
+                        "symlink with escaping or absolute target rejected: {}",
                         link_target.display()
                     );
                 }
@@ -291,6 +300,16 @@ mod tests {
     }
 
     #[test]
+    fn extract_tarball_rejects_absolute_paths() {
+        let temp = TempDir::new().unwrap();
+        let dest = temp.path().join("action_dest");
+
+        let tar_bytes = create_test_tarball(&[("/escape.txt", b"evil")]);
+        let result = extract_tarball(&tar_bytes, &dest);
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn extract_tarball_rejects_hard_links() {
         let temp = TempDir::new().unwrap();
         let dest = temp.path().join("action_dest");
@@ -325,7 +344,7 @@ mod tests {
         assert!(result
             .unwrap_err()
             .to_string()
-            .contains("symlink with absolute target rejected"));
+            .contains("symlink with escaping or absolute target rejected"));
     }
 
     #[test]
@@ -366,6 +385,36 @@ mod tests {
         assert!(result.is_err());
         // Verify outside file was untouched
         assert_eq!(std::fs::read_to_string(&outside_file).unwrap(), "initial");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extract_tarball_masks_special_permission_bits() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let dest = temp.path().join("action_dest");
+
+        // Entry with setuid (0o4755)
+        let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        {
+            let mut tar = tar::Builder::new(&mut enc);
+            let mut header = tar::Header::new_gnu();
+            header.set_size(5);
+            header.set_mode(0o4755);
+            header.set_entry_type(tar::EntryType::Regular);
+            header.as_mut_bytes()[.."root/script.sh".len()].copy_from_slice(b"root/script.sh");
+            header.set_cksum();
+            tar.append(&header, &b"echo\n"[..]).unwrap();
+            tar.finish().unwrap();
+        }
+        let tar_bytes = enc.finish().unwrap();
+        extract_tarball(&tar_bytes, &dest).unwrap();
+
+        let metadata = std::fs::metadata(dest.join("script.sh")).unwrap();
+        let mode = metadata.permissions().mode();
+        // The setuid bit (0o4000) must be stripped, leaving only rwxr-xr-x (0o755)
+        assert_eq!(mode & 0o7777, 0o755);
     }
 
     #[tokio::test]

--- a/crates/preloop-runner/src/worker/handlers/factory.rs
+++ b/crates/preloop-runner/src/worker/handlers/factory.rs
@@ -59,6 +59,18 @@ pub fn load_action_manifest(action_dir: &Path) -> Result<ActionManifest> {
         );
     };
 
+    if let (Ok(canonical_dir), Ok(canonical_manifest)) =
+        (action_dir.canonicalize(), manifest_path.canonicalize())
+    {
+        if !canonical_manifest.starts_with(&canonical_dir) {
+            anyhow::bail!(
+                "action manifest {} escapes action directory {}",
+                manifest_path.display(),
+                action_dir.display()
+            );
+        }
+    }
+
     let content = std::fs::read_to_string(&manifest_path)
         .with_context(|| format!("reading {}", manifest_path.display()))?;
 
@@ -506,5 +518,31 @@ runs:
             steps[1].get("if").and_then(|v| v.as_str()),
             Some("runner.os == 'Linux'")
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_action_manifest_rejects_escaping_symlink() {
+        let temp = TempDir::new().unwrap();
+        let action_dir = temp.path().join("action");
+        std::fs::create_dir_all(&action_dir).unwrap();
+
+        let outside_dir = temp.path().join("outside");
+        std::fs::create_dir_all(&outside_dir).unwrap();
+        let outside_manifest = outside_dir.join("action.yml");
+        std::fs::write(
+            &outside_manifest,
+            "name: Evil\nruns:\n  using: node20\n  main: index.js\n",
+        )
+        .unwrap();
+
+        std::os::unix::fs::symlink(&outside_manifest, action_dir.join("action.yml")).unwrap();
+
+        let result = load_action_manifest(&action_dir);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("escapes action directory"));
     }
 }

--- a/crates/preloop-runner/src/worker/handlers/node.rs
+++ b/crates/preloop-runner/src/worker/handlers/node.rs
@@ -183,6 +183,19 @@ pub async fn run_node_action(
         anyhow::bail!("action entry point not found: {}", entry_point.display());
     }
 
+    // Validate that the canonical entry point path stays within the action directory
+    if let (Ok(canonical_dir), Ok(canonical_entry)) =
+        (action_dir.canonicalize(), entry_point.canonicalize())
+    {
+        if !canonical_entry.starts_with(&canonical_dir) {
+            anyhow::bail!(
+                "action entry point {} escapes action directory {}",
+                entry_point.display(),
+                action_dir.display()
+            );
+        }
+    }
+
     // Resolve node binary and apply the runner's Node 20 migration policy.
     let runs_using = manifest.runs_using.as_str();
     if runs_using == "node12" || runs_using == "node16" {
@@ -675,5 +688,43 @@ mod tests {
         .unwrap_err();
 
         assert!(err.to_string().contains("missing runs.main"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn escaping_entry_point_symlink_errors() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let action_dir = temp.path().join("action");
+        std::fs::create_dir_all(&action_dir).unwrap();
+
+        let outside_dir = temp.path().join("outside");
+        std::fs::create_dir_all(&outside_dir).unwrap();
+        let outside_script = outside_dir.join("payload.js");
+        std::fs::write(&outside_script, "console.log('evil');").unwrap();
+
+        std::os::unix::fs::symlink(&outside_script, action_dir.join("index.js")).unwrap();
+
+        let manifest = node_manifest("index.js");
+        let mut job = crate::worker::contexts::JobContext::new(
+            "job".into(),
+            "job".into(),
+            serde_json::json!({}),
+            serde_json::json!({}),
+        );
+        let mut ctx = StepContext::new(&mut job, "step1".into(), "Step".into());
+        let (_tx, cancel_rx) = tokio::sync::watch::channel(false);
+
+        let err = run_node_action(
+            &manifest,
+            &action_dir,
+            &serde_json::json!({}),
+            action_dir.to_str().unwrap(),
+            &mut ctx,
+            cancel_rx,
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("escapes action directory"));
     }
 }


### PR DESCRIPTION
## Summary

Hardens third-party GitHub action archive extraction using `cap-std` capability-based filesystem sandboxing:

1. **Capability Sandboxing**:
   - Uses `cap_std::fs::Dir::open_ambient_dir` on the action extraction target directory.
   - Ensures directory tree creation and file unpacking stay strictly confined within `_work/_actions/{owner}/{repo}/{resolvedSha}/`.

2. **Zip Slip & Path Traversal Prevention**:
   - Rejects tarball entries attempting to write outside the sandbox via `..`, absolute paths, or escaping prefixes.
   - Prevents malicious third-party actions from planting symlinks or files into host directories (`/root/.ssh`, `/etc`, etc.).

3. **Tests**:
   - Added unit tests for safe archive unpacking and path traversal rejection.

## Verification

- `cargo fmt --check`: Passed
- `cargo clippy --workspace --all-targets -- -D warnings`: Passed (0 warnings)
- `cargo test -p preloop-runner --lib worker::actions::manager`: Passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens action extraction and local action handling against path traversal and cache poisoning by sandboxing extraction with `cap-std` and staging writes in a temp directory that is atomically renamed only on success.

- Rejects archive entries with `..`, absolute paths, hard links, and unsupported entry types.
- Resolves symlink targets against their physical parent, rejecting absolute or escaping targets (including chained escapes) while preserving in-root relative symlinks.
- Strips setuid, setgid, and sticky bits when preserving Unix file permissions.
- Rejects action manifests and node entry points whose canonical path escapes the action directory.
- Rejects local action copies containing absolute or escaping symlinks.

<sup>Written for commit 9e36740ed568c6b80711ac7b9526fea56384bfc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Archive extraction blocks absolute paths and links that escape the intended destination.
  * Action manifests and entry points cannot resolve outside their action directories.
  * Unsafe symlinks and special file permission bits are filtered out.

* **Bug Fixes**
  * Downloads and local actions are staged and published atomically to prevent incomplete results.
  * Permission-setting failures during extraction are reported clearly.
  * Relative symlink targets are resolved safely against their parent directories across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->