### PR TITLE
fix(dap): mask and sanitize server-supplied debugger welcome text

### DIFF
--- a/crates/preloop-dap/src/debugger.rs
+++ b/crates/preloop-dap/src/debugger.rs
@@ -453,15 +453,7 @@ impl DapDebugger {
                 if req.raw.command == "configurationDone" {
                     // Send welcome output event after configurationDone
                     // (matches official runner ordering).
-                    let welcome = if core.override_welcome {
-                        core.welcome_message.clone()
-                    } else {
-                        Some(
-                            core.welcome_message
-                                .clone()
-                                .unwrap_or_else(default_welcome_message),
-                        )
-                    };
+                    let welcome = resolve_welcome_message(&core);
                     if let Some(mut msg) = welcome {
                         if !msg.is_empty() {
                             if !msg.ends_with('\n') {
@@ -740,6 +732,45 @@ async fn dispatch_one(core: &Arc<DebuggerCore>, req: &Request, seq: i64) -> Resp
 
 fn default_welcome_message() -> String {
     "Debugger attached. Use DAP continue/next/stepIn/stepOut to navigate steps.".to_string()
+}
+
+/// Resolve the welcome message shown after `configurationDone`.
+///
+/// The welcome message carried in [`DebuggerConfig::welcome_message`] is
+/// server-supplied and never rendered verbatim: secrets are masked and control
+/// characters stripped before it reaches the console. Only
+/// [`default_welcome_message`] is runner-controlled and therefore trusted.
+/// Mirrors `SanitizeConsoleText(MaskUserVisibleText(WelcomeMessage))` in
+/// `DapDebugger.cs` (actions/runner v2.337.0).
+fn resolve_welcome_message(core: &Arc<DebuggerCore>) -> Option<String> {
+    let sanitize_server = |msg: &str| {
+        let masks = core.masks.lock().clone();
+        sanitize_console_text(&dap_mask_closure(&masks)(msg))
+    };
+    if core.override_welcome {
+        core.welcome_message.as_deref().map(sanitize_server)
+    } else {
+        Some(
+            core.welcome_message
+                .as_deref()
+                .map(sanitize_server)
+                .unwrap_or_else(default_welcome_message),
+        )
+    }
+}
+
+/// Strip C0/C1 control characters (except tab, carriage return and line feed)
+/// so server-supplied text cannot inject ANSI escape sequences or terminal
+/// control codes into the DAP console.
+///
+/// Mirrors `DapDebugger.cs::SanitizeConsoleText` (actions/runner v2.337.0).
+/// `char::is_control` covers C0 (U+0000–U+001F), DEL (U+007F) and
+/// C1 (U+0080–U+009F); tab/LF/CR are the only whitespace controls preserved.
+fn sanitize_console_text(value: &str) -> String {
+    value
+        .chars()
+        .filter(|c| !c.is_control() || matches!(c, '\t' | '\n' | '\r'))
+        .collect()
 }
 
 fn which_devtunnel() -> Option<std::path::PathBuf> {
@@ -1136,5 +1167,45 @@ mod tests {
             Some(v) => std::env::set_var(crate::env_vars::DAP_CONNECTION_TIMEOUT, v),
             None => std::env::remove_var(crate::env_vars::DAP_CONNECTION_TIMEOUT),
         }
+    }
+
+    #[test]
+    fn sanitize_console_text_strips_control_chars_but_keeps_whitespace() {
+        // ESC (C0), a C1 control (U+0085), DEL and a NUL are stripped;
+        // tab/CR/LF and printable text (incl. non-ASCII) survive.
+        let raw = "a\x1b[31mb\u{0085}c\x7f\td\r\ne\0f";
+        assert_eq!(sanitize_console_text(raw), "a[31mbc\td\r\nef");
+        assert_eq!(sanitize_console_text("plain café ✓"), "plain café ✓");
+        assert_eq!(sanitize_console_text(""), "");
+    }
+
+    #[test]
+    fn override_welcome_message_is_masked_and_sanitized() {
+        // Server-supplied override message carrying a secret and an ANSI
+        // escape sequence must be both masked and control-char stripped.
+        let cfg = DebuggerConfig::new(
+            true,
+            Some(sample_tunnel()),
+            true,
+            Some("hi \x1b[2Jsuper-secret done".to_string()),
+        );
+        let dbg = DapDebugger::new(cfg);
+        dbg.update_context(
+            serde_json::json!({}),
+            std::collections::HashSet::from(["super-secret".to_string()]),
+        );
+        let out = resolve_welcome_message(&dbg.core).unwrap();
+        assert!(!out.contains("super-secret"), "secret leaked: {out}");
+        assert!(!out.contains('\x1b'), "control char leaked: {out}");
+        assert_eq!(out, "hi [2J*** done");
+    }
+
+    #[test]
+    fn default_welcome_message_used_without_server_text() {
+        let dbg = DapDebugger::new(sample_config());
+        assert_eq!(
+            resolve_welcome_message(&dbg.core),
+            Some(default_welcome_message())
+        );
     }
 }


### PR DESCRIPTION
## Problem

The DAP debugger welcome message carried in `DebuggerConfig::welcome_message` (mirroring the wire field `AgentJobRequestMessage.DebuggerWelcomeMessage`) is **server-supplied** but was written to the DAP console **verbatim**. That let:

- **secret values leak** into the console (no masking), and
- **terminal/ANSI escape sequences** be injected via control bytes (e.g. `ESC` `\x1b`).

## Change

Ports actions/runner v2.337.0's `SanitizeConsoleText(MaskUserVisibleText(WelcomeMessage))` handling in `crates/preloop-dap/src/debugger.rs`:

- **`sanitize_console_text(value)`** — strips control characters (`char::is_control`: C0 `U+0000–001F`, DEL `U+007F`, C1 `U+0080–009F`) while preserving `\t`/`\n`/`\r` and all printable/non-ASCII text. Mirrors `DapDebugger.cs::SanitizeConsoleText`.
- **`resolve_welcome_message(core)`** — extracted the `configurationDone` welcome logic into a testable helper. Server-supplied text is masked first (existing `dap_mask_closure`, `***` marker, longest-first, DAP-keyword exclusions) then sanitized. Only the runner-controlled `default_welcome_message()` stays trusted and untouched.
- Dispatcher `configurationDone` arm now calls `resolve_welcome_message(&core)`.

The helper was extracted because the welcome event is only emitted inside the socket serve loop; this makes the mask+sanitize contract unit-testable without standing up a socket.

## Tests (3 new)

- `sanitize_console_text_strips_control_chars_but_keeps_whitespace` — ESC/C1/DEL/NUL stripped; tab/CR/LF + `café ✓` preserved.
- `override_welcome_message_is_masked_and_sanitized` — `"hi \x1b[2Jsuper-secret done"` + secret → `"hi [2J*** done"` (secret and ESC both gone; verifies mask→sanitize order).
- `default_welcome_message_used_without_server_text` — trusted default unchanged.

## Verification

`cargo test -p preloop-dap` → 70 unit + 1 doc test pass, 0 failures.

## Scope note

The sync spec also lists `DebuggerTunnelException` / tunnel-disconnect infrastructure-failure entries. Those describe upstream's Dev Tunnel `ConnectionStatusChanged` relay host, which has no counterpart here (this crate runs `devtunnel` as a subprocess, not an in-process relay), so there is nothing faithful to port for those yet. The sanitize/mask gap — the one this branch is named for — is what this PR implements.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Masks secrets and strips control characters from server-supplied DAP debugger welcome text before it reaches the console. Previously written verbatim, the message could leak secret values and inject ANSI escape sequences; it now matches actions/runner v2.337.0's `SanitizeConsoleText(MaskUserVisibleText(...))` handling.

- Extracted `resolve_welcome_message` from the socket serve loop so mask+sanitize behavior is unit-testable without a live connection.
- `sanitize_console_text` drops C0/C1 control chars and DEL, keeping tab, CR, LF, and printable non-ASCII text.
- Masking happens before sanitizing; the runner-controlled `default_welcome_message` is never masked or sanitized.
- Added 3 tests covering control-char stripping, mask-then-sanitize ordering, and the untouched default.
- Sync-spec tunnel-disconnect entries (`DebuggerTunnelException`) have no in-process relay counterpart here, so they aren't ported.

<sup>Written for commit 36a805b89488d73ff5a3ef61c9cf0631983504e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

