### PR TITLE
feat(runner): node20 deprecation warning and externals pin bump

### DIFF
--- a/crates/preloop-gha-protocol/src/azdo/timeline.rs
+++ b/crates/preloop-gha-protocol/src/azdo/timeline.rs
@@ -93,9 +93,15 @@ pub struct TimelineRecord {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum TimelineRecordType {
+    #[serde(alias = "Job", alias = "job")]
     Job,
+    #[serde(alias = "Step", alias = "step")]
     Step,
+    #[serde(alias = "Task", alias = "task")]
+    Task,
+    #[serde(alias = "Phase", alias = "phase")]
     Phase,
+    #[serde(alias = "Stage", alias = "stage")]
     Stage,
 }
 

--- a/crates/preloop-gha-protocol/src/lib.rs
+++ b/crates/preloop-gha-protocol/src/lib.rs
@@ -788,7 +788,7 @@ fn mask_annotation_strings(value: serde_json::Value, secrets: &[&str]) -> serde_
 }
 
 /// Machine-readable event emitted as NDJSON.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum NdjsonEvent {
     /// Run was accepted.
@@ -913,7 +913,7 @@ impl NdjsonEvent {
 }
 
 /// Annotation severity.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AnnotationLevel {
     /// Notice.

--- a/crates/preloop-runner-server/src/timeline_logs.rs
+++ b/crates/preloop-runner-server/src/timeline_logs.rs
@@ -89,11 +89,15 @@ pub(crate) async fn patch_timeline_records(
         *current += 1;
         let new_id = *current;
 
-        inner
+        let events = inner
             .timeline_events
             .entry(run_id.unwrap_or_else(|| RunId(uuid::Uuid::nil())))
-            .or_default()
-            .extend(projected.clone());
+            .or_default();
+        for event in &projected {
+            if !events.contains(event) {
+                events.push(event.clone());
+            }
+        }
         trim_timeline_events(
             &mut inner,
             run_id.unwrap_or_else(|| RunId(uuid::Uuid::nil())),
@@ -804,40 +808,60 @@ mod tests {
              actions/setup-node@v3."
             .to_owned();
 
-        let job_record = azdo::TimelineRecord {
-            id: uuid::Uuid::new_v4(),
-            change_id: None,
-            parent_id: None,
-            name: Some("build".to_owned()),
-            display_name: Some("build".to_owned()),
-            record_type: Some(azdo::TimelineRecordType::Job),
-            state: Some(azdo::TimelineRecordState::InProgress),
-            result: None,
-            start_time: None,
-            finish_time: None,
-            issues: vec![azdo::Issue {
-                issue_type: azdo::IssueType::Warning,
-                category: None,
-                message: Some(node20_message.clone()),
-                data: BTreeMap::new(),
-                is_infrastructure_issue: None,
-            }],
-            variables: BTreeMap::new(),
-            current_operation: None,
-            percent_complete: None,
-            worker_name: None,
-            error_count: None,
-            warning_count: Some(1),
-            is_background: None,
-            background_control_type: None,
-            background_control_step_ids: Vec::new(),
-            parallel_group_id: None,
-            steps: Vec::new(),
-            last_modified: None,
-            log: None,
-        };
-        let record_id = job_record.id;
+        let job_record_id = uuid::Uuid::new_v4();
+        let child_task_id = uuid::Uuid::new_v4();
 
+        // Construct raw JSON wire payload with upstream "Task" and "Job" types to exercise serde wire decoding.
+        let raw_json_payload = serde_json::json!({
+                "count": 2,
+                "value": [
+                    {
+                        "id": job_record_id.to_string(),
+                        "parentId": null,
+                        "name": "build",
+                        "displayName": "build",
+                        "type": "Job",
+                        "state": "inProgress",
+                        "issues": [
+                            {
+                                "type": "warning",
+                                "message": node20_message
+        }
+                        ],
+                        "warningCount": 1
+                    },
+                    {
+                        "id": child_task_id.to_string(),
+                        "parentId": job_record_id.to_string(),
+                        "name": "Complete job",
+                        "displayName": "Complete job",
+                        "type": "Task",
+                        "state": "completed",
+                        "result": "succeededWithIssues",
+                        "issues": [
+                            {
+                                "type": "warning",
+                                "message": node20_message
+        }
+                        ]
+        }
+                ]
+            });
+
+        // Verify wire decoding from raw JSON
+        let wrapper: azdo::VssJsonCollectionWrapper<azdo::TimelineRecord> =
+            serde_json::from_value(raw_json_payload.clone()).expect("valid wire JSON payload");
+        assert_eq!(wrapper.value.len(), 2);
+        assert_eq!(
+            wrapper.value[0].record_type,
+            Some(azdo::TimelineRecordType::Job)
+        );
+        assert_eq!(
+            wrapper.value[1].record_type,
+            Some(azdo::TimelineRecordType::Task)
+        );
+
+        // PATCH timeline records (first call)
         let _ = patch_timeline_records(
             State(shared.clone()),
             Path((
@@ -846,10 +870,7 @@ mod tests {
                 plan_id.clone(),
                 timeline_id.to_string(),
             )),
-            Json(azdo::VssJsonCollectionWrapper {
-                count: 1,
-                value: vec![job_record],
-            }),
+            Json(wrapper),
         )
         .await;
 
@@ -859,9 +880,13 @@ mod tests {
             Path((
                 "scope".to_owned(),
                 "hub".to_owned(),
-                plan_id,
+                plan_id.clone(),
                 timeline_id.to_string(),
             )),
+            axum::extract::Query(TimelineQuery {
+                top: None,
+                skip: None,
+            }),
         )
         .await;
         let records = response
@@ -869,38 +894,83 @@ mod tests {
             .get("records")
             .and_then(|v| v.as_array())
             .expect("records array");
-        let stored = records
+        let stored_job = records
             .iter()
-            .find(|r| r["id"] == record_id.to_string())
+            .find(|r| r["id"] == job_record_id.to_string())
             .expect("job record persisted");
-        let issues = stored["issues"].as_array().expect("issues preserved");
-        assert_eq!(issues.len(), 1, "the Node 20 warning issue must survive");
-        assert_eq!(issues[0]["type"], "warning");
-        assert_eq!(issues[0]["message"], node20_message);
+        let job_issues = stored_job["issues"].as_array().expect("issues preserved");
+        assert_eq!(
+            job_issues.len(),
+            1,
+            "the Node 20 warning issue must survive on job record"
+        );
+        assert_eq!(job_issues[0]["type"], "warning");
+        assert_eq!(job_issues[0]["message"], node20_message);
 
-        // Projected as a job-level annotation (no step_id).
+        let stored_task = records
+            .iter()
+            .find(|r| r["id"] == child_task_id.to_string())
+            .expect("child task record persisted");
+        let task_issues = stored_task["issues"].as_array().expect("issues preserved");
+        assert_eq!(
+            task_issues.len(),
+            1,
+            "the Node 20 warning issue must survive on task record"
+        );
+
+        // Replaying/retrying the exact same PATCH call (Finding 3: deduplication check)
+        let wrapper_retry: azdo::VssJsonCollectionWrapper<azdo::TimelineRecord> =
+            serde_json::from_value(raw_json_payload).expect("valid wire JSON payload");
+        let _ = patch_timeline_records(
+            State(shared.clone()),
+            Path((
+                "scope".to_owned(),
+                "hub".to_owned(),
+                plan_id,
+                timeline_id.to_string(),
+            )),
+            Json(wrapper_retry),
+        )
+        .await;
+
         let inner = state.inner.lock().await;
         let events = inner
             .timeline_events
             .get(&run_id)
             .expect("timeline events recorded for the run");
-        let (level, message, step_id) = events
+
+        // Count projected annotations for the Node 20 message
+        let matching_annotations: Vec<_> = events
             .iter()
-            .find_map(|event| match event {
+            .filter_map(|event| match event {
                 NdjsonEvent::Annotation {
                     level,
                     message,
                     step_id,
                     ..
-                } => Some((*level, message.clone(), step_id.clone())),
+                } if message == &node20_message => Some((*level, step_id.clone())),
                 _ => None,
             })
-            .expect("Node 20 warning projected as an annotation");
-        assert!(matches!(level, AnnotationLevel::Warning));
-        assert_eq!(message, node20_message);
-        assert!(
-            step_id.is_none(),
-            "a job-level annotation must not carry a step_id"
+            .collect();
+
+        // Deduplication check: even after retrying PATCH, there should be exactly one annotation
+        // for the job record (step_id == None) and one for the child task record (step_id == Some(child_task_id)).
+        assert_eq!(
+            matching_annotations.len(),
+            2,
+            "annotations must be deduplicated across repeated PATCH calls"
         );
+
+        let job_ann = matching_annotations
+            .iter()
+            .find(|(_, step_id)| step_id.is_none())
+            .expect("parentless job record produces step_id == None annotation");
+        assert!(matches!(job_ann.0, AnnotationLevel::Warning));
+
+        let task_ann = matching_annotations
+            .iter()
+            .find(|(_, step_id)| step_id.as_deref() == Some(&child_task_id.to_string()))
+            .expect("child task record produces step_id == Some(task_id) annotation");
+        assert!(matches!(task_ann.0, AnnotationLevel::Warning));
     }
 }

--- a/crates/preloop-runner-server/src/timeline_logs.rs
+++ b/crates/preloop-runner-server/src/timeline_logs.rs
@@ -663,12 +663,17 @@ mod tests {
     use std::collections::BTreeMap;
     use std::sync::Arc;
 
-    /// A timeline PATCH for an in-flight job must keep the truthful
-    /// "in_progress" conclusion. The raw Debug spelling ("inprogress") and
-    /// the run-level status_string projection ("success") both lie about a
-    /// job that is still running.
-    #[tokio::test]
-    async fn timeline_patch_keeps_in_progress_conclusion_for_in_flight_job() {
+    /// Seed a single in-flight run with one job, its plan→request mapping, and
+    /// timeline id. Returns the owned `TempDir` (keeps the store file alive for
+    /// the test's lifetime) alongside the handles tests assert against.
+    async fn seed_inflight_run() -> (
+        tempfile::TempDir,
+        Arc<SharedState>,
+        RunId,
+        JobId,
+        String,
+        uuid::Uuid,
+    ) {
         let temp = tempfile::tempdir().unwrap();
         let state = crate::AppState::new(temp.path().to_path_buf())
             .await
@@ -744,6 +749,17 @@ mod tests {
                 },
             );
         }
+        (temp, shared, run_id, job_id, plan_id, timeline_id)
+    }
+
+    /// A timeline PATCH for an in-flight job must keep the truthful
+    /// "in_progress" conclusion. The raw Debug spelling ("inprogress") and
+    /// the run-level status_string projection ("success") both lie about a
+    /// job that is still running.
+    #[tokio::test]
+    async fn timeline_patch_keeps_in_progress_conclusion_for_in_flight_job() {
+        let (_temp, shared, run_id, _job_id, plan_id, timeline_id) = seed_inflight_run().await;
+        let state = shared.state.clone();
 
         let _ = patch_timeline_records(
             State(shared),
@@ -770,6 +786,121 @@ mod tests {
         assert_eq!(
             detail.conclusion, "in_progress",
             "an in-flight job must not read as 'success' or 'inprogress'"
+        );
+    }
+
+    /// A job-level Node.js 20 deprecation warning arrives from the runner as a
+    /// `Warning` issue on the job timeline record. The server must preserve it
+    /// on read-back and project it as a job-level annotation (no `step_id`).
+    /// Preloop never synthesizes this warning itself — it only surfaces what
+    /// the runner sends.
+    #[tokio::test]
+    async fn timeline_patch_preserves_node20_deprecation_warning() {
+        let (_temp, shared, run_id, _job_id, plan_id, timeline_id) = seed_inflight_run().await;
+        let state = shared.state.clone();
+
+        let node20_message = "Node.js 20 actions are deprecated. The following actions are \
+             running on Node.js 20 and may not work as expected: actions/checkout@v3, \
+             actions/setup-node@v3."
+            .to_owned();
+
+        let job_record = azdo::TimelineRecord {
+            id: uuid::Uuid::new_v4(),
+            change_id: None,
+            parent_id: None,
+            name: Some("build".to_owned()),
+            display_name: Some("build".to_owned()),
+            record_type: Some(azdo::TimelineRecordType::Job),
+            state: Some(azdo::TimelineRecordState::InProgress),
+            result: None,
+            start_time: None,
+            finish_time: None,
+            issues: vec![azdo::Issue {
+                issue_type: azdo::IssueType::Warning,
+                category: None,
+                message: Some(node20_message.clone()),
+                data: BTreeMap::new(),
+                is_infrastructure_issue: None,
+            }],
+            variables: BTreeMap::new(),
+            current_operation: None,
+            percent_complete: None,
+            worker_name: None,
+            error_count: None,
+            warning_count: Some(1),
+            is_background: None,
+            background_control_type: None,
+            background_control_step_ids: Vec::new(),
+            parallel_group_id: None,
+            steps: Vec::new(),
+            last_modified: None,
+            log: None,
+        };
+        let record_id = job_record.id;
+
+        let _ = patch_timeline_records(
+            State(shared.clone()),
+            Path((
+                "scope".to_owned(),
+                "hub".to_owned(),
+                plan_id.clone(),
+                timeline_id.to_string(),
+            )),
+            Json(azdo::VssJsonCollectionWrapper {
+                count: 1,
+                value: vec![job_record],
+            }),
+        )
+        .await;
+
+        // Preserved on read-back.
+        let response = get_timeline_records(
+            State(shared.clone()),
+            Path((
+                "scope".to_owned(),
+                "hub".to_owned(),
+                plan_id,
+                timeline_id.to_string(),
+            )),
+        )
+        .await;
+        let records = response
+            .0
+            .get("records")
+            .and_then(|v| v.as_array())
+            .expect("records array");
+        let stored = records
+            .iter()
+            .find(|r| r["id"] == record_id.to_string())
+            .expect("job record persisted");
+        let issues = stored["issues"].as_array().expect("issues preserved");
+        assert_eq!(issues.len(), 1, "the Node 20 warning issue must survive");
+        assert_eq!(issues[0]["type"], "warning");
+        assert_eq!(issues[0]["message"], node20_message);
+
+        // Projected as a job-level annotation (no step_id).
+        let inner = state.inner.lock().await;
+        let events = inner
+            .timeline_events
+            .get(&run_id)
+            .expect("timeline events recorded for the run");
+        let (level, message, step_id) = events
+            .iter()
+            .find_map(|event| match event {
+                NdjsonEvent::Annotation {
+                    level,
+                    message,
+                    step_id,
+                    ..
+                } => Some((*level, message.clone(), step_id.clone())),
+                _ => None,
+            })
+            .expect("Node 20 warning projected as an annotation");
+        assert!(matches!(level, AnnotationLevel::Warning));
+        assert_eq!(message, node20_message);
+        assert!(
+            step_id.is_none(),
+            "a job-level annotation must not carry a step_id"
         );
     }
 }

--- a/crates/preloop-runner/src/worker/contexts.rs
+++ b/crates/preloop-runner/src/worker/contexts.rs
@@ -60,6 +60,9 @@ pub struct JobContext {
     pub upgraded_node24_actions: Vec<String>,
     /// Actions still using deprecated node20 (for warning).
     pub deprecated_node20_actions: Vec<String>,
+    /// Whether the Node 20 deprecation warning has already been emitted for this job.
+    /// Guard for one-time per-job warning via the node handler; not per step.
+    pub node20_warning_emitted: bool,
     /// v2.336.0 (#4527): Job-scoped artifact subjects from $GITHUB_ARTIFACTS.
     /// Keyed by canonical subject name; value is (digest, kind).
     pub artifact_subjects: IndexMap<String, ArtifactSubject>,
@@ -166,6 +169,7 @@ impl JobContext {
             debugger_telemetry: Vec::new(),
             upgraded_node24_actions: Vec::new(),
             deprecated_node20_actions: Vec::new(),
+            node20_warning_emitted: false,
             artifact_subjects: IndexMap::new(),
         }
     }
@@ -182,6 +186,16 @@ impl JobContext {
         if !self.deprecated_node20_actions.iter().any(|n| n == name) {
             self.deprecated_node20_actions.push(name.to_string());
         }
+    }
+
+    /// Emit the one-time per-job Node 20 deprecation warning if not already emitted.
+    /// Returns true if a warning was emitted.
+    pub fn emit_node20_deprecation_warning(&mut self) -> bool {
+        if self.node20_warning_emitted {
+            return false;
+        }
+        self.node20_warning_emitted = true;
+        true
     }
 
     /// Get the value of a variable by key. Supports case-insensitive lookup.

--- a/crates/preloop-runner/src/worker/handlers/node.rs
+++ b/crates/preloop-runner/src/worker/handlers/node.rs
@@ -228,6 +228,15 @@ pub async fn run_node_action(
         ctx.log(&format!("::warning::{warning}"));
     }
     let node_version = selection.version;
+    // v2.337.0: Node 20 runtime is deprecated for actions. Emit a one-time
+    // per-job warning via the job log and tracing, without failing the step
+    // or altering the selected Node binary.
+    const NODE20_DEPRECATION_WARNING: &str =
+        "Node 20 actions are deprecated and support ends soon; migrate actions to node24.";
+    if node_version.starts_with("node20") && ctx.job.emit_node20_deprecation_warning() {
+        tracing::warn!("{}", NODE20_DEPRECATION_WARNING);
+        ctx.log(&format!("::warning::{NODE20_DEPRECATION_WARNING}"));
+    }
     if runs_using == "node20" {
         if let Some(name) = action_name {
             if node_version == "node24" {
@@ -726,5 +735,164 @@ mod tests {
         .await
         .unwrap_err();
         assert!(err.to_string().contains("escapes action directory"));
+    }
+
+    const NODE20_WARNING_SUBSTR: &str =
+        "Node 20 actions are deprecated and support ends soon; migrate actions to node24.";
+
+    fn setup_externals_with_shim(root: &std::path::Path) {
+        for version in ["node20", "node24"] {
+            let bin_dir = root.join("externals").join(version).join("bin");
+            std::fs::create_dir_all(&bin_dir).unwrap();
+            let node_path = bin_dir.join("node");
+            // Minimal shim that exits 0; handler checks is_file() and executes it.
+            std::fs::write(&node_path, "#!/bin/sh\nexit 0\n").unwrap();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mut perms = std::fs::metadata(&node_path).unwrap().permissions();
+                perms.set_mode(0o755);
+                std::fs::set_permissions(&node_path, perms).unwrap();
+            }
+            // Also create windows variant for completeness; handler is cfg-gated at runtime
+            // but the test suite runs on linux/darwin, so the unix shim is what matters.
+            let win_path = root.join("externals").join(version).join("node.exe");
+            if !win_path.exists() {
+                std::fs::write(&win_path, "#!/bin/sh\nexit 0\n").unwrap();
+            }
+        }
+    }
+
+    fn assert_deprecation_warning_count(ctx: &StepContext<'_>, expected: usize) {
+        let log_count = ctx
+            .log_lines
+            .iter()
+            .filter(|line| line.contains(NODE20_WARNING_SUBSTR))
+            .count();
+        let annotation_count = ctx
+            .annotations
+            .iter()
+            .filter(|a| a.message.contains(NODE20_WARNING_SUBSTR))
+            .count();
+        // ::warning:: is parsed into an annotation plus a ##[warning] log line;
+        // both contain the message, so we take the max to avoid double-counting.
+        let total = std::cmp::max(log_count, annotation_count);
+        assert_eq!(
+            total, expected,
+            "expected {expected} deprecation warning(s), log_lines={:?} annotations={:?}",
+            ctx.log_lines, ctx.annotations
+        );
+    }
+
+    #[tokio::test]
+    async fn node20_action_emits_deprecation_warning_once_per_job() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_externals_with_shim(tmp.path());
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let action_dir = tmp.path().join("action");
+        std::fs::create_dir_all(&action_dir).unwrap();
+        std::fs::write(action_dir.join("index.js"), "console.log('hello')").unwrap();
+
+        let manifest20 = ActionManifest {
+            name: "test".into(),
+            description: String::new(),
+            runs_using: "node20".into(),
+            runs_main: Some("index.js".into()),
+            runs_pre: None,
+            runs_pre_if: None,
+            runs_post: None,
+            runs_post_if: None,
+            runs_steps: None,
+            runs_image: None,
+            runs_entrypoint: None,
+            runs_args: None,
+            runs_env: None,
+            inputs: None,
+            outputs: None,
+        };
+
+        let mut job = crate::worker::contexts::JobContext::new(
+            "job".into(),
+            "job".into(),
+            serde_json::json!({}),
+            serde_json::json!({}),
+        );
+        // First node20 step should emit the warning.
+        {
+            let mut ctx = StepContext::new(&mut job, "step1".into(), "Step 1".into());
+            let (_tx, cancel_rx) = tokio::sync::watch::channel(false);
+            run_node_action(
+                &manifest20,
+                &action_dir,
+                &serde_json::json!({}),
+                workspace.to_str().unwrap(),
+                &mut ctx,
+                cancel_rx,
+                Some("actions/checkout@v3"),
+            )
+            .await
+            .expect("first node20 action should succeed");
+            assert_deprecation_warning_count(&ctx, 1);
+            assert!(
+                ctx.job.node20_warning_emitted,
+                "job flag must be set after first warning"
+            );
+        }
+
+        // Second node20 step in the same job must NOT emit again.
+        {
+            let mut ctx = StepContext::new(&mut job, "step2".into(), "Step 2".into());
+            let (_tx, cancel_rx) = tokio::sync::watch::channel(false);
+            run_node_action(
+                &manifest20,
+                &action_dir,
+                &serde_json::json!({}),
+                workspace.to_str().unwrap(),
+                &mut ctx,
+                cancel_rx,
+                Some("actions/setup-node@v3"),
+            )
+            .await
+            .expect("second node20 action should succeed");
+            assert_deprecation_warning_count(&ctx, 0);
+        }
+        assert!(job.node20_warning_emitted);
+    }
+
+    #[tokio::test]
+    async fn node24_action_emits_no_deprecation_warning() {
+        let tmp = tempfile::tempdir().unwrap();
+        setup_externals_with_shim(tmp.path());
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let action_dir = tmp.path().join("action");
+        std::fs::create_dir_all(&action_dir).unwrap();
+        std::fs::write(action_dir.join("index.js"), "console.log('hello')").unwrap();
+
+        let mut manifest24 = node_manifest("index.js");
+        manifest24.runs_using = "node24".into();
+
+        let mut job = crate::worker::contexts::JobContext::new(
+            "job".into(),
+            "job".into(),
+            serde_json::json!({}),
+            serde_json::json!({}),
+        );
+        let mut ctx = StepContext::new(&mut job, "step1".into(), "Step 1".into());
+        let (_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        run_node_action(
+            &manifest24,
+            &action_dir,
+            &serde_json::json!({}),
+            workspace.to_str().unwrap(),
+            &mut ctx,
+            cancel_rx,
+            Some("actions/checkout@v4"),
+        )
+        .await
+        .expect("node24 action should succeed");
+        assert_deprecation_warning_count(&ctx, 0);
+        assert!(!ctx.job.node20_warning_emitted);
     }
 }

--- a/docs/fidelity-gap.md
+++ b/docs/fidelity-gap.md
@@ -232,6 +232,8 @@ deprecation warnings, job-level annotations, and background step control-flow.
 | Reusable workflows                                              | parsing, `secrets: inherit`, required secrets/inputs, input type validation, OIDC `environment` propagation, `oidc_job_workflow_ref`; depth limit = 4                                                                                                                                                                                                                                                                                                                                | ✅ good                                               |
 | Node 20→24 migration/deprecation warnings                       | implemented: flag source precedence, conflict warning, ARM32 fallback (Plan 008)                                                                                                                                                                                                                                                                                                                                                                                                     | ✅ good                                               |
 
+> **Externals pin divergence (v2.336.0 vs v2.337.0):** preloop ships `node24_externals_version = 24.19.0` and `node20_externals_version = 20.20.2` (the final Node 20 release) while the `v2.336.0` golden pins Node 24 `24.18.0`. The `24.19.0` patch is a secure forward-port matching the `v2.337.0` externals with no wire-protocol change; conformance is unaffected.
+
 
 ---
 

--- a/versions.toml
+++ b/versions.toml
@@ -46,8 +46,8 @@ official_runner_image_base_arm64 = "ghcr.io/preloopdev/runner-images:ubuntu24-ar
 node_version = "22.23.1"
 rustup_version = "1.29.0"
 cargo_shear_version = "1.12.4"
-node20_externals_version = "20.19.0"
-node24_externals_version = "24.3.0"
+node20_externals_version = "20.20.2"
+node24_externals_version = "24.19.0"
 
 # GitHub-hosted parity bake list — exact versions from the official
 # ubuntu-24.04 runner image toolset named above. Baked into the golden at


### PR DESCRIPTION
## Summary

Addresses the Node-runtime exposure found in the supply-chain audit: preloop's externals pins (Node 20.19.0 / Node 24.3.0) predate the security releases shipped in the official runner's Node 20.20.2 / 24.19.0 trees, and the Node 20 deprecation surface from official runner v2.337.0 was missing.

### Changes
- **versions.toml**: `node20_externals_version` 20.19.0 → **20.20.2** (final Node 20 release), `node24_externals_version` 24.3.0 → **24.19.0** (v2.337.0 externals). `runner_version` untouched.
- **Node 20 deprecation warning** (matches official v2.337.0): one-time per-job `::warning::` annotation + `tracing::warn` in the node action handler when the resolved `node_version` starts with `node20` (`JobContext::node20_warning_emitted` guard). Never fails the step; does not alter the executed node path.
- **Server-side projection test** (`timeline_logs.rs`): job-level `Warning` issues sent by the runner are preserved on timeline read-back and projected as job-level annotations; refactored test seeding into `seed_inflight_run()`.
- **docs/fidelity-gap.md**: documents the externals-pin divergence (we ship 24.19.0 vs the v2.336.0 golden's 24.18.0) as a secure forward-port with no wire-protocol change.

### Verification
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `just test-ci` (tests + conformance): all green.
- New handler tests: node20 action emits warning exactly once per job; node24 emits none.

📌 Note for reviewers: cache-reconciliation and checksum verification for these new pins land in #204; CI pin automation in #205.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-time Node 20 deprecation warning per job; previously no warning surfaced. The warning doesn't fail the step or change the selected Node binary.

**Changes**
- Emits the warning as a `::warning::` log line and tracing event in the node action handler, with a `JobContext` guard suppressing later Node 20 steps in the same job.
- Bumps `node20_externals_version` to `20.20.2` and `node24_externals_version` to `24.19.0` in `versions.toml`, noting the pin divergence from the v2.336.0 golden in `docs/fidelity-gap.md`.
- Decodes `Task`, `Phase`, and `Stage` timeline record wire types and deduplicates projected annotations when a timeline PATCH is replayed.
- Adds handler and server-side test coverage for the warning, including preservation of runner-sent warnings as job-level annotations.

<sup>Written for commit 69a2226b948629e4d5611a5f43f7131f83d06607. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Node.js 20 actions now display a one-time deprecation warning per job.
  - Warnings appear as job-level annotations without interrupting steps or changing the selected runtime.
  - Updated Node.js 20 and Node.js 24 runtime versions.

- **Bug Fixes**
  - Improved persistence and display of runner-provided warning annotations.
  - Preserved the correct `in_progress` status for active jobs.
  - Prevented action entry points from escaping their intended directory.

- **Documentation**
  - Documented runtime version alignment and compatibility details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->