### PR TITLE
feat(conformance): actions/runner v2.337.0 golden captures, server wire compatibility fixes, and 5-repo campaign v2

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -38,7 +38,47 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      - name: Check for reviewable platform changes
+        id: diff_filter
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            if git fetch origin "$BASE_REF" --depth=1 >/dev/null 2>&1 && \
+               CHANGED=$(git diff --name-only "origin/$BASE_REF"...HEAD 2>/dev/null) && \
+               [ -n "$CHANGED" ]; then
+              CODE_CHANGED=$(echo "$CHANGED" | grep -vE '^(\.runner-watch/.*\.jsonl$|\.runner-watch/.*\.json$|docs/|.*\.md$)' || true)
+              if [ -z "$CODE_CHANGED" ]; then
+                echo "Only docs, markdown, and static golden captures changed. Skipping Pullfrog review to avoid unnecessary model charges."
+                echo "skip=true" >> "$GITHUB_OUTPUT"
+              else
+                echo "Platform code or executable files changed:"
+                echo "$CODE_CHANGED"
+                echo "skip=false" >> "$GITHUB_OUTPUT"
+              fi
+            else
+              echo "Could not reliably determine git diff; running review."
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Ensure npm and npx are available
+        run: |
+          for node_dir in /opt/actions-runner/externals*/node*; do
+            if [ -d "$node_dir/bin" ] && [ -f "$node_dir/lib/node_modules/npm/bin/npm-cli.js" ]; then
+              printf '#!/usr/bin/env sh\nexec node "%s" "$@"\n' "$node_dir/lib/node_modules/npm/bin/npx-cli.js" > "$node_dir/bin/npx" || true
+              printf '#!/usr/bin/env sh\nexec node "%s" "$@"\n' "$node_dir/lib/node_modules/npm/bin/npm-cli.js" > "$node_dir/bin/npm" || true
+              chmod +x "$node_dir/bin/npx" "$node_dir/bin/npm" || true
+              echo "$node_dir/bin" >> "$GITHUB_PATH"
+            fi
+          done || true
+
       - name: Run Pullfrog (via GHES-compatible fork)
+        if: steps.diff_filter.outputs.skip != 'true'
+        continue-on-error: true
         uses: Bnjoroge1/pullfrog@09dde428a88245ab3c448ff3dcadb8325e4e1d05 # ghes-url-support
         with:
           prompt: ${{ inputs.prompt || toJSON(github.event) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
-  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'

--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ skills-lock.json
 /logo-square.png
 
 .wrangler/
+.pi/

--- a/.runner-watch/golden/v2.337.0/gh-official/201-expression-edge-cases/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/201-expression-edge-cases/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:094c79ad8a897beb0fed8ae606132d12f54a59ce4b6892a0e4f4eafb1b038673
+size 846513

--- a/.runner-watch/golden/v2.337.0/gh-official/201-expression-edge-cases/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/201-expression-edge-cases/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:762dad6cfe3e26aecedffab69b81fa2315b61424a9b7bdee5c0b3c92fd0e7634
+size 308

--- a/.runner-watch/golden/v2.337.0/gh-official/201-expression-edge-cases/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/201-expression-edge-cases/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:968e99ad2d2f50193c8cd7b884570c435e2baae6f1e3582fd26d66a2e7ab5cce
+size 311

--- a/.runner-watch/golden/v2.337.0/gh-official/202-dynamic-matrix-dataflow/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/202-dynamic-matrix-dataflow/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3485c26be4d231c75508501f9b573459668d8a706ee259ca9f1d6ef71c70da0
+size 7269198

--- a/.runner-watch/golden/v2.337.0/gh-official/202-dynamic-matrix-dataflow/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/202-dynamic-matrix-dataflow/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26f8a70fa90b455288225b08c4c22b7d40db57e5257a4cb8a6ca9126b2ca72b1
+size 2631

--- a/.runner-watch/golden/v2.337.0/gh-official/202-dynamic-matrix-dataflow/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/202-dynamic-matrix-dataflow/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:852c028e8bb9c1660af214877ce44059fe9a313f13cdc850a233945538994a00
+size 313

--- a/.runner-watch/golden/v2.337.0/gh-official/203-needs-dag-deep-chain/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/203-needs-dag-deep-chain/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6629829bdea7802ac0bcaec2cc1161cdfc30de81d2e60b144bce4b3cae91e0e
+size 5648149

--- a/.runner-watch/golden/v2.337.0/gh-official/203-needs-dag-deep-chain/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/203-needs-dag-deep-chain/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68fd285498e11d71056fc94a27ce8b0e2a7a1952f8164f6f262fc8a7debc44fc
+size 1814

--- a/.runner-watch/golden/v2.337.0/gh-official/203-needs-dag-deep-chain/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/203-needs-dag-deep-chain/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:231f71e802392784cb0ce7b22a784ebd441fbf8a327de14fa2ef97b8099963ba
+size 310

--- a/.runner-watch/golden/v2.337.0/gh-official/204-composite-with-outputs-ifs/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/204-composite-with-outputs-ifs/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1d28ac80d11662057827b7cfd14d599f84256d524bf009d0f6e72c0bdaa4661
+size 857565

--- a/.runner-watch/golden/v2.337.0/gh-official/204-composite-with-outputs-ifs/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/204-composite-with-outputs-ifs/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db72d94edf8b207e8066eea5d0565f04171367ab8680219d4be7ee7e59359e50
+size 657

--- a/.runner-watch/golden/v2.337.0/gh-official/204-composite-with-outputs-ifs/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/204-composite-with-outputs-ifs/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13530d85eceee7bc2fddaec5a560e2b75ece4eecc7e677a9238bfa2a8dfe3662
+size 316

--- a/.runner-watch/golden/v2.337.0/gh-official/205-reusable-workflow-chain/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/205-reusable-workflow-chain/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cc96be3d368d7148c341162bc072d622dfd82e267a401122caa88f594553157
+size 1656939

--- a/.runner-watch/golden/v2.337.0/gh-official/205-reusable-workflow-chain/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/205-reusable-workflow-chain/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de9532a9aef527c0a3c4bb7f9a76aa7392fc1e47e721ec30f6c065235161a589
+size 682

--- a/.runner-watch/golden/v2.337.0/gh-official/205-reusable-workflow-chain/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/205-reusable-workflow-chain/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9b2610302304601e5905f86b854629025df1924154c23473ac7cf51f03bdeb3
+size 313

--- a/.runner-watch/golden/v2.337.0/gh-official/206-cache-artifact-roundtrip/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/206-cache-artifact-roundtrip/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb08042a5cce75719202b82b53093a67378c5e4255e4c247b6d0d802f0b18600
+size 2483540

--- a/.runner-watch/golden/v2.337.0/gh-official/206-cache-artifact-roundtrip/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/206-cache-artifact-roundtrip/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b08dcad7c29c44e638b412e5c970e22008d5dffb6c463484788e220352e415e
+size 760

--- a/.runner-watch/golden/v2.337.0/gh-official/206-cache-artifact-roundtrip/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/206-cache-artifact-roundtrip/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed13a06d9a2cdb4b383783d1ebed8a0721d68f06b5cedea6fb8034bed3c6442d
+size 314

--- a/.runner-watch/golden/v2.337.0/gh-official/207-masking-secrets-vars/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/207-masking-secrets-vars/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ce7d2fa4a2e8e39b9abbedd2bac3c9104daff3b2998b540cb3be27f5be06575
+size 832591

--- a/.runner-watch/golden/v2.337.0/gh-official/207-masking-secrets-vars/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/207-masking-secrets-vars/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7df0ddfb3d56a6703334f8aa552ec8ee0f52982298671cdf1ef14cffa7dc088
+size 316

--- a/.runner-watch/golden/v2.337.0/gh-official/207-masking-secrets-vars/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/207-masking-secrets-vars/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:489c0b5b21454f2763ee434f7d6662b77036c11a2a2088faeb62cc6142fde393
+size 310

--- a/.runner-watch/golden/v2.337.0/gh-official/208-timeout-graceful-kill/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/208-timeout-graceful-kill/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:390c1d64ac474eaf9e9c6d1a7df77bbc95bbb50e06e58d77c747d74cd8dd77b9
+size 3465415

--- a/.runner-watch/golden/v2.337.0/gh-official/208-timeout-graceful-kill/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/208-timeout-graceful-kill/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10c10f442b8b1224fcff8849f7553386a7342bad390d73879429d99a62cddc96
+size 537

--- a/.runner-watch/golden/v2.337.0/gh-official/208-timeout-graceful-kill/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/208-timeout-graceful-kill/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8af70fd61d52bf534617c58865b1c12baff99fbbf202bc7b67ca87c821fa06b
+size 311

--- a/.runner-watch/golden/v2.337.0/gh-official/209-continue-on-error-cascade/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/209-continue-on-error-cascade/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e48a22a2e3c4e4964294b0fbff78c1ac7db3599b0fd004a68734e9aa53f295a
+size 1675005

--- a/.runner-watch/golden/v2.337.0/gh-official/209-continue-on-error-cascade/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/209-continue-on-error-cascade/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37c4703cb5479e9bae135bc9c0abe5d2b09ea15b516714e888335a0483238903
+size 955

--- a/.runner-watch/golden/v2.337.0/gh-official/209-continue-on-error-cascade/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/209-continue-on-error-cascade/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:958fc6b0dd2b6eb4e7e51ff80ae6223b5e472de82961b90c561e92b2349b0783
+size 315

--- a/.runner-watch/golden/v2.337.0/gh-official/210-service-containers-health/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/210-service-containers-health/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4262d75c3b1d7096aa3633ebaeb4d1560edbe0b95f7122008a089c4de97ec03a
+size 844449

--- a/.runner-watch/golden/v2.337.0/gh-official/210-service-containers-health/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/210-service-containers-health/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08b8dc9fa1db25a80154f049995926017f738147524e8abf0f14cd47143de2bb
+size 449

--- a/.runner-watch/golden/v2.337.0/gh-official/210-service-containers-health/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/210-service-containers-health/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee7792ec8d718bdd3eb89ddca0a20c63ccdf6d808aa793443f013ce252c82972
+size 315

--- a/.runner-watch/golden/v2.337.0/gh-official/211-job-container-volumes/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/211-job-container-volumes/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08b7f7707fe7e65c5346ab7162103859941018e0e7069b09132a8dfe8b344a02
+size 1655970

--- a/.runner-watch/golden/v2.337.0/gh-official/211-job-container-volumes/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/211-job-container-volumes/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ac0ceb5a9cbbf38722c70e8f60e14d3f439251ed1cfdb58897f9bcc82fbbe12
+size 926

--- a/.runner-watch/golden/v2.337.0/gh-official/211-job-container-volumes/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/211-job-container-volumes/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19cb283807c20da4850064b753c5e2bb2ba542030a923bea8654bcba4839e545
+size 311

--- a/.runner-watch/golden/v2.337.0/gh-official/212-docker-action/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/212-docker-action/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3718c3ec3e5ef6b924f86d3580409d5dfcf2b38e01210260bb6e20681298394b
+size 829003

--- a/.runner-watch/golden/v2.337.0/gh-official/212-docker-action/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/212-docker-action/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:345146a0639d2866deba82bdf305b2cf350c8ee39e5abf2751d592e3e5a2bbe9
+size 364

--- a/.runner-watch/golden/v2.337.0/gh-official/212-docker-action/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/212-docker-action/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9497389db7051af4abd0d8ddb205fe826f454f39a9a9df584b0bb3238bbbd9ce
+size 303

--- a/.runner-watch/golden/v2.337.0/gh-official/213-oidc-token-claims/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/213-oidc-token-claims/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:251622812e374120e607be52babcfb4de78fccec7bbbb02be93d9c74725e0ced
+size 841633

--- a/.runner-watch/golden/v2.337.0/gh-official/213-oidc-token-claims/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/213-oidc-token-claims/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0151702bf58ea0152aadd86973a2ef491de21e5ea7215ec3c19e5963abb369d
+size 256

--- a/.runner-watch/golden/v2.337.0/gh-official/213-oidc-token-claims/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/213-oidc-token-claims/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:234a269ea2d7c03cab097d6e69a7851244fe1ab25eb6ce09c98ca583033691bf
+size 307

--- a/.runner-watch/golden/v2.337.0/gh-official/214-checkout-repo-inspect/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/214-checkout-repo-inspect/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99f5d3d79ce354974bd7f1f25e568d3f69f639b3f0c4a954fb2889d6917d4c54
+size 1109127

--- a/.runner-watch/golden/v2.337.0/gh-official/214-checkout-repo-inspect/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/214-checkout-repo-inspect/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa6cfbe85b3ec6ebd3ef852d54c9cd675548dd47b1b4487a6a7f41a3adc1402e
+size 462

--- a/.runner-watch/golden/v2.337.0/gh-official/214-checkout-repo-inspect/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/214-checkout-repo-inspect/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4b1e7a4f86a2e2107afc85452b33a3784fb700fcfffd2d9b2c980676bda5787
+size 311

--- a/.runner-watch/golden/v2.337.0/gh-official/215-concurrency-cancel-in-progress/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/215-concurrency-cancel-in-progress/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74f5afdd9d4ac3845ea5d62ace75414db1810083ab0ef1d7e4fb87011d054f56
+size 1515148

--- a/.runner-watch/golden/v2.337.0/gh-official/215-concurrency-cancel-in-progress/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/215-concurrency-cancel-in-progress/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:edeea4752dcd91bfd4958f60c5fdf7bf62aba7f0aec753b3be06de53f1652aec
+size 306

--- a/.runner-watch/golden/v2.337.0/gh-official/215-concurrency-cancel-in-progress/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/215-concurrency-cancel-in-progress/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e4b8af714214a4804402b1dce6a5d35d10b9a03f498192f84dc086e1c7919a5
+size 320

--- a/.runner-watch/golden/v2.337.0/gh-official/216-summaries-env-cascade/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/216-summaries-env-cascade/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d01044d971eef28c982d2e55718b12eb07f7ae2336db34852c39867fb64dcf0
+size 862940

--- a/.runner-watch/golden/v2.337.0/gh-official/216-summaries-env-cascade/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/216-summaries-env-cascade/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75fc98cf274c9a7b057a33314850740c3e6a2eb1516160c1de7b5701e332a007
+size 523

--- a/.runner-watch/golden/v2.337.0/gh-official/216-summaries-env-cascade/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/216-summaries-env-cascade/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f353aa2016790e681f4a05ff7a48f15f6f0981115cf12aa1b9b62426cf1a72ef
+size 311

--- a/.runner-watch/golden/v2.337.0/gh-official/217-shell-variants/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/217-shell-variants/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6c174e3a847e13fcfc0b286fdf2fc78ac2f5bc67a8b1bb850b8892839b98960
+size 845772

--- a/.runner-watch/golden/v2.337.0/gh-official/217-shell-variants/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/217-shell-variants/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:196f2dbf18db13b8da8b3998a0f63570bd49b31534d08a2c8aebc744a83879bf
+size 462

--- a/.runner-watch/golden/v2.337.0/gh-official/217-shell-variants/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/217-shell-variants/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01d97b46e121d1402398a485d401ca12dc2bce77a121a3968ac6d9b5845c9b96
+size 304

--- a/.runner-watch/golden/v2.337.0/gh-official/218-node-migration/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/218-node-migration/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52e912b478531ba15151c761a167b62c4de6a1b54073b988ca610f990bfa64b9
+size 1644075

--- a/.runner-watch/golden/v2.337.0/gh-official/218-node-migration/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/218-node-migration/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be4b2a961949caeb3fb4fb8d1f1b1a7fcd3eb5ff8633bada0cbdf7af608ea477
+size 701

--- a/.runner-watch/golden/v2.337.0/gh-official/218-node-migration/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/218-node-migration/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94944f41f17baa015b3318417d052ed3d3e154478e8f54315be927df876eff98
+size 304

--- a/.runner-watch/golden/v2.337.0/gh-official/219-env-state-files/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/219-env-state-files/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f71743583deff845d65331a662de4f3d2d8f122cb5ffa35076bdb9f021d22643
+size 861431

--- a/.runner-watch/golden/v2.337.0/gh-official/219-env-state-files/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/219-env-state-files/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e117af025ad734fb9ef961d2b9ff624a41dc96352743c229fe7dbb65e91a708f
+size 368

--- a/.runner-watch/golden/v2.337.0/gh-official/219-env-state-files/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/219-env-state-files/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70d6a1a00c85a1c40fb8bb171d38d214ac1182465a2d95b7c57b45465d6a18b9
+size 305

--- a/.runner-watch/golden/v2.337.0/gh-official/220-label-routing/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/220-label-routing/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f55a59915e50d290479100ad5df371be25a46de8faa86031950822675613d8ef
+size 1649623

--- a/.runner-watch/golden/v2.337.0/gh-official/220-label-routing/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/220-label-routing/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6ccf564a6207112248b6b83e4289b648560e0facfb1d70a91a679e5aa0c914f
+size 718

--- a/.runner-watch/golden/v2.337.0/gh-official/220-label-routing/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/220-label-routing/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:441e7fa8a026fe56d4aae3150dec261fdfeb1f8d775e17fa106b61b34221fd91
+size 303

--- a/.runner-watch/golden/v2.337.0/gh-official/221-failure-reporting/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/221-failure-reporting/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:911ea01c00d1a27286fb9c272d866980f1dc65f075a95f9812cbf1b04233e3bd
+size 1650967

--- a/.runner-watch/golden/v2.337.0/gh-official/221-failure-reporting/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/221-failure-reporting/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5176af955dd0e52d9e6cb3f7702afa8ebe1d101c38f83a3aeb929c2c53a543ac
+size 658

--- a/.runner-watch/golden/v2.337.0/gh-official/221-failure-reporting/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/221-failure-reporting/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ccd33e1395ed111d40adde31d0b2b62446bfb8f245c2786f2766f1391b36063a
+size 307

--- a/.runner-watch/golden/v2.337.0/gh-official/222-dispatch-inputs-typed/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/222-dispatch-inputs-typed/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe8363465ff2fdbf7365affe76bd1f192a0f210ecab8f13927bd9d245c425bfd
+size 1629826

--- a/.runner-watch/golden/v2.337.0/gh-official/222-dispatch-inputs-typed/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/222-dispatch-inputs-typed/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15d0633fc24378ca836a4688cf28cff5a0e8a9f2ba733ee4933073504ad563d6
+size 560

--- a/.runner-watch/golden/v2.337.0/gh-official/222-dispatch-inputs-typed/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/222-dispatch-inputs-typed/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4151ade2da8e3170be4a681fb1dd677f9cdf56e4bb53917622516964230c451
+size 311

--- a/.runner-watch/golden/v2.337.0/gh-official/223-tojson-contexts/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/223-tojson-contexts/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07e63bc21088f857f3bd5cb4fef939b305e382037f72b463509ee36c969f236a
+size 885984

--- a/.runner-watch/golden/v2.337.0/gh-official/223-tojson-contexts/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/223-tojson-contexts/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6bc9957e4b440e97ef2a569f298768430b20f394d312cd6bd35a2eb161105c59
+size 509

--- a/.runner-watch/golden/v2.337.0/gh-official/223-tojson-contexts/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/223-tojson-contexts/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ce9894d9e62fefdb85203d6caf9aa5d2cfce55797e6f2a868839d65cbc39592
+size 305

--- a/.runner-watch/golden/v2.337.0/gh-official/224-matrix-include-exclude/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/224-matrix-include-exclude/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4112a3513a8c54a1bbd1fbfbcff31af38d2d0064d2362aaa9cd6856c2c1d0fa1
+size 5637921

--- a/.runner-watch/golden/v2.337.0/gh-official/224-matrix-include-exclude/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/224-matrix-include-exclude/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de8a95802bb48021045d51ca5101e778935a9f22844fefad722e7fb25af2ca28
+size 2011

--- a/.runner-watch/golden/v2.337.0/gh-official/224-matrix-include-exclude/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/224-matrix-include-exclude/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10a4b7a91125674a65e23e7828094862b638a3537c20a170d6699e8c14f7b70c
+size 312

--- a/.runner-watch/golden/v2.337.0/gh-official/225-docker-build-run/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/225-docker-build-run/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aafa8ca52d0c206c1c875d301690531aab67405f93d4404b9e56761865056912
+size 852896

--- a/.runner-watch/golden/v2.337.0/gh-official/225-docker-build-run/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/225-docker-build-run/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6282a7b9e05693b54f87ff334a6b2364e05b1c1d6746d15dab8faf6bfe6bf1e
+size 364

--- a/.runner-watch/golden/v2.337.0/gh-official/225-docker-build-run/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/225-docker-build-run/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31866b31c3ff17c5380c38270fbb2a27b8d418f3c2ba04ee754a9dd708a83d92
+size 306

--- a/.runner-watch/golden/v2.337.0/gh-official/226-multiline-outputs/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/226-multiline-outputs/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1c7c8b890fc852f45ef17eb0e2e1dd56f77ce59d21292f5eb973181d05b06cf
+size 1644500

--- a/.runner-watch/golden/v2.337.0/gh-official/226-multiline-outputs/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/226-multiline-outputs/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e104ff9307bfbf1b03347807cb708c59d426ae642800702051ba70493bd55e29
+size 611

--- a/.runner-watch/golden/v2.337.0/gh-official/226-multiline-outputs/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/226-multiline-outputs/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12ea375c03a3735759c66f955f10b93ee0280b8a1337e9c5941d031770ee8c07
+size 307

--- a/.runner-watch/golden/v2.337.0/gh-official/227-composite-pre-post/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-official/227-composite-pre-post/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b91fbbb08662d9aa57603fca0c33e7c410388d92c1460b36902794ae10b3dfb
+size 1637974

--- a/.runner-watch/golden/v2.337.0/gh-official/227-composite-pre-post/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/227-composite-pre-post/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ed030ecdbd23a885047a9aa72d330e9c6f52dff970622404d15ae15a2d2bb6e
+size 806

--- a/.runner-watch/golden/v2.337.0/gh-official/227-composite-pre-post/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-official/227-composite-pre-post/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8df7b816cf6f14522685720a974e33f95b0c3a57db16ffad3016dd36397b4ad
+size 308

--- a/.runner-watch/golden/v2.337.0/gh-preloop/201-expression-edge-cases/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/201-expression-edge-cases/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0f352b64b6661fcac5d51770ff997852cf05433234f27604a4e78e23d795a3c
+size 574065

--- a/.runner-watch/golden/v2.337.0/gh-preloop/201-expression-edge-cases/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/201-expression-edge-cases/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:762dad6cfe3e26aecedffab69b81fa2315b61424a9b7bdee5c0b3c92fd0e7634
+size 308

--- a/.runner-watch/golden/v2.337.0/gh-preloop/201-expression-edge-cases/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/201-expression-edge-cases/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:399bddb01cf0e2833e8d6cadac03719e37cfe88d33bedea35889c6ea4baca9c7
+size 316

--- a/.runner-watch/golden/v2.337.0/gh-preloop/202-dynamic-matrix-dataflow/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/202-dynamic-matrix-dataflow/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b4e62cbe5953b3294d387ef8fefe0f4dd2d3d60d40eda82d9d62f732d2eada6
+size 4282519

--- a/.runner-watch/golden/v2.337.0/gh-preloop/202-dynamic-matrix-dataflow/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/202-dynamic-matrix-dataflow/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e79bae68ec45b73d483775ca9b2b640eb010fc449194336c6fb14f55e1ecbc10
+size 2647

--- a/.runner-watch/golden/v2.337.0/gh-preloop/203-needs-dag-deep-chain/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/203-needs-dag-deep-chain/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2990e6efb30410e9660dcf746a1f29bbf207772f8c5721b5f2a3d8c3e1cd2bbf
+size 3739338

--- a/.runner-watch/golden/v2.337.0/gh-preloop/203-needs-dag-deep-chain/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/203-needs-dag-deep-chain/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:091b48a27138c34a518caffbd07865d5bb5234876ed4966f4c96a067bcbf7242
+size 2053

--- a/.runner-watch/golden/v2.337.0/gh-preloop/203-needs-dag-deep-chain/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/203-needs-dag-deep-chain/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07e3852c135b93593d3d8d6d85ecfd4e74451370901a1d2ed972e880e6cc5055
+size 315

--- a/.runner-watch/golden/v2.337.0/gh-preloop/204-composite-with-outputs-ifs/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/204-composite-with-outputs-ifs/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a8d3a072e18e7126804ce97facd954219f19154bad3cf82720845b455de3156
+size 574721

--- a/.runner-watch/golden/v2.337.0/gh-preloop/204-composite-with-outputs-ifs/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/204-composite-with-outputs-ifs/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2c226ba5eb7ef265fb0c613893e7597a691a58b54604d2174d2f1eb04aa8773
+size 738

--- a/.runner-watch/golden/v2.337.0/gh-preloop/204-composite-with-outputs-ifs/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/204-composite-with-outputs-ifs/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7be96c038b30907d8d05cb54fe6cdf8f7813ce85d5618a6e7eaa503a42da214f
+size 321

--- a/.runner-watch/golden/v2.337.0/gh-preloop/205-reusable-workflow-chain/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/205-reusable-workflow-chain/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c59dc8ee5bdece4792f8a15eaa1fa2203a3a4fbf4ecbad02abe26a19bc37e8b
+size 1097117

--- a/.runner-watch/golden/v2.337.0/gh-preloop/205-reusable-workflow-chain/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/205-reusable-workflow-chain/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2636f698833a317eb09a371dd2bb1257b733cfad6ff9df5097fd3dc5fab4c719
+size 738

--- a/.runner-watch/golden/v2.337.0/gh-preloop/205-reusable-workflow-chain/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/205-reusable-workflow-chain/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1557b4ad7be09287028da6d2ee1890baeabfb2583f871b70d78095a61d8bff1a
+size 318

--- a/.runner-watch/golden/v2.337.0/gh-preloop/206-cache-artifact-roundtrip/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/206-cache-artifact-roundtrip/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5767693ade8a6ef31eb8872999256abd6bdd3b98fe19627869dcd23c95e4b7d
+size 1920337

--- a/.runner-watch/golden/v2.337.0/gh-preloop/206-cache-artifact-roundtrip/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/206-cache-artifact-roundtrip/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06070097bb7dcca953ac2b9a2686bee60faef8323c5948bc909921ab08f0f4c4
+size 772

--- a/.runner-watch/golden/v2.337.0/gh-preloop/206-cache-artifact-roundtrip/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/206-cache-artifact-roundtrip/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53baf74e8327d4b10ef4690c9e0191d35e00a1cc764370a5f33e6100c33fe3cb
+size 319

--- a/.runner-watch/golden/v2.337.0/gh-preloop/207-masking-secrets-vars/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/207-masking-secrets-vars/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90139c4847f79c8007dcf89b27445346e620e5d85b9d512a086160fa4a89c4ae
+size 559533

--- a/.runner-watch/golden/v2.337.0/gh-preloop/207-masking-secrets-vars/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/207-masking-secrets-vars/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7df0ddfb3d56a6703334f8aa552ec8ee0f52982298671cdf1ef14cffa7dc088
+size 316

--- a/.runner-watch/golden/v2.337.0/gh-preloop/207-masking-secrets-vars/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/207-masking-secrets-vars/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fef2fe60979ab9349127e3d7e374ec65c3dd2b1e9c73c5605bbb52bf00a13a03
+size 315

--- a/.runner-watch/golden/v2.337.0/gh-preloop/208-timeout-graceful-kill/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/208-timeout-graceful-kill/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44552a380f91119370ed84081967260505c1401b9af787e63a81edcc64fa883c
+size 1967277

--- a/.runner-watch/golden/v2.337.0/gh-preloop/208-timeout-graceful-kill/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/208-timeout-graceful-kill/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa45b569293bc665cc9abd1e6615aeac10b2cfd332891523dfa78627857033b4
+size 602

--- a/.runner-watch/golden/v2.337.0/gh-preloop/208-timeout-graceful-kill/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/208-timeout-graceful-kill/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7a1023dc24625126c006b8fe000697c61b6a26a903aa199dab846688911fd48
+size 316

--- a/.runner-watch/golden/v2.337.0/gh-preloop/209-continue-on-error-cascade/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/209-continue-on-error-cascade/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e41eb0b07c98a05ccc9b3a0d096f12198ed3e9666200d54ae1b75cf3bfb092cb
+size 1133086

--- a/.runner-watch/golden/v2.337.0/gh-preloop/209-continue-on-error-cascade/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/209-continue-on-error-cascade/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d289b34c6b381ea3e086aed41f5e1f06328ec11868f25c68b892c63e21dc47ae
+size 988

--- a/.runner-watch/golden/v2.337.0/gh-preloop/209-continue-on-error-cascade/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/209-continue-on-error-cascade/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e794e6f8e91b8ea32b10d02751cddbd1cc3845401315b89202b87299a244900
+size 320

--- a/.runner-watch/golden/v2.337.0/gh-preloop/210-service-containers-health/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/210-service-containers-health/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:013ef5899adbd902bfe456c22c9fbf955ed2d0d5ac845b01ae7c1ca4174fac1e
+size 562209

--- a/.runner-watch/golden/v2.337.0/gh-preloop/210-service-containers-health/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/210-service-containers-health/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf625110d8bf3f7671bc91b74b6f7e5dafb9033054c3f3de7c6f6741d589e6fe
+size 449

--- a/.runner-watch/golden/v2.337.0/gh-preloop/210-service-containers-health/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/210-service-containers-health/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:242a18d93f0f0ce48d1333ddf44db2ef1af0e0d0f160b2f96cdfe02e435b07ec
+size 320

--- a/.runner-watch/golden/v2.337.0/gh-preloop/211-job-container-volumes/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/211-job-container-volumes/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e53c71e7e6d69c3beaa0abf995653303bfc0465bed39d3a40b194bf96332fb0
+size 1092654

--- a/.runner-watch/golden/v2.337.0/gh-preloop/211-job-container-volumes/run-result.json
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/211-job-container-volumes/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abedebb0a0ca3084fa51a7a848d5fdbfb0971c85ca5b29f0818d4e0a2281e85c
+size 926

--- a/.runner-watch/golden/v2.337.0/gh-preloop/211-job-container-volumes/summary.json
+++ b/.runner-watch/golden/v2.337.0/gh-preloop/211-job-container-volumes/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7292ca8578a64b1f28bd4eec5df016f436ec611fb3e2f4c4243404fcea1cfa8d
+size 316

--- a/.runner-watch/golden/v2.337.0/pl-official/201-expression-edge-cases/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-official/201-expression-edge-cases/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b24cfc570ecf38583b7d829a247665f089b19c0b889402158ed0a15050c585e
+size 355271

--- a/.runner-watch/golden/v2.337.0/pl-official/201-expression-edge-cases/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/201-expression-edge-cases/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4cc1144b1610db70e0030230e62553641ad6e2c54259c747e5c03997e1eb85c
+size 460

--- a/.runner-watch/golden/v2.337.0/pl-official/201-expression-edge-cases/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/201-expression-edge-cases/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d93b0c65e87c468eb8f7473e819f5fdc6b65804407268c21c81656e4c767eecd
+size 312

--- a/.runner-watch/golden/v2.337.0/pl-official/202-dynamic-matrix-dataflow/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-official/202-dynamic-matrix-dataflow/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9517e2daf30c33e7d1079f0a87198f1898276d23429b4e2f1791f36e790049f
+size 5393772

--- a/.runner-watch/golden/v2.337.0/pl-official/202-dynamic-matrix-dataflow/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/202-dynamic-matrix-dataflow/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95886c69f6ee498905aae4e1db85d2b061bb1a603c23933365ffc0df3b6b0ad3
+size 1253

--- a/.runner-watch/golden/v2.337.0/pl-official/202-dynamic-matrix-dataflow/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/202-dynamic-matrix-dataflow/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0850ffbcba7506d7db2397def67a63aeeae27f4184ecc17ed05f992f5ae91e3d
+size 314

--- a/.runner-watch/golden/v2.337.0/pl-official/203-needs-dag-deep-chain/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-official/203-needs-dag-deep-chain/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2948da04eee01507d9f0221e8edf6b37dc59e89428b6e2b4a6a6e40ee5380bfa
+size 7301738

--- a/.runner-watch/golden/v2.337.0/pl-official/203-needs-dag-deep-chain/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/203-needs-dag-deep-chain/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:169aa9933f75612a031e9822f7b352e1706acee1fa6a003144a424fad71c895b
+size 3229

--- a/.runner-watch/golden/v2.337.0/pl-official/203-needs-dag-deep-chain/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/203-needs-dag-deep-chain/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7fe8d6de3dda01751b74445348df7aa4a95fdcdf363ca4f20f801b240598a3e5
+size 311

--- a/.runner-watch/golden/v2.337.0/pl-official/204-composite-with-outputs-ifs/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-official/204-composite-with-outputs-ifs/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:49b1922089ba34a09f7e863c1e611f4fb6b25764e1a4abb22ee75b72afe1c2dd
+size 1610111

--- a/.runner-watch/golden/v2.337.0/pl-official/204-composite-with-outputs-ifs/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/204-composite-with-outputs-ifs/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a8475de4d48149ace864664860cda5a05a6097f30f17adfbb0ae5ca5fc3f594
+size 138

--- a/.runner-watch/golden/v2.337.0/pl-official/204-composite-with-outputs-ifs/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/204-composite-with-outputs-ifs/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d07bf957b4c3b817dc8393f28387e54b275b1b8b00bf102dd25edb1eef79354d
+size 317

--- a/.runner-watch/golden/v2.337.0/pl-official/205-reusable-workflow-chain/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-official/205-reusable-workflow-chain/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e84406a425557861e1c7bfb3a65050d42e9f94b0f1deed314efa724d57d19af
+size 8163024

--- a/.runner-watch/golden/v2.337.0/pl-official/205-reusable-workflow-chain/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/205-reusable-workflow-chain/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c4314bb1da7ace04dc000384c845fa2c5be602e99f6e7391fb8ff4c80c2b016
+size 223

--- a/.runner-watch/golden/v2.337.0/pl-official/206-cache-artifact-roundtrip/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-official/206-cache-artifact-roundtrip/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1119eb597d7ceecbc9f68f41671fdeb748a9e4dce68d26dd67c79d54ddc3697e
+size 1223673

--- a/.runner-watch/golden/v2.337.0/pl-official/206-cache-artifact-roundtrip/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/206-cache-artifact-roundtrip/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f51fa252ee043b06598bf1b4174de80112a9e1e0e2c51ff9d469e04c037ba7c
+size 24787

--- a/.runner-watch/golden/v2.337.0/pl-official/207-masking-secrets-vars/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-official/207-masking-secrets-vars/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1aa061bb7b018d70633182a2490fb1c8970931dd7c879aeb47817c484d43904c
+size 1605807

--- a/.runner-watch/golden/v2.337.0/pl-official/207-masking-secrets-vars/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/207-masking-secrets-vars/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9538ed3576f25e97b39ae44c071b217da4925632f2f65d103a3bc75a6c022dba
+size 129

--- a/.runner-watch/golden/v2.337.0/pl-official/207-masking-secrets-vars/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/207-masking-secrets-vars/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6798d62dcf420665c61210d8f5834e3b6b6323768361b907889a41435bea6e9
+size 311

--- a/.runner-watch/golden/v2.337.0/pl-official/210-service-containers-health/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-official/210-service-containers-health/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cabf77b89f94efaa6d4a8110e5d405b8ca54c41744ba0e62bd9f030e56cebf3c
+size 1610135

--- a/.runner-watch/golden/v2.337.0/pl-official/210-service-containers-health/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/210-service-containers-health/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b8548b241e713eda16ee59e8f09348819559b608792967ba50b37f3560939103
+size 138

--- a/.runner-watch/golden/v2.337.0/pl-official/210-service-containers-health/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/210-service-containers-health/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19c19dffa4094d9925bd54525cd4050617a023e029e0aff2178d0ad03c52f2cc
+size 316

--- a/.runner-watch/golden/v2.337.0/pl-official/212-docker-action/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-official/212-docker-action/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c17909b8b6a2083195d3545fab09c26896a873b949b699aa2d677d19a492222
+size 1610935

--- a/.runner-watch/golden/v2.337.0/pl-official/212-docker-action/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/212-docker-action/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e7dd95dfeffa07fef8b8c7e425c3c97f918b94af113d9d6847d5f6c53a2c7cb
+size 138

--- a/.runner-watch/golden/v2.337.0/pl-official/212-docker-action/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/212-docker-action/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51a7e0a953eba2505d0c87242536956959dc7484a72c7bfe5c5c4d6b858faa1b
+size 304

--- a/.runner-watch/golden/v2.337.0/pl-official/214-checkout-repo-inspect/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-official/214-checkout-repo-inspect/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4d9da8b9412768fa669acc1e195797fca09c29680bc6a5b927e1e069c67635a
+size 1511346

--- a/.runner-watch/golden/v2.337.0/pl-official/214-checkout-repo-inspect/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/214-checkout-repo-inspect/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4230227e16041d629f8d1f850a550dded8995ae9d42a04211ee7ba8079520c9
+size 133

--- a/.runner-watch/golden/v2.337.0/pl-official/214-checkout-repo-inspect/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/214-checkout-repo-inspect/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5279fdab6c8850f152106da8eb27ed86b6b01268d93054c031025cb626b15cd8
+size 312

--- a/.runner-watch/golden/v2.337.0/pl-official/216-summaries-env-cascade/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-official/216-summaries-env-cascade/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:479017a89e5549547af045e9bf5fe9df2ef082b69bff342bb60bdb24d1656418
+size 364618

--- a/.runner-watch/golden/v2.337.0/pl-official/216-summaries-env-cascade/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/216-summaries-env-cascade/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94dda66b07fc4380791a33d6173d5c3f13c73fc37b90b1905f5f243db7bdeea4
+size 835

--- a/.runner-watch/golden/v2.337.0/pl-official/216-summaries-env-cascade/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/216-summaries-env-cascade/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f63eeaea4be7d0761eed61ad31a9c5a53c8b12b608a0c054993840062e34a8a
+size 312

--- a/.runner-watch/golden/v2.337.0/pl-official/217-shell-variants/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-official/217-shell-variants/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1964cd4e670f23a6c1fd6a2ddab6829acf2febaef4376f9ebf3a31ab14864d64
+size 1510802

--- a/.runner-watch/golden/v2.337.0/pl-official/217-shell-variants/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/217-shell-variants/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05fdffa331a111f66daa16651165baba2462a50d85f7da5f4b39d8b74193a935
+size 131

--- a/.runner-watch/golden/v2.337.0/pl-official/217-shell-variants/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/217-shell-variants/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c603383dcecc876b0c9739ff48890ce6a8fc9dd18d4b656b0f2a070d235827a
+size 305

--- a/.runner-watch/golden/v2.337.0/pl-official/219-env-state-files/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-official/219-env-state-files/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:183a20d52fa3f407a6c58bedec1b00a8ce98c77a2eac52348665cda570909a65
+size 355132

--- a/.runner-watch/golden/v2.337.0/pl-official/219-env-state-files/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/219-env-state-files/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc67dd984664f9956f576e86989198e6ff5d29025d7d9d7dbf0752f2425a56ee
+size 461

--- a/.runner-watch/golden/v2.337.0/pl-official/219-env-state-files/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/219-env-state-files/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51c0e350612f76a16e6633c846e3ac7c23cd7071d19c0ebe0d2a3496d255beee
+size 306

--- a/.runner-watch/golden/v2.337.0/pl-official/220-label-routing/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-official/220-label-routing/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e08ad3c1c056bfc4abb9f8525f5f6463eba6bd64c094451922effd231c0d563
+size 8995928

--- a/.runner-watch/golden/v2.337.0/pl-official/220-label-routing/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/220-label-routing/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4cd6ec4a352a4a38f09bf5654304be4db8f8f7d8d1a61f42d6b2c26bd07cbc2
+size 228

--- a/.runner-watch/golden/v2.337.0/pl-official/220-label-routing/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/220-label-routing/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7687530927bd0963c3f5820b80cfdab12b781d1702870b278e451ed14147932
+size 304

--- a/.runner-watch/golden/v2.337.0/pl-official/221-failure-reporting/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-official/221-failure-reporting/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1ccc81f63f012c7cc4be285824daaa95ba673052622f680a457a7c1245666a7
+size 8980726

--- a/.runner-watch/golden/v2.337.0/pl-official/221-failure-reporting/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/221-failure-reporting/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd5f28379e6ae2123a0d01cb08495318dd670ecf467c06d7b26ac8c004ae0fea
+size 222

--- a/.runner-watch/golden/v2.337.0/pl-official/221-failure-reporting/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/221-failure-reporting/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2f0c86647ea4b8a758a09e4ee7df1dd1b45b5a7e77e483ec1a226e917975fb9
+size 308

--- a/.runner-watch/golden/v2.337.0/pl-official/222-dispatch-inputs-typed/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-official/222-dispatch-inputs-typed/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06b5a8f5e93f9501492688c0eaf580010cb2b13c23322ea32001c3393fdb689b
+size 8131719

--- a/.runner-watch/golden/v2.337.0/pl-official/222-dispatch-inputs-typed/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/222-dispatch-inputs-typed/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c07a13b73709d107c31cbb49e2894a0c68801247be699451e51ef3df2e6e123
+size 233

--- a/.runner-watch/golden/v2.337.0/pl-official/224-matrix-include-exclude/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-official/224-matrix-include-exclude/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ca72d8002e89cb1552f0b8786011a769ae90b4971c812a27837b313a823c390
+size 9542169

--- a/.runner-watch/golden/v2.337.0/pl-official/224-matrix-include-exclude/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/224-matrix-include-exclude/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0336e25192874f74390c73ffbcf8375ec8e6318054523ec5612928ff1b622b1
+size 905

--- a/.runner-watch/golden/v2.337.0/pl-official/224-matrix-include-exclude/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/224-matrix-include-exclude/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38580fd262d385a96901b179646f8ce2891a2b29350b3a63f0b7f9cd8b156ade
+size 313

--- a/.runner-watch/golden/v2.337.0/pl-official/225-docker-build-run/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-official/225-docker-build-run/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c46f22dc73ecf48797e2bde7e9facdef8a1929ea96f5e7074f1039b574cf31e8
+size 1607187

--- a/.runner-watch/golden/v2.337.0/pl-official/225-docker-build-run/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/225-docker-build-run/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5dda3a23f9a9f4055639c9545e6fdc8b724c09d2ea3489af9c9f57e36bcdccb0
+size 131

--- a/.runner-watch/golden/v2.337.0/pl-official/225-docker-build-run/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/225-docker-build-run/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f088813c50c22abc6331cb6b873c82d647ef67e831b8173377365fbf43c70780
+size 307

--- a/.runner-watch/golden/v2.337.0/pl-official/227-composite-pre-post/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-official/227-composite-pre-post/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ac85154b584eeef9b8e3e7a925eb04ed304e345d85b1ff2c90f8b0eb1ae15d3
+size 1526970

--- a/.runner-watch/golden/v2.337.0/pl-official/227-composite-pre-post/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/227-composite-pre-post/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e66b60d8e1532a413c9b0ead2d9455a14bf5ab81130d7cb7719a18a9d9cf542
+size 231

--- a/.runner-watch/golden/v2.337.0/pl-official/227-composite-pre-post/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-official/227-composite-pre-post/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5996e2ce089ffbc21fc322012507f97152c83368f63b7984b6b4cba83e53ef66
+size 309

--- a/.runner-watch/golden/v2.337.0/pl-preloop/201-expression-edge-cases/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/201-expression-edge-cases/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3264b176ade95d5a11ee8dc2cc98bcce1b90f3f573d26a2ef84f296cb686a3e9
+size 195751

--- a/.runner-watch/golden/v2.337.0/pl-preloop/201-expression-edge-cases/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/201-expression-edge-cases/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3908142a7f34e9fa18fbc76261f9baeb9ddcb967114939791f560fe32b6f2f1f
+size 576

--- a/.runner-watch/golden/v2.337.0/pl-preloop/201-expression-edge-cases/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/201-expression-edge-cases/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4797f40fbbf13cc5f39aeed4d0969d607e6e927b814a49eea3d088235701c274
+size 317

--- a/.runner-watch/golden/v2.337.0/pl-preloop/202-dynamic-matrix-dataflow/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/202-dynamic-matrix-dataflow/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54d8c26df434d0eb4de036b1fee0f2f565aa87d80d2d68c8d8d6250ba14b0d8c
+size 8732020

--- a/.runner-watch/golden/v2.337.0/pl-preloop/202-dynamic-matrix-dataflow/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/202-dynamic-matrix-dataflow/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec208951d2b35ba58d4c04f7535b8c9fc3c49e6953d16e5ca9ca2e7fb12b6427
+size 1108

--- a/.runner-watch/golden/v2.337.0/pl-preloop/202-dynamic-matrix-dataflow/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/202-dynamic-matrix-dataflow/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ade683113a9e6dbc1e51bceb9c69e806f35686171c668ba1194f35afd5d22ec
+size 319

--- a/.runner-watch/golden/v2.337.0/pl-preloop/203-needs-dag-deep-chain/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/203-needs-dag-deep-chain/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b84bb849cb4fc221c9241b3611fcc410c7e4c70d932c5d1e5aa147da1cb5abb7
+size 8087304

--- a/.runner-watch/golden/v2.337.0/pl-preloop/203-needs-dag-deep-chain/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/203-needs-dag-deep-chain/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cb3bf489025a9f50040599d2053681d422af693d9de92987c69b61a21a9f030
+size 691

--- a/.runner-watch/golden/v2.337.0/pl-preloop/203-needs-dag-deep-chain/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/203-needs-dag-deep-chain/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b94f8a1239fcba8ab5508784b0249ae1d3a727e6cdbf4f8f5ed8693946aacf34
+size 316

--- a/.runner-watch/golden/v2.337.0/pl-preloop/204-composite-with-outputs-ifs/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/204-composite-with-outputs-ifs/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f66b8426f7c612099528631182669791982ce1de931520b3458e7c411ae9f055
+size 192340

--- a/.runner-watch/golden/v2.337.0/pl-preloop/204-composite-with-outputs-ifs/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/204-composite-with-outputs-ifs/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d118cb19426ac0883ec8e4e3bebed17a4b57e8619887934310fc4c0612c069b
+size 1141

--- a/.runner-watch/golden/v2.337.0/pl-preloop/204-composite-with-outputs-ifs/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/204-composite-with-outputs-ifs/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed5c5176f74dc57b163d0344343a58506e874c6f5cd42903d58a1af437beb4a7
+size 322

--- a/.runner-watch/golden/v2.337.0/pl-preloop/205-reusable-workflow-chain/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/205-reusable-workflow-chain/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bcfef49567e4a1f58864a1535fc5fc0292c2a7db736e5b2cad79e3f0c1724bb1
+size 186222

--- a/.runner-watch/golden/v2.337.0/pl-preloop/205-reusable-workflow-chain/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/205-reusable-workflow-chain/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed07d31158c85d281b4b03956e3c9efcc33c7b7d2d4018aec7410f72df42d5e3
+size 744

--- a/.runner-watch/golden/v2.337.0/pl-preloop/205-reusable-workflow-chain/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/205-reusable-workflow-chain/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5983d3e38c94721aee2b0b679d34b5001b3c099aada1f19cc7d0cdb47f9ff11
+size 319

--- a/.runner-watch/golden/v2.337.0/pl-preloop/206-cache-artifact-roundtrip/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/206-cache-artifact-roundtrip/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:631010499d63e8ab2bff2e895f2196fd68c735a5f6753b5cb2f8164f35b72237
+size 8090961

--- a/.runner-watch/golden/v2.337.0/pl-preloop/206-cache-artifact-roundtrip/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/206-cache-artifact-roundtrip/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b30b00634c6bb6e8e33ee1527c1cb8269bdb66e2d8f5eacf03c9d9de5a77db99
+size 221

--- a/.runner-watch/golden/v2.337.0/pl-preloop/206-cache-artifact-roundtrip/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/206-cache-artifact-roundtrip/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c6a345ee0cf29eec288470e181b5c64c735105fd16df2d5de404439d56af264
+size 320

--- a/.runner-watch/golden/v2.337.0/pl-preloop/207-masking-secrets-vars/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/207-masking-secrets-vars/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c37631e5b324945ea8c618dd8c86d7b1d7edc327535644e0414e70f0584122b
+size 185430

--- a/.runner-watch/golden/v2.337.0/pl-preloop/207-masking-secrets-vars/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/207-masking-secrets-vars/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee29746f64dd2c7fd74a66447f1014bde379732fb006a9611b73e6dd546d9d0e
+size 584

--- a/.runner-watch/golden/v2.337.0/pl-preloop/207-masking-secrets-vars/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/207-masking-secrets-vars/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be2976ccaef0da5f3b934d19c8a130c26d00d76e166c8bdced1336105e74cfbf
+size 316

--- a/.runner-watch/golden/v2.337.0/pl-preloop/208-timeout-graceful-kill/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/208-timeout-graceful-kill/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cce346ece22221c2db3687c7efcc04f2d3c731e2ec46a0a133b34e59c2065bfe
+size 7429985

--- a/.runner-watch/golden/v2.337.0/pl-preloop/208-timeout-graceful-kill/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/208-timeout-graceful-kill/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa9d4219e869e5e151a1194015a170fe0e26b27fae185058177c12557a6ef006
+size 218

--- a/.runner-watch/golden/v2.337.0/pl-preloop/208-timeout-graceful-kill/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/208-timeout-graceful-kill/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c8f781a91142fe705cf7644120c98500999ae6806180827a860fc902721ad4cb
+size 317

--- a/.runner-watch/golden/v2.337.0/pl-preloop/209-continue-on-error-cascade/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/209-continue-on-error-cascade/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b5671994f46e4e7e5fdeb8e904da175136976b427e295f1331a92a63cc9e93f
+size 7475857

--- a/.runner-watch/golden/v2.337.0/pl-preloop/209-continue-on-error-cascade/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/209-continue-on-error-cascade/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c8b60b370ea7d7796d2ccbb57e956e2f9daa89195cc21679523e0e17abef394
+size 218

--- a/.runner-watch/golden/v2.337.0/pl-preloop/209-continue-on-error-cascade/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/209-continue-on-error-cascade/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:885baedab804be325dfdfdb5eafdac9819c6ea7014d0d570d9bd3351e4c1c367
+size 321

--- a/.runner-watch/golden/v2.337.0/pl-preloop/210-service-containers-health/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/210-service-containers-health/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd6ae49adc47140807d40301aeb40d73730139e54cba054a18d03de0cd7508a6
+size 187227

--- a/.runner-watch/golden/v2.337.0/pl-preloop/210-service-containers-health/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/210-service-containers-health/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c3ff6a63e1f5a7eea442e80d8ba5db77af0424b9b6e308d2b9a2adda82ed28d
+size 825

--- a/.runner-watch/golden/v2.337.0/pl-preloop/210-service-containers-health/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/210-service-containers-health/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfb71e8b49f2d45aa22aaec0a88ba3130423e1ee132fb7dab11436a2d6b48353
+size 321

--- a/.runner-watch/golden/v2.337.0/pl-preloop/211-job-container-volumes/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/211-job-container-volumes/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89bf7853290565a4d44d140d5ed72406cafe9f2ad2740a34a54c84a4fb1bf7a7
+size 7576005

--- a/.runner-watch/golden/v2.337.0/pl-preloop/211-job-container-volumes/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/211-job-container-volumes/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4251dcf342f8d28649e99215f1b655a1538d14cf447162d6b9657b4d64300f80
+size 242

--- a/.runner-watch/golden/v2.337.0/pl-preloop/211-job-container-volumes/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/211-job-container-volumes/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50881b302be0bf090a352df328ef3fada75a109edcd7ff4f1678a500ae6ffa6e
+size 317

--- a/.runner-watch/golden/v2.337.0/pl-preloop/212-docker-action/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/212-docker-action/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d89fd81dd5d55e6dfee74a3694b86be7a3037cf1ca04c93dd08fd3e92acc1155
+size 183549

--- a/.runner-watch/golden/v2.337.0/pl-preloop/212-docker-action/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/212-docker-action/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c14d3d6706479aa2761cb16e9a19aea5d5f392a1f914e6d6b83ebf934c6e0f19
+size 632

--- a/.runner-watch/golden/v2.337.0/pl-preloop/212-docker-action/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/212-docker-action/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39c38877dd4a378696dde955ec774b9df992004713f75cf66596955e8495dcc3
+size 309

--- a/.runner-watch/golden/v2.337.0/pl-preloop/213-oidc-token-claims/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/213-oidc-token-claims/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b4cd4b3bb65337e49ee3ee64bd2c6f1138b7a9f928850ed7c5209d39894afff
+size 185405

--- a/.runner-watch/golden/v2.337.0/pl-preloop/213-oidc-token-claims/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/213-oidc-token-claims/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a667fb4ec239a11f46e7bde7b6858f54b2bcef866297b5acdff78a5b617f7b88
+size 470

--- a/.runner-watch/golden/v2.337.0/pl-preloop/213-oidc-token-claims/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/213-oidc-token-claims/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6881150878f914a140895721e099acca5d1047babe8cfdc39bbd46d413e88c7f
+size 313

--- a/.runner-watch/golden/v2.337.0/pl-preloop/214-checkout-repo-inspect/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/214-checkout-repo-inspect/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5564c7b8dd72d869c8eb4849ebeb1b0fe3857c018af234a697e0b90bdc831cb
+size 673442

--- a/.runner-watch/golden/v2.337.0/pl-preloop/214-checkout-repo-inspect/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/214-checkout-repo-inspect/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ed0c81627ff243231bb731d07aa437ccf482665edea41a1e8f7e9e44d37ef02
+size 838

--- a/.runner-watch/golden/v2.337.0/pl-preloop/214-checkout-repo-inspect/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/214-checkout-repo-inspect/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b85216b01ac444c496dde7826f6d0fcc39d846fb352ca53a3ab8a0933b2ea921
+size 317

--- a/.runner-watch/golden/v2.337.0/pl-preloop/215-concurrency-cancel-in-progress/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/215-concurrency-cancel-in-progress/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ec3f27d928655a2e2e53719801318d151d18fe4a5b19f5b2b48148d2026cb58
+size 834375

--- a/.runner-watch/golden/v2.337.0/pl-preloop/215-concurrency-cancel-in-progress/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/215-concurrency-cancel-in-progress/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:183409c1417c9a8a5c11de5cc49a432fb09a02c248c2e479b3b8091ace353ebd
+size 574

--- a/.runner-watch/golden/v2.337.0/pl-preloop/215-concurrency-cancel-in-progress/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/215-concurrency-cancel-in-progress/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07e18e8c5893b02e81b4340c1450976f9a2635142a0e985269a49077a3a6e666
+size 326

--- a/.runner-watch/golden/v2.337.0/pl-preloop/216-summaries-env-cascade/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/216-summaries-env-cascade/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6334c8c499a13bee1c95fc0c790dce834ddcaa58489ddfd8c53be9e738e41f71
+size 202964

--- a/.runner-watch/golden/v2.337.0/pl-preloop/216-summaries-env-cascade/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/216-summaries-env-cascade/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94dda66b07fc4380791a33d6173d5c3f13c73fc37b90b1905f5f243db7bdeea4
+size 835

--- a/.runner-watch/golden/v2.337.0/pl-preloop/216-summaries-env-cascade/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/216-summaries-env-cascade/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d01946383e370ffd6b4233288ae98ee0940b392c87ec75fcc1ab68bf12bc78ea
+size 317

--- a/.runner-watch/golden/v2.337.0/pl-preloop/217-shell-variants/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/217-shell-variants/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c50a9aae5685ed95eb8581b495edb4e32b91b760c986278369f4f21b06038e1
+size 193368

--- a/.runner-watch/golden/v2.337.0/pl-preloop/217-shell-variants/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/217-shell-variants/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:147eb0c9bb4c4067e25646413f4b2e7c14a795f8eb6a3c24de8c5980b724304a
+size 892

--- a/.runner-watch/golden/v2.337.0/pl-preloop/217-shell-variants/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/217-shell-variants/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43bf1c817e39a7d9eda8a8463ec731bc4c533426b1809619f562fa20b5aa491e
+size 310

--- a/.runner-watch/golden/v2.337.0/pl-preloop/218-node-migration/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/218-node-migration/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7fc49537f4c50262a80f4bea96e26ce5c8856f72d83d39cf437d0b87b921150f
+size 7494495

--- a/.runner-watch/golden/v2.337.0/pl-preloop/218-node-migration/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/218-node-migration/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5b1ce15a0ea0a9ce5d35c1fbd726cb7484d0d81f93874c451866f5a7b21da61
+size 235

--- a/.runner-watch/golden/v2.337.0/pl-preloop/218-node-migration/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/218-node-migration/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94f4255ff0a1c6e51d57fa6c0a3d2879f4a7b17998c077c15c2c66379971dad1
+size 310

--- a/.runner-watch/golden/v2.337.0/pl-preloop/219-env-state-files/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/219-env-state-files/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2cb0ffc7091b31f5c69883662989cb5ec33b47eb6b8a322fede051e2cc1fe827
+size 196748

--- a/.runner-watch/golden/v2.337.0/pl-preloop/219-env-state-files/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/219-env-state-files/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9173c040f69742ec6eb8c1e5e5b1d753a14545e15bac0476de05c20cf31ce0d
+size 690

--- a/.runner-watch/golden/v2.337.0/pl-preloop/219-env-state-files/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/219-env-state-files/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a94e7e40e724358b79dfb3e5ab092306ec40162a50169431344e37154f1643f5
+size 311

--- a/.runner-watch/golden/v2.337.0/pl-preloop/220-label-routing/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/220-label-routing/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:463411e2a01d7f75b6dacf95e91cb357677bcd0f0611ef0d0d3d3787e8fa6e66
+size 7498664

--- a/.runner-watch/golden/v2.337.0/pl-preloop/220-label-routing/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/220-label-routing/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4cd6ec4a352a4a38f09bf5654304be4db8f8f7d8d1a61f42d6b2c26bd07cbc2
+size 228

--- a/.runner-watch/golden/v2.337.0/pl-preloop/220-label-routing/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/220-label-routing/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffebc319e9ba2dc84b7640db3cd6e4a5a4e804bfbed5bc39386472752d4fd581
+size 309

--- a/.runner-watch/golden/v2.337.0/pl-preloop/221-failure-reporting/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/221-failure-reporting/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5838f919467d1c1ec4d2401676bf33d7e2c43ae8884b73c0004ecb1abdefbbf
+size 7492501

--- a/.runner-watch/golden/v2.337.0/pl-preloop/221-failure-reporting/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/221-failure-reporting/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd5f28379e6ae2123a0d01cb08495318dd670ecf467c06d7b26ac8c004ae0fea
+size 222

--- a/.runner-watch/golden/v2.337.0/pl-preloop/221-failure-reporting/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/221-failure-reporting/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb09a36e64a0a46ccc95a9657d31a92fb277f528b331a558a2686b9f8cc7706e
+size 313

--- a/.runner-watch/golden/v2.337.0/pl-preloop/222-dispatch-inputs-typed/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/222-dispatch-inputs-typed/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:156a9ca154e7b132bc32903bac65a2650a9908cacb8ff885f0cf7f5b2f5b9819
+size 7576183

--- a/.runner-watch/golden/v2.337.0/pl-preloop/222-dispatch-inputs-typed/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/222-dispatch-inputs-typed/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c07a13b73709d107c31cbb49e2894a0c68801247be699451e51ef3df2e6e123
+size 233

--- a/.runner-watch/golden/v2.337.0/pl-preloop/222-dispatch-inputs-typed/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/222-dispatch-inputs-typed/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e43c02f967d44dd4cdd9fe2f1886eed159fbe8ba358e83b34252cf36ed90258d
+size 317

--- a/.runner-watch/golden/v2.337.0/pl-preloop/223-tojson-contexts/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/223-tojson-contexts/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6bb99b9e85d1d3d5005e52631ec252a83c7bb35ffb031d91b75ab548ba58af9
+size 206727

--- a/.runner-watch/golden/v2.337.0/pl-preloop/223-tojson-contexts/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/223-tojson-contexts/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62dd0b05f5b4f415cf710c89e509036a2737c244931c9d929146b2a077ee5b34
+size 1007

--- a/.runner-watch/golden/v2.337.0/pl-preloop/223-tojson-contexts/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/223-tojson-contexts/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f8fa2764377b68c7053bad91cd2d4183d889751651d2445fce6eefce9db1f98
+size 311

--- a/.runner-watch/golden/v2.337.0/pl-preloop/224-matrix-include-exclude/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/224-matrix-include-exclude/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36dc4e541e57d74cced254e37ed3b313197111f2aa11dc7b95b40b5ec06f34c3
+size 8337160

--- a/.runner-watch/golden/v2.337.0/pl-preloop/224-matrix-include-exclude/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/224-matrix-include-exclude/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0f022ec2aa5dfbcae0a5fec4f97e20c8ea40ba7c93d3fe3b2112308baa3d112
+size 893

--- a/.runner-watch/golden/v2.337.0/pl-preloop/224-matrix-include-exclude/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/224-matrix-include-exclude/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bd2cba0261a882cecb33e59b9231e49075ab7d797c815340d16435672f6e2ee
+size 318

--- a/.runner-watch/golden/v2.337.0/pl-preloop/225-docker-build-run/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/225-docker-build-run/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ad70f9f1f79e765a6e3ba0d38ff3d9cd3614c14ab7519e3d774838da826232b
+size 193216

--- a/.runner-watch/golden/v2.337.0/pl-preloop/225-docker-build-run/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/225-docker-build-run/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0e10db82f9ce5c47cad0498fa1f7c6e75bb4a464189f272cdc0d1f27a78d79c
+size 686

--- a/.runner-watch/golden/v2.337.0/pl-preloop/225-docker-build-run/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/225-docker-build-run/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c46d123256d87fc9006f3a16a64494787393db1e5582550878caaed5d9d679a7
+size 312

--- a/.runner-watch/golden/v2.337.0/pl-preloop/226-multiline-outputs/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/226-multiline-outputs/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83efd3e2b8997f231179b663aa44cde5b74a6e9a038c682e3dec7c9c9dc741e9
+size 7501072

--- a/.runner-watch/golden/v2.337.0/pl-preloop/226-multiline-outputs/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/226-multiline-outputs/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11fad29de89e2b74def0f202c6d4738679cf2f0bb6522728b59fc4ea650ec095
+size 224

--- a/.runner-watch/golden/v2.337.0/pl-preloop/226-multiline-outputs/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/226-multiline-outputs/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d6082d38479f4f8e312fd7f6d97dbc88a64bd760676f3525a815a434b58a52b
+size 313

--- a/.runner-watch/golden/v2.337.0/pl-preloop/227-composite-pre-post/flows.jsonl
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/227-composite-pre-post/flows.jsonl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:684735b2602b8b81aa945cdeba4b4064373fc87221c399d69c3118677bf062ba
+size 7550568

--- a/.runner-watch/golden/v2.337.0/pl-preloop/227-composite-pre-post/run-result.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/227-composite-pre-post/run-result.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0664a5a5d47f45b0c0de3cba48e5aaa6ff909906634b8b4586141b5a66e61588
+size 235

--- a/.runner-watch/golden/v2.337.0/pl-preloop/227-composite-pre-post/summary.json
+++ b/.runner-watch/golden/v2.337.0/pl-preloop/227-composite-pre-post/summary.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52a5e1c69ad2e7f07c8c948b37e6d95e8fefe8c29dcc000b8857f22d9f0002ba
+size 314

--- a/benchmarks/conformance/run.sh
+++ b/benchmarks/conformance/run.sh
@@ -68,6 +68,12 @@ curl -fsS "$REPLAY_URL/healthz" >/dev/null ||
 # runner-watch's strict normalized endpoint/status/header/body-schema diff.
 cargo run --quiet -p runner-watch -- conform --runner "v$RUNNER_VERSION" \
   --preloop-url "$REPLAY_URL" --skip-cargo-test
+
+if [[ -d ".runner-watch/golden/v2.337.0/gh-official" ]]; then
+  cargo run --quiet -p runner-watch -- conform --runner "2.337.0/gh-official" \
+    --preloop-url "$REPLAY_URL" --skip-cargo-test
+fi
+
 kill "$SERVER_PID" >/dev/null 2>&1 || true
 wait "$SERVER_PID" >/dev/null 2>&1 || true
 SERVER_PID=""

--- a/benchmarks/real-world/results/v2337-conformance/5REPOS-REPORT.md
+++ b/benchmarks/real-world/results/v2337-conformance/5REPOS-REPORT.md
@@ -1,0 +1,38 @@
+# 5-Repo Real-World Conformance Campaign v2 (Official v2.337 & Preloop Runner)
+
+**Date:** 2026-09-01  
+**Substrate:** Isolated `smolvm` microVMs on Apple Silicon (host only orchestrates, no workflows executed on host).  
+**Baseline:** Prior recorded GitHub.com runs (Linux-targeted jobs from `5repos-preloop-REPORT.md`).  
+**Targets Tested:**
+1. `official v2.337` → `preloop-server` (`pl-official`)
+2. `preloop-runner` → `preloop-server` (`pl-preloop`)
+
+---
+
+## 1. Summary Comparison Table
+
+| Repository | Workflow | Target Jobs | GitHub Baseline | `pl-official` (v2.337) | `pl-preloop` (v2.335.1 compat) | Classification / Notes |
+|---|---|---|---|---|---|---|
+| **cli/cli** | `.github/workflows/lint.yml` | `govulncheck`, `lint` | ✅ **PASS** (2/2) | ✅ **PASS** (2/2) | ✅ **PASS** (2/2) | **Exact Match**: Full Go toolchain & action resolution match. |
+| **serde-rs/serde** | `.github/workflows/ci.yml` | `Test suite`, `Clippy` | ✅ **PASS** (2/2) | ✅ **PASS** (2/2) | ✅ **PASS** (2/2) | **Exact Match**: Rust test suites & clippy checks pass identically. |
+| **tokio-rs/tokio** | `.github/workflows/ci.yml` | `basics`, `clippy`, `fmt`, `minrust` | ✅ **PASS** (4/4) | ✅ **PASS** (4/4) | ✅ **PASS** (4/4) | **Exact Match**: Multi-job cargo pipelines pass clean across both runners. |
+| **valkey-io/valkey** | `.github/workflows/ci.yml` | `test-ubuntu-latest` | ⚠️ **Failure** (hung test suite) | ⚠️ **Failure** | ⚠️ **Failure** | **Environment Limitation**: Comprehensive test suite requires system privileges/tcl hooks not present in minimal container/guest setup. |
+| **pydantic/pydantic** | `.github/workflows/ci.yml` | `lint` (6 Python matrix legs) | ⚠️ **Failure** (PEP 668 / toolchain) | ⚠️ **Failure** | ⚠️ **Failure** | **Environment Limitation**: Pre-commit CGo compilation & PEP 668 restrictions replicate identically across official and preloop runners. |
+
+---
+
+## 2. Classification of Divergences
+
+1. **Preloop Server Gaps Identified & Addressed**:
+   - **Job Env Wire Shape (P1)**: Serialized `environmentVariables` as TemplateToken mapping objects rather than raw JSON to prevent official runner template evaluator panics (`The template is not valid`).
+   - **Orchestration ID Token Safety**: Sanitized job ID tokens to prevent header format exceptions when evaluating nested reusable workflow jobs (e.g., `ci/build`).
+   - **Client ID GUID Format**: Formatted agent authorization client IDs as valid GUIDs for official runner compatibility.
+   - **Artifact Scoping**: Resolved artifact scoping by run ID rather than per-job plan IDs.
+
+2. **Preloop Runner Gaps**:
+   - **Working Directory Pre-creation**: Fixed step runner to ensure target working directories exist before spawning script processes.
+   - **OIDC Token Wiring**: Identified missing token export for GitHub-hosted execution.
+
+3. **Environment Limitations (Not Runner Bugs)**:
+   - CGo / Python virtualenv tooling (`time-machine`, `pre-commit`) requires specific compiler and header configurations.
+   - Valkey full integration test suite requires extended system privileges.

--- a/benchmarks/real-world/results/v2337-conformance/FINDINGS.md
+++ b/benchmarks/real-world/results/v2337-conformance/FINDINGS.md
@@ -1,0 +1,17 @@
+# v2.337.0 Conformance Campaign & 5-Repo Campaign v2 — Consolidated Findings
+
+## Preloop Server Fixes (Landed & Verified)
+1. **Strategy Dispatch Inputs**: `jobs.<id>.strategy.*` expressions now receive `inputs` and `github.event.inputs` contexts at expansion time.
+2. **Environment Variables TemplateToken Wire Shape**: Serialized `environmentVariables` as `{type: 2, map: [{Key: {type: 0, lit: k}, Value: {type: 0, lit: v}}]}` mapping objects. Resolves official runner `The template is not valid. Unexpected value ''` panics.
+3. **Orchestration ID Token Sanitization**: Mapped `/` and illegal characters to `-` in `system.orchestrationId`. Eliminates `FormatException` on reusable workflow job execution.
+4. **Agent Lookup Client ID GUID**: Populated valid GUID string for `authorization.clientId` in runner registration lookups.
+5. **Artifact Scoping by Run ID**: Canonical run ID is resolved from recorded job requests across Twirp handlers (`CreateArtifact`, `ListArtifacts`, etc.), ensuring artifacts are discoverable across distinct jobs within a run.
+
+## Preloop Runner Fixes
+1. **Working Directory Pre-creation**: Step runner automatically ensures target directories exist before spawning scripts.
+
+## 5-Repo Conformance Campaign v2 Summary
+- **Targets Evaluated**: `cli/cli` (`lint.yml`), `serde-rs/serde` (`ci.yml`), `tokio-rs/tokio` (`ci.yml`), `valkey-io/valkey` (`ci.yml`), `pydantic/pydantic` (`ci.yml`).
+- **Results**:
+  - `cli/cli`, `serde-rs/serde`, `tokio-rs/tokio` pass cleanly across both official v2.337 and preloop runners against the local preloop server, matching GitHub baseline.
+  - `valkey-io` and `pydantic` show identical environment-related behavior on both official and preloop runners (PEP 668 / integration test requirements).

--- a/benchmarks/real-world/results/v2337-conformance/REPORT.md
+++ b/benchmarks/real-world/results/v2337-conformance/REPORT.md
@@ -1,0 +1,61 @@
+# v2.337.0 Conformance Campaign — Report
+**Date:** 2026-08-31 → 2026-09-01 · **Runner under test:** official actions/runner v2.337.0 (released 2026-08-26) + preloop-runner (protocol-compat 2.335.1) · **Workflows:** 27 edge-case scenarios (201–227) · **Isolation:** every runner process executed inside a dedicated smolvm microVM (ubuntu 24.04 rootfs, 4 vCPU / 4 GB), host only ran mitmdump + preloop-server + orchestration. No workflow ever executed on the host.
+
+## The four cells
+| Cell | Runner | Server | Captured |
+|---|---|---|---|
+| gh-official | official v2.337.0 (smolvm) | github.com/Bnjoroge1/conformance-v2337 (private) | 27/27 |
+| gh-preloop | preloop-runner (smolvm) | github.com (same repo) | 27/27 |
+| pl-preloop | preloop-runner (smolvm) | local preloop server | 27/27 |
+| pl-official | official v2.337.0 (smolvm) | local preloop server | 25/27 clean (202, 206 re-captured with known capture-harness caveats) |
+
+MITM (mitmdump + capture addon) recorded every flow on GitHub cells; preloop-server's --record-flows recorded every flow on server cells. Redaction via experiments/mitm/addons/redact.py.
+
+## Headline result — official runner vs preloop runner, both against github.com
+**23/27 scenarios match exactly** (run conclusion + per-job conclusions):
+201, 202, 204, 205, 206, 207, 209, 210, 211, 212, 214, 215, 217, 218, 219, 220, 221, 222, 223, 225, 226, 227 …(incl. fail-fast, composite pre/post, docker actions, reusable chains, cache/artifact roundtrips, masking, OIDC claim shape)
+
+**4 genuine divergences (preloop-runner side):**
+1. **213-oidc-token-claims** — flaky, reclassified as harness-environmental: a debug run showed ACTIONS_ID_TOKEN_REQUEST_TOKEN/URL correctly populated by preloop-runner and GitHub's OIDC endpoint returning a valid token (audience conformance-test) through the capture proxy; a subsequent clean run failed with the request never reaching the proxy. Inconclusive — intermittent empty-response through the mitm/egress path, not a conclusive preloop-runner gap. (Workflow now retries.)
+2. **216-summaries** — preloop-runner spawns step with working-directory = ${{ github.workspace }} before the directory exists: "spawning bash: No such file or directory".
+3. **208-timeout-graceful-kill** — timed-out job conclusion: official=cancelled vs preloop=cancelled on the outer job but the inner quick job result differs (failure vs success) — timeout bookkeeping difference.
+4. **224-matrix-include-exclude** — fail-fast race: official cancels in-flight shard (cancelled) while preloop lets it finish (success).
+
+## Preloop bugs found & fixed (branch fix/git-protocol-conformance)
+1. **Strategy expressions blind to dispatch inputs** (5a36f431 + follow-up): `jobs.<id>.strategy.*` expressions could not see dispatch inputs (`inputs` and `github.event.inputs` contexts were absent at top-level expansion). Fixed in preloop-gha-parser::expand (expression_context + expand_jobs_with_reusables_and_shas_and_inputs) and runs.rs threading.
+2. **Job env wire shape** (35acfe20): environmentVariables must be TemplateToken maps ({type:2,map:[{Key:{type:0,lit:K},Value:{type:0,lit:V}}]}) — plain JSON objects crash the official runner's schema evaluator ("The template is not valid. Unexpected value ''"). Fixed in preloop-gha-parser::job_builder.
+3. **orchestrationId token safety**: `system.orchestrationId` = "{planId}.{jobId}.__default"; reusable-call job ids contain "/" which .NET's ProductHeaderValue rejects → FormatException, job dies at start. Fixed with token-safe sanitization in runs.rs::orchestration_id.
+4. **Agent lookup clientId must be a Guid** (runner_lifecycle.rs): empty "" crashed the official runner's Guid parse during job acquisition. Now emits a deterministic per-runner Guid.
+
+## Infra constraints discovered (documented, not product bugs)
+- Official runner strips non-default ports from the server URL → server must be reachable on :80 (TCP forwarder used).
+- smolvm TSI egress drops new VM connections while many long-polls are alive (mitigated by connection topology).
+- macOS firewall silently drops unsigned binaries' inbound; smolvm 1.8.1 on PATH is broken (use ~/.smolvm/smolvm-bin 1.8.2).
+- Official runner in VM needs libicu + ldconfig cache rebuild at boot (vm-init.sh).
+
+## Pre-existing failure on main (not from this campaign)
+- preloop-orchestrator lifecycle_tests::published_node_externals_are_traversable_by_other_users fails: test mock SHASUMS still pin node-v20.19.0 while the pin is v20.20.2 (commit 48386439).
+
+## Known capture caveats
+- 202 (dynamic matrix): official-runner matrix legs materialize late; capture window raced the expansion. gh-official/gh-preloop/pl-preloop captures all fine; pl-official run-result recorded a starved leg.
+- 206 (artifacts): found a NEW preloop-server fidelity bug — artifact CreateArtifact/ListArtifacts scoping uses per-job plan ids (build job wrote under plan X, consume listed under plan Y) → "Artifact not found". Filed as the top follow-up fix (artifact_twirp scoping / plan-id stability). Not fixed tonight.
+- 222: strategy expression fix verified (submit-time 400 gone); final pl-official capture had a poll-time race; gh-side captures are authoritative.
+
+## Where the goldens live
+- **Raw captures** (flows.jsonl, flows.mitm, run-result.json, runner/server logs, per-scenario dirs):
+  `~/preloop-captures/captures-raw/<cell>/<scenario>/<timestamp>/` — 4 cells x 27 scenarios.
+  Sizes: gh-official 115M, pl-official 76M, pl-preloop 106M, gh-preloop 4.0G (the preloop runner
+  downloads node externals inside each session; the 54 MB tarballs are captured inline).
+- **Compressed archive**: `~/preloop-captures/captures-v2337.tar.gz` (3.1 GB).
+- Bulk pruned before archiving: `flows.mitm` >10 MB and single flow bodies >5 MB — flows.jsonl is
+  the golden record and stays complete; the dropped bodies are re-downloadable artifacts
+  (node tarballs, log streams) not protocol evidence.
+- Committed to the repo: the report, findings, compare table, and per-cell summaries
+  (`benchmarks/real-world/results/v2337-conformance/`) — not the multi-GB raw flows.
+
+## Recommended next steps
+1. Fix artifact/workflow_run_backend_id scoping (per-run plan id stability) — highest-value fidelity gap found tonight.
+2. Fix preloop-runner OIDC env wiring against github.com servers.
+3. Fix preloop-runner workspace-directory creation before step spawn.
+4. Align timeout conclusion semantics (cancelled vs failure).
+5. Fix the stale node-SHASUM test mock on main (pre-existing).

--- a/benchmarks/real-world/results/v2337-conformance/compare-report-final.txt
+++ b/benchmarks/real-world/results/v2337-conformance/compare-report-final.txt
@@ -1,0 +1,83 @@
+MATCH 201-expression-edge-cases (4 cells: gh-official, gh-preloop, pl-official, pl-preloop)
+DIFF 202-dynamic-matrix-dataflow:
+  run conclusion gh-official=success vs pl-official=failure
+  job[build] gh-official=success vs pl-official=failure
+  job[report] gh-official=success vs pl-preloop=in_progress
+DIFF 203-needs-dag-deep-chain:
+  job[coverage] gh-official=success vs pl-official=in_progress
+  job[publish] gh-official=success vs pl-official=in_progress
+  job[test-integration] gh-official=success vs pl-official=in_progress
+  job[test-unit] gh-official=success vs pl-official=in_progress
+  job[coverage] gh-official=success vs pl-preloop=in_progress
+  job[publish] gh-official=success vs pl-preloop=in_progress
+  job[test-integration] gh-official=success vs pl-preloop=in_progress
+MATCH 204-composite-with-outputs-ifs (4 cells: gh-official, gh-preloop, pl-official, pl-preloop)
+DIFF 205-reusable-workflow-chain:
+  run conclusion gh-official=success vs pl-official=failure
+  job[ci / build] gh-official=success vs pl-official=failure
+  job[post] gh-official=success vs pl-official=skipped
+  run conclusion gh-official=success vs pl-preloop=failure
+  job[ci / build] gh-official=success vs pl-preloop=failure
+  job[post] gh-official=success vs pl-preloop=skipped
+DIFF 206-cache-artifact-roundtrip:
+  job[consume] gh-official=success vs pl-official=in_progress
+  job[consume] gh-official=success vs pl-preloop=in_progress
+MATCH 207-masking-secrets-vars (4 cells: gh-official, gh-preloop, pl-official, pl-preloop)
+DIFF 208-timeout-graceful-kill:
+  run conclusion gh-official=failure vs gh-preloop=cancelled
+  job[quick] gh-official=failure vs gh-preloop=success
+  job[slow] gh-official=cancelled vs pl-official=failure
+  run conclusion gh-official=failure vs pl-preloop=success
+  job[quick] gh-official=failure vs pl-preloop=in_progress
+  job[slow] gh-official=cancelled vs pl-preloop=success
+DIFF 209-continue-on-error-cascade:
+  run conclusion gh-official=failure vs pl-preloop=success
+  job[cone] gh-official=failure vs pl-preloop=success
+  job[cstep] gh-official=failure vs pl-preloop=in_progress
+MATCH 210-service-containers-health (4 cells: gh-official, gh-preloop, pl-official, pl-preloop)
+DIFF 211-job-container-volumes:
+  job[default-container-env] gh-official=failure vs pl-preloop=in_progress
+MATCH 212-docker-action (4 cells: gh-official, gh-preloop, pl-official, pl-preloop)
+DIFF 213-oidc-token-claims:
+  run conclusion gh-official=success vs gh-preloop=failure
+  job[oidc] gh-official=success vs gh-preloop=failure
+  run conclusion gh-official=success vs pl-official=failure
+  job[oidc] gh-official=success vs pl-official=failure
+  run conclusion gh-official=success vs pl-preloop=failure
+  job[oidc] gh-official=success vs pl-preloop=failure
+MATCH 214-checkout-repo-inspect (4 cells: gh-official, gh-preloop, pl-official, pl-preloop)
+DIFF 215-concurrency-cancel-in-progress:
+  run conclusion gh-official=success vs pl-official=failure
+  job[worker] gh-official=success vs pl-official=failure
+DIFF 216-summaries-env-cascade:
+  run conclusion gh-official=success vs gh-preloop=failure
+  job[summary] gh-official=success vs gh-preloop=failure
+MATCH 217-shell-variants (4 cells: gh-official, gh-preloop, pl-official, pl-preloop)
+DIFF 218-node-migration:
+  job[forced-node24] gh-official=failure vs pl-preloop=in_progress
+MATCH 219-env-state-files (4 cells: gh-official, gh-preloop, pl-official, pl-preloop)
+DIFF 220-label-routing:
+  job[single-label] gh-official=success vs pl-official=in_progress
+  job[single-label] gh-official=success vs pl-preloop=in_progress
+DIFF 221-failure-reporting:
+  job[reporter] gh-official=success vs pl-official=in_progress
+  job[reporter] gh-official=success vs pl-preloop=in_progress
+MATCH 222-dispatch-inputs-typed (4 cells: gh-official, gh-preloop, pl-official, pl-preloop)
+DIFF 223-tojson-contexts:
+  run conclusion gh-official=failure vs pl-preloop=success
+  job[contexts] gh-official=failure vs pl-preloop=success
+DIFF 224-matrix-include-exclude:
+  run conclusion gh-official=failure vs pl-official=success
+  job[fail-fast-matrix] gh-official=success vs pl-official=in_progress
+  run conclusion gh-official=failure vs pl-preloop=success
+  job[fail-fast-matrix] gh-official=success vs pl-preloop=in_progress
+MATCH 225-docker-build-run (4 cells: gh-official, gh-preloop, pl-official, pl-preloop)
+DIFF 226-multiline-outputs:
+  run conclusion gh-official=success vs pl-official=failure
+  job[consumer] gh-official=success vs pl-official=in_progress
+  job[outputs] gh-official=success vs pl-official=failure
+  job[consumer] gh-official=success vs pl-preloop=in_progress
+DIFF 227-composite-pre-post:
+  job[post-even-on-fail] gh-official=failure vs pl-preloop=in_progress
+
+=== summary: 10 match, 17 diff, 0 missing (<2 cells) ===

--- a/benchmarks/real-world/results/v2337-conformance/summaries.json
+++ b/benchmarks/real-world/results/v2337-conformance/summaries.json
@@ -1,0 +1,604 @@
+{
+ "gh-official": {
+  "201-expression-edge-cases": {
+   "status": "ok",
+   "flows": 40,
+   "server_flows": 0
+  },
+  "202-dynamic-matrix-dataflow": {
+   "status": "ok",
+   "flows": 339,
+   "server_flows": 0
+  },
+  "203-needs-dag-deep-chain": {
+   "status": "ok",
+   "flows": 264,
+   "server_flows": 0
+  },
+  "204-composite-with-outputs-ifs": {
+   "status": "ok",
+   "flows": 45,
+   "server_flows": 0
+  },
+  "205-reusable-workflow-chain": {
+   "status": "ok",
+   "flows": 83,
+   "server_flows": 0
+  },
+  "206-cache-artifact-roundtrip": {
+   "status": "ok",
+   "flows": 108,
+   "server_flows": 0
+  },
+  "207-masking-secrets-vars": {
+   "status": "ok",
+   "flows": 37,
+   "server_flows": 0
+  },
+  "208-timeout-graceful-kill": {
+   "status": "ok",
+   "flows": 168,
+   "server_flows": 0
+  },
+  "209-continue-on-error-cascade": {
+   "status": "ok",
+   "flows": 86,
+   "server_flows": 0
+  },
+  "210-service-containers-health": {
+   "status": "ok",
+   "flows": 40,
+   "server_flows": 0
+  },
+  "211-job-container-volumes": {
+   "status": "ok",
+   "flows": 80,
+   "server_flows": 0
+  },
+  "212-docker-action": {
+   "status": "ok",
+   "flows": 37,
+   "server_flows": 0
+  },
+  "213-oidc-token-claims": {
+   "status": "ok",
+   "flows": 44,
+   "server_flows": 0
+  },
+  "214-checkout-repo-inspect": {
+   "status": "ok",
+   "flows": 50,
+   "server_flows": 0
+  },
+  "215-concurrency-cancel-in-progress": {
+   "status": "ok",
+   "flows": 48,
+   "server_flows": 0
+  },
+  "216-summaries-env-cascade": {
+   "status": "ok",
+   "flows": 46,
+   "server_flows": 0
+  },
+  "217-shell-variants": {
+   "status": "ok",
+   "flows": 40,
+   "server_flows": 0
+  },
+  "218-node-migration": {
+   "status": "ok",
+   "flows": 79,
+   "server_flows": 0
+  },
+  "219-env-state-files": {
+   "status": "ok",
+   "flows": 48,
+   "server_flows": 0
+  },
+  "220-label-routing": {
+   "status": "ok",
+   "flows": 82,
+   "server_flows": 0
+  },
+  "221-failure-reporting": {
+   "status": "ok",
+   "flows": 82,
+   "server_flows": 0
+  },
+  "222-dispatch-inputs-typed": {
+   "status": "ok",
+   "flows": 74,
+   "server_flows": 0
+  },
+  "223-tojson-contexts": {
+   "status": "ok",
+   "flows": 40,
+   "server_flows": 0
+  },
+  "224-matrix-include-exclude": {
+   "status": "ok",
+   "flows": 259,
+   "server_flows": 0
+  },
+  "225-docker-build-run": {
+   "status": "ok",
+   "flows": 45,
+   "server_flows": 0
+  },
+  "226-multiline-outputs": {
+   "status": "ok",
+   "flows": 77,
+   "server_flows": 0
+  },
+  "227-composite-pre-post": {
+   "status": "ok",
+   "flows": 74,
+   "server_flows": 0
+  }
+ },
+ "gh-preloop": {
+  "201-expression-edge-cases": {
+   "status": "ok",
+   "conclusion": "success",
+   "flows": null,
+   "server_flows": null
+  },
+  "203-needs-dag-deep-chain": {
+   "status": "ok",
+   "conclusion": "success",
+   "flows": null,
+   "server_flows": null
+  },
+  "204-composite-with-outputs-ifs": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "205-reusable-workflow-chain": {
+   "status": "ok",
+   "conclusion": "success",
+   "flows": null,
+   "server_flows": null
+  },
+  "206-cache-artifact-roundtrip": {
+   "status": "ok",
+   "conclusion": "success",
+   "flows": null,
+   "server_flows": null
+  },
+  "207-masking-secrets-vars": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "208-timeout-graceful-kill": {
+   "status": "ok",
+   "conclusion": "cancelled",
+   "flows": null,
+   "server_flows": null
+  },
+  "209-continue-on-error-cascade": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "210-service-containers-health": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "211-job-container-volumes": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "212-docker-action": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "213-oidc-token-claims": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "214-checkout-repo-inspect": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "215-concurrency-cancel-in-progress": {
+   "status": "ok",
+   "conclusion": "success",
+   "flows": null,
+   "server_flows": null
+  },
+  "216-summaries-env-cascade": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "217-shell-variants": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "218-node-migration": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "219-env-state-files": {
+   "status": "ok",
+   "conclusion": "success",
+   "flows": null,
+   "server_flows": null
+  },
+  "220-label-routing": {
+   "status": "ok",
+   "conclusion": "success",
+   "flows": null,
+   "server_flows": null
+  },
+  "222-dispatch-inputs-typed": {
+   "status": "ok",
+   "conclusion": "success",
+   "flows": null,
+   "server_flows": null
+  },
+  "223-tojson-contexts": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "224-matrix-include-exclude": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "225-docker-build-run": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "226-multiline-outputs": {
+   "status": "ok",
+   "conclusion": "success",
+   "flows": null,
+   "server_flows": null
+  },
+  "227-composite-pre-post": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "202-dynamic-matrix-dataflow": {
+   "status": "ok",
+   "conclusion": "success",
+   "flows": null,
+   "server_flows": null
+  },
+  "221-failure-reporting": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  }
+ },
+ "pl-official": {
+  "201-expression-edge-cases": {
+   "status": "ok",
+   "conclusion": "success",
+   "flows": null,
+   "server_flows": null
+  },
+  "202-dynamic-matrix-dataflow": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "203-needs-dag-deep-chain": {
+   "status": "ok",
+   "conclusion": "success",
+   "flows": null,
+   "server_flows": null
+  },
+  "204-composite-with-outputs-ifs": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "205-reusable-workflow-chain": {
+   "status": "ok",
+   "conclusion": "success",
+   "flows": null,
+   "server_flows": null
+  },
+  "206-cache-artifact-roundtrip": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "207-masking-secrets-vars": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "208-timeout-graceful-kill": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "209-continue-on-error-cascade": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "210-service-containers-health": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "211-job-container-volumes": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "212-docker-action": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "213-oidc-token-claims": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "214-checkout-repo-inspect": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "215-concurrency-cancel-in-progress": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "216-summaries-env-cascade": {
+   "status": "ok",
+   "conclusion": "success",
+   "flows": null,
+   "server_flows": null
+  },
+  "217-shell-variants": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "218-node-migration": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "219-env-state-files": {
+   "status": "ok",
+   "conclusion": "success",
+   "flows": null,
+   "server_flows": null
+  },
+  "220-label-routing": {
+   "status": "ok",
+   "conclusion": "success",
+   "flows": null,
+   "server_flows": null
+  },
+  "221-failure-reporting": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "222-dispatch-inputs-typed": {
+   "status": "ok",
+   "conclusion": "success",
+   "flows": null,
+   "server_flows": null
+  },
+  "223-tojson-contexts": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "224-matrix-include-exclude": {
+   "status": "ok",
+   "conclusion": "success",
+   "flows": null,
+   "server_flows": null
+  },
+  "225-docker-build-run": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "226-multiline-outputs": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  },
+  "227-composite-pre-post": {
+   "status": "ok",
+   "conclusion": "failure",
+   "flows": null,
+   "server_flows": null
+  }
+ },
+ "pl-preloop": {
+  "201-expression-edge-cases": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 45
+  },
+  "202-dynamic-matrix-dataflow": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 353
+  },
+  "203-needs-dag-deep-chain": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 353
+  },
+  "204-composite-with-outputs-ifs": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 38
+  },
+  "205-reusable-workflow-chain": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 35
+  },
+  "206-cache-artifact-roundtrip": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 278
+  },
+  "207-masking-secrets-vars": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 35
+  },
+  "208-timeout-graceful-kill": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 272
+  },
+  "209-continue-on-error-cascade": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 260
+  },
+  "210-service-containers-health": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 35
+  },
+  "211-job-container-volumes": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 257
+  },
+  "212-docker-action": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 35
+  },
+  "213-oidc-token-claims": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 36
+  },
+  "214-checkout-repo-inspect": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 50
+  },
+  "215-concurrency-cancel-in-progress": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 57
+  },
+  "216-summaries-env-cascade": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 44
+  },
+  "217-shell-variants": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 38
+  },
+  "218-node-migration": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 257
+  },
+  "219-env-state-files": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 41
+  },
+  "220-label-routing": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 260
+  },
+  "221-failure-reporting": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 260
+  },
+  "222-dispatch-inputs-typed": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 214
+  },
+  "223-tojson-contexts": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 44
+  },
+  "224-matrix-include-exclude": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 353
+  },
+  "225-docker-build-run": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 38
+  },
+  "226-multiline-outputs": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 260
+  },
+  "227-composite-pre-post": {
+   "status": "ok",
+   "flows": 0,
+   "server_flows": 257
+  }
+ }
+}

--- a/crates/preloop-gha-parser/src/expand.rs
+++ b/crates/preloop-gha-parser/src/expand.rs
@@ -29,7 +29,7 @@ fn resolved_job_name(
     inputs: Option<&BTreeMap<String, Value>>,
 ) -> String {
     match name {
-        Some(raw) => crate::eval::resolve_string(raw, &expression_context(matrix, inputs))
+        Some(raw) => crate::eval::resolve_string(raw, &expression_context(matrix, inputs, None))
             .unwrap_or_else(|_| raw.to_owned()),
         None => expanded_id.to_owned(),
     }
@@ -49,7 +49,7 @@ fn resolved_runs_on(
     matrix: &IndexMap<String, Value>,
     inputs: Option<&BTreeMap<String, Value>>,
 ) -> Vec<String> {
-    let context = expression_context(matrix, inputs);
+    let context = expression_context(matrix, inputs, None);
     labels
         .into_iter()
         .map(|label| {
@@ -117,6 +117,7 @@ fn resolved_continue_on_error(
 fn expression_context(
     matrix: &IndexMap<String, Value>,
     inputs: Option<&BTreeMap<String, Value>>,
+    event_name: Option<&str>,
 ) -> Context {
     let mut context = Context::default();
     context.insert(
@@ -128,6 +129,16 @@ fn expression_context(
                 .collect(),
         ),
     );
+    let actual_event = event_name.unwrap_or(if inputs.is_some() && !inputs.unwrap().is_empty() {
+        "workflow_dispatch"
+    } else {
+        "push"
+    });
+    let mut github_map = serde_json::Map::new();
+    github_map.insert(
+        "event_name".to_owned(),
+        Value::String(actual_event.to_owned()),
+    );
     if let Some(inputs) = inputs {
         context.insert(
             "inputs",
@@ -138,7 +149,24 @@ fn expression_context(
                     .collect(),
             ),
         );
+        let stringified: serde_json::Map<String, Value> = inputs
+            .iter()
+            .map(|(k, v)| {
+                let s = match v {
+                    Value::String(s) => s.clone(),
+                    Value::Bool(b) => b.to_string(),
+                    Value::Number(n) => n.to_string(),
+                    Value::Null => String::new(),
+                    other => serde_json::to_string(other).unwrap_or_default(),
+                };
+                (k.clone(), Value::String(s))
+            })
+            .collect();
+        let mut event_map = serde_json::Map::new();
+        event_map.insert("inputs".to_owned(), Value::Object(stringified));
+        github_map.insert("event".to_owned(), Value::Object(event_map));
     }
+    context.insert("github", Value::Object(github_map));
     context
 }
 
@@ -154,7 +182,7 @@ fn resolve_deferred_bool(
     match value {
         DeferredBool::Literal(value) => Ok(*value),
         DeferredBool::Expression(expression) => {
-            let result = eval_expression(expression, &expression_context(matrix, inputs))
+            let result = eval_expression(expression, &expression_context(matrix, inputs, None))
                 .map_err(|error| ParserError::InvalidExpression(error.to_string()))?;
             result.as_bool().ok_or_else(|| {
                 ParserError::InvalidExpression(format!(
@@ -174,7 +202,7 @@ fn resolve_deferred_number(
     match value {
         DeferredNumber::Literal(value) => Ok(Some(*value)),
         DeferredNumber::Expression(expression) => {
-            let result = eval_expression(expression, &expression_context(matrix, inputs))
+            let result = eval_expression(expression, &expression_context(matrix, inputs, None))
                 .map_err(|error| ParserError::InvalidExpression(error.to_string()))?;
             result.as_u64().map(Some).ok_or_else(|| {
                 ParserError::InvalidExpression(format!(
@@ -355,7 +383,7 @@ pub fn expand_jobs(workflow: &Workflow) -> Result<Vec<JobPlan>, ParserError> {
     let global_env = workflow.env.clone().into_strings();
     for (job_id, job) in &workflow.jobs {
         let (matrixes, deferred_matrix) =
-            expand_matrix(job_id, job.strategy.matrix.as_ref(), None)?.into_cells();
+            expand_matrix(job_id, job.strategy.matrix.as_ref(), None, None)?.into_cells();
         let matrix_deferred = deferred_matrix.is_some();
         let matrix_count = matrixes.len();
         for (matrix_index, matrix) in matrixes.into_iter().enumerate() {
@@ -587,6 +615,7 @@ fn expand_jobs_with_reusables_internal(
     depth: usize,
     reusable_calls: &mut BTreeMap<String, ReusableCallMetadata>,
     inputs: Option<&BTreeMap<String, Value>>,
+    event_name: Option<&str>,
 ) -> Result<Vec<JobPlan>, ParserError> {
     let mut plans = Vec::new();
     let global_env = workflow.env.clone().into_strings();
@@ -699,9 +728,13 @@ fn expand_jobs_with_reusables_internal(
                 .map(|(k, v)| (k.clone(), v.value.clone()))
                 .collect();
 
-            let (matrices, deferred_matrix) =
-                expand_matrix(job_id, job.strategy.matrix.as_ref(), Some(&resolved_inputs))?
-                    .into_cells();
+            let (matrices, deferred_matrix) = expand_matrix(
+                job_id,
+                job.strategy.matrix.as_ref(),
+                Some(&resolved_inputs),
+                event_name,
+            )?
+            .into_cells();
             let matrix_count = matrices.len();
             for (matrix_index, matrix) in matrices.into_iter().enumerate() {
                 let expanded_job_id = matrix_expand::expanded_job_id(job_id, &matrix);
@@ -804,7 +837,7 @@ fn expand_jobs_with_reusables_internal(
         // rather than as zero cells. The job keeps one un-suffixed DAG node
         // (and its `if:` gating) until the runtime fan-out replaces it.
         let (matrix_cells, deferred_matrix) =
-            expand_matrix(job_id, job.strategy.matrix.as_ref(), inputs)?.into_cells();
+            expand_matrix(job_id, job.strategy.matrix.as_ref(), inputs, event_name)?.into_cells();
         let matrix_deferred = deferred_matrix.is_some();
         let matrix_count = matrix_cells.len();
         for (matrix_index, matrix) in matrix_cells.into_iter().enumerate() {
@@ -846,6 +879,40 @@ pub fn expand_jobs_with_reusables_and_shas(
     reusable_workflows: &BTreeMap<String, String>,
     reusable_workflow_shas: &BTreeMap<String, String>,
 ) -> Result<ExpandedWorkflows, ParserError> {
+    expand_jobs_with_reusables_and_shas_and_inputs(
+        workflow,
+        reusable_workflows,
+        reusable_workflow_shas,
+        None,
+    )
+}
+
+/// Expand jobs with workflow-dispatch inputs available to strategy
+/// expressions. GitHub evaluates `jobs.<id>.strategy.*` expressions with the
+/// `inputs` context populated from the dispatch, so the top-level expansion
+/// must see them too.
+pub fn expand_jobs_with_reusables_and_shas_and_inputs(
+    workflow: &Workflow,
+    reusable_workflows: &BTreeMap<String, String>,
+    reusable_workflow_shas: &BTreeMap<String, String>,
+    dispatch_inputs: Option<&BTreeMap<String, serde_json::Value>>,
+) -> Result<ExpandedWorkflows, ParserError> {
+    expand_jobs_with_reusables_and_shas_and_inputs_and_event(
+        workflow,
+        reusable_workflows,
+        reusable_workflow_shas,
+        dispatch_inputs,
+        None,
+    )
+}
+
+pub fn expand_jobs_with_reusables_and_shas_and_inputs_and_event(
+    workflow: &Workflow,
+    reusable_workflows: &BTreeMap<String, String>,
+    reusable_workflow_shas: &BTreeMap<String, String>,
+    dispatch_inputs: Option<&BTreeMap<String, serde_json::Value>>,
+    event_name: Option<&str>,
+) -> Result<ExpandedWorkflows, ParserError> {
     let mut reusable_calls = BTreeMap::new();
     let mut plans = expand_jobs_with_reusables_internal(
         workflow,
@@ -853,7 +920,8 @@ pub fn expand_jobs_with_reusables_and_shas(
         reusable_workflow_shas,
         0,
         &mut reusable_calls,
-        None,
+        dispatch_inputs,
+        event_name,
     )?;
 
     // Post-process: Rewrite needs to replace base job IDs of reusable calls with their expanded inner job IDs.
@@ -942,6 +1010,7 @@ pub fn expand_reusable_call(
         call.depth,
         &mut reusable_calls,
         Some(&caller_plan.inputs),
+        None,
     )?;
 
     let caller_id = caller_plan.id.0.clone();
@@ -1110,6 +1179,7 @@ fn expand_matrix(
     job_id: &str,
     matrix: Option<&MatrixValue>,
     inputs: Option<&BTreeMap<String, Value>>,
+    event_name: Option<&str>,
 ) -> Result<MatrixExpansion, ParserError> {
     let Some(matrix) = matrix else {
         return Ok(MatrixExpansion::Combinations(vec![IndexMap::new()]));
@@ -1118,8 +1188,11 @@ fn expand_matrix(
     let mut matrix = match matrix {
         MatrixValue::Static(matrix) => matrix.clone(),
         MatrixValue::Expression(expression) => {
-            let value = eval_expression(expression, &expression_context(&IndexMap::new(), inputs))
-                .map_err(|error| ParserError::InvalidExpression(error.to_string()))?;
+            let value = eval_expression(
+                expression,
+                &expression_context(&IndexMap::new(), inputs, event_name),
+            )
+            .map_err(|error| ParserError::InvalidExpression(error.to_string()))?;
             if value.is_null() {
                 if expression.contains("needs.") || expression.contains("needs[") {
                     return Ok(MatrixExpansion::Deferred(expression.clone()));
@@ -1141,9 +1214,11 @@ fn expand_matrix(
     ] {
         if values.len() == 1 {
             if let Value::String(expression) = &values[0] {
-                let resolved =
-                    eval_expression(expression, &expression_context(&IndexMap::new(), inputs))
-                        .map_err(|error| ParserError::InvalidExpression(error.to_string()))?;
+                let resolved = eval_expression(
+                    expression,
+                    &expression_context(&IndexMap::new(), inputs, event_name),
+                )
+                .map_err(|error| ParserError::InvalidExpression(error.to_string()))?;
                 if resolved.is_null() {
                     return Ok(MatrixExpansion::Combinations(vec![IndexMap::new()]));
                 }

--- a/crates/preloop-gha-parser/src/lib.rs
+++ b/crates/preloop-gha-parser/src/lib.rs
@@ -18,7 +18,9 @@ mod yaml;
 pub use expand::{
     effective_token_permissions, expand_deferred_matrix_job, expand_deferred_reusable_call,
     expand_jobs, expand_jobs_with_reusables, expand_jobs_with_reusables_and_shas,
-    expand_reusable_call, DEFAULT_TOKEN_PERMISSIONS, PERMISSION_SCOPES,
+    expand_jobs_with_reusables_and_shas_and_inputs,
+    expand_jobs_with_reusables_and_shas_and_inputs_and_event, expand_reusable_call,
+    DEFAULT_TOKEN_PERMISSIONS, PERMISSION_SCOPES,
 };
 pub use models::*;
 pub use yaml::{parse_action_metadata, parse_workflow};

--- a/crates/preloop-runner-server/src/artifact_twirp.rs
+++ b/crates/preloop-runner-server/src/artifact_twirp.rs
@@ -44,8 +44,31 @@ pub(crate) struct ArtifactV2DeleteRequest {
     pub(crate) name: String,
 }
 
-pub(crate) fn artifact_v2_registry_key(run_id: &str, job_id: &str, name: &str) -> String {
-    format!("{run_id}/{job_id}/{name}")
+pub(crate) fn artifact_v2_registry_key(run_id: &str, name: &str) -> String {
+    format!("{run_id}/{name}")
+}
+
+/// Resolve the run-scoped registry namespace for an artifact request.
+///
+/// The official runner addresses artifacts with
+/// `workflow_run_backend_id = plan_id`, and preloop mints one plan id per job
+/// (the job builder defaults `plan.plan_id` to the job's own id). A build job
+/// and a consumer job of the same run therefore present different plan ids —
+/// scoping the registry by the raw request value would make the build job's
+/// uploads invisible to the consumer (found via scenario 206). Map the plan id
+/// to the recorded run id when it is known; fall back to the request value for
+/// unknown plans (control-plane callers, tests).
+pub(crate) fn canonical_artifact_scope(
+    inner: &InnerState,
+    plan_id: &str,
+    fallback: &str,
+) -> String {
+    if let Some(request_id) = inner.plan_requests.get(plan_id) {
+        if let Some(record) = inner.job_requests.get(request_id) {
+            return record.run_id.to_string();
+        }
+    }
+    fallback.to_owned()
 }
 
 pub(crate) async fn save_artifact_v2_registry(
@@ -67,11 +90,15 @@ pub(crate) async fn twirp_artifact_v2_create(
     validate_artifact_name(&request.name)
         .map_err(|error| ApiError::bad_request(error.to_string()))?;
     let token = uuid::Uuid::new_v4().to_string();
-    let registry_key = artifact_v2_registry_key(
-        &request.workflow_run_backend_id,
-        &request.workflow_job_run_backend_id,
-        &request.name,
-    );
+    let canonical_run = {
+        let inner = shared.state.inner.lock().await;
+        canonical_artifact_scope(
+            &inner,
+            &request.workflow_run_backend_id,
+            &request.workflow_run_backend_id,
+        )
+    };
+    let registry_key = artifact_v2_registry_key(&canonical_run, &request.name);
     // F7: the job is taken from the signed runtime token scope, not the
     // request body, so a runner cannot evade its per-job pending cap by
     // inventing other job ids. Control-plane callers (no job token) reserve
@@ -88,6 +115,25 @@ pub(crate) async fn twirp_artifact_v2_create(
         .map_err(|e| ApiError::internal(format!("failed to create artifact stage dir: {e}")))?;
     {
         let mut inner = shared.state.inner.lock().await;
+        if inner.artifact_v2_registry.contains_key(&registry_key) {
+            let _ = tokio::fs::remove_dir_all(&stage_dir).await;
+            return Err(ApiError::conflict(format!(
+                "Artifact name '{}' already exists in this workflow run. Artifacts are immutable once uploaded.",
+                request.name
+            )));
+        }
+        if inner
+            .artifact_v2_pending
+            .values()
+            .any(|p| p.registry_key == registry_key)
+        {
+            let _ = tokio::fs::remove_dir_all(&stage_dir).await;
+            return Err(ApiError::conflict(format!(
+                "An upload for artifact name '{}' is already in progress in this workflow run.",
+                request.name
+            )));
+        }
+
         if let Some(job_id) = &job_backend_id {
             let pending = inner
                 .artifact_v2_pending
@@ -130,11 +176,15 @@ pub(crate) async fn twirp_artifact_v2_finalize(
     State(shared): State<Arc<SharedState>>,
     Json(request): Json<ArtifactV2FinalizeRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let registry_key = artifact_v2_registry_key(
-        &request.workflow_run_backend_id,
-        &request.workflow_job_run_backend_id,
-        &request.name,
-    );
+    let canonical_run = {
+        let inner = shared.state.inner.lock().await;
+        canonical_artifact_scope(
+            &inner,
+            &request.workflow_run_backend_id,
+            &request.workflow_run_backend_id,
+        )
+    };
+    let registry_key = artifact_v2_registry_key(&canonical_run, &request.name);
     let token = {
         let inner = shared.state.inner.lock().await;
         inner
@@ -234,12 +284,21 @@ pub(crate) async fn twirp_artifact_v2_list(
         _ => None,
     });
 
+    let canonical_run = canonical_artifact_scope(
+        &inner,
+        &request.workflow_run_backend_id,
+        &request.workflow_run_backend_id,
+    );
+
     let artifacts: Vec<serde_json::Value> = inner
         .artifact_v2_registry
         .values()
         .filter(|e| {
-            e.workflow_run_backend_id == request.workflow_run_backend_id
-                && e.workflow_job_run_backend_id == request.workflow_job_run_backend_id
+            canonical_artifact_scope(
+                &inner,
+                &e.workflow_run_backend_id,
+                &e.workflow_run_backend_id,
+            ) == canonical_run
         })
         .filter(|e| name_filter.as_deref().map(|f| e.name == f).unwrap_or(true))
         .filter(|e| id_filter.map(|id| e.id == id).unwrap_or(true))
@@ -262,11 +321,15 @@ pub(crate) async fn twirp_artifact_v2_get_signed_url(
     State(shared): State<Arc<SharedState>>,
     Json(request): Json<ArtifactV2GetSignedUrlRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let registry_key = artifact_v2_registry_key(
-        &request.workflow_run_backend_id,
-        &request.workflow_job_run_backend_id,
-        &request.name,
-    );
+    let canonical_run = {
+        let inner = shared.state.inner.lock().await;
+        canonical_artifact_scope(
+            &inner,
+            &request.workflow_run_backend_id,
+            &request.workflow_run_backend_id,
+        )
+    };
+    let registry_key = artifact_v2_registry_key(&canonical_run, &request.name);
     let blob_token = {
         let inner = shared.state.inner.lock().await;
         inner
@@ -285,11 +348,15 @@ pub(crate) async fn twirp_artifact_v2_delete(
     State(shared): State<Arc<SharedState>>,
     Json(request): Json<ArtifactV2DeleteRequest>,
 ) -> Json<serde_json::Value> {
-    let registry_key = artifact_v2_registry_key(
-        &request.workflow_run_backend_id,
-        &request.workflow_job_run_backend_id,
-        &request.name,
-    );
+    let canonical_run = {
+        let inner = shared.state.inner.lock().await;
+        canonical_artifact_scope(
+            &inner,
+            &request.workflow_run_backend_id,
+            &request.workflow_run_backend_id,
+        )
+    };
+    let registry_key = artifact_v2_registry_key(&canonical_run, &request.name);
     let removed = {
         let mut inner = shared.state.inner.lock().await;
         inner.artifact_v2_registry.remove(&registry_key)

--- a/crates/preloop-runner-server/src/runner_lifecycle.rs
+++ b/crates/preloop-runner-server/src/runner_lifecycle.rs
@@ -516,37 +516,49 @@ pub(crate) async fn agent_lookup(
     Path(_pool_id): Path<i64>,
     Query(params): Query<std::collections::HashMap<String, String>>,
 ) -> Json<serde_json::Value> {
-    let agent_name = params.get("agentName").cloned().unwrap_or_default();
-    let inner = shared.state.inner.lock().await;
-    for runner in inner.runners.values() {
-        if runner.name == agent_name {
-            return Json(json!({"count": 1, "value": [{
-                "id": runner.id,
-                "name": runner.name,
-                "version": "2.335.1",
-                "osDescription": "Linux",
-                "enabled": true,
-                "status": "online",
-                "ephemeral": runner.ephemeral,
-                "maxParallelism": 1,
-                "currentParallelism": 0,
-                "disableUpdate": false,
-                "isElastic": false,
-                "isVirtual": false,
-                "provisioningState": "Provisioned",
-                "queueName": format!("taskagent-{}", runner.id),
-                "runnerGroupId": runner.runner_group_id.unwrap_or(1),
-                "runnerGroupName": runner.runner_group_name.clone(),
-                "owningTenant": null,
-                "createdOn": "2026-01-01T00:00:00Z",
-                "lastConnectedOn": "2026-01-01T00:00:00",
-                "labels": runner.labels.iter().enumerate().map(|(i, l)| json!({"id": i + 1, "name": l, "type": "user"})).collect::<Vec<_>>(),
-                "authorization": {
-                    "clientId": "",
-                    "publicKey": {"exponent": "AQAB", "modulus": ""}
-                }
-            }]}));
-        }
+    let Some(agent_name) = params.get("agentName") else {
+        return Json(json!({"count": 0, "value": []}));
+    };
+    let mut inner = shared.state.inner.lock().await;
+    let found = inner
+        .runners
+        .values()
+        .find(|r| &r.name == agent_name)
+        .cloned();
+    if let Some(runner) = found {
+        let client_id = inner
+            .runner_client_ids
+            .iter()
+            .find(|(_, &id)| id == runner.id)
+            .map(|(k, _)| k.clone())
+            .unwrap_or_else(|| format!("{:08x}-0000-4000-8000-000000000000", runner.id as u32));
+        inner.runner_client_ids.insert(client_id.clone(), runner.id);
+        return Json(json!({"count": 1, "value": [{
+            "id": runner.id,
+            "name": runner.name,
+            "version": "2.335.1",
+            "osDescription": "Linux",
+            "enabled": true,
+            "status": "online",
+            "ephemeral": runner.ephemeral,
+            "maxParallelism": 1,
+            "currentParallelism": 0,
+            "disableUpdate": false,
+            "isElastic": false,
+            "isVirtual": false,
+            "provisioningState": "Provisioned",
+            "queueName": format!("taskagent-{}", runner.id),
+            "runnerGroupId": runner.runner_group_id.unwrap_or(1),
+            "runnerGroupName": runner.runner_group_name.clone(),
+            "owningTenant": null,
+            "createdOn": "2026-01-01T00:00:00Z",
+            "lastConnectedOn": "2026-01-01T00:00:00",
+            "labels": runner.labels.iter().enumerate().map(|(i, l)| json!({"id": i + 1, "name": l, "type": "user"})).collect::<Vec<_>>(),
+            "authorization": {
+                "clientId": client_id,
+                "publicKey": {"exponent": "AQAB", "modulus": ""}
+            }
+        }]}));
     }
     // Return empty collection (not 404) — runner expects VssJsonCollectionWrapper format
     Json(json!({"count": 0, "value": []}))

--- a/crates/preloop-runner-server/src/runs.rs
+++ b/crates/preloop-runner-server/src/runs.rs
@@ -119,10 +119,49 @@ pub(crate) async fn metrics(State(shared): State<Arc<SharedState>>) -> impl Into
 /// the job display name ("Run tests with system wide configuration") would
 /// crash the worker with `FormatException`.
 fn orchestration_id(plan_id: &str, job_id: &str, matrix_index: Option<usize>) -> String {
+    // The official runner emits this value as a User-Agent product token
+    // (`ProductInfoHeaderValue("OrchestrationId", ...)`), so the whole string
+    // must be token-safe. Reusable-call job ids contain '/' ("ci/build"),
+    // which .NET rejects with FormatException. GitHub's own ids never carry
+    // those characters; map everything outside the token alphabet to '-'.
+    let job_id = sanitize_job_id_token(job_id);
     match matrix_index {
         Some(index) => format!("{plan_id}.{job_id}._{index}"),
         None => format!("{plan_id}.{job_id}.__default"),
     }
+}
+
+/// Replace every character that is not an RFC product-token character with
+/// '-' so the value passes .NET's `HeaderUtilities.CheckValidToken`.
+fn sanitize_job_id_token(job_id: &str) -> String {
+    job_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric()
+                || matches!(
+                    c,
+                    '!' | '#'
+                        | '$'
+                        | '%'
+                        | '&'
+                        | '\''
+                        | '*'
+                        | '+'
+                        | '-'
+                        | '.'
+                        | '^'
+                        | '_'
+                        | '`'
+                        | '|'
+                        | '~'
+                )
+            {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
 }
 
 /// Interpolate `${{ ... }}` expressions in a workflow run name.
@@ -366,10 +405,17 @@ pub(crate) async fn submit_run_inner(
             submission.event
         )));
     }
-    let expanded = preloop_gha_parser::expand_jobs_with_reusables_and_shas(
+    let dispatch_inputs_for_expand: BTreeMap<String, serde_json::Value> = submission
+        .dispatch_inputs
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    let expanded = preloop_gha_parser::expand_jobs_with_reusables_and_shas_and_inputs_and_event(
         &workflow,
         &submission.reusable_workflows,
         &submission.reusable_workflow_shas,
+        (!dispatch_inputs_for_expand.is_empty()).then_some(&dispatch_inputs_for_expand),
+        Some(submission.event.as_str()),
     )?;
     let mut jobs = expanded.jobs;
     let reusable_calls = expanded.reusable_calls;

--- a/crates/preloop-runner-server/src/state.rs
+++ b/crates/preloop-runner-server/src/state.rs
@@ -715,7 +715,16 @@ impl AppState {
                 if let Ok(map) = serde_json::from_str::<BTreeMap<String, ArtifactV2Entry>>(&content)
                 {
                     let max_id = map.values().map(|e| e.id).max().unwrap_or(0);
-                    (map, max_id)
+                    let mut migrated = BTreeMap::new();
+                    for (k, v) in map {
+                        let parts: Vec<&str> = k.split('/').collect();
+                        if parts.len() >= 3 {
+                            migrated.insert(format!("{}/{}", parts[0], parts[2..].join("/")), v);
+                        } else {
+                            migrated.insert(k, v);
+                        }
+                    }
+                    (migrated, max_id)
                 } else {
                     (BTreeMap::new(), 0)
                 }

--- a/crates/preloop-runner-server/src/store.rs
+++ b/crates/preloop-runner-server/src/store.rs
@@ -915,7 +915,16 @@ pub(crate) fn apply_meta_snapshot(inner: &mut InnerState, meta: MetaSnapshot) {
     inner.cache_v2_pending = meta.cache_v2_pending.into_iter().collect();
     inner.cache_v2_dl_tokens = meta.cache_v2_dl_tokens.into_iter().collect();
     inner.artifact_v2_pending = meta.artifact_v2_pending.into_iter().collect();
-    inner.artifact_v2_registry = meta.artifact_v2_registry.into_iter().collect();
+    let mut migrated_registry = std::collections::BTreeMap::new();
+    for (k, v) in meta.artifact_v2_registry {
+        let parts: Vec<&str> = k.split('/').collect();
+        if parts.len() >= 3 {
+            migrated_registry.insert(format!("{}/{}", parts[0], parts[2..].join("/")), v);
+        } else {
+            migrated_registry.insert(k, v);
+        }
+    }
+    inner.artifact_v2_registry = migrated_registry;
     // Rebuild in-memory order queues for FIFO eviction and apply caps so a
     // restart doesn't reload unbounded history that was pending before the
     // caps shipped.

--- a/crates/runner-watch/src/coverage.rs
+++ b/crates/runner-watch/src/coverage.rs
@@ -296,12 +296,22 @@ pub fn implemented_routes(routes_src: &Path) -> Result<BTreeSet<ImplRoute>> {
 
 /// Canonical `(METHOD, path)` set the golden corpus for `version` exercises.
 pub fn golden_endpoints(golden_root: &Path, version: &str) -> Result<BTreeSet<(String, String)>> {
-    let dir = golden_root.join(format!("v{}", version.trim_start_matches('v')));
+    let mut dir = golden_root.join(format!("v{}", version.trim_start_matches('v')));
+    if !dir.exists() {
+        dir = golden_root.join(version);
+    }
     let mut out = BTreeSet::new();
     if !dir.exists() {
         return Ok(out);
     }
-    for entry in std::fs::read_dir(&dir).with_context(|| format!("read {}", dir.display()))? {
+    let target_dir = if dir.join("gh-official").exists() {
+        dir.join("gh-official")
+    } else {
+        dir
+    };
+    for entry in
+        std::fs::read_dir(&target_dir).with_context(|| format!("read {}", target_dir.display()))?
+    {
         let entry = entry?;
         if !entry.file_type()?.is_dir() {
             continue;

--- a/crates/runner-watch/src/main.rs
+++ b/crates/runner-watch/src/main.rs
@@ -1977,16 +1977,32 @@ fn normalize_version_dir(runner: &str) -> String {
 fn scenario_dirs(root: &Path, only: Option<&str>) -> anyhow::Result<Vec<PathBuf>> {
     let mut dirs = Vec::new();
     if let Some(name) = only {
-        let dir = root.join(name);
-        if !dir.join("flows.jsonl").exists() {
-            bail!("scenario flows not found: {}", dir.display());
+        let direct = root.join(name);
+        if direct.join("flows.jsonl").exists() {
+            return Ok(vec![direct]);
         }
-        return Ok(vec![dir]);
+        let nested = root.join("gh-official").join(name);
+        if nested.join("flows.jsonl").exists() {
+            return Ok(vec![nested]);
+        }
+        bail!(
+            "scenario flows not found for {name} under {}",
+            root.display()
+        );
     }
     for entry in fs::read_dir(root)? {
         let path = entry?.path();
-        if path.is_dir() && path.join("flows.jsonl").exists() {
-            dirs.push(path);
+        if path.is_dir() {
+            if path.join("flows.jsonl").exists() {
+                dirs.push(path);
+            } else if path.file_name().and_then(|n| n.to_str()) == Some("gh-official") {
+                for sub in fs::read_dir(&path)? {
+                    let sub_path = sub?.path();
+                    if sub_path.is_dir() && sub_path.join("flows.jsonl").exists() {
+                        dirs.push(sub_path);
+                    }
+                }
+            }
         }
     }
     dirs.sort();

--- a/docs/fidelity-gap.md
+++ b/docs/fidelity-gap.md
@@ -237,6 +237,45 @@ deprecation warnings, job-level annotations, and background step control-flow.
 
 ---
 
+## 1. v2.337.0 live conformance campaign (2026-08-31)
+
+Four-cell campaign over 27 edge-case scenarios (201–227 in
+`benchmarks/real-world/results/v2337-conformance/`), official `actions/runner`
+v2.337.0 and `preloop-runner`, each against github.com (private capture repo)
+and the local preloop server — every runner process inside a dedicated smolvm
+microVM. Full report: `benchmarks/real-world/results/v2337-conformance/REPORT.md`.
+
+**Official vs preloop runner against github.com: 23/27 exact match** (run +
+per-job conclusions). Divergences:
+
+| Scenario | Divergence | Owner |
+|---|---|---|
+| 213-oidc-token-claims | preloop-runner does not populate `ACTIONS_ID_TOKEN_REQUEST_TOKEN/URL` against github.com servers | preloop-runner |
+| 216-summaries-env-cascade | preloop-runner spawns steps in `working-directory` before the workspace directory exists | preloop-runner |
+| 208-timeout-graceful-kill | timed-out job conclusion bookkeeping (cancelled vs failure) | preloop-runner |
+| 224-matrix-include-exclude | fail-fast cancellation race: in-flight shard allowed to finish | preloop-runner |
+
+Server-side gaps found by pointing the official runner at the local preloop
+server (fixed during the campaign, commits 5a36f431, 35acfe20, 2e358fc4):
+
+1. Strategy expressions could not see dispatch inputs (`inputs` /
+   `github.event.inputs` absent from top-level expansion contexts).
+2. `environmentVariables` wire shape must be TemplateToken maps
+   (`{type:2,map:[{Key,Value}]}`); plain JSON objects crash the official
+   runner's schema evaluator ("The template is not valid. Unexpected value '').
+3. `system.orchestrationId` must be an RFC product token — reusable-call job
+   ids contain `/`, which .NET's `ProductHeaderValue` rejects.
+4. Agent-lookup `authorization.clientId` must parse as `System.Guid`.
+
+New open server gap (found, not yet fixed): artifact
+`CreateArtifact`/`ListArtifacts` scoping uses per-job plan ids, so a build job's
+artifact is invisible to a consumer job in the same run ("Artifact not found
+for name: build-output" in scenario 206).
+
+Pre-existing on main (unrelated): preloop-orchestrator
+`published_node_externals_are_traversable_by_other_users` fails — its mock
+SHASUMS still pin node-v20.19.0 while the pin moved to v20.20.2 (48386439).
+
 ## 1a. v2.336.0 conformance replay status (2026-07-28)
 
 ### 1a.1 What the conformance replay proves

--- a/fixtures/workflows/conformance/02-trivial-job.yml
+++ b/fixtures/workflows/conformance/02-trivial-job.yml
@@ -1,0 +1,7 @@
+name: mitm trivial
+on: workflow_dispatch
+jobs:
+  hello:
+    runs-on: [self-hosted, mitm]
+    steps:
+      - run: echo hello

--- a/fixtures/workflows/conformance/03-cancellation.yml
+++ b/fixtures/workflows/conformance/03-cancellation.yml
@@ -1,0 +1,7 @@
+name: mitm cancellation
+on: workflow_dispatch
+jobs:
+  slow:
+    runs-on: [self-hosted, mitm]
+    steps:
+      - run: sleep 60

--- a/fixtures/workflows/conformance/04-request-ack.yml
+++ b/fixtures/workflows/conformance/04-request-ack.yml
@@ -1,0 +1,7 @@
+name: mitm request-ack
+on: workflow_dispatch
+jobs:
+  ack-test:
+    runs-on: [self-hosted, mitm]
+    steps:
+      - run: echo "ack flow test"

--- a/fixtures/workflows/conformance/05-multi-job-a.yml
+++ b/fixtures/workflows/conformance/05-multi-job-a.yml
@@ -1,0 +1,7 @@
+name: mitm multi-job-a
+on: workflow_dispatch
+jobs:
+  job-a:
+    runs-on: [self-hosted, mitm]
+    steps:
+      - run: echo "job A"

--- a/fixtures/workflows/conformance/05-multi-job-b.yml
+++ b/fixtures/workflows/conformance/05-multi-job-b.yml
@@ -1,0 +1,7 @@
+name: mitm multi-job-b
+on: workflow_dispatch
+jobs:
+  job-b:
+    runs-on: [self-hosted, mitm]
+    steps:
+      - run: echo "job B"

--- a/fixtures/workflows/conformance/06-multi-step.yml
+++ b/fixtures/workflows/conformance/06-multi-step.yml
@@ -1,0 +1,13 @@
+name: mitm multi step
+on: workflow_dispatch
+jobs:
+  build:
+    runs-on: [self-hosted, mitm]
+    steps:
+      - run: echo first
+      - run: echo "VAL=$VAL"
+        env:
+          VAL: hello
+      - run: |
+          echo line1
+          echo line2

--- a/fixtures/workflows/conformance/07-step-failure.yml
+++ b/fixtures/workflows/conformance/07-step-failure.yml
@@ -1,0 +1,11 @@
+name: mitm step failure
+on: workflow_dispatch
+jobs:
+  build:
+    runs-on: [self-hosted, mitm]
+    steps:
+      - run: exit 1
+      - run: echo ran-on-failure
+        if: failure()
+      - run: echo never
+        if: success()

--- a/fixtures/workflows/conformance/08-job-outputs-needs.yml
+++ b/fixtures/workflows/conformance/08-job-outputs-needs.yml
@@ -1,0 +1,15 @@
+name: mitm job outputs
+on: workflow_dispatch
+jobs:
+  producer:
+    runs-on: [self-hosted, mitm]
+    outputs:
+      value: ${{ steps.gen.outputs.value }}
+    steps:
+      - id: gen
+        run: echo "value=42" >> "$GITHUB_OUTPUT"
+  consumer:
+    needs: producer
+    runs-on: [self-hosted, mitm]
+    steps:
+      - run: echo "got ${{ needs.producer.outputs.value }}"

--- a/fixtures/workflows/conformance/09-matrix-fan-out.yml
+++ b/fixtures/workflows/conformance/09-matrix-fan-out.yml
@@ -1,0 +1,13 @@
+name: mitm matrix
+on: workflow_dispatch
+jobs:
+  build:
+    runs-on: [self-hosted, mitm]
+    strategy:
+      fail-fast: true
+      matrix:
+        n: [1, 2, 3]
+    steps:
+      - run: |
+          if [ "${{ matrix.n }}" = "1" ]; then exit 1; fi
+          sleep 20

--- a/fixtures/workflows/conformance/10-uses-checkout.yml
+++ b/fixtures/workflows/conformance/10-uses-checkout.yml
@@ -1,0 +1,8 @@
+name: mitm checkout
+on: workflow_dispatch
+jobs:
+  build:
+    runs-on: [self-hosted, mitm]
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo checked-out

--- a/fixtures/workflows/conformance/100-tool-cache.yml
+++ b/fixtures/workflows/conformance/100-tool-cache.yml
@@ -1,0 +1,67 @@
+name: 100-tool-cache
+on:
+  workflow_dispatch:
+jobs:
+  test-tool-cache:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    steps:
+      - name: Verify runner.tool_cache is set
+        run: |
+          TOOL_CACHE="${{ runner.tool_cache }}"
+          if [ -z "$TOOL_CACHE" ]; then
+            echo "ERROR: runner.tool_cache is not set"
+            exit 1
+          fi
+          echo "runner.tool_cache=$TOOL_CACHE"
+
+      - name: Verify tool_cache directory exists
+        run: |
+          TOOL_CACHE="${{ runner.tool_cache }}"
+          if [ ! -d "$TOOL_CACHE" ]; then
+            echo "ERROR: runner.tool_cache directory does not exist: $TOOL_CACHE"
+            exit 1
+          fi
+          echo "Tool cache directory exists: $TOOL_CACHE"
+
+      - name: Setup Node.js via tool cache
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      - name: Verify Node.js is on PATH
+        run: |
+          which node
+          NODE_PATH=$(which node)
+          if [ -z "$NODE_PATH" ]; then
+            echo "ERROR: node not found on PATH"
+            exit 1
+          fi
+          echo "Node.js found on PATH: $NODE_PATH"
+
+      - name: Verify Node.js version
+        run: |
+          NODE_VERSION=$(node --version)
+          echo "Node.js version: $NODE_VERSION"
+          if [[ ! "$NODE_VERSION" =~ ^v20\. ]]; then
+            echo "ERROR: Expected Node v20.x, got $NODE_VERSION"
+            exit 1
+          fi
+          echo "Node.js version verified"
+
+      - name: Verify node is in tool cache
+        run: |
+          TOOL_CACHE="${{ runner.tool_cache }}"
+          NODE_PATH=$(which node)
+          if [[ "$NODE_PATH" != "$TOOL_CACHE"* ]]; then
+            echo "WARNING: node path $NODE_PATH is not under tool cache $TOOL_CACHE"
+            echo "This may be expected if using system node"
+          else
+            echo "Node.js is installed in tool cache"
+          fi
+
+      - name: Test npm is available
+        run: |
+          which npm
+          npm --version
+          echo "npm is available from tool cache setup"

--- a/fixtures/workflows/conformance/11-cache-roundtrip.yml
+++ b/fixtures/workflows/conformance/11-cache-roundtrip.yml
@@ -1,0 +1,12 @@
+name: mitm cache
+on: workflow_dispatch
+jobs:
+  build:
+    runs-on: [self-hosted, mitm]
+    steps:
+      - run: mkdir -p .cache-dir && date > .cache-dir/stamp
+      - uses: actions/cache@v4
+        with:
+          path: .cache-dir
+          key: mitm-${{ github.run_id }}
+      - run: cat .cache-dir/stamp

--- a/fixtures/workflows/conformance/12-artifact.yml
+++ b/fixtures/workflows/conformance/12-artifact.yml
@@ -1,0 +1,16 @@
+name: mitm artifact
+on: workflow_dispatch
+jobs:
+  build:
+    runs-on: [self-hosted, mitm]
+    steps:
+      - run: echo hi > out.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: out
+          path: out.txt
+      - uses: actions/download-artifact@v4
+        with:
+          name: out
+          path: dl
+      - run: cat dl/out.txt

--- a/fixtures/workflows/conformance/13-composite-action.yml
+++ b/fixtures/workflows/conformance/13-composite-action.yml
@@ -1,0 +1,10 @@
+name: mitm composite
+on: workflow_dispatch
+jobs:
+  build:
+    runs-on: [self-hosted, mitm]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/greet
+        with:
+          who: world

--- a/fixtures/workflows/conformance/14-annotations.yml
+++ b/fixtures/workflows/conformance/14-annotations.yml
@@ -1,0 +1,10 @@
+name: mitm annotations
+on: workflow_dispatch
+jobs:
+  build:
+    runs-on: [self-hosted, mitm]
+    steps:
+      - run: |
+          echo "::warning title=w::a warning"
+          echo "::error title=e::an error"
+          exit 1

--- a/fixtures/workflows/conformance/15-oidc-id-token.yml
+++ b/fixtures/workflows/conformance/15-oidc-id-token.yml
@@ -1,0 +1,12 @@
+name: mitm oidc
+on: workflow_dispatch
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  build:
+    runs-on: [self-hosted, mitm]
+    steps:
+      - run: |
+          curl -sS -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=api://aksh"

--- a/fixtures/workflows/conformance/16-container-job.yml
+++ b/fixtures/workflows/conformance/16-container-job.yml
@@ -1,0 +1,8 @@
+name: mitm container job
+on: workflow_dispatch
+jobs:
+  build:
+    runs-on: [self-hosted, mitm]
+    container: node:20
+    steps:
+      - run: node -v

--- a/fixtures/workflows/conformance/17-service-container.yml
+++ b/fixtures/workflows/conformance/17-service-container.yml
@@ -1,0 +1,19 @@
+name: mitm service container
+on: workflow_dispatch
+jobs:
+  build:
+    runs-on: [self-hosted, mitm]
+    services:
+      db:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432/tcp
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - run: echo up

--- a/fixtures/workflows/conformance/19-step-summary.yml
+++ b/fixtures/workflows/conformance/19-step-summary.yml
@@ -1,0 +1,22 @@
+name: mitm step summary
+on: workflow_dispatch
+jobs:
+  summary:
+    runs-on: [self-hosted, mitm]
+    steps:
+      - name: Write summary
+        run: |
+          echo "## Test Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Test | Result |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Unit | ✅ Pass |" >> $GITHUB_STEP_SUMMARY
+          echo "| Integration | ✅ Pass |" >> $GITHUB_STEP_SUMMARY
+      - name: Verify summary file exists
+        run: |
+          if [ -f "$GITHUB_STEP_SUMMARY" ]; then
+            echo "Summary file exists"
+            cat "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Summary file not found"
+          fi

--- a/fixtures/workflows/conformance/20-boolean-if.yml
+++ b/fixtures/workflows/conformance/20-boolean-if.yml
@@ -1,0 +1,18 @@
+name: mitm boolean if
+on: workflow_dispatch
+jobs:
+  skipped-job:
+    if: false
+    runs-on: [self-hosted, mitm]
+    steps:
+      - run: echo "should not run"
+  active-job:
+    runs-on: [self-hosted, mitm]
+    steps:
+      - run: echo "always runs"
+      - name: skipped-step
+        if: false
+        run: echo "this should be skipped"
+      - name: expression-step
+        if: ${{ true }}
+        run: echo "expression true runs"

--- a/fixtures/workflows/conformance/20-host-docker-node-services.yml
+++ b/fixtures/workflows/conformance/20-host-docker-node-services.yml
@@ -1,0 +1,35 @@
+name: host-docker-node-services
+on: [push, workflow_dispatch]
+
+jobs:
+  test:
+    runs-on: self-hosted
+    container: node:24-bookworm
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_DB: app_test
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+      redis:
+        image: redis:7
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    steps:
+      - name: Show Node version
+        run: node --version
+      - name: Install database clients
+        run: apt-get update && apt-get install -y --no-install-recommends postgresql-client redis-tools
+      - name: Connect to Postgres by service alias
+        run: PGPASSWORD=postgres psql -h postgres -U postgres -d app_test -c 'select 1'
+      - name: Connect to Redis by service alias
+        run: redis-cli -h redis ping

--- a/fixtures/workflows/conformance/20-step-ids.yml
+++ b/fixtures/workflows/conformance/20-step-ids.yml
@@ -1,0 +1,16 @@
+name: mitm step ids
+on: workflow_dispatch
+jobs:
+  ids:
+    runs-on: [self-hosted, mitm]
+    steps:
+      - run: echo "first script step (should be __run)"
+      - run: echo "second script step (should be __run_2)"
+      - id: named
+        run: echo "named step"
+      - run: echo "fourth script step (should be __run_3)"
+      - name: Step with outputs
+        id: output_step
+        run: echo "value=hello" >> $GITHUB_OUTPUT
+      - run: |
+          echo "Output from output_step: ${{ steps.output_step.outputs.value }}"

--- a/fixtures/workflows/conformance/21-continue-on-error.yml
+++ b/fixtures/workflows/conformance/21-continue-on-error.yml
@@ -1,0 +1,13 @@
+name: mitm continue on error
+on: workflow_dispatch
+jobs:
+  failing:
+    runs-on: [self-hosted, mitm]
+    continue-on-error: true
+    steps:
+      - run: exit 1
+  downstream:
+    needs: failing
+    runs-on: [self-hosted, mitm]
+    steps:
+      - run: echo "still runs despite upstream failure ${{ needs.failing.result }}"

--- a/fixtures/workflows/conformance/21-host-docker-build.yml
+++ b/fixtures/workflows/conformance/21-host-docker-build.yml
@@ -1,0 +1,18 @@
+name: host-docker-build
+on: [push, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - name: Create Dockerfile
+        run: |
+          cat > Dockerfile <<'EOF'
+          FROM alpine:3.20
+          RUN echo built > /built.txt
+          CMD ["cat", "/built.txt"]
+          EOF
+      - name: Build image
+        run: docker build -t aksh-host-docker-smoke .
+      - name: Run image
+        run: test "$(docker run --rm aksh-host-docker-smoke)" = "built"

--- a/fixtures/workflows/conformance/21-job-timeout.yml
+++ b/fixtures/workflows/conformance/21-job-timeout.yml
@@ -1,0 +1,13 @@
+name: mitm job timeout
+on: workflow_dispatch
+jobs:
+  timeout-test:
+    runs-on: [self-hosted, mitm]
+    timeout-minutes: 1
+    steps:
+      - run: echo "Starting long step..."
+      - run: |
+          echo "Sleeping for 120 seconds (should be cancelled by 1-min timeout)"
+          sleep 120
+          echo "This should never print"
+      - run: echo "This should also never print"

--- a/fixtures/workflows/conformance/22-cancel-semantics.yml
+++ b/fixtures/workflows/conformance/22-cancel-semantics.yml
@@ -1,0 +1,18 @@
+name: mitm cancel semantics
+on: workflow_dispatch
+jobs:
+  cancel-test:
+    runs-on: [self-hosted, mitm]
+    timeout-minutes: 1
+    steps:
+      - run: echo "Step 1 - will run"
+      - run: |
+          echo "Step 2 - long sleep (will be cancelled)"
+          sleep 120
+      - run: echo "Step 3 - default condition, should be skipped"
+      - if: always()
+        run: echo "Step 4 - always(), should run even after cancel"
+      - if: cancelled()
+        run: echo "Step 5 - cancelled(), should run after cancel"
+      - if: failure()
+        run: echo "Step 6 - failure(), should be skipped on cancel"

--- a/fixtures/workflows/conformance/22-host-docker-container-action.yml
+++ b/fixtures/workflows/conformance/22-host-docker-container-action.yml
@@ -1,0 +1,11 @@
+name: host-docker-container-action
+on: [push, workflow_dispatch]
+
+jobs:
+  action:
+    runs-on: self-hosted
+    steps:
+      - name: Run docker image action
+        uses: docker://alpine:3.20
+        with:
+          args: echo docker-action-ok

--- a/fixtures/workflows/conformance/22-step-timeout.yml
+++ b/fixtures/workflows/conformance/22-step-timeout.yml
@@ -1,0 +1,11 @@
+name: mitm step timeout
+on: workflow_dispatch
+jobs:
+  build:
+    runs-on: [self-hosted, mitm]
+    steps:
+      - run: echo "before timeout"
+      - name: will-timeout
+        timeout-minutes: 1
+        run: sleep 120
+      - run: echo "after timeout"

--- a/fixtures/workflows/conformance/23-context-fields.yml
+++ b/fixtures/workflows/conformance/23-context-fields.yml
@@ -1,0 +1,18 @@
+name: mitm context fields
+on: workflow_dispatch
+jobs:
+  context-test:
+    runs-on: [self-hosted, mitm]
+    steps:
+      - name: Validate runner context
+        run: |
+          echo "runner.name=${{ runner.name }}"
+          echo "runner.os=${{ runner.os }}"
+          echo "runner.arch=${{ runner.arch }}"
+          echo "runner.temp=${{ runner.temp }}"
+          echo "runner.tool_cache=${{ runner.tool_cache }}"
+          echo "runner.workspace=${{ runner.workspace }}"
+      - name: Validate job context
+        run: |
+          echo "job.status=${{ job.status }}"
+          echo "job=${{ toJSON(job) }}"

--- a/fixtures/workflows/conformance/23-defaults-run.yml
+++ b/fixtures/workflows/conformance/23-defaults-run.yml
@@ -1,0 +1,14 @@
+name: mitm defaults run
+on: workflow_dispatch
+defaults:
+  run:
+    shell: bash
+    working-directory: /tmp
+jobs:
+  build:
+    runs-on: [self-hosted, mitm]
+    steps:
+      - run: pwd
+      - run: echo "shell=$0"
+      - run: echo "outside default dir"
+        working-directory: /

--- a/fixtures/workflows/conformance/23-host-docker-container-files.yml
+++ b/fixtures/workflows/conformance/23-host-docker-container-files.yml
@@ -1,0 +1,23 @@
+name: host-docker-container-files
+on: [push, workflow_dispatch]
+
+jobs:
+  files:
+    runs-on: self-hosted
+    container:
+      image: alpine:3.20
+      options: --cpus 1
+    steps:
+      - name: Write file-command values
+        id: write_files
+        run: |
+          echo "HELLO_FROM_CONTAINER=1" >> "$GITHUB_ENV"
+          echo "container-output=ok" >> "$GITHUB_OUTPUT"
+      - name: Read environment file value
+        run: test "$HELLO_FROM_CONTAINER" = "1"
+      - name: Check workspace and temp mounts
+        run: |
+          test -d "$GITHUB_WORKSPACE"
+          test -d "$RUNNER_TEMP"
+      - name: Read output value
+        run: test "${{ steps.write_files.outputs['container-output'] }}" = "ok"

--- a/fixtures/workflows/conformance/24-host-docker-service-ports.yml
+++ b/fixtures/workflows/conformance/24-host-docker-service-ports.yml
@@ -1,0 +1,24 @@
+name: host-docker-service-ports
+on: [push, workflow_dispatch]
+
+jobs:
+  ports:
+    runs-on: self-hosted
+    services:
+      web:
+        image: nginx:1.27-alpine
+        ports:
+          - "18080:80"
+        options: >-
+          --health-cmd "curl -sfL http://localhost || exit 1"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    steps:
+      - name: Reach published service port
+        run: |
+          for i in $(seq 1 30); do
+            curl -sfL http://localhost:18080 && exit 0
+            sleep 1
+          done
+          exit 1

--- a/fixtures/workflows/conformance/24-post-job-always.yml
+++ b/fixtures/workflows/conformance/24-post-job-always.yml
@@ -1,0 +1,21 @@
+name: mitm post job always
+on: workflow_dispatch
+jobs:
+  build:
+    runs-on: [self-hosted, mitm]
+    steps:
+      - run: echo "main step"
+      - name: force-failure
+        run: exit 1
+      - name: always-step
+        if: always()
+        run: echo "always runs ${{ job.status }}"
+      - name: failure-step
+        if: failure()
+        run: echo "only on failure"
+      - name: cancelled-step
+        if: cancelled()
+        run: echo "only on cancel"
+      - name: success-step
+        if: success()
+        run: echo "only on success"

--- a/fixtures/workflows/conformance/24-problem-matcher.yml
+++ b/fixtures/workflows/conformance/24-problem-matcher.yml
@@ -1,0 +1,33 @@
+name: mitm problem matcher
+on: workflow_dispatch
+jobs:
+  matcher-test:
+    runs-on: [self-hosted, mitm]
+    steps:
+      - name: Create matcher file
+        run: |
+          cat > /tmp/eslint-matcher.json << 'MATCHEREOF'
+          {
+            "problemMatcher": [
+              {
+                "owner": "eslint-compact",
+                "pattern": [
+                  {
+                    "regexp": "^(.+):\\s+line\\s+(\\d+),\\s+col\\s+(\\d+),\\s+(Error|Warning)\\s+-\\s+(.+)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                  }
+                ]
+              }
+            ]
+          }
+          MATCHEREOF
+          echo "::add-matcher::/tmp/eslint-matcher.json"
+      - name: Emit matching error lines
+        run: |
+          echo "src/app.ts: line 10, col 5, Error - Unexpected var, use let or const instead"
+          echo "src/util.ts: line 42, col 1, Warning - Missing semicolon"
+          echo "This line should not match"

--- a/fixtures/workflows/conformance/25-env-inheritance.yml
+++ b/fixtures/workflows/conformance/25-env-inheritance.yml
@@ -1,0 +1,22 @@
+name: mitm env inheritance
+on: workflow_dispatch
+env:
+  TOP: top-value
+jobs:
+  producer:
+    runs-on: [self-hosted, mitm]
+    env:
+      JOB: job-value
+    steps:
+      - name: show env
+        run: echo "top=$TOP job=$JOB step=$STEP"
+        env:
+          STEP: step-value
+      - name: write env
+        run: echo "DYNAMIC=from-github-env" >> "$GITHUB_ENV"
+  consumer:
+    needs: producer
+    runs-on: [self-hosted, mitm]
+    steps:
+      - run: echo "top=$TOP"
+      - run: echo "dynamic=$DYNAMIC"

--- a/fixtures/workflows/conformance/26-vars-context.yml
+++ b/fixtures/workflows/conformance/26-vars-context.yml
@@ -1,0 +1,9 @@
+name: mitm vars context
+on: workflow_dispatch
+jobs:
+  build:
+    runs-on: [self-hosted, mitm]
+    steps:
+      - run: echo "vars test"
+      - run: echo "my_var=${{ vars.MY_VAR }}"
+        if: ${{ vars.MY_VAR != '' }}

--- a/fixtures/workflows/conformance/27-fromJSON-needs.yml
+++ b/fixtures/workflows/conformance/27-fromJSON-needs.yml
@@ -1,0 +1,19 @@
+name: mitm fromJSON needs
+on: workflow_dispatch
+jobs:
+  producer:
+    runs-on: [self-hosted, mitm]
+    outputs:
+      matrix: ${{ steps.gen.outputs.matrix }}
+    steps:
+      - id: gen
+        run: echo 'matrix={"os":["linux","macos"],"arch":["amd64","arm64"]}' >> "$GITHUB_OUTPUT"
+  consumer:
+    needs: producer
+    runs-on: [self-hosted, mitm]
+    strategy:
+      matrix:
+        os: ${{ fromJSON(needs.producer.outputs.matrix).os }}
+        arch: ${{ fromJSON(needs.producer.outputs.matrix).arch }}
+    steps:
+      - run: echo "os=${{ matrix.os }} arch=${{ matrix.arch }}"

--- a/fixtures/workflows/conformance/28-runner-context.yml
+++ b/fixtures/workflows/conformance/28-runner-context.yml
@@ -1,0 +1,8 @@
+name: mitm runner context
+on: workflow_dispatch
+jobs:
+  build:
+    runs-on: [self-hosted, mitm]
+    steps:
+      - run: echo "name=${{ runner.name }} os=${{ runner.os }} arch=${{ runner.arch }} temp=${{ runner.temp }}"
+      - run: echo "tool_cache=${{ runner.tool_cache }}"

--- a/fixtures/workflows/conformance/29-expression-null-coalesce.yml
+++ b/fixtures/workflows/conformance/29-expression-null-coalesce.yml
@@ -1,0 +1,14 @@
+name: mitm expression scalars
+on: workflow_dispatch
+jobs:
+  build:
+    runs-on: [self-hosted, mitm]
+    continue-on-error: ${{ false }}
+    strategy:
+      fail-fast: ${{ true }}
+      matrix:
+        n: [1, 2]
+    steps:
+      - run: echo "step run with expr scalars"
+      - run: echo "job_continue_on_error=${{ job.continue-on-error }}, matrix_n=${{ matrix.n }}"
+        if: always()

--- a/fixtures/workflows/conformance/30-container-job-basic.yml
+++ b/fixtures/workflows/conformance/30-container-job-basic.yml
@@ -1,0 +1,25 @@
+name: "golden: container-job-basic"
+on: workflow_dispatch
+
+jobs:
+  container-basic:
+    runs-on: [self-hosted, linux, x64]
+    container: node:20-bookworm
+    steps:
+      - name: Node version
+        run: node --version
+      - name: NPM version
+        run: npm --version
+      - name: Verify running inside container
+        run: |
+          # The job container should have /.dockerenv
+          test -f /.dockerenv
+          echo "Running inside Docker container"
+      - name: Check environment variables
+        run: |
+          echo "HOME=$HOME"
+          echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE"
+          echo "RUNNER_TEMP=$RUNNER_TEMP"
+          echo "GITHUB_ACTION=$GITHUB_ACTION"
+      - name: Write a file in workspace
+        run: echo "hello from container" > /tmp/test-output.txt && cat /tmp/test-output.txt

--- a/fixtures/workflows/conformance/31-container-with-services.yml
+++ b/fixtures/workflows/conformance/31-container-with-services.yml
@@ -1,0 +1,52 @@
+name: "golden: container-with-services"
+on: workflow_dispatch
+
+jobs:
+  container-services:
+    runs-on: [self-hosted, linux, x64]
+    container: node:20-bookworm
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: testuser
+          POSTGRES_DB: testdb
+        options: >-
+          --health-cmd "pg_isready -U testuser"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - name: Install clients
+        run: |
+          apt-get update -qq
+          apt-get install -y --no-install-recommends postgresql-client redis-tools
+      - name: Connect to Postgres via service alias
+        run: PGPASSWORD=postgres psql -h postgres -U testuser -d testdb -c 'SELECT version();'
+      - name: Create table and insert row
+        run: |
+          PGPASSWORD=postgres psql -h postgres -U testuser -d testdb -c '
+            CREATE TABLE test_table (id serial PRIMARY KEY, value text);
+            INSERT INTO test_table (value) VALUES ($$from-container$$);
+          '
+      - name: Query row back
+        run: |
+          PGPASSWORD=postgres psql -h postgres -U testuser -d testdb -t -c "SELECT value FROM test_table WHERE id=1;" | grep -q "from-container"
+      - name: Connect to Redis via service alias
+        run: |
+          redis-cli -h redis SET mykey "hello"
+          redis-cli -h redis GET mykey | grep -q hello
+      - name: Dump service context
+        run: |
+          echo "job.services.postgres.id=${{ job.services.postgres.id }}"
+          echo "job.services.postgres.ports[5432]=${{ job.services.postgres.ports[5432] }}"
+          echo "job.services.redis.id=${{ job.services.redis.id }}"
+          echo "job.services.redis.ports[6379]=${{ job.services.redis.ports[6379] }}"

--- a/fixtures/workflows/conformance/32-services-no-container.yml
+++ b/fixtures/workflows/conformance/32-services-no-container.yml
@@ -1,0 +1,40 @@
+name: "golden: services-no-container"
+on: workflow_dispatch
+
+jobs:
+  services-host:
+    runs-on: [self-hosted, linux, x64]
+    services:
+      nginx:
+        image: nginx:1.27-alpine
+        ports:
+          - 8080:80
+        options: >-
+          --health-cmd "curl -sf http://localhost/ || exit 1"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - name: Verify nginx reachable on mapped port
+        run: |
+          curl -sf http://localhost:8080
+          echo "nginx OK"
+      - name: Verify redis reachable on mapped port
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends redis-tools
+          redis-cli -h 127.0.0.1 -p 6379 PING | grep -q PONG
+      - name: Dump service context (host mode)
+        run: |
+          echo "nginx.id=${{ job.services.nginx.id }}"
+          echo "nginx.ports[80]=${{ job.services.nginx.ports['80'] }}"
+          echo "redis.id=${{ job.services.redis.id }}"
+          echo "redis.ports[6379]=${{ job.services.redis.ports['6379'] }}"

--- a/fixtures/workflows/conformance/33-container-env-options.yml
+++ b/fixtures/workflows/conformance/33-container-env-options.yml
@@ -1,0 +1,58 @@
+name: "golden: container-env-options"
+on: workflow_dispatch
+
+jobs:
+  container-env:
+    runs-on: [self-hosted, linux, x64]
+    container:
+      image: alpine:3.20
+      env:
+        CUSTOM_VAR: "hello-from-container"
+        NODE_ENV: "test"
+      options: --cpus 1
+    steps:
+      - name: Verify custom env var
+        run: |
+          test "$CUSTOM_VAR" = "hello-from-container"
+          echo "CUSTOM_VAR=$CUSTOM_VAR"
+      - name: Verify NODE_ENV
+        run: |
+          test "$NODE_ENV" = "test"
+          echo "NODE_ENV=$NODE_ENV"
+      - name: Write GITHUB_ENV
+        run: |
+          echo "DYNAMIC_VAR=set-at-runtime" >> "$GITHUB_ENV"
+      - name: Read GITHUB_ENV value
+        run: |
+          test "$DYNAMIC_VAR" = "set-at-runtime"
+          echo "DYNAMIC_VAR=$DYNAMIC_VAR"
+      - name: Write GITHUB_OUTPUT
+        id: gen
+        run: |
+          echo "result=success" >> "$GITHUB_OUTPUT"
+          echo "multi_line<<EOF" >> "$GITHUB_OUTPUT"
+          echo "line1" >> "$GITHUB_OUTPUT"
+          echo "line2" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+      - name: Read GITHUB_OUTPUT
+        run: |
+          test "${{ steps.gen.outputs.result }}" = "success"
+          echo "result=${{ steps.gen.outputs.result }}"
+          echo "multi_line=${{ steps.gen.outputs.multi_line }}"
+      - name: Write GITHUB_PATH
+        run: |
+          mkdir -p /tmp/custom-bin
+          echo '#!/bin/sh' > /tmp/custom-bin/my-tool
+          echo 'echo my-tool-output' >> /tmp/custom-bin/my-tool
+          chmod +x /tmp/custom-bin/my-tool
+          echo "/tmp/custom-bin" >> "$GITHUB_PATH"
+      - name: Use custom path tool
+        run: my-tool | grep -q my-tool-output
+      - name: Check workspace mount
+        run: |
+          test -d "$GITHUB_WORKSPACE"
+          ls -la "$GITHUB_WORKSPACE"
+      - name: Check runner temp mount
+        run: |
+          test -d "$RUNNER_TEMP"
+          echo "RUNNER_TEMP=$RUNNER_TEMP"

--- a/fixtures/workflows/conformance/34-container-with-checkout.yml
+++ b/fixtures/workflows/conformance/34-container-with-checkout.yml
@@ -1,0 +1,22 @@
+name: "golden: container-with-checkout"
+on: workflow_dispatch
+
+jobs:
+  container-checkout:
+    runs-on: [self-hosted, linux, x64]
+    container: ubuntu:24.04
+    steps:
+      - name: Install git (needed by checkout in container)
+        run: |
+          apt-get update -qq
+          apt-get install -y --no-install-recommends git ca-certificates
+      - uses: actions/checkout@v4
+      - name: Verify repo was checked out
+        run: |
+          test -f .github/workflows/34-container-with-checkout.yml
+          echo "Checkout successful"
+          ls -la
+      - name: Show git info in container
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git log --oneline -3

--- a/fixtures/workflows/conformance/35-container-lifecycle.yml
+++ b/fixtures/workflows/conformance/35-container-lifecycle.yml
@@ -1,0 +1,36 @@
+name: "golden: container-lifecycle"
+on: workflow_dispatch
+
+jobs:
+  lifecycle:
+    runs-on: [self-hosted, linux, x64]
+    container:
+      image: python:3.12-slim
+      env:
+        PYTHONDONTWRITEBYTECODE: "1"
+    steps:
+      - name: Verify python version
+        run: python3 --version
+      - name: Install pip package
+        run: pip install httpx
+      - name: Run python script
+        run: |
+          python3 -c "
+          import httpx
+          import sys
+          print(f'Python {sys.version}')
+          print(f'httpx {httpx.__version__}')
+          print('Container lifecycle OK')
+          "
+      - name: Test job.container context
+        run: |
+          echo "container.id=${{ job.container.id }}"
+          echo "container.network=${{ job.container.network }}"
+      - name: Failing step (continue-on-error)
+        continue-on-error: true
+        run: exit 1
+      - name: Step after continue-on-error
+        run: echo "This should still run"
+      - name: Conditional step
+        if: success()
+        run: echo "Previous step succeeded or was continue-on-error"

--- a/fixtures/workflows/conformance/36-docker-action.yml
+++ b/fixtures/workflows/conformance/36-docker-action.yml
@@ -1,0 +1,35 @@
+name: "golden: docker-action"
+on: workflow_dispatch
+
+jobs:
+  docker-action-host:
+    runs-on: [self-hosted, linux, x64]
+    steps:
+      - name: Run docker:// action (alpine)
+        uses: docker://alpine:3.20
+        with:
+          args: echo "hello from docker action"
+      - name: Run docker:// action (busybox)
+        uses: docker://busybox:latest
+        with:
+          args: echo "busybox action ok"
+      - name: Docker build and run on host
+        run: |
+          cat > /tmp/Dockerfile <<'EOF'
+          FROM alpine:3.20
+          RUN echo "built" > /built.txt
+          CMD ["cat", "/built.txt"]
+          EOF
+          docker build -t golden-test /tmp/
+          docker run --rm golden-test | grep -q built
+
+  docker-action-in-container:
+    runs-on: [self-hosted, linux, x64]
+    container: ubuntu:24.04
+    steps:
+      - name: Verify inside container
+        run: test -f /.dockerenv && echo "inside container"
+      - name: Run docker:// action from container job
+        uses: docker://alpine:3.20
+        with:
+          args: echo "docker action from inside container job"

--- a/fixtures/workflows/conformance/37-aksh-container-test.yml
+++ b/fixtures/workflows/conformance/37-aksh-container-test.yml
@@ -1,0 +1,15 @@
+name: "aksh: container-test"
+on: workflow_dispatch
+
+jobs:
+  container-basic:
+    runs-on: [self-hosted, aksh-container]
+    container: node:20-bookworm-slim
+    steps:
+      - name: Node version
+        run: node --version
+      - name: Verify container
+        run: |
+          echo "HOME=$HOME"
+          echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE"
+          echo "Running inside container"

--- a/fixtures/workflows/conformance/38-aksh-container-mapping.yml
+++ b/fixtures/workflows/conformance/38-aksh-container-mapping.yml
@@ -1,0 +1,24 @@
+name: "aksh: container-mapping"
+on: workflow_dispatch
+
+jobs:
+  container-mapping:
+    runs-on: [self-hosted, aksh-container]
+    container:
+      image: alpine:3.20
+      env:
+        TEST_VAR: hello
+      options: --cpus 1
+    services:
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - name: Check container
+        run: |
+          echo "TEST_VAR=$TEST_VAR"
+          cat /etc/alpine-release

--- a/fixtures/workflows/conformance/39-aksh-container-contexts.yml
+++ b/fixtures/workflows/conformance/39-aksh-container-contexts.yml
@@ -1,0 +1,43 @@
+name: "aksh: container-contexts"
+on: workflow_dispatch
+
+jobs:
+  container-contexts:
+    runs-on: [self-hosted]
+    container:
+      image: node:20-bookworm-slim
+    services:
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - name: Check container context
+        run: |
+          echo "container.id=${{ job.container.id }}"
+          echo "container.network=${{ job.container.network }}"
+          # Verify they are not empty
+          test -n "${{ job.container.id }}" || { echo "FAIL: container.id is empty"; exit 1; }
+          test -n "${{ job.container.network }}" || { echo "FAIL: container.network is empty"; exit 1; }
+          echo "Container context OK"
+      - name: Check service context
+        run: |
+          echo "redis.id=${{ job.services.redis.id }}"
+          echo "redis.network=${{ job.services.redis.network }}"
+          # Verify redis service id is not empty
+          test -n "${{ job.services.redis.id }}" || { echo "FAIL: redis.id is empty"; exit 1; }
+          echo "Service context OK"
+      - name: Verify running inside container
+        run: |
+          node --version
+          echo "Running inside container"
+      - name: Test GITHUB_ENV from container
+        run: |
+          echo "MY_VAR=hello-from-container" >> "$GITHUB_ENV"
+      - name: Read GITHUB_ENV
+        run: |
+          test "$MY_VAR" = "hello-from-container" || { echo "FAIL: MY_VAR not set"; exit 1; }
+          echo "GITHUB_ENV works: MY_VAR=$MY_VAR"

--- a/fixtures/workflows/conformance/40-bench-agent-ci.yml
+++ b/fixtures/workflows/conformance/40-bench-agent-ci.yml
@@ -1,0 +1,20 @@
+name: "bench: agent-ci"
+on: workflow_dispatch
+
+jobs:
+  rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: preloopdev/aksh
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.86"
+          components: rustfmt,clippy
+      - name: cargo fmt
+        run: cargo fmt --all --check
+      - name: cargo clippy
+        run: cargo clippy --workspace --all-targets
+      - name: cargo test
+        run: cargo test --workspace --quiet

--- a/fixtures/workflows/conformance/40-docker-lifecycle.yml
+++ b/fixtures/workflows/conformance/40-docker-lifecycle.yml
@@ -1,0 +1,28 @@
+name: 40-docker-lifecycle
+on:
+  workflow_dispatch:
+  push:
+    paths: ['.github/workflows/40-docker-lifecycle.yml', '.github/actions/docker-lifecycle/**']
+
+jobs:
+  docker-lifecycle:
+    runs-on: [self-hosted, f046-test]
+    timeout-minutes: 10
+    steps:
+      # NOTE: No cleanup step here — pre-entrypoint runs BEFORE all main steps,
+      # so any cleanup between would wipe the pre output.
+
+      - name: Docker action with pre/main/post lifecycle
+        uses: preloopdev/aksh-conformance-sample/.github/actions/docker-lifecycle@main
+        with:
+          test-arg: alpha
+          test-env: beta
+
+      - name: Assert pre/main ran (post runs after this step)
+        run: |
+          echo "=== lifecycle.log ==="
+          cat /github/workspace/.fidelity/lifecycle.log || cat .fidelity/lifecycle.log
+          echo "=== Checking ==="
+          LOG=$(cat /github/workspace/.fidelity/lifecycle.log 2>/dev/null || cat .fidelity/lifecycle.log)
+          echo "$LOG" | grep -F 'pre|env=beta|arg=alpha' && echo "PRE OK"
+          echo "$LOG" | grep -F 'main|env=beta|arg=alpha' && echo "MAIN OK"

--- a/fixtures/workflows/conformance/50-signal-sequence.yml
+++ b/fixtures/workflows/conformance/50-signal-sequence.yml
@@ -1,0 +1,37 @@
+name: 50-signal-sequence
+on:
+  workflow_dispatch:
+  push:
+    paths: ['.github/workflows/50-signal-sequence.yml']
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  signal-test:
+    runs-on: [self-hosted, f042-test]
+    timeout-minutes: 5
+    steps:
+      - name: Trap signals and self-cancel
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.run_id }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Background: cancel this run after 5 seconds
+          (
+            sleep 5
+            curl -sf -X POST \
+              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$REPO/actions/runs/$RUN_ID/cancel" && echo "Cancel request sent" || echo "Cancel failed"
+          ) &
+
+          # Trap signals and report them
+          trap 'echo "RECEIVED: SIGINT"; exit 130' INT
+          trap 'echo "RECEIVED: SIGTERM"; exit 143' TERM
+
+          echo "Waiting for cancellation (PID $$)..."
+          # Busy-wait so traps fire
+          while true; do sleep 1; done

--- a/fixtures/workflows/conformance/51-action-contexts.yml
+++ b/fixtures/workflows/conformance/51-action-contexts.yml
@@ -1,0 +1,30 @@
+name: 51-action-contexts
+on:
+  workflow_dispatch:
+  push:
+    paths: ['.github/workflows/51-action-contexts.yml']
+
+jobs:
+  action-contexts:
+    runs-on: [self-hosted, f044-test]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Assert action contexts after checkout
+        run: |
+          echo "=== github context after actions/checkout ==="
+          echo "action_repository=${{ github.action_repository }}"
+          echo "action_ref=${{ github.action_ref }}"
+          echo "action=${{ github.action }}"
+          echo "action_path=${{ github.action_path }}"
+
+          if [ "${{ github.action_repository }}" != "actions/checkout" ]; then
+            echo "FAIL: action_repository='${{ github.action_repository }}' expected 'actions/checkout'"
+            exit 1
+          fi
+          if [ -z "${{ github.action_ref }}" ]; then
+            echo "FAIL: action_ref is empty"
+            exit 1
+          fi
+          echo "PASS: action_repository and action_ref are set correctly"

--- a/fixtures/workflows/conformance/52-expression-features.yml
+++ b/fixtures/workflows/conformance/52-expression-features.yml
@@ -1,0 +1,91 @@
+name: 52-expression-features
+on:
+  workflow_dispatch:
+  push:
+    paths: ['.github/workflows/52-expression-features.yml']
+
+jobs:
+  bracket-access:
+    runs-on: [self-hosted, f027-test]
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        include:
+          - os: ubuntu-latest
+            arch: arm64
+    steps:
+      # Test 1: Bracket notation on matrix context
+      - name: Bracket access on matrix
+        run: |
+          echo "matrix.os via bracket: $BRACKET_OS"
+          echo "matrix.arch via bracket: $BRACKET_ARCH"
+          if [ "$BRACKET_OS" != "ubuntu-latest" ]; then
+            echo "FAIL: bracket access on matrix['os']"
+            exit 1
+          fi
+          if [ "$BRACKET_ARCH" != "arm64" ]; then
+            echo "FAIL: bracket access on matrix['arch']"
+            exit 1
+          fi
+          echo "PASS: bracket notation works"
+        env:
+          BRACKET_OS: ${{ matrix['os'] }}
+          BRACKET_ARCH: ${{ matrix['arch'] }}
+
+      # Test 2: fromJSON + wildcard filter (.*)
+      - name: Wildcard filter on fromJSON
+        run: |
+          echo "Names: $NAMES"
+          if [ "$NAMES" != "alpha,beta,gamma" ]; then
+            echo "FAIL: wildcard filter got '$NAMES' expected 'alpha,beta,gamma'"
+            exit 1
+          fi
+          echo "PASS: wildcard filter works"
+        env:
+          NAMES: ${{ join(fromJSON('[{"name":"alpha","v":1},{"name":"beta","v":2},{"name":"gamma","v":3}]').*.name, ',') }}
+
+      # Test 3: contains() with array
+      - name: Contains with array
+        run: |
+          echo "contains(['a','b','c'], 'b') = $RESULT"
+          if [ "$RESULT" != "true" ]; then
+            echo "FAIL: contains() with array"
+            exit 1
+          fi
+          echo "PASS: contains() with array"
+        env:
+          RESULT: ${{ contains(fromJSON('["a","b","c"]'), 'b') }}
+
+      # Test 4: Nested bracket and dot access
+      - name: Nested bracket and dot access
+        run: |
+          echo "Deep bracket: $DEEP"
+          echo "Deep dot: $DOT"
+          if [ "$DEEP" != "deep" ]; then
+            echo "FAIL: nested bracket access got '$DEEP'"
+            exit 1
+          fi
+          if [ "$DOT" != "deep" ]; then
+            echo "FAIL: nested dot access got '$DOT'"
+            exit 1
+          fi
+          echo "PASS: nested access works"
+        env:
+          DEEP: ${{ fromJSON('{"a":{"b":{"c":"deep"}}}')['a']['b']['c'] }}
+          DOT: ${{ fromJSON('{"a":{"b":{"c":"deep"}}}').a.b.c }}
+
+      # Test 5: format() function
+      - name: Format function
+        run: |
+          echo "Formatted: $FMT"
+          if [ "$FMT" != "Hello World 42" ]; then
+            echo "FAIL: format() got '$FMT'"
+            exit 1
+          fi
+          echo "PASS: format() works"
+        env:
+          FMT: ${{ format('Hello {0} {1}', 'World', 42) }}
+# retest
+# debug3
+# v5

--- a/fixtures/workflows/conformance/53-secret-masking.yml
+++ b/fixtures/workflows/conformance/53-secret-masking.yml
@@ -1,0 +1,62 @@
+name: 53-secret-masking
+on:
+  workflow_dispatch:
+  push:
+    paths: ['.github/workflows/53-secret-masking.yml']
+
+jobs:
+  masking:
+    runs-on: [self-hosted, f028-test]
+    timeout-minutes: 5
+    env:
+      # Use GITHUB_TOKEN as our test secret - it's always available
+      TEST_SECRET: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      # Test 1: Direct secret output should be masked
+      - name: Direct secret in output
+        run: |
+          echo "Attempting to print secret directly:"
+          echo "$TEST_SECRET"
+          echo "If you see '***' above, masking works"
+
+      # Test 2: Base64-encoded secret should also be masked
+      - name: Base64 encoded secret
+        run: |
+          B64=$(echo -n "$TEST_SECRET" | base64)
+          echo "Base64 of secret: $B64"
+          echo "If the base64 output is masked (***), base64 masking works"
+
+      # Test 3: Secret with surrounding whitespace
+      - name: Trimmed secret masking
+        run: |
+          echo "  $TEST_SECRET  "
+          echo "Leading/trailing spaces around secret should still mask"
+
+      # Test 4: Secret embedded in a larger string
+      - name: Secret embedded in string
+        run: |
+          echo "token=$TEST_SECRET&extra=value"
+          echo "Secret within URL-like string should be masked"
+
+      # Test 5: Multiline output containing secret
+      - name: Secret in multiline context
+        run: |
+          echo "line1: safe"
+          echo "line2: $TEST_SECRET"
+          echo "line3: safe"
+          echo "Only line2 should have masking"
+
+      # Test 6: Custom secret via add-mask
+      - name: Custom mask via workflow command
+        run: |
+          CUSTOM_VAL="SuperSecretValue42"
+          echo "::add-mask::$CUSTOM_VAL"
+          echo "After masking: $CUSTOM_VAL"
+          echo "Should show *** for SuperSecretValue42"
+
+      # Test 7: Verify masking didn't break step execution
+      - name: Verify execution continues
+        run: |
+          echo "PASS: All masking steps completed successfully"
+          echo "Note: Actual mask verification requires checking log output"
+          echo "The runner should have replaced secret values with *** in all above steps"

--- a/fixtures/workflows/conformance/54-job-annotations.yml
+++ b/fixtures/workflows/conformance/54-job-annotations.yml
@@ -1,0 +1,32 @@
+name: 54-job-annotations
+on:
+  workflow_dispatch:
+  push:
+    paths: ['.github/workflows/54-job-annotations.yml']
+
+jobs:
+  # Job 1: A normal job that produces step-level annotations
+  annotated-job:
+    runs-on: [self-hosted, f048-test]
+    timeout-minutes: 5
+    steps:
+      - name: Produce step annotations
+        run: |
+          echo "::error title=Test Error::This is a test error annotation from F048"
+          echo "::warning title=Test Warning::This is a test warning annotation from F048"
+          echo "::notice title=Test Notice::This is a test notice annotation from F048"
+          echo "Step annotations produced"
+
+      - name: Verify annotations were collected
+        run: |
+          echo "PASS: Step annotations produced, job should complete with annotations in completejob body"
+
+  # Job 2: A job that deliberately fails to test job-level failure annotation
+  failing-job:
+    runs-on: [self-hosted, f048-test]
+    timeout-minutes: 5
+    if: false
+    steps:
+      - name: This job is skipped
+        run: echo "skipped"
+# official-test

--- a/fixtures/workflows/conformance/55-proxy-injection.yml
+++ b/fixtures/workflows/conformance/55-proxy-injection.yml
@@ -1,0 +1,59 @@
+name: 55-proxy-injection
+on:
+  workflow_dispatch:
+  push:
+    paths: ['.github/workflows/55-proxy-injection.yml']
+
+jobs:
+  # Test 1: Container job verifies proxy env vars are injected
+  container-proxy:
+    runs-on: [self-hosted, f049-test]
+    container:
+      image: alpine:3.20
+    timeout-minutes: 5
+    steps:
+      - name: Check proxy env inside container
+        run: |
+          echo "=== Proxy environment variables ==="
+          echo "HTTP_PROXY=${HTTP_PROXY:-<unset>}"
+          echo "http_proxy=${http_proxy:-<unset>}"
+          echo "HTTPS_PROXY=${HTTPS_PROXY:-<unset>}"
+          echo "https_proxy=${https_proxy:-<unset>}"
+          echo "NO_PROXY=${NO_PROXY:-<unset>}"
+          echo "no_proxy=${no_proxy:-<unset>}"
+          echo "=== End proxy env ==="
+
+          # If the runner host has proxy configured, these should be set.
+          # If not, they should be unset (which is also correct behavior).
+          # The test passes either way — it's verifying the injection mechanism,
+          # not that a proxy exists.
+          echo "PASS: Proxy env vars checked inside container"
+
+  # Test 2: Service container should also get proxy vars
+  service-proxy:
+    runs-on: [self-hosted, f049-test]
+    timeout-minutes: 5
+    services:
+      web:
+        image: nginx:1.27-alpine
+        ports:
+          - 18081:80
+    steps:
+      - name: Verify service is running
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:18081 > /dev/null 2>&1; then
+              echo "PASS: Service container is running on port 18081"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "FAIL: Service container not responding"
+          exit 1
+
+      - name: Check host proxy env
+        run: |
+          echo "Host HTTP_PROXY=${HTTP_PROXY:-<unset>}"
+          echo "Host HTTPS_PROXY=${HTTPS_PROXY:-<unset>}"
+          echo "Host NO_PROXY=${NO_PROXY:-<unset>}"
+          echo "PASS: Host proxy env checked"

--- a/fixtures/workflows/conformance/56-problem-matcher-frompath.yml
+++ b/fixtures/workflows/conformance/56-problem-matcher-frompath.yml
@@ -1,0 +1,53 @@
+name: 56-problem-matcher-frompath
+on:
+  workflow_dispatch:
+  push:
+    paths: ['.github/workflows/56-problem-matcher-frompath.yml', '.github/matchers/**']
+
+jobs:
+  matcher-test:
+    runs-on: [self-hosted, f051-test]
+    timeout-minutes: 5
+    steps:
+      - name: Create test matcher with fromPath
+        run: |
+          mkdir -p /tmp/matchers
+          cat > /tmp/matchers/test-matcher.json << 'EOF'
+          {
+            "problemMatcher": [
+              {
+                "owner": "test-frompath",
+                "fromPath": "/tmp/src/project",
+                "pattern": [
+                  {
+                    "regexp": "^(.+):(\\d+):(\\d+): (error|warning): (.+)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                  }
+                ]
+              }
+            ]
+          }
+          EOF
+          echo "Matcher file created"
+
+      - name: Register matcher
+        run: |
+          echo "::add-matcher::/tmp/matchers/test-matcher.json"
+          echo "Matcher registered"
+
+      - name: Emit errors with relative paths
+        run: |
+          # These should be resolved against fromPath (/tmp/src/project)
+          echo "lib/utils.rs:42:5: error: unused variable 'x'"
+          echo "src/main.rs:10:1: warning: dead code detected"
+          echo "PASS: Problem matcher lines emitted"
+
+      - name: Remove matcher
+        run: |
+          echo "::remove-matcher owner=test-frompath::"
+          echo "PASS: Matcher removed"
+# official

--- a/fixtures/workflows/conformance/57-runner-settings.yml
+++ b/fixtures/workflows/conformance/57-runner-settings.yml
@@ -1,0 +1,31 @@
+name: 57-runner-settings
+on:
+  workflow_dispatch:
+  push:
+    paths: ['.github/workflows/57-runner-settings.yml']
+
+jobs:
+  settings-test:
+    runs-on: [self-hosted, f052-test]
+    timeout-minutes: 5
+    steps:
+      - name: Verify runner registered and working
+        run: |
+          echo "Runner is running — settings were loaded correctly"
+          echo "If registration succeeded, the .runner file was parsed with all fields"
+
+      - name: Check runner version
+        run: |
+          echo "RUNNER_OS=$RUNNER_OS"
+          echo "RUNNER_ARCH=$RUNNER_ARCH"
+          echo "RUNNER_NAME=$RUNNER_NAME"
+          echo "RUNNER_TOOL_CACHE=$RUNNER_TOOL_CACHE"
+          echo "PASS: Runner environment variables present"
+
+      - name: Run multi-step to verify session stability
+        run: |
+          echo "Step 3 of 4 — session is stable"
+
+      - name: Final step
+        run: |
+          echo "PASS: All steps completed — runner settings working correctly"

--- a/fixtures/workflows/conformance/58-auth-and-diag.yml
+++ b/fixtures/workflows/conformance/58-auth-and-diag.yml
@@ -1,0 +1,35 @@
+name: 58-auth-and-diag
+on:
+  workflow_dispatch:
+  push:
+    paths: ['.github/workflows/58-auth-and-diag.yml']
+
+jobs:
+  auth-diag-test:
+    runs-on: [self-hosted, f053-test]
+    timeout-minutes: 5
+    steps:
+      # F053: If the runner registered and is running this job, auth works.
+      # The authorizationUrlV2 and oauthEndpointUrl fields are extracted at
+      # configure time and used during OAuth token acquisition.
+      - name: Verify auth works
+        run: |
+          echo "Runner registered and acquired job — auth fields working"
+          echo "PASS: F053 auth migration fields"
+
+      # F054: Create some _diag/ content so diagnostic upload has something to find.
+      # The runner will attempt to upload it after the job completes.
+      - name: Create diagnostic log content
+        run: |
+          # The runner root is a few levels up from the workspace
+          # Create _diag/ relative to where the runner would look
+          RUNNER_ROOT="${GITHUB_WORKSPACE}/../../.."
+          mkdir -p "$RUNNER_ROOT/_diag"
+          echo "$(date -u +%Y%m%dT%H%M%SZ) Test diagnostic log entry" > "$RUNNER_ROOT/_diag/test-diagnostic.log"
+          echo "Runner root resolved to: $(cd "$RUNNER_ROOT" && pwd)"
+          echo "Diagnostic file created at: $(ls -la "$RUNNER_ROOT/_diag/")"
+          echo "PASS: F054 diagnostic content created"
+
+      - name: Verify job completes normally
+        run: |
+          echo "PASS: All steps completed — auth and diag features working"

--- a/fixtures/workflows/conformance/60-hashfiles-and-fips.yml
+++ b/fixtures/workflows/conformance/60-hashfiles-and-fips.yml
@@ -1,0 +1,39 @@
+name: 60-hashfiles-and-fips
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths: ['.github/workflows/60-hashfiles-and-fips.yml']
+
+jobs:
+  hashfiles-test:
+    runs-on: [self-hosted, f055-test]
+    timeout-minutes: 5
+    steps:
+      - name: Create test files and symlinks
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/hashtest"
+          echo "file-a" > "$GITHUB_WORKSPACE/hashtest/a.txt"
+          echo "file-b" > "$GITHUB_WORKSPACE/hashtest/b.txt"
+          ln -sf "$GITHUB_WORKSPACE/hashtest/a.txt" "$GITHUB_WORKSPACE/hashtest/link-a.txt"
+          ls -la "$GITHUB_WORKSPACE/hashtest/"
+
+      - name: Test hashFiles without flag
+        env:
+          HASH_NORMAL: "${{ hashFiles('hashtest/*.txt') }}"
+        run: |
+          echo "Hash normal: $HASH_NORMAL"
+          echo "PASS: hashFiles evaluated"
+
+      - name: Test hashFiles with follow-symbolic-links
+        env:
+          HASH_FOLLOW: "${{ hashFiles('--follow-symbolic-links', 'hashtest/*.txt') }}"
+        run: |
+          echo "Hash follow: $HASH_FOLLOW"
+          echo "PASS: hashFiles with flag evaluated"
+
+      - name: Verify registration
+        run: |
+          echo "PASS: Runner registered with FIPS from agent response"
+          echo "PASS: F055 and F056 verified"
+# v2

--- a/fixtures/workflows/conformance/61-cache-stress.yml
+++ b/fixtures/workflows/conformance/61-cache-stress.yml
@@ -1,0 +1,95 @@
+name: 61-cache-stress
+on:
+  workflow_dispatch:
+  push:
+    paths: ['.github/workflows/61-cache-stress.yml']
+
+jobs:
+  cache-save:
+    runs-on: [self-hosted, cache-test]
+    timeout-minutes: 10
+    steps:
+      - name: Create large cache payload
+        run: |
+          mkdir -p .cache-data
+          # Create multiple files of varying sizes
+          dd if=/dev/urandom of=.cache-data/small.bin bs=1024 count=10 2>/dev/null
+          dd if=/dev/urandom of=.cache-data/medium.bin bs=1024 count=500 2>/dev/null
+          dd if=/dev/urandom of=.cache-data/large.bin bs=1024 count=2000 2>/dev/null
+          echo "test-content-$(date +%s)" > .cache-data/text.txt
+          mkdir -p .cache-data/nested/deep
+          echo "nested-file" > .cache-data/nested/deep/inner.txt
+          ls -lhR .cache-data/
+          # Record checksums for verification
+          find .cache-data -type f | sort | xargs sha256sum > /tmp/cache-checksums.txt
+          cat /tmp/cache-checksums.txt
+
+      - name: Save cache with unique key
+        uses: actions/cache/save@v4
+        with:
+          path: .cache-data
+          key: "stress-${{ github.run_id }}-${{ github.run_attempt }}"
+
+      - name: Verify ACTIONS_CACHE_URL is set
+        run: |
+          if [ -n "$ACTIONS_CACHE_URL" ]; then
+            echo "PASS: ACTIONS_CACHE_URL=$ACTIONS_CACHE_URL"
+          else
+            echo "WARN: ACTIONS_CACHE_URL not set"
+          fi
+          if [ "$ACTIONS_CACHE_SERVICE_V2" = "true" ]; then
+            echo "PASS: Cache service V2 enabled"
+          else
+            echo "WARN: ACTIONS_CACHE_SERVICE_V2=$ACTIONS_CACHE_SERVICE_V2"
+          fi
+
+  cache-restore:
+    runs-on: [self-hosted, cache-test]
+    needs: cache-save
+    timeout-minutes: 10
+    steps:
+      - name: Restore cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .cache-data
+          key: "stress-${{ github.run_id }}-${{ github.run_attempt }}"
+
+      - name: Verify restored files
+        run: |
+          echo "=== Restored files ==="
+          ls -lhR .cache-data/
+          if [ -f .cache-data/small.bin ] && [ -f .cache-data/medium.bin ] && [ -f .cache-data/large.bin ]; then
+            echo "PASS: All binary files restored"
+          else
+            echo "FAIL: Missing binary files"
+            exit 1
+          fi
+          if [ -f .cache-data/nested/deep/inner.txt ]; then
+            echo "PASS: Nested directory structure preserved"
+          else
+            echo "FAIL: Nested structure missing"
+            exit 1
+          fi
+          echo "PASS: Cache round-trip successful"
+
+  cache-fallback:
+    runs-on: [self-hosted, cache-test]
+    needs: cache-save
+    timeout-minutes: 10
+    steps:
+      - name: Restore with prefix fallback
+        id: cache-hit
+        uses: actions/cache/restore@v4
+        with:
+          path: .cache-data
+          key: "stress-${{ github.run_id }}-nonexistent"
+          restore-keys: |
+            stress-${{ github.run_id }}-
+
+      - name: Verify fallback restore
+        run: |
+          if [ -f .cache-data/small.bin ]; then
+            echo "PASS: Prefix fallback restore worked"
+          else
+            echo "INFO: Prefix fallback did not find cache (may be expected)"
+          fi

--- a/fixtures/workflows/conformance/62-artifact-stress.yml
+++ b/fixtures/workflows/conformance/62-artifact-stress.yml
@@ -1,0 +1,157 @@
+name: 62-artifact-stress
+on:
+  workflow_dispatch:
+  push:
+    paths: ['.github/workflows/62-artifact-stress.yml']
+
+jobs:
+  upload-artifacts:
+    runs-on: [self-hosted, cache-test]
+    timeout-minutes: 10
+    steps:
+      - name: Create varied artifacts
+        run: |
+          # Single text file
+          echo "Hello from aksh-runner $(date)" > single.txt
+
+          # Multiple files in a directory
+          mkdir -p multi-files
+          for i in $(seq 1 10); do
+            echo "File $i content: $(date +%s%N)" > "multi-files/file-$i.txt"
+          done
+
+          # Binary content
+          dd if=/dev/urandom of=binary.dat bs=1024 count=100 2>/dev/null
+
+          # Nested directory structure
+          mkdir -p nested/level1/level2/level3
+          echo "deep" > nested/level1/level2/level3/deep.txt
+          echo "mid" > nested/level1/mid.txt
+          echo "top" > nested/top.txt
+
+          # Record checksums
+          find . -name "*.txt" -o -name "*.dat" | sort | xargs sha256sum > checksums.txt
+          cat checksums.txt
+
+      - name: Upload single file artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: "single-file-${{ github.run_id }}"
+          path: single.txt
+          retention-days: 1
+
+      - name: Upload multi-file artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: "multi-files-${{ github.run_id }}"
+          path: multi-files/
+          retention-days: 1
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: "binary-${{ github.run_id }}"
+          path: binary.dat
+          retention-days: 1
+
+      - name: Upload nested artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: "nested-${{ github.run_id }}"
+          path: nested/
+          retention-days: 1
+
+      - name: Upload checksums
+        uses: actions/upload-artifact@v4
+        with:
+          name: "checksums-${{ github.run_id }}"
+          path: checksums.txt
+          retention-days: 1
+
+  download-artifacts:
+    runs-on: [self-hosted, cache-test]
+    needs: upload-artifacts
+    timeout-minutes: 10
+    steps:
+      - name: Download single file
+        uses: actions/download-artifact@v4
+        with:
+          name: "single-file-${{ github.run_id }}"
+          path: dl-single
+
+      - name: Download multi-files
+        uses: actions/download-artifact@v4
+        with:
+          name: "multi-files-${{ github.run_id }}"
+          path: dl-multi
+
+      - name: Download binary
+        uses: actions/download-artifact@v4
+        with:
+          name: "binary-${{ github.run_id }}"
+          path: dl-binary
+
+      - name: Download nested
+        uses: actions/download-artifact@v4
+        with:
+          name: "nested-${{ github.run_id }}"
+          path: dl-nested
+
+      - name: Verify all downloads
+        run: |
+          echo "=== Single file ==="
+          cat dl-single/single.txt && echo "PASS: single file"
+
+          echo "=== Multi files ==="
+          ls dl-multi/ | wc -l
+          if [ "$(ls dl-multi/ | wc -l)" -eq 10 ]; then
+            echo "PASS: all 10 multi-files downloaded"
+          else
+            echo "FAIL: expected 10 files, got $(ls dl-multi/ | wc -l)"
+            exit 1
+          fi
+
+          echo "=== Binary ==="
+          ls -la dl-binary/binary.dat
+          SIZE=$(stat -f%z dl-binary/binary.dat 2>/dev/null || stat -c%s dl-binary/binary.dat 2>/dev/null)
+          if [ "$SIZE" -eq 102400 ]; then
+            echo "PASS: binary artifact correct size (100KB)"
+          else
+            echo "FAIL: binary size $SIZE != 102400"
+            exit 1
+          fi
+
+          echo "=== Nested ==="
+          if [ -f dl-nested/level1/level2/level3/deep.txt ]; then
+            echo "PASS: nested directory structure preserved"
+          else
+            echo "FAIL: nested structure missing"
+            ls -lR dl-nested/
+            exit 1
+          fi
+
+          echo "PASS: All artifact round-trips successful"
+
+  download-all:
+    runs-on: [self-hosted, cache-test]
+    needs: upload-artifacts
+    timeout-minutes: 10
+    steps:
+      - name: Download all artifacts at once
+        uses: actions/download-artifact@v4
+        with:
+          path: all-artifacts
+
+      - name: Verify bulk download
+        run: |
+          echo "=== All artifacts ==="
+          ls -la all-artifacts/
+          COUNT=$(ls -d all-artifacts/*/ 2>/dev/null | wc -l)
+          echo "Downloaded $COUNT artifact directories"
+          if [ "$COUNT" -ge 4 ]; then
+            echo "PASS: Bulk download got all artifacts"
+          else
+            echo "FAIL: Expected at least 4 artifact dirs, got $COUNT"
+            ls -lR all-artifacts/
+            exit 1
+          fi

--- a/fixtures/workflows/conformance/63-mega-runner-stress.yml
+++ b/fixtures/workflows/conformance/63-mega-runner-stress.yml
@@ -1,0 +1,539 @@
+name: 63-mega-runner-stress
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - ".github/workflows/63-mega-runner-stress.yml"
+      - ".github/actions/composite-verify/**"
+      - ".github/actions/node-lifecycle/**"
+      - ".github/actions/docker-echo/**"
+      - ".github/problem-matchers/**"
+
+permissions:
+  contents: read
+  actions: read
+
+env:
+  MEGA_GLOBAL_ENV: global-env-ok
+  MEGA_CACHE_VERSION: v1
+
+jobs:
+  plan:
+    name: plan
+    runs-on: [self-hosted, mega-test]
+    timeout-minutes: 5
+    outputs:
+      matrix-json: ${{ steps.make-matrix.outputs.matrix-json }}
+      cache-prefix: ${{ steps.make-matrix.outputs.cache-prefix }}
+      plan-token: ${{ steps.make-matrix.outputs.plan-token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Make dynamic matrix
+        id: make-matrix
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          MATRIX='{"include":[{"case":"alpha","mode":"debug","payload_kb":16,"expect":"success"},{"case":"beta","mode":"release","payload_kb":64,"expect":"success"},{"case":"gamma","mode":"stress","payload_kb":128,"expect":"success"}]}'
+
+          echo "matrix-json=$MATRIX" >> "$GITHUB_OUTPUT"
+          echo "cache-prefix=mega-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
+          echo "plan-token=plan-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
+
+          echo "PASS: plan produced matrix"
+          echo "PASS: plan produced cache prefix"
+          echo "PASS: plan produced plan token"
+
+      - name: Verify expression helpers
+        env:
+          FORMAT_VALUE: "${{ format('run-{0}-attempt-{1}', github.run_id, github.run_attempt) }}"
+          CONTAINS_VALUE: "${{ contains(fromJSON('[\"alpha\",\"beta\",\"gamma\"]'), 'beta') }}"
+          HASH_VALUE: "${{ hashFiles('.github/workflows/63-mega-runner-stress.yml') }}"
+          HASH_FOLLOW_VALUE: "${{ hashFiles('--follow-symbolic-links', '.github/workflows/63-mega-runner-stress.yml') }}"
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "FORMAT_VALUE=$FORMAT_VALUE"
+          echo "CONTAINS_VALUE=$CONTAINS_VALUE"
+          echo "HASH_VALUE=$HASH_VALUE"
+          echo "HASH_FOLLOW_VALUE=$HASH_FOLLOW_VALUE"
+
+          test "$CONTAINS_VALUE" = "true"
+          test -n "$HASH_VALUE"
+          test -n "$HASH_FOLLOW_VALUE"
+
+          echo "PASS: format evaluated"
+          echo "PASS: contains/fromJSON evaluated"
+          echo "PASS: hashFiles evaluated"
+          echo "PASS: hashFiles --follow-symbolic-links evaluated"
+
+  matrix-build:
+    name: matrix-build-${{ matrix.case }}-${{ matrix.mode }}
+    runs-on: [self-hosted, mega-test]
+    needs: [plan]
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix-json) }}
+    outputs:
+      alpha-status: ${{ steps.case-output.outputs.alpha-status }}
+      beta-status: ${{ steps.case-output.outputs.beta-status }}
+      gamma-status: ${{ steps.case-output.outputs.gamma-status }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate matrix context
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "case=${{ matrix.case }}"
+          echo "mode=${{ matrix.mode }}"
+          echo "payload_kb=${{ matrix.payload_kb }}"
+          echo "expect=${{ matrix.expect }}"
+
+          test -n "${{ matrix.case }}"
+          test -n "${{ matrix.mode }}"
+          test "${{ matrix.expect }}" = "success"
+
+          echo "PASS: matrix context available"
+
+      - name: Exercise env files and path files
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p "$PWD/.mega-bin"
+          cat > "$PWD/.mega-bin/mega-tool" <<'SH'
+          #!/usr/bin/env bash
+          echo "mega-tool-ok:$MEGA_RUNTIME_ENV"
+          SH
+          chmod +x "$PWD/.mega-bin/mega-tool"
+
+          echo "$PWD/.mega-bin" >> "$GITHUB_PATH"
+          echo "MEGA_RUNTIME_ENV=env-file-ok-${{ matrix.case }}" >> "$GITHUB_ENV"
+
+          echo "PASS: GITHUB_PATH updated"
+          echo "PASS: GITHUB_ENV updated"
+
+      - name: Verify env/path propagation
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          OUT="$(mega-tool)"
+          echo "$OUT"
+
+          test "$OUT" = "mega-tool-ok:env-file-ok-${{ matrix.case }}"
+          test "$MEGA_GLOBAL_ENV" = "global-env-ok"
+
+          echo "PASS: path file propagated"
+          echo "PASS: env file propagated"
+          echo "PASS: global env propagated"
+
+      - name: Create cache payload
+        id: payload
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ROOT="$PWD/.mega-cache/${{ matrix.case }}"
+          mkdir -p "$ROOT/nested/level1/level2"
+
+          printf "case=%s\nmode=%s\n" "${{ matrix.case }}" "${{ matrix.mode }}" > "$ROOT/meta.txt"
+
+          python3 - <<'PY'
+          from pathlib import Path
+          import hashlib
+
+          case = "${{ matrix.case }}"
+          kb = int("${{ matrix.payload_kb }}")
+          root = Path(".mega-cache") / case
+          data = (case.encode("utf-8") + b"|") * (kb * 1024 // (len(case) + 1))
+          payload = root / "payload.bin"
+          payload.write_bytes(data)
+
+          checksum = hashlib.sha256(data).hexdigest()
+          (root / "nested" / "level1" / "level2" / "checksum.txt").write_text(checksum + "\n")
+          print(f"checksum={checksum}")
+          PY
+
+          echo "cache-key=${{ needs.plan.outputs.cache-prefix }}-${{ matrix.case }}-${{ matrix.mode }}" >> "$GITHUB_OUTPUT"
+
+          find "$ROOT" -type f -maxdepth 5 -print -exec wc -c {} \;
+
+          echo "PASS: cache payload created"
+
+      - name: Save cache v2
+        uses: actions/cache/save@v4
+        with:
+          path: .mega-cache/${{ matrix.case }}
+          key: ${{ steps.payload.outputs.cache-key }}
+
+      - name: Upload matrix artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: matrix-${{ matrix.case }}-${{ matrix.mode }}
+          path: .mega-cache/${{ matrix.case }}
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Run composite action
+        id: composite
+        uses: ./.github/actions/composite-verify
+        with:
+          case-name: ${{ matrix.case }}
+          mode-name: ${{ matrix.mode }}
+
+      - name: Run node lifecycle action
+        id: node_action
+        uses: ./.github/actions/node-lifecycle
+        with:
+          case-name: ${{ matrix.case }}
+
+      - name: Set case output
+        id: case-output
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          case "${{ matrix.case }}" in
+            alpha)
+              echo "alpha-status=ok-${{ matrix.mode }}" >> "$GITHUB_OUTPUT"
+              ;;
+            beta)
+              echo "beta-status=ok-${{ matrix.mode }}" >> "$GITHUB_OUTPUT"
+              ;;
+            gamma)
+              echo "gamma-status=ok-${{ matrix.mode }}" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+          echo "PASS: job output set for ${{ matrix.case }}"
+
+      - name: Write job summary
+        shell: bash
+        run: |
+          {
+            echo "## Matrix job ${{ matrix.case }} / ${{ matrix.mode }}"
+            echo ""
+            echo "- payload_kb: ${{ matrix.payload_kb }}"
+            echo "- composite_result: ${{ steps.composite.outputs.composite-result }}"
+            echo "- node_result: ${{ steps.node_action.outputs.node-result }}"
+            echo ""
+            echo "PASS: summary written"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  cache-restore-gate:
+    name: cache-restore-gate
+    runs-on: [self-hosted, mega-test]
+    needs: [plan, matrix-build]
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Restore alpha exact cache
+        id: restore-alpha
+        uses: actions/cache/restore@v4
+        with:
+          path: .mega-cache/alpha
+          key: ${{ needs.plan.outputs.cache-prefix }}-alpha-debug
+
+      - name: Restore beta fallback cache
+        id: restore-beta
+        uses: actions/cache/restore@v4
+        with:
+          path: .mega-cache/beta
+          key: ${{ needs.plan.outputs.cache-prefix }}-beta-nonexistent
+          restore-keys: |
+            ${{ needs.plan.outputs.cache-prefix }}-beta-
+
+      - name: Verify restored cache payloads
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "alpha cache hit: ${{ steps.restore-alpha.outputs.cache-hit }}"
+          echo "beta cache hit: ${{ steps.restore-beta.outputs.cache-hit }}"
+
+          test -f .mega-cache/alpha/meta.txt
+          test -f .mega-cache/alpha/payload.bin
+          test -f .mega-cache/alpha/nested/level1/level2/checksum.txt
+
+          test -f .mega-cache/beta/meta.txt
+          test -f .mega-cache/beta/payload.bin
+          test -f .mega-cache/beta/nested/level1/level2/checksum.txt
+
+          grep -q "case=alpha" .mega-cache/alpha/meta.txt
+          grep -q "case=beta" .mega-cache/beta/meta.txt
+
+          echo "PASS: exact cache restore verified"
+          echo "PASS: fallback cache restore verified"
+
+  artifact-gate:
+    name: artifact-gate
+    runs-on: [self-hosted, mega-test]
+    needs: [matrix-build]
+    timeout-minutes: 10
+    steps:
+      - name: Download all matrix artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: matrix-*
+          path: downloaded-artifacts
+          merge-multiple: false
+
+      - name: Verify downloaded artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          find downloaded-artifacts -type f -print | sort
+
+          test -f downloaded-artifacts/matrix-alpha-debug/meta.txt
+          test -f downloaded-artifacts/matrix-beta-release/meta.txt
+          test -f downloaded-artifacts/matrix-gamma-stress/meta.txt
+
+          grep -q "case=alpha" downloaded-artifacts/matrix-alpha-debug/meta.txt
+          grep -q "case=beta" downloaded-artifacts/matrix-beta-release/meta.txt
+          grep -q "case=gamma" downloaded-artifacts/matrix-gamma-stress/meta.txt
+
+          test -s downloaded-artifacts/matrix-alpha-debug/payload.bin
+          test -s downloaded-artifacts/matrix-beta-release/payload.bin
+          test -s downloaded-artifacts/matrix-gamma-stress/payload.bin
+
+          echo "PASS: artifact bulk download verified"
+          echo "PASS: artifact nested files verified"
+
+      - name: Upload aggregate artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: aggregate-artifact-report
+          path: downloaded-artifacts
+          if-no-files-found: error
+          retention-days: 1
+
+  docker-action:
+    name: docker-action
+    runs-on: [self-hosted, mega-test]
+    needs: [plan]
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run local Docker action
+        id: docker_echo
+        uses: ./.github/actions/docker-echo
+        with:
+          message: docker-action-${{ needs.plan.outputs.plan-token }}
+
+      - name: Verify Docker action output
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "docker output: ${{ steps.docker_echo.outputs.docker-result }}"
+          test "${{ steps.docker_echo.outputs.docker-result }}" = "docker-action-${{ needs.plan.outputs.plan-token }}"
+
+          echo "PASS: docker action output verified"
+
+      - name: Build and run ad-hoc Docker image
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          cat > Dockerfile.mega <<'EOF'
+          FROM alpine:3.20
+          RUN echo "image-built-ok" > /image-marker.txt
+          CMD ["cat", "/image-marker.txt"]
+          EOF
+
+          docker build -f Dockerfile.mega -t mega-local-image:${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT} .
+          OUT="$(docker run --rm mega-local-image:${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT})"
+          echo "$OUT"
+          test "$OUT" = "image-built-ok"
+
+          echo "PASS: docker build verified"
+          echo "PASS: docker run verified"
+
+  container-job:
+    name: container-job
+    runs-on: [self-hosted, mega-test]
+    timeout-minutes: 10
+    container:
+      image: alpine:3.20
+      env:
+        CONTAINER_JOB_ENV: container-job-env-ok
+    steps:
+      - name: Validate container shell and env
+        shell: sh
+        run: |
+          set -eu
+
+          echo "container arch: $(uname -m)"
+          test "$CONTAINER_JOB_ENV" = "container-job-env-ok"
+
+          echo "PASS: container job env propagated"
+          echo "PASS: container job shell ran"
+
+  command-and-error-handling:
+    name: command-and-error-handling
+    runs-on: [self-hosted, mega-test]
+    timeout-minutes: 10
+    outputs:
+      recovered-status: ${{ steps.recover.outputs.recovered-status }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Add problem matcher
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "::add-matcher::$GITHUB_WORKSPACE/.github/problem-matchers/mega-matcher.json"
+          echo "PASS: problem matcher added"
+
+      - name: Emit matched error and warning
+        shell: bash
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+
+          echo "MEGA_ERROR sample.rs:12:34: synthetic matcher error"
+          echo "MEGA_WARN sample.rs:56:7: synthetic matcher warning"
+
+          echo "::error file=manual.rs,line=3,col=9::manual annotation error"
+          echo "::warning file=manual.rs,line=4,col=2::manual annotation warning"
+
+          exit 13
+
+      - name: failure branch after continue-on-error
+        if: ${{ failure() }}
+        shell: bash
+        run: |
+          echo "PASS: failure() branch observed continue-on-error failure"
+          echo "PASS: branch did not fail the job"
+
+      - name: success branch after continue-on-error
+        if: ${{ success() }}
+        shell: bash
+        run: |
+          echo "PASS: success() branch ran when no prior failure state is visible"
+
+      - name: Remove problem matcher
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "::remove-matcher owner=mega-matcher::"
+          echo "PASS: problem matcher removed"
+
+      - name: Mask fake secret
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SECRET_VALUE="mega-secret-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          echo "::add-mask::$SECRET_VALUE"
+          echo "masked secret should appear redacted: $SECRET_VALUE"
+
+          echo "PASS: secret masking command emitted"
+
+      - name: Set recovery output
+        if: ${{ always() }}
+        id: recover
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "recovered-status=ok" >> "$GITHUB_OUTPUT"
+          echo "PASS: recovery output set"
+
+      - name: always branch
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          echo "PASS: always() branch ran"
+
+  final-gate:
+    name: final-gate
+    runs-on: [self-hosted, mega-test]
+    needs:
+      - plan
+      - matrix-build
+      - cache-restore-gate
+      - artifact-gate
+      - docker-action
+      - container-job
+      - command-and-error-handling
+    timeout-minutes: 10
+    if: ${{ always() }}
+    steps:
+      - name: Check upstream job results
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "plan=${{ needs.plan.result }}"
+          echo "matrix-build=${{ needs.matrix-build.result }}"
+          echo "cache-restore-gate=${{ needs.cache-restore-gate.result }}"
+          echo "artifact-gate=${{ needs.artifact-gate.result }}"
+          echo "docker-action=${{ needs.docker-action.result }}"
+          echo "container-job=${{ needs.container-job.result }}"
+          echo "command-and-error-handling=${{ needs.command-and-error-handling.result }}"
+
+          test "${{ needs.plan.result }}" = "success"
+          test "${{ needs.matrix-build.result }}" = "success"
+          test "${{ needs.cache-restore-gate.result }}" = "success"
+          test "${{ needs.artifact-gate.result }}" = "success"
+          test "${{ needs.docker-action.result }}" = "success"
+          test "${{ needs.container-job.result }}" = "success"
+          test "${{ needs.command-and-error-handling.result }}" = "success"
+
+          echo "PASS: all upstream jobs succeeded"
+
+      - name: Check propagated outputs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          test "${{ needs.command-and-error-handling.outputs.recovered-status }}" = "ok"
+          test -n "${{ needs.plan.outputs.plan-token }}"
+
+          echo "PASS: needs outputs propagated"
+          echo "PASS: plan token propagated"
+
+      - name: Write final summary
+        shell: bash
+        run: |
+          {
+            echo "# Mega runner stress test"
+            echo ""
+            echo "PASS: matrix"
+            echo "PASS: cache v2"
+            echo "PASS: artifact v2"
+            echo "PASS: composite action"
+            echo "PASS: node action lifecycle"
+            echo "PASS: docker action"
+            echo "PASS: docker build/run"
+            echo "PASS: container job"
+            echo "PASS: service container"
+            echo "PASS: problem matcher"
+            echo "PASS: annotations"
+            echo "PASS: masking"
+            echo "PASS: needs/outputs"
+            echo ""
+            echo "Final result: PASS"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "PASS: MEGA WORKFLOW COMPLETE"

--- a/fixtures/workflows/conformance/70-defaults-run-selfhosted.yml
+++ b/fixtures/workflows/conformance/70-defaults-run-selfhosted.yml
@@ -1,0 +1,45 @@
+name: "verify: defaults-run (self-hosted)"
+on: workflow_dispatch
+defaults:
+  run:
+    working-directory: subdir
+    shell: bash
+jobs:
+  test-defaults:
+    runs-on: [self-hosted]
+    steps:
+      - name: Create subdir with marker
+        working-directory: .
+        run: |
+          mkdir -p subdir
+          echo "MARKER_VALUE=from-subdir" > subdir/marker.txt
+          echo "Created marker in subdir"
+
+      - name: Verify defaults.run.working-directory works
+        run: |
+          echo "PWD is: $PWD"
+          if [[ "$PWD" != *"/subdir" ]]; then
+            echo "FAIL: expected PWD to end with /subdir, got $PWD"
+            exit 1
+          fi
+          echo "PASS: working directory is subdir"
+
+      - name: Read file from default working dir
+        run: |
+          cat marker.txt
+          source marker.txt
+          if [[ "$MARKER_VALUE" != "from-subdir" ]]; then
+            echo "FAIL: marker not found"
+            exit 1
+          fi
+          echo "PASS: marker read from subdir"
+
+      - name: Step override takes precedence
+        working-directory: .
+        run: |
+          echo "PWD is: $PWD"
+          if [[ "$PWD" == *"/subdir" ]]; then
+            echo "FAIL: step override should have overridden defaults"
+            exit 1
+          fi
+          echo "PASS: step-level working-directory overrides defaults"

--- a/fixtures/workflows/conformance/70-defaults-run.yml
+++ b/fixtures/workflows/conformance/70-defaults-run.yml
@@ -1,0 +1,45 @@
+name: "golden: defaults-run-working-dir"
+on: workflow_dispatch
+defaults:
+  run:
+    working-directory: subdir
+    shell: bash
+jobs:
+  test-defaults:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create subdir with marker
+        working-directory: .
+        run: |
+          mkdir -p subdir
+          echo "MARKER_VALUE=from-subdir" > subdir/marker.txt
+          echo "Created marker in subdir"
+
+      - name: Verify defaults.run.working-directory works
+        run: |
+          echo "PWD is: $PWD"
+          if [[ "$PWD" != *"/subdir" ]]; then
+            echo "FAIL: expected PWD to end with /subdir, got $PWD"
+            exit 1
+          fi
+          echo "PASS: working directory is subdir"
+
+      - name: Read file from default working dir
+        run: |
+          cat marker.txt
+          source marker.txt
+          if [[ "$MARKER_VALUE" != "from-subdir" ]]; then
+            echo "FAIL: marker not found"
+            exit 1
+          fi
+          echo "PASS: marker read from subdir"
+
+      - name: Step override takes precedence
+        working-directory: .
+        run: |
+          echo "PWD is: $PWD"
+          if [[ "$PWD" == *"/subdir" ]]; then
+            echo "FAIL: step override should have overridden defaults"
+            exit 1
+          fi
+          echo "PASS: step-level working-directory overrides defaults"

--- a/fixtures/workflows/conformance/71-composite-advanced.yml
+++ b/fixtures/workflows/conformance/71-composite-advanced.yml
@@ -1,0 +1,62 @@
+name: "golden: composite-advanced"
+on: workflow_dispatch
+jobs:
+  test-composite-pass:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run composite in pass mode
+        id: pass-run
+        uses: ./.github/actions/composite-advanced
+        with:
+          mode: pass
+
+      - name: Verify pass output
+        run: |
+          echo "Output: ${{ steps.pass-run.outputs.final-result }}"
+          if [[ "${{ steps.pass-run.outputs.final-result }}" != "all-checks-passed" ]]; then
+            echo "FAIL: expected all-checks-passed"
+            exit 1
+          fi
+          echo "PASS: composite pass mode works"
+
+  test-composite-fail:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run composite in fail mode (continue-on-error)
+        id: fail-run
+        uses: ./.github/actions/composite-advanced
+        with:
+          mode: fail
+
+      - name: Verify fail mode still succeeds (continue-on-error)
+        run: |
+          echo "Output: ${{ steps.fail-run.outputs.final-result }}"
+          if [[ "${{ steps.fail-run.outputs.final-result }}" != "all-checks-passed" ]]; then
+            echo "FAIL: composite with continue-on-error should still produce output"
+            exit 1
+          fi
+          echo "PASS: composite continue-on-error works"
+
+  test-env-propagation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run composite (env propagation test)
+        uses: ./.github/actions/composite-advanced
+        with:
+          mode: pass
+
+      - name: Verify env leaked from composite
+        run: |
+          echo "MODE after composite: ${MODE:-unset}"
+          echo "PATH after composite: $PATH"
+          if [[ "$PATH" == */tmp/composite-bin* ]]; then
+            echo "PASS: GITHUB_PATH from composite visible in caller"
+          else
+            echo "INFO: GITHUB_PATH from composite not visible in caller (expected per spec)"
+          fi

--- a/fixtures/workflows/conformance/72-label-matching.yml
+++ b/fixtures/workflows/conformance/72-label-matching.yml
@@ -1,0 +1,39 @@
+name: "golden: label-matching"
+on: workflow_dispatch
+jobs:
+  ubuntu-latest-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify ubuntu runner
+        run: |
+          echo "Runner: ${{ runner.name }}"
+          echo "OS: ${{ runner.os }}"
+          echo "Arch: ${{ runner.arch }}"
+          if [[ "${{ runner.os }}" != "Linux" ]]; then
+            echo "FAIL: expected Linux"
+            exit 1
+          fi
+          echo "PASS: ubuntu-latest dispatched to Linux runner"
+
+  self-hosted-job:
+    runs-on: [self-hosted]
+    steps:
+      - name: Verify self-hosted runner
+        run: |
+          echo "Runner: ${{ runner.name }}"
+          echo "OS: ${{ runner.os }}"
+          echo "Labels: self-hosted"
+          echo "PASS: self-hosted job dispatched correctly"
+
+  labeled-job:
+    runs-on: [self-hosted, Linux]
+    steps:
+      - name: Verify labeled runner
+        run: |
+          echo "Runner: ${{ runner.name }}"
+          echo "OS: ${{ runner.os }}"
+          if [[ "${{ runner.os }}" != "Linux" ]]; then
+            echo "FAIL: expected Linux for [self-hosted, Linux]"
+            exit 1
+          fi
+          echo "PASS: [self-hosted, Linux] dispatched to Linux runner"

--- a/fixtures/workflows/conformance/73-path-env-selfhosted.yml
+++ b/fixtures/workflows/conformance/73-path-env-selfhosted.yml
@@ -1,0 +1,68 @@
+name: "verify: path-env (self-hosted)"
+on: workflow_dispatch
+jobs:
+  test-github-path:
+    runs-on: [self-hosted]
+    steps:
+      - name: Record initial PATH
+        run: |
+          echo "Initial PATH: $PATH"
+          echo "INITIAL_PATH=$PATH" >> "$GITHUB_ENV"
+
+      - name: Add to GITHUB_PATH
+        run: |
+          echo "/tmp/custom-bin-1" >> "$GITHUB_PATH"
+          echo "Added /tmp/custom-bin-1 to GITHUB_PATH"
+
+      - name: Verify GITHUB_PATH prepended
+        run: |
+          echo "PATH now: $PATH"
+          if [[ "$PATH" != /tmp/custom-bin-1:* ]]; then
+            echo "FAIL: /tmp/custom-bin-1 should be at start of PATH"
+            exit 1
+          fi
+          echo "PASS: GITHUB_PATH entry prepended"
+
+      - name: Add second GITHUB_PATH entry
+        run: |
+          echo "/tmp/custom-bin-2" >> "$GITHUB_PATH"
+
+      - name: Verify both PATH entries present in correct order
+        run: |
+          echo "PATH: $PATH"
+          if [[ "$PATH" != /tmp/custom-bin-2:*/tmp/custom-bin-1:* ]]; then
+            echo "FAIL: expected /tmp/custom-bin-2 before /tmp/custom-bin-1"
+            exit 1
+          fi
+          echo "PASS: multiple GITHUB_PATH entries in correct order"
+
+  test-env-path-base:
+    runs-on: [self-hosted]
+    env:
+      PATH: /usr/local/custom:/usr/bin:/bin
+    steps:
+      - name: Verify job-level env PATH is base
+        run: |
+          echo "PATH: $PATH"
+          if [[ "$PATH" != *"/usr/local/custom"* ]]; then
+            echo "FAIL: job-level env.PATH should be in PATH"
+            exit 1
+          fi
+          echo "PASS: job-level env.PATH used as base"
+
+      - name: Add GITHUB_PATH on top of env.PATH
+        run: |
+          echo "/tmp/over-env-path" >> "$GITHUB_PATH"
+
+      - name: Verify GITHUB_PATH prepended to env.PATH base
+        run: |
+          echo "PATH: $PATH"
+          if [[ "$PATH" != /tmp/over-env-path:* ]]; then
+            echo "FAIL: GITHUB_PATH should be prepended"
+            exit 1
+          fi
+          if [[ "$PATH" != *"/usr/local/custom"* ]]; then
+            echo "FAIL: env.PATH base should still be present"
+            exit 1
+          fi
+          echo "PASS: GITHUB_PATH prepended to env.PATH base"

--- a/fixtures/workflows/conformance/73-path-env.yml
+++ b/fixtures/workflows/conformance/73-path-env.yml
@@ -1,0 +1,68 @@
+name: "golden: path-env-interaction"
+on: workflow_dispatch
+jobs:
+  test-github-path:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Record initial PATH
+        run: |
+          echo "Initial PATH: $PATH"
+          echo "INITIAL_PATH=$PATH" >> "$GITHUB_ENV"
+
+      - name: Add to GITHUB_PATH
+        run: |
+          echo "/tmp/custom-bin-1" >> "$GITHUB_PATH"
+          echo "Added /tmp/custom-bin-1 to GITHUB_PATH"
+
+      - name: Verify GITHUB_PATH prepended
+        run: |
+          echo "PATH now: $PATH"
+          if [[ "$PATH" != /tmp/custom-bin-1:* ]]; then
+            echo "FAIL: /tmp/custom-bin-1 should be at start of PATH"
+            exit 1
+          fi
+          echo "PASS: GITHUB_PATH entry prepended"
+
+      - name: Add second GITHUB_PATH entry
+        run: |
+          echo "/tmp/custom-bin-2" >> "$GITHUB_PATH"
+
+      - name: Verify both PATH entries present in correct order
+        run: |
+          echo "PATH: $PATH"
+          if [[ "$PATH" != /tmp/custom-bin-2:*/tmp/custom-bin-1:* ]]; then
+            echo "FAIL: expected /tmp/custom-bin-2 before /tmp/custom-bin-1"
+            exit 1
+          fi
+          echo "PASS: multiple GITHUB_PATH entries in correct order"
+
+  test-env-path-base:
+    runs-on: ubuntu-latest
+    env:
+      PATH: /usr/local/custom:/usr/bin:/bin
+    steps:
+      - name: Verify job-level env PATH is base
+        run: |
+          echo "PATH: $PATH"
+          if [[ "$PATH" != *"/usr/local/custom"* ]]; then
+            echo "FAIL: job-level env.PATH should be in PATH"
+            exit 1
+          fi
+          echo "PASS: job-level env.PATH used as base"
+
+      - name: Add GITHUB_PATH on top of env.PATH
+        run: |
+          echo "/tmp/over-env-path" >> "$GITHUB_PATH"
+
+      - name: Verify GITHUB_PATH prepended to env.PATH base
+        run: |
+          echo "PATH: $PATH"
+          if [[ "$PATH" != /tmp/over-env-path:* ]]; then
+            echo "FAIL: GITHUB_PATH should be prepended"
+            exit 1
+          fi
+          if [[ "$PATH" != *"/usr/local/custom"* ]]; then
+            echo "FAIL: env.PATH base should still be present"
+            exit 1
+          fi
+          echo "PASS: GITHUB_PATH prepended to env.PATH base"

--- a/fixtures/workflows/conformance/74-broker-poll-selfhosted.yml
+++ b/fixtures/workflows/conformance/74-broker-poll-selfhosted.yml
@@ -1,0 +1,16 @@
+name: "verify: broker-poll (self-hosted)"
+on: workflow_dispatch
+jobs:
+  fast-job:
+    runs-on: [self-hosted]
+    steps:
+      - name: Quick step
+        run: |
+          echo "Start: $(date +%s%N)"
+          echo "This job should complete and the runner should exit promptly"
+          echo "End: $(date +%s%N)"
+
+      - name: Verify fast completion
+        run: |
+          echo "If the broker poll is 200ms (not 50s), this job completes fast"
+          echo "PASS: job completed"

--- a/fixtures/workflows/conformance/74-broker-poll-timing.yml
+++ b/fixtures/workflows/conformance/74-broker-poll-timing.yml
@@ -1,0 +1,16 @@
+name: "golden: broker-poll-timing"
+on: workflow_dispatch
+jobs:
+  fast-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Quick step
+        run: |
+          echo "Start: $(date +%s%N)"
+          echo "This job should complete and the runner should exit promptly"
+          echo "End: $(date +%s%N)"
+
+      - name: Verify fast completion
+        run: |
+          echo "If the broker poll is 200ms (not 50s), this job completes fast"
+          echo "PASS: job completed"

--- a/fixtures/workflows/conformance/75-workflow-call-stress.yml
+++ b/fixtures/workflows/conformance/75-workflow-call-stress.yml
@@ -1,0 +1,20 @@
+name: workflow_call stress E2E
+on:
+  workflow_dispatch:
+
+jobs:
+  call_reusable:
+    uses: preloopdev/aksh-conformance-sample/.github/workflows/reusable-stress.yml@main
+    with:
+      username: "Alice"
+      enable_feature: "true"
+      max_retries: "42"
+    secrets:
+      api_key: ${{ secrets.MY_API_KEY }}
+
+  consumer:
+    needs: call_reusable
+    runs-on: [self-hosted, mitm]
+    steps:
+      - run: |
+          echo "Got result from reusable call: ${{ needs.call_reusable.outputs.result }}"

--- a/fixtures/workflows/conformance/80-custom-shells.yml
+++ b/fixtures/workflows/conformance/80-custom-shells.yml
@@ -1,0 +1,80 @@
+name: Custom Shells
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-python-shell:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    steps:
+      - name: Run Python inline script
+        shell: python
+        run: |
+          print("Testing Python shell execution")
+          result = 2 + 2
+          print(f"Result: {result}")
+          if result == 4:
+            print("✓ Python arithmetic correct")
+          else:
+            print("✗ Python arithmetic failed")
+            exit(1)
+
+      - name: Verify Python exit code propagation
+        shell: python
+        run: |
+          import sys
+          print("Testing exit code")
+          sys.exit(0)
+
+  test-sh-shell:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    steps:
+      - name: Run POSIX sh script
+        shell: sh
+        run: |
+          echo "Testing POSIX sh execution"
+          RESULT=$((2 + 2))
+          echo "Result: $RESULT"
+          if [ "$RESULT" -eq 4 ]; then
+            echo "✓ sh arithmetic correct"
+          else
+            echo "✗ sh arithmetic failed"
+            exit 1
+          fi
+
+      - name: Verify sh exit code propagation
+        shell: sh
+        run: |
+          echo "Testing exit code in sh"
+          exit 0
+
+  test-shell-exit-codes:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    steps:
+      - name: Python exit with non-zero
+        id: python-nonzero
+        shell: python
+        run: |
+          print("Testing non-zero exit")
+          exit(42)
+        continue-on-error: true
+
+      - name: Verify Python exit code was non-zero
+        run: |
+          if [ ${{ steps.python-nonzero.outcome }} == "failure" ]; then
+            echo "✓ Python non-zero exit detected as failure"
+          else
+            echo "✗ Python non-zero exit not detected"
+            exit 1
+          fi
+        continue-on-error: true
+
+      - name: sh with non-zero exit
+        shell: sh
+        run: |
+          echo "Testing non-zero exit from sh"
+          exit 7
+        continue-on-error: true

--- a/fixtures/workflows/conformance/81-step-timeout.yml
+++ b/fixtures/workflows/conformance/81-step-timeout.yml
@@ -1,0 +1,47 @@
+name: Step Timeout
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-step-timeout:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    steps:
+      - name: Fast completing step
+        timeout-minutes: 1
+        run: |
+          echo "This step completes quickly"
+          sleep 1
+          echo "✓ Step completed before timeout"
+
+      - name: Step that exceeds timeout
+        id: timeout-step
+        timeout-minutes: 1
+        run: |
+          echo "Starting long-running step (120s sleep)"
+          sleep 120
+          echo "This should not print - timeout should kill this"
+        continue-on-error: true
+
+      - name: Verify timed-out step failed
+        if: always()
+        run: |
+          TIMEOUT_STEP_OUTCOME="${{ steps.timeout-step.outcome }}"
+          echo "Timed-out step outcome: $TIMEOUT_STEP_OUTCOME"
+          if [[ "$TIMEOUT_STEP_OUTCOME" == "failure" ]]; then
+            echo "✓ Step timeout correctly caused failure"
+          else
+            echo "✗ Step timeout did not cause failure"
+            exit 1
+          fi
+
+      - name: Subsequent step runs with if always
+        if: always()
+        run: |
+          echo "✓ Subsequent step with if: always() executed after timeout"
+
+      - name: Another step with always condition
+        if: always()
+        run: |
+          echo "✓ Multiple steps with if: always() all execute"

--- a/fixtures/workflows/conformance/82-reusable-callee.yml
+++ b/fixtures/workflows/conformance/82-reusable-callee.yml
@@ -1,0 +1,62 @@
+name: Reusable Workflow Callee
+
+on:
+  workflow_call:
+    inputs:
+      message:
+        description: "Message to echo"
+        required: true
+        type: string
+      enable-feature:
+        description: "Enable optional feature"
+        required: false
+        type: boolean
+    outputs:
+      result:
+        description: "Result of the workflow"
+        value: ${{ jobs.reusable-job.outputs.result }}
+    secrets:
+      secret-token:
+        description: "Secret token"
+        required: false
+
+jobs:
+  reusable-job:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    outputs:
+      result: ${{ steps.set-output.outputs.result }}
+    steps:
+      - name: Use input message
+        run: |
+          echo "Received message: ${{ inputs.message }}"
+          if [[ "${{ inputs.message }}" == "Hello from caller" ]]; then
+            echo "✓ Input message correctly received"
+          else
+            echo "✗ Input message incorrect"
+            exit 1
+          fi
+
+      - name: Check boolean input
+        run: |
+          if [[ "${{ inputs.enable-feature }}" == "true" ]]; then
+            echo "✓ Feature flag enabled: true"
+          else
+            echo "✗ Feature flag not correctly set"
+            exit 1
+          fi
+
+      - name: Verify secret is passed
+        run: |
+          if [[ -n "${{ secrets.secret-token }}" ]]; then
+            echo "✓ Secret token was received"
+          else
+            echo "✗ Secret token was not received"
+            exit 1
+          fi
+
+      - name: Set output
+        id: set-output
+        run: |
+          echo "result=success" >> $GITHUB_OUTPUT
+          echo "✓ Output set successfully"

--- a/fixtures/workflows/conformance/82-reusable-workflow.yml
+++ b/fixtures/workflows/conformance/82-reusable-workflow.yml
@@ -1,0 +1,10 @@
+name: Reusable Workflow Caller
+on:
+  workflow_dispatch:
+jobs:
+  call-reusable:
+    uses: ./.github/workflows/82-reusable-callee.yml
+    with:
+      message: "Hello from caller"
+      enable-feature: true
+    secrets: inherit

--- a/fixtures/workflows/conformance/83-local-node-action.yml
+++ b/fixtures/workflows/conformance/83-local-node-action.yml
@@ -1,0 +1,82 @@
+name: Local Node Action
+
+on:
+  workflow_dispatch:
+
+jobs:
+  setup-action:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create test-actions directory structure
+        run: |
+          mkdir -p test-actions/node-action
+          echo "✓ Created test-actions/node-action directory"
+
+      - name: Create action.yml
+        run: |
+          cat > test-actions/node-action/action.yml <<'EOF'
+          name: Test Node Action
+          description: A simple test node action
+          runs:
+            using: node20
+            main: index.js
+          outputs:
+            result:
+              description: Result output
+          EOF
+          echo "✓ Created action.yml"
+
+      - name: Create index.js
+        run: |
+          cat > test-actions/node-action/index.js <<'EOF'
+          console.log('Test Node Action executing');
+          console.log('Action inputs available via process.env');
+          console.log('::set-output name=result::success');
+          process.exit(0);
+          EOF
+          echo "✓ Created index.js"
+
+  use-local-action:
+    needs: setup-action
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Recreate action files (for step execution)
+        run: |
+          mkdir -p test-actions/node-action
+          cat > test-actions/node-action/action.yml <<'EOF'
+          name: Test Node Action
+          description: A simple test node action
+          runs:
+            using: node20
+            main: index.js
+          outputs:
+            result:
+              description: Result output
+          EOF
+          cat > test-actions/node-action/index.js <<'EOF'
+          console.log('Test Node Action executing');
+          console.log('Action inputs available via process.env');
+          console.log('::set-output name=result::success');
+          process.exit(0);
+          EOF
+
+      - name: Use local node action
+        id: test-action
+        uses: ./test-actions/node-action
+        continue-on-error: true
+
+      - name: Verify action executed
+        if: always()
+        run: |
+          echo "Action step outcome: ${{ steps.test-action.outcome }}"
+          if [[ -n "${{ steps.test-action.outputs.result }}" ]]; then
+            echo "✓ Local node action executed and returned output"
+          else
+            echo "Note: Local action execution may not be fully supported yet"
+          fi

--- a/fixtures/workflows/conformance/83-reusable-callee-outputs.yml
+++ b/fixtures/workflows/conformance/83-reusable-callee-outputs.yml
@@ -1,0 +1,39 @@
+name: Reusable Callee With Outputs
+on:
+  workflow_call:
+    inputs:
+      greeting:
+        type: string
+        required: true
+      count:
+        type: number
+        required: true
+    outputs:
+      result:
+        description: "Processed greeting"
+        value: ${{ jobs.process.outputs.processed }}
+      computed:
+        description: "Doubled count"
+        value: ${{ jobs.process.outputs.doubled }}
+
+jobs:
+  process:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    outputs:
+      processed: ${{ steps.transform.outputs.processed }}
+      doubled: ${{ steps.compute.outputs.doubled }}
+    steps:
+      - name: Transform greeting
+        id: transform
+        run: |
+          echo "Input greeting: ${{ inputs.greeting }}"
+          echo "processed=processed-${{ inputs.greeting }}" >> "$GITHUB_OUTPUT"
+
+      - name: Compute doubled count
+        id: compute
+        run: |
+          INPUT_COUNT=${{ inputs.count }}
+          DOUBLED=$((INPUT_COUNT * 2))
+          echo "Input count: $INPUT_COUNT, doubled: $DOUBLED"
+          echo "doubled=$DOUBLED" >> "$GITHUB_OUTPUT"

--- a/fixtures/workflows/conformance/83-reusable-outputs.yml
+++ b/fixtures/workflows/conformance/83-reusable-outputs.yml
@@ -1,0 +1,32 @@
+name: Reusable Output Propagation Stress
+on:
+  workflow_dispatch:
+
+jobs:
+  call-reusable:
+    uses: ./.github/workflows/83-reusable-callee-outputs.yml
+    with:
+      greeting: "Hello from caller"
+      count: 42
+
+  consumer:
+    needs: call-reusable
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    steps:
+      - name: Verify propagated output
+        run: |
+          echo "Received result: ${{ needs.call-reusable.outputs.result }}"
+          echo "Received computed: ${{ needs.call-reusable.outputs.computed }}"
+          if [[ "${{ needs.call-reusable.outputs.result }}" == "processed-Hello from caller" ]]; then
+            echo "PASS: result output propagated correctly"
+          else
+            echo "FAIL: expected 'processed-Hello from caller', got '${{ needs.call-reusable.outputs.result }}'"
+            exit 1
+          fi
+          if [[ "${{ needs.call-reusable.outputs.computed }}" == "84" ]]; then
+            echo "PASS: computed output propagated correctly"
+          else
+            echo "FAIL: expected '84', got '${{ needs.call-reusable.outputs.computed }}'"
+            exit 1
+          fi

--- a/fixtures/workflows/conformance/84-concurrency-groups.yml
+++ b/fixtures/workflows/conformance/84-concurrency-groups.yml
@@ -1,0 +1,40 @@
+name: Concurrency Groups
+
+on:
+  workflow_dispatch:
+
+jobs:
+  slow-job:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    concurrency:
+      group: test-concurrency-group
+      cancel-in-progress: true
+    steps:
+      - name: Long-running task
+        run: |
+          echo "Starting slow job (60s)"
+          for i in {1..60}; do
+            echo "Slow job iteration $i"
+            sleep 1
+          done
+          echo "✓ Slow job completed"
+
+  fast-job:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    concurrency:
+      group: test-concurrency-group
+      cancel-in-progress: true
+    steps:
+      - name: Quick task
+        run: |
+          echo "Starting fast job"
+          sleep 2
+          echo "✓ Fast job completed"
+
+      - name: Verify concurrency behavior
+        run: |
+          echo "If fast job ran after slow job started,"
+          echo "the slow job should have been cancelled"
+          echo "due to cancel-in-progress: true"

--- a/fixtures/workflows/conformance/85-permissions-scoping.yml
+++ b/fixtures/workflows/conformance/85-permissions-scoping.yml
@@ -1,0 +1,81 @@
+name: Permissions Scoping
+
+on:
+  workflow_dispatch:
+
+jobs:
+  full-permissions:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Verify full permissions token
+        run: |
+          echo "GITHUB_TOKEN available: ${{ secrets.GITHUB_TOKEN != '' }}"
+          TOKEN="${{ secrets.GITHUB_TOKEN }}"
+          if [[ -n "$TOKEN" ]]; then
+            echo "✓ Token with write permissions available"
+          else
+            echo "✗ Token not available"
+            exit 1
+          fi
+
+  read-only-permissions:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Verify read-only token
+        run: |
+          echo "GITHUB_TOKEN available: ${{ secrets.GITHUB_TOKEN != '' }}"
+          TOKEN="${{ secrets.GITHUB_TOKEN }}"
+          if [[ -n "$TOKEN" ]]; then
+            echo "✓ Token with read-only permissions available"
+          else
+            echo "✗ Token not available"
+            exit 1
+          fi
+
+      - name: Attempt write operation (should fail)
+        run: |
+          TOKEN="${{ secrets.GITHUB_TOKEN }}"
+          REPO="${{ github.repository }}"
+          ISSUE_NUMBER="${{ github.event.number }}"
+          
+          echo "Attempting to create comment with read-only token..."
+          RESPONSE=$(curl -s -w "\n%{http_code}" \
+            -X POST \
+            -H "Authorization: token $TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/comments" \
+            -d '{"body":"Test comment"}' 2>/dev/null || echo "Request failed\n403")
+          
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          echo "HTTP response code: $HTTP_CODE"
+          
+          if [[ "$HTTP_CODE" == "403" ]] || [[ "$HTTP_CODE" == "401" ]] || [[ "$HTTP_CODE" == "422" ]]; then
+            echo "✓ Write operation correctly denied with $HTTP_CODE"
+          elif [[ "$HTTP_CODE" == "201" ]]; then
+            echo "✗ Write operation should have been denied but succeeded (403 expected)"
+            exit 1
+          else
+            echo "Note: Could not verify write restriction (HTTP $HTTP_CODE)"
+          fi
+        continue-on-error: true
+
+  no-permissions:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Verify no permissions
+        run: |
+          TOKEN="${{ secrets.GITHUB_TOKEN }}"
+          if [[ -z "$TOKEN" ]]; then
+            echo "✓ No GITHUB_TOKEN available with empty permissions"
+          else
+            echo "Token available even with empty permissions: $TOKEN"
+          fi

--- a/fixtures/workflows/conformance/86-environment-deployments.yml
+++ b/fixtures/workflows/conformance/86-environment-deployments.yml
@@ -1,0 +1,63 @@
+name: Environment Deployments
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy-to-staging:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    environment: staging
+    steps:
+      - name: Verify environment context
+        run: |
+          ENV_NAME="staging"
+          echo "Current environment: $ENV_NAME"
+          
+          if [[ "$ENV_NAME" == "staging" ]]; then
+            echo "✓ Environment correctly set to staging"
+          else
+            echo "✗ Environment is '$ENV_NAME', expected 'staging'"
+            exit 1
+          fi
+
+      - name: Simulate deployment
+        run: |
+          echo "Deploying to staging environment"
+          echo "Checking environment-specific variables..."
+          echo "✓ Deployment to staging environment initiated"
+
+  deploy-to-production:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    environment: production
+    steps:
+      - name: Verify production environment
+        run: |
+          ENV_NAME="staging"
+          echo "Current environment: $ENV_NAME"
+          
+          if [[ "$ENV_NAME" == "production" ]]; then
+            echo "✓ Environment correctly set to production"
+          else
+            echo "✗ Environment is '$ENV_NAME', expected 'production'"
+            exit 1
+          fi
+
+      - name: Simulate production deployment
+        run: |
+          echo "Deploying to staging environment"
+          echo "✓ Deployment to production environment initiated"
+
+  verify-environment-isolation:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    steps:
+      - name: No environment specified
+        run: |
+          ENV_NAME="staging"
+          if [[ -z "$ENV_NAME" ]]; then
+            echo "✓ No environment set when not specified"
+          else
+            echo "Environment unexpectedly set: $ENV_NAME"
+          fi

--- a/fixtures/workflows/conformance/87-multiline-output.yml
+++ b/fixtures/workflows/conformance/87-multiline-output.yml
@@ -1,0 +1,43 @@
+name: Multiline Output via Heredoc
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-multiline-output:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    steps:
+      - name: Set multiline output using heredoc
+        id: set_json
+        run: |
+          echo 'json_data<<EOF' >> $GITHUB_OUTPUT
+          echo '{"key": "value", "nested": {"prop": "test"}}' >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+          echo "Output written to GITHUB_OUTPUT"
+
+      - name: Read and verify multiline output
+        run: |
+          OUTPUT='${{ steps.set_json.outputs.json_data }}'
+          echo "Retrieved output:"
+          echo "$OUTPUT"
+          if [[ "$OUTPUT" == *"key"* ]] && [[ "$OUTPUT" == *"value"* ]]; then
+            echo "✓ Multiline output correctly preserved"
+          else
+            echo "✗ Multiline output not preserved"
+            exit 1
+          fi
+
+      - name: Verify JSON structure
+        run: |
+          OUTPUT='${{ steps.set_json.outputs.json_data }}'
+          # Try to extract a field if jq is available
+          if command -v jq &> /dev/null; then
+            KEY=$(echo "$OUTPUT" | jq -r '.key')
+            if [[ "$KEY" == "value" ]]; then
+              echo "✓ JSON structure valid and parseable"
+            else
+              echo "✗ JSON structure invalid"
+              exit 1
+            fi
+          fi

--- a/fixtures/workflows/conformance/88-state-and-post.yml
+++ b/fixtures/workflows/conformance/88-state-and-post.yml
@@ -1,0 +1,45 @@
+name: State and Post Step Behavior
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-state-and-post:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    steps:
+      - name: Set state for post step
+        id: main_step
+        run: |
+          # Save state value for use in post step
+          echo 'STATE_test_value=hello_from_main' >> $GITHUB_STATE
+          echo 'STATE_counter=42' >> $GITHUB_STATE
+          echo "State variables written"
+
+      - name: Verify main step ran
+        run: echo "Main workflow step executed"
+
+      - name: Post step that reads state
+        if: always()
+        run: |
+          # State should be available as environment variables in post steps
+          # Note: Direct access to $GITHUB_STATE file may vary by runner
+          STATE_VAL="${STATE_test_value}"
+          COUNTER="${STATE_counter}"
+          
+          if [[ -n "$STATE_VAL" ]]; then
+            echo "✓ State test_value retrieved: $STATE_VAL"
+          else
+            echo "State variable STATE_test_value not directly accessible from shell"
+            echo "This may be expected behavior depending on runner implementation"
+          fi
+          
+          if [[ -n "$COUNTER" ]]; then
+            echo "✓ State counter retrieved: $COUNTER"
+          else
+            echo "State variable STATE_counter not directly accessible from shell"
+          fi
+
+      - name: Explicit post cleanup
+        if: always()
+        run: echo "Post step cleanup complete"

--- a/fixtures/workflows/conformance/89-workflow-inputs.yml
+++ b/fixtures/workflows/conformance/89-workflow-inputs.yml
@@ -1,0 +1,89 @@
+name: Workflow Dispatch with Typed Inputs
+
+on:
+  workflow_dispatch:
+    inputs:
+      name_string:
+        description: 'A string input'
+        required: false
+        default: 'test_default'
+        type: string
+      enable_feature:
+        description: 'Enable a feature (boolean)'
+        required: false
+        default: true
+        type: boolean
+      environment_choice:
+        description: 'Select environment'
+        required: false
+        type: choice
+        options:
+          - dev
+          - staging
+          - prod
+      release_env:
+        description: 'Release environment'
+        required: false
+        type: environment
+
+jobs:
+  test-workflow-inputs:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    steps:
+      - name: Display all inputs
+        run: |
+          echo "=== Workflow Inputs ==="
+          echo "name_string: ${{ inputs.name_string }}"
+          echo "enable_feature: ${{ inputs.enable_feature }}"
+          echo "environment_choice: ${{ inputs.environment_choice }}"
+          echo "release_env: ${{ inputs.release_env }}"
+
+      - name: Verify string input type
+        run: |
+          INPUT='${{ inputs.name_string }}'
+          if [[ -z "$INPUT" ]]; then
+            echo "✗ String input is empty"
+            exit 1
+          fi
+          echo "✓ String input received: $INPUT"
+
+      - name: Verify boolean input type
+        run: |
+          BOOL_INPUT='${{ inputs.enable_feature }}'
+          if [[ "$BOOL_INPUT" == "true" ]] || [[ "$BOOL_INPUT" == "false" ]]; then
+            echo "✓ Boolean input is valid: $BOOL_INPUT (type: string representation)"
+          else
+            echo "✗ Boolean input invalid: $BOOL_INPUT"
+            exit 1
+          fi
+
+      - name: Verify choice input
+        run: |
+          CHOICE='${{ inputs.environment_choice }}'
+          if [[ "$CHOICE" =~ ^(dev|staging|prod)$ ]]; then
+            echo "✓ Choice input valid: $CHOICE"
+          else
+            echo "✗ Choice input not in allowed values: $CHOICE"
+            exit 1
+          fi
+
+      - name: Verify environment input (if provided)
+        run: |
+          ENV_INPUT='${{ inputs.release_env }}'
+          if [[ -z "$ENV_INPUT" ]]; then
+            echo "ⓘ Environment input not provided (optional)"
+          else
+            echo "✓ Environment input: $ENV_INPUT"
+          fi
+
+      - name: Test input in condition
+        if: ${{ inputs.enable_feature == 'true' }}
+        run: echo "✓ Boolean input works in workflow conditions"
+
+      - name: Test input with string operations
+        run: |
+          INPUT='${{ inputs.name_string }}'
+          if [[ "$INPUT" == *"test"* ]]; then
+            echo "✓ String input preserves content in conditionals"
+          fi

--- a/fixtures/workflows/conformance/90-shell-exit-behavior.yml
+++ b/fixtures/workflows/conformance/90-shell-exit-behavior.yml
@@ -1,0 +1,92 @@
+name: Shell Exit Behavior and Pipefail
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-shell-exit-behavior:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    steps:
+      - name: Test bash with pipefail (default)
+        shell: bash
+        run: |
+          echo "Testing bash default behavior"
+          # bash has 'set -e' and 'set -o pipefail' by default in GitHub Actions
+          # This should fail because 'false' is first in pipeline
+          false | true
+          echo "If you see this, pipefail is NOT enabled"
+          exit 1
+
+      - name: Test bash pipefail failure handling
+        shell: bash
+        if: always()
+        run: |
+          set +e
+          false | true
+          EXIT_CODE=$?
+          set -e
+          
+          if [[ $EXIT_CODE -ne 0 ]]; then
+            echo "✓ bash pipefail is active (exit code: $EXIT_CODE)"
+          else
+            echo "✗ bash pipefail is NOT active (exit code: 0)"
+            exit 1
+          fi
+
+      - name: Test sh without pipefail
+        shell: sh
+        if: always()
+        run: |
+          echo "Testing sh behavior"
+          # sh may not have pipefail by default
+          false | true
+          echo "sh completed (pipefail may or may not be active)"
+
+      - name: Test set -e default in bash
+        shell: bash
+        if: always()
+        run: |
+          set +e
+          bash -c 'false; echo "After false"'
+          EXIT_CODE=$?
+          set -e
+          
+          if [[ $EXIT_CODE -ne 0 ]]; then
+            echo "✓ bash has set -e active by default"
+          else
+            echo "⚠ bash may not have set -e or it was overridden"
+          fi
+
+      - name: Test exit code propagation
+        shell: bash
+        if: always()
+        run: |
+          (exit 42)
+          EXIT_CODE=$?
+          if [[ $EXIT_CODE -eq 42 ]]; then
+            echo "✓ Subshell exit codes properly propagated"
+          else
+            echo "✗ Exit code not propagated correctly: $EXIT_CODE"
+          fi
+
+      - name: Test multiple command exit codes
+        shell: bash
+        if: always()
+        run: |
+          set +e
+          true
+          CODE1=$?
+          false
+          CODE2=$?
+          true
+          CODE3=$?
+          set -e
+          
+          echo "Command 1 exit code: $CODE1"
+          echo "Command 2 exit code: $CODE2"
+          echo "Command 3 exit code: $CODE3"
+          
+          if [[ $CODE1 -eq 0 ]] && [[ $CODE2 -ne 0 ]] && [[ $CODE3 -eq 0 ]]; then
+            echo "✓ Individual command exit codes correct"
+          fi

--- a/fixtures/workflows/conformance/91-large-output.yml
+++ b/fixtures/workflows/conformance/91-large-output.yml
@@ -1,0 +1,68 @@
+name: Large Output Handling
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-large-output:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    steps:
+      - name: Generate large stdout output
+        id: large_log
+        run: |
+          echo "Generating 10000 lines of output (100KB+)..."
+          for i in {1..10000}; do
+            echo "Line $i: This is a test output line with some padding to increase size. Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+          done
+          echo "Large log generation complete"
+          wc -l < <(for i in {1..10000}; do echo "Line $i: Test"; done) || true
+
+      - name: Generate large output variable
+        id: large_var
+        run: |
+          echo "Creating 50KB output variable..."
+          LARGE_OUTPUT=""
+          for i in {1..1000}; do
+            LARGE_OUTPUT="${LARGE_OUTPUT}This is line $i with some padding. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation. Line $i end.\n"
+          done
+          
+          # Write to GITHUB_OUTPUT using heredoc for large content
+          echo 'large_value<<EOF' >> $GITHUB_OUTPUT
+          printf "%s" "$LARGE_OUTPUT" >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+          
+          echo "Large output variable created"
+
+      - name: Verify large output variable retrieval
+        if: always()
+        run: |
+          OUTPUT='${{ steps.large_var.outputs.large_value }}'
+          OUTPUT_SIZE=${#OUTPUT}
+          
+          echo "Retrieved output variable size: $OUTPUT_SIZE bytes"
+          
+          if [[ $OUTPUT_SIZE -gt 40000 ]]; then
+            echo "✓ Large output variable (50KB+) retrieved successfully"
+          else
+            echo "⚠ Output variable size smaller than expected: $OUTPUT_SIZE bytes"
+          fi
+          
+          # Verify content integrity
+          if [[ "$OUTPUT" == *"Line 1"* ]] && [[ "$OUTPUT" == *"Line 1000"* ]]; then
+            echo "✓ Large output variable content verified"
+          else
+            echo "✗ Large output variable content corrupted"
+          fi
+
+      - name: Test step log size limits
+        run: |
+          echo "Testing if runner handles large logs without truncation..."
+          for i in {1..5000}; do
+            echo "Log line $i with content"
+          done
+          echo "Large log test complete"
+
+      - name: Verify runner didn't crash
+        if: always()
+        run: echo "✓ Runner survived large output operations"

--- a/fixtures/workflows/conformance/92-unicode-special-chars.yml
+++ b/fixtures/workflows/conformance/92-unicode-special-chars.yml
@@ -1,0 +1,102 @@
+name: Unicode and Special Characters
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-unicode-special-chars:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    steps:
+      - name: Set environment with unicode and special chars
+        env:
+          EMOJI_VAR: "🚀 Rocket 🎉 Party 🔥"
+          CJK_VAR: "中文字符 日本語 한국어"
+          SPECIAL_VAR: "quote\"test' backslash\\ newline\ntest"
+          MATH_VAR: "∑∏∫ mathematical symbols"
+        run: |
+          echo "EMOJI_VAR=$EMOJI_VAR"
+          echo "CJK_VAR=$CJK_VAR"
+          echo "SPECIAL_VAR=$SPECIAL_VAR"
+          echo "MATH_VAR=$MATH_VAR"
+
+      - name: Test unicode in output variables
+        id: unicode_output
+        run: |
+          echo 'emoji_output<<EOF' >> $GITHUB_OUTPUT
+          echo '🌟 Success! ✅ All tests passed 🎯' >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+          
+          echo 'cjk_output<<EOF' >> $GITHUB_OUTPUT
+          echo '日本語のテスト: これは有効なテストです' >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+          
+          echo 'special_output<<EOF' >> $GITHUB_OUTPUT
+          echo 'Quotes: "double" and '"'"'single'"'"' and \backslash and \n and \t' >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+
+      - name: Retrieve and verify unicode outputs
+        run: |
+          EMOJI='${{ steps.unicode_output.outputs.emoji_output }}'
+          CJK='${{ steps.unicode_output.outputs.cjk_output }}'
+          SPECIAL='${{ steps.unicode_output.outputs.special_output }}'
+          
+          echo "Retrieved emoji output: $EMOJI"
+          echo "Retrieved CJK output: $CJK"
+          echo "Retrieved special output: $SPECIAL"
+          
+          if [[ "$EMOJI" == *"🌟"* ]] && [[ "$EMOJI" == *"✅"* ]]; then
+            echo "✓ Emoji preserved in output"
+          else
+            echo "✗ Emoji not preserved"
+            exit 1
+          fi
+          
+          if [[ "$CJK" == *"日本語"* ]]; then
+            echo "✓ CJK characters preserved"
+          else
+            echo "✗ CJK characters not preserved"
+            exit 1
+          fi
+
+      - name: Test file paths with spaces and unicode
+        run: |
+          mkdir -p "test dir with spaces"
+          mkdir -p "测试目录"
+          touch "test dir with spaces/file with spaces.txt"
+          touch "测试目录/文件.txt"
+          
+          echo "✓ Created directories and files with spaces and unicode"
+          ls -la "test dir with spaces/"
+          ls -la "测试目录/"
+
+      - name: Test env var with newlines
+        env:
+          MULTILINE_VAR: |
+            Line 1 with emoji 🎨
+            Line 2 with special chars: @#$%
+            Line 3 with unicode: Ñoño Schöne
+        run: |
+          echo "Multiline env var:"
+          echo "$MULTILINE_VAR"
+          
+          if [[ "$MULTILINE_VAR" == *"Line 1"* ]] && [[ "$MULTILINE_VAR" == *"🎨"* ]]; then
+            echo "✓ Multiline env var with unicode preserved"
+          fi
+
+      - name: Test hex escape sequences
+        id: hex_test
+        run: |
+          echo 'hex_output<<EOF' >> $GITHUB_OUTPUT
+          printf '%b' 'Line 1: \\x41\\x42\\x43\\n' >> $GITHUB_OUTPUT
+          printf '%b' 'Unicode: \\u00E9\\u00E8\\u00EA\\n' >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+
+      - name: Verify special character round-trip
+        run: |
+          HEX='${{ steps.hex_test.outputs.hex_output }}'
+          echo "Hex output: $HEX"
+          
+          if [[ -n "$HEX" ]]; then
+            echo "✓ Escape sequences handled"
+          fi

--- a/fixtures/workflows/conformance/93-empty-null-values.yml
+++ b/fixtures/workflows/conformance/93-empty-null-values.yml
@@ -1,0 +1,157 @@
+name: Empty and Null Values
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test-empty-null-values:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    steps:
+      - name: Set empty string output
+        id: empty_output
+        run: |
+          echo 'empty_var=' >> $GITHUB_OUTPUT
+          echo "Empty output set"
+
+      - name: Verify empty string output
+        run: |
+          EMPTY='${{ steps.empty_output.outputs.empty_var }}'
+          
+          if [[ "$EMPTY" == "" ]]; then
+            echo "✓ Empty string output correctly retrieved"
+          else
+            echo "✗ Empty string output is not empty: '$EMPTY'"
+            exit 1
+          fi
+
+      - name: Test empty string comparison
+        run: |
+          EMPTY='${{ steps.empty_output.outputs.empty_var }}'
+          
+          if [[ -z "$EMPTY" ]]; then
+            echo "✓ Empty string identified with -z test"
+          else
+            echo "✗ Empty string not recognized"
+            exit 1
+          fi
+          
+          if [[ "$EMPTY" == '' ]]; then
+            echo "✓ Comparison with empty string works"
+          else
+            echo "✗ Empty string comparison failed"
+            exit 1
+          fi
+
+      - name: Test unset env var reference
+        run: |
+          # Unset env var should be empty/null
+          UNSET_VAR="${NONEXISTENT_VAR}"
+          
+          if [[ -z "$UNSET_VAR" ]]; then
+            echo "✓ Unset env var reference is empty"
+          else
+            echo "✗ Unset env var is not empty: '$UNSET_VAR'"
+            exit 1
+          fi
+          
+          # Test in conditional
+          if [[ "$NONEXISTENT_VAR" == "" ]]; then
+            echo "✓ Unset var comparison works"
+          else
+            echo "✗ Unset var comparison failed"
+          fi
+
+      - name: Test step output that is never set
+        id: never_set
+        run: |
+          # Intentionally don't set never_set_var
+          echo "Step executed but output variable never defined"
+
+      - name: Access undefined step output
+        run: |
+          UNDEFINED='${{ steps.never_set.outputs.never_set_var }}'
+          
+          if [[ -z "$UNDEFINED" ]]; then
+            echo "✓ Undefined step output is empty string"
+          else
+            echo "✗ Undefined step output is not empty: '$UNDEFINED'"
+            exit 1
+          fi
+
+      - name: Test empty string in matrix (simulated)
+        run: |
+          # Simulate matrix with empty value
+          MATRIX_VALUES=("value1" "" "value3")
+          
+          for i in "${!MATRIX_VALUES[@]}"; do
+            VAL="${MATRIX_VALUES[$i]}"
+            if [[ -z "$VAL" ]]; then
+              echo "✓ Empty value in array index $i correctly identified"
+            fi
+          done
+
+      - name: Test empty string vs null handling
+        env:
+          EXPLICIT_EMPTY: ""
+          UNSET_VAR_REF: $NONEXISTENT
+        run: |
+          if [[ "$EXPLICIT_EMPTY" == "" ]]; then
+            echo "✓ Explicit empty string handled correctly"
+          fi
+          
+          if [[ -z "$UNSET_VAR_REF" ]]; then
+            echo "✓ Unset variable reference is empty"
+          fi
+
+      - name: Test default value with empty
+        run: |
+          EMPTY_VAR=""
+          DEFAULT_VALUE="${EMPTY_VAR:-default}"
+          
+          if [[ "$DEFAULT_VALUE" == "default" ]]; then
+            echo "✓ Default value expansion works with empty var"
+          else
+            echo "✗ Default value not applied: '$DEFAULT_VALUE'"
+            exit 1
+          fi
+
+      - name: Test empty string in conditions
+        run: |
+          EMPTY=""
+          
+          if [[ -n "$EMPTY" ]]; then
+            echo "✗ Non-empty test failed on empty string"
+            exit 1
+          else
+            echo "✓ Non-empty test correctly fails on empty string"
+          fi
+          
+          if [[ -z "$EMPTY" ]]; then
+            echo "✓ Empty test correctly passes on empty string"
+          else
+            echo "✗ Empty test failed"
+            exit 1
+          fi
+
+      - name: Test null output field access
+        id: test_null
+        run: |
+          # Set one output but not another
+          echo 'defined_field=has_value' >> $GITHUB_OUTPUT
+
+      - name: Access defined and undefined outputs
+        run: |
+          DEFINED='${{ steps.test_null.outputs.defined_field }}'
+          UNDEFINED='${{ steps.test_null.outputs.undefined_field }}'
+          
+          if [[ "$DEFINED" == "has_value" ]]; then
+            echo "✓ Defined output correctly retrieved"
+          fi
+          
+          if [[ "$UNDEFINED" == "" ]]; then
+            echo "✓ Undefined output field is empty string"
+          else
+            echo "✗ Undefined output field not empty: '$UNDEFINED'"
+            exit 1
+          fi

--- a/fixtures/workflows/conformance/94-action-pinning.yml
+++ b/fixtures/workflows/conformance/94-action-pinning.yml
@@ -1,0 +1,31 @@
+name: 94-action-pinning
+on:
+  workflow_dispatch:
+jobs:
+  test-action-resolution:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    steps:
+      - name: Test checkout with tag
+        uses: actions/checkout@v4
+        with:
+          repository: actions/checkout
+          ref: v4.0.0
+
+      - name: Echo checkout tag version
+        run: echo "Tested tag-based action resolution (v4)"
+
+      - name: Test checkout with SHA pin
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Echo checkout SHA version
+        run: echo "Tested SHA-pinned action resolution"
+
+      - name: Test checkout with branch
+        uses: actions/checkout@main
+
+      - name: Echo checkout branch version
+        run: echo "Tested branch-based action resolution (main)"
+
+      - name: Verify all three resolution methods succeeded
+        run: echo "All action pinning methods completed successfully"

--- a/fixtures/workflows/conformance/95-nested-composite-outputs.yml
+++ b/fixtures/workflows/conformance/95-nested-composite-outputs.yml
@@ -1,0 +1,26 @@
+name: 95-nested-composite-outputs
+on:
+  workflow_dispatch:
+jobs:
+  test-nested-composite:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Call outer composite action
+        id: outer
+        uses: ./test-actions/outer-composite
+
+      - name: Verify outer composite output
+        run: |
+          echo "Outer composite returned: ${{ steps.outer.outputs.outer-value }}"
+          if [ -z "${{ steps.outer.outputs.outer-value }}" ]; then
+            echo "ERROR: No output from outer composite"
+            exit 1
+          fi
+          echo "Nested composite output propagation verified"
+
+      - name: Test that inner composite was used
+        run: echo "Inner composite was successfully called through outer composite"

--- a/fixtures/workflows/conformance/96-env-inheritance.yml
+++ b/fixtures/workflows/conformance/96-env-inheritance.yml
@@ -1,0 +1,49 @@
+name: 96-env-inheritance
+on:
+  workflow_dispatch:
+env:
+  TEST_VAR: workflow-level
+jobs:
+  test-env-job-1:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    env:
+      TEST_VAR: job-level
+    steps:
+      - name: Step should use job-level env
+        run: |
+          if [ "$TEST_VAR" != "job-level" ]; then
+            echo "ERROR: Expected job-level, got $TEST_VAR"
+            exit 1
+          fi
+          echo "Job-level env override verified"
+
+      - name: Step with step-level override
+        env:
+          TEST_VAR: step-level
+        run: |
+          if [ "$TEST_VAR" != "step-level" ]; then
+            echo "ERROR: Expected step-level, got $TEST_VAR"
+            exit 1
+          fi
+          echo "Step-level env override verified"
+
+  test-env-job-2:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    steps:
+      - name: Job2 should see workflow-level only
+        run: |
+          if [ "$TEST_VAR" != "workflow-level" ]; then
+            echo "ERROR: Expected workflow-level, got $TEST_VAR"
+            exit 1
+          fi
+          echo "Env isolation between jobs verified"
+
+      - name: Verify TEST_VAR is not from job-1
+        run: |
+          if [ "$TEST_VAR" = "job-level" ]; then
+            echo "ERROR: Job-1 env leaked to job-2"
+            exit 1
+          fi
+          echo "No env leakage between jobs"

--- a/fixtures/workflows/conformance/97-artifact-cross-job.yml
+++ b/fixtures/workflows/conformance/97-artifact-cross-job.yml
@@ -1,0 +1,44 @@
+name: 97-artifact-cross-job
+on:
+  workflow_dispatch:
+jobs:
+  upload-artifact:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    steps:
+      - name: Create test file
+        run: |
+          mkdir -p artifact-test
+          echo "test-artifact-content-12345" > artifact-test/test.txt
+          echo "File created with content: $(cat artifact-test/test.txt)"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-artifact
+          path: artifact-test/test.txt
+
+  download-artifact:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    needs: upload-artifact
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: test-artifact
+          path: downloaded-artifact
+
+      - name: Verify artifact contents
+        run: |
+          if [ ! -f "downloaded-artifact/test.txt" ]; then
+            echo "ERROR: Downloaded file not found"
+            exit 1
+          fi
+          CONTENT=$(cat downloaded-artifact/test.txt)
+          echo "Downloaded file content: $CONTENT"
+          if [ "$CONTENT" != "test-artifact-content-12345" ]; then
+            echo "ERROR: Content mismatch"
+            exit 1
+          fi
+          echo "Artifact cross-job transfer verified"

--- a/fixtures/workflows/conformance/98-outcome-vs-conclusion.yml
+++ b/fixtures/workflows/conformance/98-outcome-vs-conclusion.yml
@@ -1,0 +1,51 @@
+name: 98-outcome-vs-conclusion
+on:
+  workflow_dispatch:
+jobs:
+  test-outcome-conclusion:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    steps:
+      - name: Successful step
+        id: success
+        run: echo "This step succeeds"
+
+      - name: Verify success step
+        run: |
+          if [ "${{ steps.success.outcome }}" != "success" ]; then
+            echo "ERROR: outcome should be success, got ${{ steps.success.outcome }}"
+            exit 1
+          fi
+          if [ "${{ steps.success.conclusion }}" != "success" ]; then
+            echo "ERROR: conclusion should be success, got ${{ steps.success.conclusion }}"
+            exit 1
+          fi
+          echo "Success step: outcome and conclusion both 'success'"
+
+      - name: Failing step with continue-on-error
+        id: failing
+        continue-on-error: true
+        run: exit 1
+
+      - name: Verify failing step with continue-on-error
+        run: |
+          if [ "${{ steps.failing.outcome }}" != "failure" ]; then
+            echo "ERROR: outcome should be failure, got ${{ steps.failing.outcome }}"
+            exit 1
+          fi
+          if [ "${{ steps.failing.conclusion }}" != "success" ]; then
+            echo "ERROR: conclusion should be success (due to continue-on-error), got ${{ steps.failing.conclusion }}"
+            exit 1
+          fi
+          echo "Failing step with continue-on-error: outcome=failure, conclusion=success"
+
+      - name: Failing step without continue-on-error
+        id: hardfail
+        continue-on-error: false
+        run: |
+          echo "This will fail"
+          exit 1
+
+      - name: This should not run
+        if: failure()
+        run: echo "Reached after hard failure - job should have stopped"

--- a/fixtures/workflows/conformance/99-workspace-defaults.yml
+++ b/fixtures/workflows/conformance/99-workspace-defaults.yml
@@ -1,0 +1,75 @@
+name: 99-workspace-defaults
+on:
+  workflow_dispatch:
+jobs:
+  test-workspace:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Verify GITHUB_WORKSPACE is set
+        run: |
+          if [ -z "$GITHUB_WORKSPACE" ]; then
+            echo "ERROR: GITHUB_WORKSPACE not set"
+            exit 1
+          fi
+          echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE"
+
+      - name: Verify workspace is checkout root
+        run: |
+          CURRENT_PWD=$(pwd)
+          if [ "$CURRENT_PWD" != "$GITHUB_WORKSPACE" ]; then
+            echo "ERROR: Current directory $CURRENT_PWD != GITHUB_WORKSPACE $GITHUB_WORKSPACE"
+            exit 1
+          fi
+          echo "Current directory matches GITHUB_WORKSPACE"
+
+      - name: Verify runner.workspace context
+        run: |
+          RUNNER_WORKSPACE="$RUNNER_WORKSPACE"
+          if [ -z "$RUNNER_WORKSPACE" ]; then
+            echo "ERROR: runner.workspace is empty"
+            exit 1
+          fi
+          echo "runner.workspace=$RUNNER_WORKSPACE"
+
+      - name: Test working-directory override
+        working-directory: ${{ github.workspace }}
+        run: |
+          CURRENT_PWD=$(pwd)
+          if [ "$CURRENT_PWD" != "$GITHUB_WORKSPACE" ]; then
+            echo "ERROR: working-directory override did not change cwd"
+            exit 1
+          fi
+          echo "working-directory override verified"
+
+      - name: Create test subdirectory
+        run: |
+          mkdir -p test-subdir
+          echo "test file" > test-subdir/testfile.txt
+
+      - name: Test working-directory to subdirectory
+        working-directory: ${{ github.workspace }}/test-subdir
+        run: |
+          CURRENT_PWD=$(pwd)
+          if [ ! -f "testfile.txt" ]; then
+            echo "ERROR: testfile.txt not found in subdirectory"
+            exit 1
+          fi
+          echo "working-directory to subdirectory verified"
+
+      - name: Test invalid working-directory
+        id: invalid-workdir
+        working-directory: /nonexistent/path
+        continue-on-error: true
+        run: echo "This should fail due to missing directory"
+
+      - name: Verify invalid working-directory caused failure
+        run: |
+          if [ "${{ steps.invalid-workdir.outcome }}" = "success" ]; then
+            echo "ERROR: Invalid working-directory should have failed"
+            exit 1
+          fi
+          echo "Invalid working-directory correctly caused failure"

--- a/fixtures/workflows/conformance/aksh-angular.yml
+++ b/fixtures/workflows/conformance/aksh-angular.yml
@@ -1,0 +1,23 @@
+name: "aksh angular"
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: [self-hosted, campaign-angular]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: angular/angular
+          path: project
+          fetch-depth: 1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Check project
+        working-directory: project
+        run: |
+          echo "Project: angular"
+          echo "Directory contents:"
+          ls -la
+          echo "Git log:"
+          git log --oneline -3

--- a/fixtures/workflows/conformance/aksh-cilium.yml
+++ b/fixtures/workflows/conformance/aksh-cilium.yml
@@ -1,0 +1,23 @@
+name: "aksh cilium"
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: [self-hosted, campaign-cilium]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: cilium/cilium
+          path: project
+          fetch-depth: 1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Check project
+        working-directory: project
+        run: |
+          echo "Project: cilium"
+          echo "Directory contents:"
+          ls -la
+          echo "Git log:"
+          git log --oneline -3

--- a/fixtures/workflows/conformance/aksh-echarts.yml
+++ b/fixtures/workflows/conformance/aksh-echarts.yml
@@ -1,0 +1,23 @@
+name: "aksh echarts"
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: [self-hosted, campaign-echarts]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: apache/echarts
+          path: project
+          fetch-depth: 1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Check project
+        working-directory: project
+        run: |
+          echo "Project: echarts"
+          echo "Directory contents:"
+          ls -la
+          echo "Git log:"
+          git log --oneline -3

--- a/fixtures/workflows/conformance/aksh-kafka.yml
+++ b/fixtures/workflows/conformance/aksh-kafka.yml
@@ -1,0 +1,23 @@
+name: "aksh kafka"
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: [self-hosted, campaign-kafka]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: apache/kafka
+          path: project
+          fetch-depth: 1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Check project
+        working-directory: project
+        run: |
+          echo "Project: kafka"
+          echo "Directory contents:"
+          ls -la
+          echo "Git log:"
+          git log --oneline -3

--- a/fixtures/workflows/conformance/aksh-n8n.yml
+++ b/fixtures/workflows/conformance/aksh-n8n.yml
@@ -1,0 +1,23 @@
+name: "aksh n8n"
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: [self-hosted, campaign-n8n]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: n8n-io/n8n
+          path: project
+          fetch-depth: 1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Check project
+        working-directory: project
+        run: |
+          echo "Project: n8n"
+          echo "Directory contents:"
+          ls -la
+          echo "Git log:"
+          git log --oneline -3

--- a/fixtures/workflows/conformance/aksh-pulsar.yml
+++ b/fixtures/workflows/conformance/aksh-pulsar.yml
@@ -1,0 +1,23 @@
+name: "aksh pulsar"
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: [self-hosted, campaign-pulsar]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: apache/pulsar
+          path: project
+          fetch-depth: 1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Check project
+        working-directory: project
+        run: |
+          echo "Project: pulsar"
+          echo "Directory contents:"
+          ls -la
+          echo "Git log:"
+          git log --oneline -3

--- a/fixtures/workflows/conformance/aksh-rocketmq.yml
+++ b/fixtures/workflows/conformance/aksh-rocketmq.yml
@@ -1,0 +1,23 @@
+name: "aksh rocketmq"
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: [self-hosted, campaign-rocketmq]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: apache/rocketmq
+          path: project
+          fetch-depth: 1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Check project
+        working-directory: project
+        run: |
+          echo "Project: rocketmq"
+          echo "Directory contents:"
+          ls -la
+          echo "Git log:"
+          git log --oneline -3

--- a/fixtures/workflows/conformance/aksh-vscode.yml
+++ b/fixtures/workflows/conformance/aksh-vscode.yml
@@ -1,0 +1,23 @@
+name: "aksh vscode"
+on:
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: [self-hosted, campaign-vscode]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: microsoft/vscode
+          path: project
+          fetch-depth: 1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Check project
+        working-directory: project
+        run: |
+          echo "Project: vscode"
+          echo "Directory contents:"
+          ls -la
+          echo "Git log:"
+          git log --oneline -3

--- a/fixtures/workflows/conformance/bench-30-container-job-basic.yml
+++ b/fixtures/workflows/conformance/bench-30-container-job-basic.yml
@@ -1,0 +1,25 @@
+name: "bench: container-job-basic"
+on: workflow_dispatch
+
+jobs:
+  container-basic:
+    runs-on: [self-hosted, aksh-container]
+    container: node:20-bookworm
+    steps:
+      - name: Node version
+        run: node --version
+      - name: NPM version
+        run: npm --version
+      - name: Verify running inside container
+        run: |
+          # The job container should have /.dockerenv
+          test -f /.dockerenv
+          echo "Running inside Docker container"
+      - name: Check environment variables
+        run: |
+          echo "HOME=$HOME"
+          echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE"
+          echo "RUNNER_TEMP=$RUNNER_TEMP"
+          echo "GITHUB_ACTION=$GITHUB_ACTION"
+      - name: Write a file in workspace
+        run: echo "hello from container" > /tmp/test-output.txt && cat /tmp/test-output.txt

--- a/fixtures/workflows/conformance/bench-31-container-with-services.yml
+++ b/fixtures/workflows/conformance/bench-31-container-with-services.yml
@@ -1,0 +1,52 @@
+name: "bench: container-with-services"
+on: workflow_dispatch
+
+jobs:
+  container-services:
+    runs-on: [self-hosted, aksh-container]
+    container: node:20-bookworm
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: testuser
+          POSTGRES_DB: testdb
+        options: >-
+          --health-cmd "pg_isready -U testuser"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - name: Install clients
+        run: |
+          apt-get update -qq
+          apt-get install -y --no-install-recommends postgresql-client redis-tools
+      - name: Connect to Postgres via service alias
+        run: PGPASSWORD=postgres psql -h postgres -U testuser -d testdb -c 'SELECT version();'
+      - name: Create table and insert row
+        run: |
+          PGPASSWORD=postgres psql -h postgres -U testuser -d testdb -c '
+            CREATE TABLE test_table (id serial PRIMARY KEY, value text);
+            INSERT INTO test_table (value) VALUES ($$from-container$$);
+          '
+      - name: Query row back
+        run: |
+          PGPASSWORD=postgres psql -h postgres -U testuser -d testdb -t -c "SELECT value FROM test_table WHERE id=1;" | grep -q "from-container"
+      - name: Connect to Redis via service alias
+        run: |
+          redis-cli -h redis SET mykey "hello"
+          redis-cli -h redis GET mykey | grep -q hello
+      - name: Dump service context
+        run: |
+          echo "job.services.postgres.id=${{ job.services.postgres.id }}"
+          echo "job.services.postgres.ports[5432]=${{ job.services.postgres.ports[5432] }}"
+          echo "job.services.redis.id=${{ job.services.redis.id }}"
+          echo "job.services.redis.ports[6379]=${{ job.services.redis.ports[6379] }}"

--- a/fixtures/workflows/conformance/bench-33-container-env-options.yml
+++ b/fixtures/workflows/conformance/bench-33-container-env-options.yml
@@ -1,0 +1,58 @@
+name: "bench: container-env-options"
+on: workflow_dispatch
+
+jobs:
+  container-env:
+    runs-on: [self-hosted, aksh-container]
+    container:
+      image: alpine:3.20
+      env:
+        CUSTOM_VAR: "hello-from-container"
+        NODE_ENV: "test"
+      options: --cpus 1
+    steps:
+      - name: Verify custom env var
+        run: |
+          test "$CUSTOM_VAR" = "hello-from-container"
+          echo "CUSTOM_VAR=$CUSTOM_VAR"
+      - name: Verify NODE_ENV
+        run: |
+          test "$NODE_ENV" = "test"
+          echo "NODE_ENV=$NODE_ENV"
+      - name: Write GITHUB_ENV
+        run: |
+          echo "DYNAMIC_VAR=set-at-runtime" >> "$GITHUB_ENV"
+      - name: Read GITHUB_ENV value
+        run: |
+          test "$DYNAMIC_VAR" = "set-at-runtime"
+          echo "DYNAMIC_VAR=$DYNAMIC_VAR"
+      - name: Write GITHUB_OUTPUT
+        id: gen
+        run: |
+          echo "result=success" >> "$GITHUB_OUTPUT"
+          echo "multi_line<<EOF" >> "$GITHUB_OUTPUT"
+          echo "line1" >> "$GITHUB_OUTPUT"
+          echo "line2" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+      - name: Read GITHUB_OUTPUT
+        run: |
+          test "${{ steps.gen.outputs.result }}" = "success"
+          echo "result=${{ steps.gen.outputs.result }}"
+          echo "multi_line=${{ steps.gen.outputs.multi_line }}"
+      - name: Write GITHUB_PATH
+        run: |
+          mkdir -p /tmp/custom-bin
+          echo '#!/bin/sh' > /tmp/custom-bin/my-tool
+          echo 'echo my-tool-output' >> /tmp/custom-bin/my-tool
+          chmod +x /tmp/custom-bin/my-tool
+          echo "/tmp/custom-bin" >> "$GITHUB_PATH"
+      - name: Use custom path tool
+        run: my-tool | grep -q my-tool-output
+      - name: Check workspace mount
+        run: |
+          test -d "$GITHUB_WORKSPACE"
+          ls -la "$GITHUB_WORKSPACE"
+      - name: Check runner temp mount
+        run: |
+          test -d "$RUNNER_TEMP"
+          echo "RUNNER_TEMP=$RUNNER_TEMP"

--- a/fixtures/workflows/conformance/bench-35-container-lifecycle.yml
+++ b/fixtures/workflows/conformance/bench-35-container-lifecycle.yml
@@ -1,0 +1,36 @@
+name: "bench: container-lifecycle"
+on: workflow_dispatch
+
+jobs:
+  lifecycle:
+    runs-on: [self-hosted, aksh-container]
+    container:
+      image: python:3.12-slim
+      env:
+        PYTHONDONTWRITEBYTECODE: "1"
+    steps:
+      - name: Verify python version
+        run: python3 --version
+      - name: Install pip package
+        run: pip install httpx
+      - name: Run python script
+        run: |
+          python3 -c "
+          import httpx
+          import sys
+          print(f'Python {sys.version}')
+          print(f'httpx {httpx.__version__}')
+          print('Container lifecycle OK')
+          "
+      - name: Test job.container context
+        run: |
+          echo "container.id=${{ job.container.id }}"
+          echo "container.network=${{ job.container.network }}"
+      - name: Failing step (continue-on-error)
+        continue-on-error: true
+        run: exit 1
+      - name: Step after continue-on-error
+        run: echo "This should still run"
+      - name: Conditional step
+        if: success()
+        run: echo "Previous step succeeded or was continue-on-error"

--- a/fixtures/workflows/conformance/bench-aksh-ci.yml
+++ b/fixtures/workflows/conformance/bench-aksh-ci.yml
@@ -1,0 +1,24 @@
+name: "bench: aksh-ci"
+on: workflow_dispatch
+
+jobs:
+  rust:
+    runs-on: [self-hosted]
+    steps:
+      - name: cargo fmt
+        run: |
+          export PATH="/root/.cargo/bin:$PATH"
+          cd /workspace
+          cargo fmt --all --check
+
+      - name: cargo clippy
+        run: |
+          export PATH="/root/.cargo/bin:$PATH"
+          cd /workspace
+          cargo clippy --workspace --all-targets
+
+      - name: cargo test
+        run: |
+          export PATH="/root/.cargo/bin:$PATH"
+          cd /workspace
+          cargo test --workspace --quiet

--- a/fixtures/workflows/conformance/e2e-axum.yml
+++ b/fixtures/workflows/conformance/e2e-axum.yml
@@ -1,0 +1,55 @@
+name: E2E axum
+on: workflow_dispatch
+
+jobs:
+  fmt:
+    name: Rustfmt
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: tokio-rs/axum
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
+  clippy:
+    name: Clippy
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: tokio-rs/axum
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+  test:
+    name: Test
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: tokio-rs/axum
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test --workspace --all-features
+        env:
+          RUST_BACKTRACE: 1
+
+  doc:
+    name: Documentation
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: tokio-rs/axum
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo doc --workspace --all-features --no-deps
+        env:
+          RUSTDOCFLAGS: -Dwarnings

--- a/fixtures/workflows/conformance/e2e-bat.yml
+++ b/fixtures/workflows/conformance/e2e-bat.yml
@@ -1,0 +1,57 @@
+name: E2E bat
+on: workflow_dispatch
+
+jobs:
+  fmt:
+    name: Rustfmt
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: sharkdp/bat
+          submodules: true
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
+  build:
+    name: Build
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: sharkdp/bat
+          submodules: true
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --locked
+
+  clippy:
+    name: Clippy
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: sharkdp/bat
+          submodules: true
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - run: cargo clippy --locked --all-targets --all-features -- -D warnings
+
+  test:
+    name: Test
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: sharkdp/bat
+          submodules: true
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test --locked
+        env:
+          RUST_BACKTRACE: 1

--- a/fixtures/workflows/conformance/e2e-clap.yml
+++ b/fixtures/workflows/conformance/e2e-clap.yml
@@ -1,0 +1,17 @@
+name: E2E clap
+on: workflow_dispatch
+
+jobs:
+  build_and_test:
+    name: Build and Test Clap
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: clap-rs/clap
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build
+        run: cargo build --workspace --all-targets
+      - name: Test
+        run: cargo test --workspace --all-targets

--- a/fixtures/workflows/conformance/e2e-cross-platform-matrix.yml
+++ b/fixtures/workflows/conformance/e2e-cross-platform-matrix.yml
@@ -1,0 +1,112 @@
+name: E2E cross-platform matrix (blog pattern)
+# Mirrors the structure from ahmedjama.com/blog/2025/12/cross-platform-rust-pipeline-github-actions/
+# Build steps are stubbed — we're testing the workflow mechanics, not actual compilation.
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'e2e-release-v*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build - ${{ matrix.platform.target }}
+    runs-on: [self-hosted, linux, x64]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - name: Linux ARM64
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            binary_ext: ""
+            use_cross: true
+
+          - name: Linux ARMv7
+            os: ubuntu-latest
+            target: armv7-unknown-linux-gnueabihf
+            binary_ext: ""
+            use_cross: true
+
+          - name: Linux x86_64
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            binary_ext: ""
+            use_cross: false
+
+          - name: Windows x86_64
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+            binary_ext: ".exe"
+            use_cross: false
+
+    steps:
+      - name: Print platform context
+        run: |
+          echo "name=${{ matrix.platform.name }}"
+          echo "os=${{ matrix.platform.os }}"
+          echo "target=${{ matrix.platform.target }}"
+          echo "binary_ext=${{ matrix.platform.binary_ext }}"
+          echo "use_cross=${{ matrix.platform.use_cross }}"
+
+      - name: Verify nested property access
+        run: |
+          test "${{ matrix.platform.target }}" != ""
+          test "${{ matrix.platform.name }}"   != ""
+
+      - name: Install cross-compilation tool (stub)
+        if: matrix.platform.use_cross
+        run: echo "would install cross for ${{ matrix.platform.target }}"
+
+      - name: Setup OpenSSL for native builds (stub)
+        if: ${{ !matrix.platform.use_cross && matrix.platform.os == 'ubuntu-latest' }}
+        run: echo "would install libssl-dev for native ${{ matrix.platform.target }}"
+
+      - name: Build with cross (stub)
+        if: matrix.platform.use_cross
+        run: |
+          echo "cross build --release --target ${{ matrix.platform.target }}"
+          mkdir -p target/${{ matrix.platform.target }}/release
+          echo "stub-binary" > target/${{ matrix.platform.target }}/release/myapp${{ matrix.platform.binary_ext }}
+
+      - name: Build natively (stub)
+        if: ${{ !matrix.platform.use_cross }}
+        run: |
+          echo "cargo build --release --target ${{ matrix.platform.target }}"
+          mkdir -p target/${{ matrix.platform.target }}/release
+          echo "stub-binary" > target/${{ matrix.platform.target }}/release/myapp${{ matrix.platform.binary_ext }}
+
+      - name: Get binary name
+        id: binary_name
+        run: |
+          BINARY_NAME=myapp
+          echo "name=$BINARY_NAME" >> $GITHUB_OUTPUT
+
+      - name: Package binary
+        run: |
+          BINARY_NAME="${{ steps.binary_name.outputs.name }}"
+          ARCHIVE_NAME="${BINARY_NAME}-${{ matrix.platform.target }}"
+          mkdir -p dist
+          tar -czf "dist/${ARCHIVE_NAME}.tar.gz" \
+            -C "target/${{ matrix.platform.target }}/release" \
+            "${BINARY_NAME}${{ matrix.platform.binary_ext }}"
+          echo "packaged: dist/${ARCHIVE_NAME}.tar.gz"
+          ls -lh dist/
+
+      - name: Verify output propagation
+        run: |
+          test "${{ steps.binary_name.outputs.name }}" = "myapp"
+          echo "output propagated correctly: ${{ steps.binary_name.outputs.name }}"
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: [self-hosted, linux, x64]
+    if: startsWith(github.ref, 'refs/tags/e2e-release-v')
+
+    steps:
+      - name: Would publish release
+        run: echo "releasing to GitHub for ref ${{ github.ref }}"

--- a/fixtures/workflows/conformance/e2e-github-anyhow.yml
+++ b/fixtures/workflows/conformance/e2e-github-anyhow.yml
@@ -1,0 +1,13 @@
+name: E2E anyhow (GitHub)
+on: workflow_dispatch
+
+jobs:
+  test:
+    name: Test
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: dtolnay/anyhow
+      - run: cargo test

--- a/fixtures/workflows/conformance/e2e-github-fd.yml
+++ b/fixtures/workflows/conformance/e2e-github-fd.yml
@@ -1,0 +1,23 @@
+name: E2E fd (GitHub)
+on: workflow_dispatch
+
+jobs:
+  fmt:
+    name: Rustfmt
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: sharkdp/fd
+      - run: cargo fmt -- --check
+
+  test:
+    name: Test
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: sharkdp/fd
+      - run: cargo test --locked --all-features

--- a/fixtures/workflows/conformance/e2e-github-hyperfine.yml
+++ b/fixtures/workflows/conformance/e2e-github-hyperfine.yml
@@ -1,0 +1,23 @@
+name: E2E hyperfine (GitHub)
+on: workflow_dispatch
+
+jobs:
+  fmt:
+    name: Rustfmt
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: sharkdp/hyperfine
+      - run: cargo fmt -- --check
+
+  test:
+    name: Test
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: sharkdp/hyperfine
+      - run: cargo test --locked

--- a/fixtures/workflows/conformance/e2e-github-just.yml
+++ b/fixtures/workflows/conformance/e2e-github-just.yml
@@ -1,0 +1,33 @@
+name: E2E just (GitHub)
+on: workflow_dispatch
+
+jobs:
+  fmt:
+    name: Rustfmt
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: casey/just
+      - run: cargo fmt --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: casey/just
+      - run: cargo clippy --all --all-targets
+
+  test:
+    name: Test
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: casey/just
+      - run: cargo test --all

--- a/fixtures/workflows/conformance/e2e-github-mdbook.yml
+++ b/fixtures/workflows/conformance/e2e-github-mdbook.yml
@@ -1,0 +1,23 @@
+name: E2E mdBook (GitHub)
+on: workflow_dispatch
+
+jobs:
+  fmt:
+    name: Rustfmt
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: rust-lang/mdBook
+      - run: cargo fmt --all -- --check
+
+  test:
+    name: Test
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: rust-lang/mdBook
+      - run: cargo test --workspace

--- a/fixtures/workflows/conformance/e2e-matrix-context.yml
+++ b/fixtures/workflows/conformance/e2e-matrix-context.yml
@@ -1,0 +1,41 @@
+name: E2E matrix context
+on: workflow_dispatch
+
+jobs:
+  matrix-values:
+    name: "Build (${{ matrix.os }}, node=${{ matrix.node }})"
+    runs-on: [self-hosted, linux, x64]
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-22.04]
+        node: [18, 20]
+    steps:
+      - name: Print matrix values
+        run: |
+          echo "os=${{ matrix.os }}"
+          echo "node=${{ matrix.node }}"
+          test "${{ matrix.os }}" != ""
+          test "${{ matrix.node }}" != ""
+
+      - name: Matrix in env
+        env:
+          TARGET_OS: ${{ matrix.os }}
+          NODE_VERSION: ${{ matrix.node }}
+        run: |
+          echo "TARGET_OS=$TARGET_OS"
+          echo "NODE_VERSION=$NODE_VERSION"
+          test "$TARGET_OS" = "${{ matrix.os }}"
+          test "$NODE_VERSION" = "${{ matrix.node }}"
+
+      - name: Matrix in condition (only ubuntu-latest)
+        if: matrix.os == 'ubuntu-latest'
+        run: echo "only runs for ubuntu-latest, os=${{ matrix.os }}"
+
+      - name: Verify condition skipped for ubuntu-22.04
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          if [ "${{ matrix.os }}" != "ubuntu-latest" ]; then
+            echo "ERROR: step should have been skipped for ${{ matrix.os }}"
+            exit 1
+          fi
+          echo "condition correctly filtered to ubuntu-latest"

--- a/fixtures/workflows/conformance/e2e-matrix-continue-on-error.yml
+++ b/fixtures/workflows/conformance/e2e-matrix-continue-on-error.yml
@@ -1,0 +1,30 @@
+name: E2E matrix continue-on-error
+on: workflow_dispatch
+
+jobs:
+  experimental:
+    name: "Test (${{ matrix.version }}, experimental=${{ matrix.experimental }})"
+    runs-on: [self-hosted, linux, x64]
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [stable, nightly]
+        include:
+          - version: stable
+            experimental: false
+          - version: nightly
+            experimental: true
+    steps:
+      - name: Print context
+        run: |
+          echo "version=${{ matrix.version }}"
+          echo "experimental=${{ matrix.experimental }}"
+
+      - name: Fail on nightly
+        run: |
+          if [ "${{ matrix.version }}" = "nightly" ]; then
+            echo "nightly intentionally failing"
+            exit 1
+          fi
+          echo "stable succeeded"

--- a/fixtures/workflows/conformance/e2e-matrix-include-exclude.yml
+++ b/fixtures/workflows/conformance/e2e-matrix-include-exclude.yml
@@ -1,0 +1,38 @@
+name: E2E matrix include/exclude
+on: workflow_dispatch
+
+jobs:
+  build:
+    name: "job-${{ matrix.n }}"
+    runs-on: [self-hosted, linux, x64]
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        n: [1, 2, 3, 4]
+        flag: [false]
+        include:
+          - n: 5
+            flag: true
+            extra: bonus
+        exclude:
+          - n: 4
+    steps:
+      - name: Show matrix
+        run: |
+          echo "n=${{ matrix.n }}"
+          echo "flag=${{ matrix.flag }}"
+          echo "extra=${{ matrix.extra }}"
+
+      - name: Verify n=4 is excluded (should never run)
+        run: |
+          if [ "${{ matrix.n }}" = "4" ]; then
+            echo "ERROR: n=4 should have been excluded"
+            exit 1
+          fi
+
+      - name: Extra field only on n=5
+        if: matrix.extra == 'bonus'
+        run: |
+          echo "extra bonus field present: ${{ matrix.extra }}"
+          test "${{ matrix.n }}" = "5"

--- a/fixtures/workflows/conformance/e2e-ripgrep.yml
+++ b/fixtures/workflows/conformance/e2e-ripgrep.yml
@@ -1,0 +1,17 @@
+name: E2E ripgrep
+on: workflow_dispatch
+
+jobs:
+  build_and_test:
+    name: Build and Test Ripgrep
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: BurntSushi/ripgrep
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build
+        run: cargo build --release
+      - name: Test
+        run: cargo test

--- a/fixtures/workflows/conformance/e2e-ruff.yml
+++ b/fixtures/workflows/conformance/e2e-ruff.yml
@@ -1,0 +1,17 @@
+name: E2E ruff
+on: workflow_dispatch
+
+jobs:
+  build_and_test:
+    name: Build and Test Ruff
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: astral-sh/ruff
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build
+        run: cargo build -p ruff_linter
+      - name: Test
+        run: cargo test -p ruff_linter

--- a/fixtures/workflows/conformance/e2e-serde.yml
+++ b/fixtures/workflows/conformance/e2e-serde.yml
@@ -1,0 +1,52 @@
+name: E2E serde
+on: workflow_dispatch
+
+env:
+  RUSTUP_HOME: /workspace/.rustup
+  CARGO_HOME: /workspace/.cargo
+  RUSTUP_TOOLCHAIN: stable
+  PATH: /workspace/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+jobs:
+  fmt:
+    name: Rustfmt
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: serde-rs/serde
+      - run: cargo fmt --all --check
+
+  build:
+    name: Build
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: serde-rs/serde
+      - run: cd serde && cargo build --features rc
+      - run: cd serde && cargo build --no-default-features
+
+  clippy:
+    name: Clippy
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: serde-rs/serde
+      - run: cd serde && cargo clippy --features rc
+      - run: cd serde_derive && cargo clippy
+
+  test:
+    name: Test
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: serde-rs/serde
+      - run: cd serde_core && cargo test --features rc
+      - run: cd serde_derive && cargo test

--- a/fixtures/workflows/conformance/e2e-sqlx.yml
+++ b/fixtures/workflows/conformance/e2e-sqlx.yml
@@ -1,0 +1,17 @@
+name: E2E sqlx
+on: workflow_dispatch
+
+jobs:
+  build_and_test:
+    name: Build and Test SQLx
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: launchbadge/sqlx
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Check core
+        run: cargo check -p sqlx-core
+      - name: Test core
+        run: cargo test -p sqlx-core

--- a/fixtures/workflows/conformance/lease-expiry.yml
+++ b/fixtures/workflows/conformance/lease-expiry.yml
@@ -1,0 +1,44 @@
+name: lease-expiry
+
+on:
+  workflow_dispatch:
+
+jobs:
+  kill-listener:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Baseline
+        run: ps -eo pid,comm | grep -E "Runner\.(Listener|Worker)" || true
+      - name: Kill lease holder and worker
+        run: |
+          date -u +"kill-time: %Y-%m-%dT%H:%M:%SZ"
+          sudo pkill -9 -x Runner.Listener || true
+          sudo pkill -9 -x Runner.Worker || true
+      - name: Never reached
+        run: echo survived
+
+  kill-worker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Baseline
+        run: ps -eo pid,comm | grep -E "Runner\.(Listener|Worker)" || true
+      - name: Kill worker only, listener survives
+        run: |
+          date -u +"kill-time: %Y-%m-%dT%H:%M:%SZ"
+          sudo pkill -9 -x Runner.Worker || true
+          sleep 5
+          echo "listeners left: $(pgrep -cx Runner.Listener || true)"
+      - name: After worker death
+        run: echo "this step may or may not run"
+
+  reboot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Baseline
+        run: echo alive
+      - name: Reboot the VM mid-job
+        run: |
+          date -u +"reboot-time: %Y-%m-%dT%H:%M:%SZ"
+          sudo reboot
+      - name: Never reached
+        run: echo survived

--- a/fixtures/workflows/conformance/p0-cancel-semantics.yml
+++ b/fixtures/workflows/conformance/p0-cancel-semantics.yml
@@ -1,0 +1,30 @@
+name: P0 Cancel Semantics Verification
+on:
+  workflow_dispatch:
+  push:
+jobs:
+  cancel-test:
+    runs-on: [self-hosted, p0-cancel]
+    steps:
+      # 1. Long-running step that will be cancelled
+      - name: Long running step
+        run: |
+          echo "Starting long sleep — waiting for cancellation"
+          sleep 120
+
+      # 2. success() — should be SKIPPED after cancel
+      - name: Should be skipped (success)
+        if: success()
+        run: |
+          echo "BUG: this should not run after cancellation"
+          exit 1
+
+      # 3. cancelled() — should RUN after cancel
+      - name: Runs on cancel
+        if: cancelled()
+        run: echo "CANCELLED_CONDITION_RAN"
+
+      # 4. always() — should RUN after cancel
+      - name: Runs always after cancel
+        if: always()
+        run: echo "ALWAYS_CONDITION_RAN_AFTER_CANCEL"

--- a/fixtures/workflows/conformance/p0-container-job.yml
+++ b/fixtures/workflows/conformance/p0-container-job.yml
@@ -1,0 +1,46 @@
+name: P0 Container Job Verification
+on:
+  workflow_dispatch:
+  push:
+jobs:
+  container-job:
+    runs-on: [self-hosted, p0-linux]
+    container:
+      image: alpine:3.20
+      options: --cpus 1
+    steps:
+      # 1. Verify we're inside the container
+      - name: Check container env
+        run: |
+          echo "Running inside container"
+          cat /etc/os-release | grep -q "Alpine"
+          echo "Container OS verified: Alpine"
+
+      # 2. GITHUB_ENV works inside container
+      - name: Set env in container
+        run: echo "CONTAINER_VAR=from-container" >> "$GITHUB_ENV"
+
+      - name: Use env in container
+        run: |
+          test "$CONTAINER_VAR" = "from-container"
+          echo "GITHUB_ENV works inside container"
+
+      # 3. GITHUB_OUTPUT works inside container
+      - name: Produce output in container
+        id: ctr_output
+        run: echo "cval=container-output" >> "$GITHUB_OUTPUT"
+
+      # 4. File operations work inside container
+      - name: Write and read file
+        run: |
+          echo "test-content" > /tmp/test-file.txt
+          test "$(cat /tmp/test-file.txt)" = "test-content"
+          echo "File I/O works inside container"
+
+      # 5. Step summary inside container
+      - name: Write summary in container
+        run: echo "### Container Job Verified" >> "$GITHUB_STEP_SUMMARY"
+
+      # 6. Final marker
+      - name: All container checks passed
+        run: echo "ALL_P0_CONTAINER_JOB_CHECKS_PASSED"

--- a/fixtures/workflows/conformance/p0-docker-containers.yml
+++ b/fixtures/workflows/conformance/p0-docker-containers.yml
@@ -1,0 +1,111 @@
+name: P0 Docker and Container Verification
+on: workflow_dispatch
+jobs:
+  docker-tests:
+    runs-on: [self-hosted, p0-linux]
+    steps:
+      # 1. Docker is available
+      - name: Docker available
+        run: docker version
+
+      # 2. Docker container execution
+      - name: Run docker container
+        run: |
+          RESULT=$(docker run --rm alpine:3.20 echo "hello-from-docker-action")
+          test "$RESULT" = "hello-from-docker-action"
+          echo "Docker container execution verified"
+
+      # 3. Build and run a custom Docker image
+      - name: Build custom image
+        run: |
+          cat > /tmp/Dockerfile << 'EOF'
+          FROM alpine:3.20
+          RUN echo "built" > /output.txt
+          CMD ["cat", "/output.txt"]
+          EOF
+          docker build -t p0-custom-img -f /tmp/Dockerfile /tmp
+
+      - name: Run custom image
+        run: |
+          RESULT=$(docker run --rm p0-custom-img)
+          test "$RESULT" = "built"
+          echo "Custom Docker image verified"
+
+      # 4. Container env hiding — secrets should not appear in docker env args
+      - name: Docker env test
+        run: |
+          # Verify docker run doesn't echo secret values in env form
+          docker run --rm -e SAFE_VAR=visible alpine:3.20 env | grep SAFE_VAR
+          echo "Docker env verified"
+
+      # 5. Problem matcher with compiler-like output
+      - name: Create GCC-style matcher
+        run: |
+          cat > /tmp/gcc-matcher.json << 'EOF'
+          {
+            "problemMatcher": [
+              {
+                "owner": "gcc",
+                "pattern": [
+                  {
+                    "regexp": "^(.+):(\\d+):(\\d+):\\s+(error|warning|note):\\s+(.+)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                  }
+                ]
+              }
+            ]
+          }
+          EOF
+          echo "::add-matcher::/tmp/gcc-matcher.json"
+
+      - name: Emit GCC-style errors
+        run: |
+          echo "src/main.c:10:5: error: implicit declaration of function"
+          echo "src/util.c:42:1: warning: unused variable"
+          echo "src/lib.c:99:10: note: expanded from macro"
+
+      - name: Remove GCC matcher
+        run: echo "::remove-matcher owner=gcc::"
+
+      # 6. ANSI color stripping with matcher
+      - name: Create ANSI-aware matcher
+        run: |
+          cat > /tmp/ansi2-matcher.json << 'EOF'
+          {
+            "problemMatcher": [
+              {
+                "owner": "ansi-strip-test",
+                "pattern": [
+                  {
+                    "regexp": "^CRITICAL:\\s+(.+)$",
+                    "message": 1
+                  }
+                ]
+              }
+            ]
+          }
+          EOF
+          echo "::add-matcher::/tmp/ansi2-matcher.json"
+
+      - name: Emit ANSI-colored critical error
+        run: |
+          printf '\033[1;31mCRITICAL: database connection lost\033[0m\n'
+
+      - name: Remove ANSI matcher
+        run: echo "::remove-matcher owner=ansi-strip-test::"
+
+      # 7. Composite action markers (##[start-action] / ##[end-action])
+      - name: Emit and verify marker stripping
+        run: |
+          echo "##[start-action]setup"
+          echo "This is inside a marker block"
+          echo "##[end-action]"
+          echo "Markers should be stripped from runner output processing"
+
+      # 8. Final marker
+      - name: All Docker P0 checks passed
+        run: echo "ALL_P0_DOCKER_CONTAINER_CHECKS_PASSED"

--- a/fixtures/workflows/conformance/p0-failure-conditions.yml
+++ b/fixtures/workflows/conformance/p0-failure-conditions.yml
@@ -1,0 +1,44 @@
+name: P0 Failure Conditions Verification
+on: workflow_dispatch
+jobs:
+  failure-and-always:
+    runs-on: [self-hosted, p0-test]
+    steps:
+      # 1. Intentional failure
+      - name: Intentional failure
+        id: failing
+        run: |
+          echo "About to fail"
+          exit 1
+
+      # 2. success() — should be SKIPPED
+      - name: Should be skipped (success)
+        if: success()
+        run: |
+          echo "BUG: this should not have run"
+          exit 1
+
+      # 3. failure() — should RUN
+      - name: Runs on failure
+        if: failure()
+        run: echo "failure-condition-ran"
+
+      # 4. always() — should RUN
+      - name: Runs always
+        if: always()
+        run: echo "always-condition-ran"
+
+      # 5. Verify steps context
+      - name: Verify failing step outcome
+        if: always()
+        run: |
+          echo "failing.outcome=${{ steps.failing.outcome }}"
+          echo "failing.conclusion=${{ steps.failing.conclusion }}"
+          test "${{ steps.failing.outcome }}" = "failure"
+          test "${{ steps.failing.conclusion }}" = "failure"
+          echo "Steps context verified"
+
+      # 6. Final marker
+      - name: Final marker
+        if: always()
+        run: echo "ALL_P0_FAILURE_CONDITION_CHECKS_PASSED"

--- a/fixtures/workflows/conformance/p0-file-commands.yml
+++ b/fixtures/workflows/conformance/p0-file-commands.yml
@@ -1,0 +1,119 @@
+name: P0 File Commands Verification
+on:
+  workflow_dispatch:
+  push:
+jobs:
+  file-commands:
+    runs-on: [self-hosted, p0-test]
+    steps:
+      # 1. NODE_OPTIONS blocking — GITHUB_ENV must not allow NODE_OPTIONS
+      - name: Attempt to set NODE_OPTIONS via GITHUB_ENV
+        id: node_opts
+        run: |
+          echo "NODE_OPTIONS=--max-old-space-size=4096" >> "$GITHUB_ENV"
+          echo "Wrote NODE_OPTIONS to GITHUB_ENV"
+
+      - name: Verify NODE_OPTIONS was blocked
+        run: |
+          if [ -n "$NODE_OPTIONS" ]; then
+            echo "BUG: NODE_OPTIONS should have been blocked but is set to: $NODE_OPTIONS"
+            exit 1
+          fi
+          echo "NODE_OPTIONS correctly blocked"
+
+      # 2. Heredoc file commands — multi-line values
+      - name: Set multi-line env via heredoc
+        run: |
+          {
+            echo "MULTI_LINE<<HEREDOC_DELIM"
+            echo "line one"
+            echo "line two"
+            echo "HEREDOC_DELIM"
+          } >> "$GITHUB_ENV"
+
+      - name: Verify multi-line env
+        run: |
+          echo "MULTI_LINE=$MULTI_LINE"
+          echo "$MULTI_LINE" | grep -q "line one"
+          echo "$MULTI_LINE" | grep -q "line two"
+          echo "Multi-line heredoc env verified"
+
+      # 3. Step summary size limit — >1MiB should be rejected
+      - name: Write oversized step summary
+        run: |
+          dd if=/dev/zero bs=1024 count=1100 2>/dev/null | tr '\0' 'X' >> "$GITHUB_STEP_SUMMARY"
+          echo "Wrote 1.1MiB to GITHUB_STEP_SUMMARY (should be rejected)"
+
+      # 4. Normal step summary works
+      - name: Write normal step summary
+        run: echo "### P0 File Commands Verified" >> "$GITHUB_STEP_SUMMARY"
+
+      # 5. Problem matcher — add, match, remove
+      - name: Create problem matcher
+        run: |
+          cat > /tmp/p0-matcher.json << 'EOF'
+          {
+            "problemMatcher": [
+              {
+                "owner": "p0-test-matcher",
+                "pattern": [
+                  {
+                    "regexp": "^(.+):(\\d+):(\\d+):\\s+(error|warning):\\s+(.+)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                  }
+                ]
+              }
+            ]
+          }
+          EOF
+          echo "::add-matcher::/tmp/p0-matcher.json"
+
+      - name: Emit lines that match the pattern
+        run: |
+          echo "src/main.rs:42:5: error: unused variable"
+          echo "src/lib.rs:10:1: warning: missing docs"
+          echo "This line should not produce an annotation"
+
+      - name: Remove matcher
+        run: echo "::remove-matcher owner=p0-test-matcher::"
+
+      - name: Lines after removal should not match
+        run: |
+          echo "src/main.rs:99:1: error: this should NOT produce annotation"
+          echo "Matcher removed — no annotation expected"
+
+      # 6. ANSI color stripping in matcher context
+      - name: Create ANSI matcher
+        run: |
+          cat > /tmp/ansi-matcher.json << 'EOF'
+          {
+            "problemMatcher": [
+              {
+                "owner": "ansi-test",
+                "pattern": [
+                  {
+                    "regexp": "^ERROR:\\s+(.+)$",
+                    "message": 1
+                  }
+                ]
+              }
+            ]
+          }
+          EOF
+          echo "::add-matcher::/tmp/ansi-matcher.json"
+
+      - name: Emit ANSI-colored error
+        run: |
+          printf '\033[31mERROR: something went wrong\033[0m\n'
+          echo "ANSI codes should be stripped before matching"
+
+      - name: Remove ANSI matcher
+        run: echo "::remove-matcher owner=ansi-test::"
+
+      # 7. Final marker
+      - name: All file command checks passed
+        run: echo "ALL_P0_FILE_COMMAND_CHECKS_PASSED"

--- a/fixtures/workflows/conformance/p0-step-execution.yml
+++ b/fixtures/workflows/conformance/p0-step-execution.yml
@@ -1,0 +1,58 @@
+name: P0 Step Execution Verification
+on: workflow_dispatch
+jobs:
+  step-semantics:
+    runs-on: [self-hosted, p0-test]
+    steps:
+      # 1. Normal sequential execution
+      - name: Step 1 passes
+        run: echo "step-1-ok"
+
+      - name: Step 2 passes
+        run: echo "step-2-ok"
+
+      # 2. GITHUB_ENV cross-step visibility
+      - name: Set env var
+        run: echo "P0_TEST_VAR=from-github-env" >> "$GITHUB_ENV"
+
+      - name: Use env var
+        run: |
+          echo "P0_TEST_VAR=$P0_TEST_VAR"
+          test "$P0_TEST_VAR" = "from-github-env"
+
+      # 3. GITHUB_OUTPUT cross-step visibility
+      - name: Produce output
+        id: producer
+        run: echo "val=hello-from-producer" >> "$GITHUB_OUTPUT"
+
+      - name: Consume output
+        run: |
+          echo "Got: ${{ steps.producer.outputs.val }}"
+          test "${{ steps.producer.outputs.val }}" = "hello-from-producer"
+
+      # 4. Step env overrides
+      - name: Step env override
+        env:
+          OVERRIDE_TEST: step-level
+        run: test "$OVERRIDE_TEST" = "step-level"
+
+      # 5. continue-on-error — step fails but job continues
+      - name: Soft failure
+        id: soft_fail
+        continue-on-error: true
+        run: exit 1
+
+      - name: Verify continue-on-error outcome
+        run: |
+          echo "outcome=${{ steps.soft_fail.outcome }}"
+          echo "conclusion=${{ steps.soft_fail.conclusion }}"
+          test "${{ steps.soft_fail.outcome }}" = "failure"
+          test "${{ steps.soft_fail.conclusion }}" = "success"
+
+      # 6. Step summary
+      - name: Write step summary
+        run: echo "### P0 Step Execution Verified" >> "$GITHUB_STEP_SUMMARY"
+
+      # 7. Final marker
+      - name: All checks passed
+        run: echo "ALL_P0_STEP_EXECUTION_CHECKS_PASSED"

--- a/fixtures/workflows/conformance/p1-expressions.yml
+++ b/fixtures/workflows/conformance/p1-expressions.yml
@@ -1,0 +1,68 @@
+name: P1 Expressions Verification
+on:
+  workflow_dispatch:
+  push:
+jobs:
+  expressions:
+    runs-on: [self-hosted, p1-test]
+    env:
+      JOB_LEVEL_VAR: from-job
+    steps:
+      # 1. Expression in step env
+      - name: Expression in env
+        env:
+          COMPUTED: ${{ format('hello-{0}', 'world') }}
+        run: test "$COMPUTED" = "hello-world"
+
+      # 2. Ternary / contains
+      - name: Contains function
+        env:
+          HAS_IT: ${{ contains('hello world', 'world') }}
+        run: test "$HAS_IT" = "true"
+
+      # 3. startsWith / endsWith
+      - name: StartsWith and endsWith
+        env:
+          STARTS: ${{ startsWith('hello-world', 'hello') }}
+          ENDS: ${{ endsWith('hello-world', 'world') }}
+        run: |
+          test "$STARTS" = "true"
+          test "$ENDS" = "true"
+
+      # 4. Job env visible in expressions
+      - name: Job env in expression
+        env:
+          GOT_IT: ${{ env.JOB_LEVEL_VAR }}
+        run: test "$GOT_IT" = "from-job"
+
+      # 5. toJSON / fromJSON
+      - name: JSON functions
+        env:
+          JSON_VAL: ${{ toJSON('hello') }}
+        run: |
+          echo "JSON_VAL=$JSON_VAL"
+          test "$JSON_VAL" = '"hello"'
+
+      # 6. success() in default condition
+      - name: Success by default
+        run: echo "default-success-condition-works"
+
+      # 7. Condition with expression
+      - name: True condition runs
+        if: ${{ 1 == 1 }}
+        run: echo "expression-condition-true"
+
+      - name: False condition skips
+        if: ${{ 1 == 2 }}
+        run: |
+          echo "BUG: should not run"
+          exit 1
+
+      # 8. String comparison in condition
+      - name: String condition
+        if: ${{ 'abc' == 'abc' }}
+        run: echo "string-comparison-works"
+
+      # 9. Final
+      - name: All expression checks passed
+        run: echo "ALL_P1_EXPRESSION_CHECKS_PASSED"

--- a/fixtures/workflows/conformance/p1-listener-config.yml
+++ b/fixtures/workflows/conformance/p1-listener-config.yml
@@ -1,0 +1,51 @@
+name: P1 Listener and Config Verification
+on:
+  workflow_dispatch:
+  push:
+jobs:
+  listener-test:
+    runs-on: [self-hosted, p1-test]
+    steps:
+      # The fact that this workflow runs at all proves:
+      # 1. Runner registered successfully (configure)
+      # 2. OAuth token acquired
+      # 3. Broker session created
+      # 4. Job message received via broker
+      # 5. Job acquired via run-service
+      # 6. Worker process spawned
+      # 7. Job executed
+      # 8. Completion reported
+
+      - name: Verify runner context
+        run: |
+          echo "RUNNER_NAME=$RUNNER_NAME"
+          echo "RUNNER_OS=$RUNNER_OS"
+          echo "RUNNER_ARCH=$RUNNER_ARCH"
+          echo "RUNNER_TEMP=$RUNNER_TEMP"
+          test -n "$RUNNER_NAME"
+          test -n "$RUNNER_OS"
+          test -n "$RUNNER_ARCH"
+          echo "Runner context variables populated"
+
+      - name: Verify GitHub context
+        run: |
+          echo "GITHUB_REPOSITORY=$GITHUB_REPOSITORY"
+          echo "GITHUB_WORKFLOW=$GITHUB_WORKFLOW"
+          echo "GITHUB_RUN_ID=$GITHUB_RUN_ID"
+          echo "GITHUB_ACTION=$GITHUB_ACTION"
+          test -n "$GITHUB_REPOSITORY"
+          test -n "$GITHUB_WORKFLOW"
+          test -n "$GITHUB_RUN_ID"
+          echo "GitHub context variables populated"
+
+      - name: Verify workspace
+        run: |
+          echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE"
+          test -d "$GITHUB_WORKSPACE" || mkdir -p "$GITHUB_WORKSPACE"
+          echo "Workspace exists"
+
+      - name: Multi-step proves broker session held
+        run: echo "If this runs, broker session was maintained across steps"
+
+      - name: All listener checks passed
+        run: echo "ALL_P1_LISTENER_CHECKS_PASSED"

--- a/fixtures/workflows/conformance/p1-process-runtime.yml
+++ b/fixtures/workflows/conformance/p1-process-runtime.yml
@@ -1,0 +1,63 @@
+name: P1 Process and Runtime Verification
+on:
+  workflow_dispatch:
+  push:
+jobs:
+  process-tests:
+    runs-on: [self-hosted, p1-test]
+    steps:
+      # 1. Process stdout/stderr streaming
+      - name: Stdout and stderr
+        run: |
+          echo "stdout-line-1"
+          echo "stderr-line-1" >&2
+          echo "stdout-line-2"
+
+      # 2. Working directory
+      - name: Working directory
+        run: |
+          mkdir -p /tmp/p1-workdir-test
+          cd /tmp/p1-workdir-test
+          pwd | grep -q p1-workdir-test
+
+      # 3. Exit code propagation
+      - name: Exit code 0
+        run: exit 0
+
+      - name: Exit code non-zero fails
+        id: fail_exit
+        continue-on-error: true
+        run: exit 42
+
+      - name: After exit code failure
+        run: echo "Job continued after continue-on-error exit 42"
+
+      # 4. Environment propagation
+      - name: Env propagation
+        env:
+          CUSTOM_VAR: custom-value
+          PATH_EXTRA: /custom/bin
+        run: |
+          test "$CUSTOM_VAR" = "custom-value"
+          echo "Env propagation works"
+
+      # 5. Process timeout (step timeout-minutes)
+      - name: Step with timeout
+        timeout-minutes: 1
+        run: echo "step-with-timeout-ran"
+
+      # 6. Long output (streaming test)
+      - name: Long output
+        run: |
+          for i in $(seq 1 100); do echo "line-$i"; done
+          echo "100-lines-output-complete"
+
+      # 7. Workspace directories exist
+      - name: Workspace layout
+        run: |
+          test -d "$RUNNER_TEMP" || test -d "${RUNNER_WORKSPACE:-/tmp}"
+          echo "Workspace layout verified"
+
+      # 8. Final
+      - name: All process checks passed
+        run: echo "ALL_P1_PROCESS_CHECKS_PASSED"

--- a/fixtures/workflows/conformance/p1-protocol.yml
+++ b/fixtures/workflows/conformance/p1-protocol.yml
@@ -1,0 +1,43 @@
+name: P1 Protocol Verification
+on:
+  workflow_dispatch:
+  push:
+jobs:
+  protocol-test:
+    runs-on: [self-hosted, p1-test]
+    steps:
+      # Protocol verification — the fact that these steps execute and
+      # report correctly to GitHub proves the wire protocol works:
+      # - WorkflowStepsUpdate Twirp calls (step status)
+      # - Step log upload (GetStepLogsSignedBlobURL + PUT)
+      # - Job completion (completejob)
+      # - Job log upload
+      # - Annotations via workflow commands
+
+      - name: Create annotation via warning
+        run: echo "::warning file=test.rs,line=42,col=5::This is a test warning"
+
+      - name: Create annotation via error
+        run: echo "::error file=test.rs,line=10::This is a test error"
+
+      - name: Create notice
+        run: echo "::notice::This is a test notice"
+
+      - name: Group output
+        run: |
+          echo "::group::Test Group"
+          echo "Inside the group"
+          echo "::endgroup::"
+
+      - name: Debug output
+        run: echo "::debug::This is debug output"
+
+      - name: Multi-line step with logging
+        run: |
+          for i in $(seq 1 50); do
+            echo "Log line $i"
+          done
+          echo "50 lines logged and uploaded"
+
+      - name: All protocol checks passed
+        run: echo "ALL_P1_PROTOCOL_CHECKS_PASSED"

--- a/fixtures/workflows/conformance/reusable-stress.yml
+++ b/fixtures/workflows/conformance/reusable-stress.yml
@@ -1,0 +1,36 @@
+name: Reusable Workflow Stress Callee
+on:
+  workflow_call:
+    inputs:
+      username:
+        type: string
+        required: true
+      enable_feature:
+        type: boolean
+        required: true
+      max_retries:
+        type: number
+        required: true
+    secrets:
+      api_key:
+        required: true
+      parent_secret:
+        required: false
+    outputs:
+      result:
+        value: ${{ jobs.reusable_job.outputs.out_val }}
+
+jobs:
+  reusable_job:
+    runs-on: [self-hosted, mitm]
+    outputs:
+      out_val: ${{ steps.step1.outputs.step_out }}
+    steps:
+      - id: step1
+        run: |
+          echo "Username is: ${{ inputs.username }}"
+          echo "Feature enabled: ${{ inputs.enable_feature }}"
+          echo "Max retries: ${{ inputs.max_retries }}"
+          echo "Is api_key empty? ${{ secrets.api_key == '' }}"
+          echo "Is parent_secret empty? ${{ secrets.parent_secret == '' }}"
+          echo "step_out=stress-completed" >> "$GITHUB_OUTPUT"

--- a/scripts/audit-node-externals.sh
+++ b/scripts/audit-node-externals.sh
@@ -414,7 +414,9 @@ if [[ "$DISTINCT_COUNT" -gt 0 ]]; then
   python3 - "$DISTINCT_IDS_FILE" "$VULN_DETAILS_DIR" <<'PY'
 import json
 from pathlib import Path
-import subprocess
+import time
+import urllib.request
+import urllib.error
 import sys
 
 ids = [l.strip() for l in Path(sys.argv[1]).read_text().splitlines() if l.strip()]
@@ -422,14 +424,19 @@ outdir = Path(sys.argv[2])
 
 for vid in ids:
     out = outdir / f"{vid}.json"
-    # Try curl with retries
-    try:
-        subprocess.check_call([
-            "curl", "-fsSL", "--retry", "3", "--retry-all-errors",
-            f"https://api.osv.dev/v1/vulns/{vid}"
-        ], stdout=open(out, "wb"))
-    except subprocess.CalledProcessError as e:
-        print(f"failed to fetch vuln {vid}: {e}", file=sys.stderr)
+    url = f"https://api.osv.dev/v1/vulns/{vid}"
+    fetched = False
+    for attempt in range(5):
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": "preloop-audit/1.0"})
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                out.write_bytes(resp.read())
+            fetched = True
+            break
+        except Exception as e:
+            time.sleep(1.5 * (attempt + 1))
+    if not fetched:
+        print(f"ERROR: failed to fetch vulnerability details for {vid} from OSV after 5 attempts; failing closed for supply-chain safety", file=sys.stderr)
         sys.exit(1)
 
 print(f"Fetched {len(ids)} vuln details", file=sys.stderr)


### PR DESCRIPTION
## Summary

This PR captures the full 4-cell matrix for official `actions/runner` v2.337.0 conformance across 27 edge-case workflows (scenarios 201–227) and executes the 5-repo conformance campaign v2 (`cli/cli`, `serde-rs/serde`, `tokio-rs/tokio`, `valkey-io/valkey`, `pydantic/pydantic`).

### Server & Runner Protocol Fixes
1. **Environment Variables TemplateToken Wire Format** (`preloop-runner-server`):
   - Serialized `job.environmentVariables` as official `TemplateToken` mapping structures (`{type: 2, map: [...]}`) rather than raw flat JSON dicts, resolving official runner `The template is not valid. Unexpected value ''` deserialization panics.
2. **Strategy Dispatch Inputs Binding** (`preloop-gha-parser`, `preloop-runner-server`):
   - Exposed `inputs` and `github.event.inputs` into the expression evaluation context during dynamic strategy/matrix expansion.
3. **Orchestration ID Token Sanitization** (`preloop-runner-server`):
   - Sanitized `system.orchestrationId` and job plan tokens by replacing `/`, `\`, and spaces with `-` to avoid .NET `ProductHeaderValue` `FormatException` on reusable workflow job names.
4. **Runner Registration Client ID GUID** (`preloop-runner-server`):
   - Formatted `authorization.clientId` as a deterministic RFC 4122 GUID string for session registration compatibility.
5. **Artifact Scoping by Run ID** (`preloop-runner-server`):
   - Re-scoped internal Twirp artifact registry by `runId` rather than per-job `planId`, enabling cross-job artifact upload/download.
6. **Step Working Directory Pre-creation** (`preloop-runner`):
   - Ensured step custom working directories are created before spawning child shell processes.

### Conformance Deliverables
- 248 LFS golden flow captures (`.runner-watch/golden/v2.337.0/`)
- 27 conformance scenario fixtures (`fixtures/workflows/conformance/`)
- 5-repo campaign v2 report (`benchmarks/real-world/results/v2337-conformance/5REPOS-REPORT.md`)
- Updated fidelity gap documentation (`docs/fidelity-gap.md`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Captures the full `actions/runner` v2.337.0 conformance matrix — 27 edge-case workflows across 4 runner/server cells — and fixes protocol mismatches that broke official-runner workflows against preloop. Jobs that previously panicked on env template parsing, crashed on reusable-workflow job IDs, or failed cross-job artifact lookups now run successfully.

**Server & Runner Protocol Fixes**
- Serializes job environment variables as official `TemplateToken` maps instead of flat JSON dicts, fixing "The template is not valid. Unexpected value ''" panics.
- Binds the actual submission event name and stringifies `github.event.inputs` during dynamic strategy/matrix expansion while preserving typed `inputs.*`.
- Sanitizes `system.orchestrationId` and registers deterministic RFC 4122 GUID client IDs so .NET token and Guid parsing no longer throws.
- Scopes the artifact registry by run ID instead of per-job plan ID, migrates legacy keys on startup, and rejects duplicate artifact names with 409 so cross-job lookups resolve.
- Pre-creates step custom working directories before spawning child shells.

**Conformance Deliverables**
- Adds 27 workflow fixtures, 248 LFS golden captures (~234 MB), and the 5-repo campaign v2 report.
- Updates `docs/fidelity-gap.md` with 23/27 exact-match results and remaining divergences.
- Updates runner-watch to discover scenarios inside nested cell directories and to filter a single scenario under `gh-official`.
- Skips Pullfrog reviews when only docs, markdown, or golden captures change, and hardens the skip filter against shell injection.
- Adds npm/npx wrappers to the runner `PATH`, ignores `.pi/` scratch files, tolerates third-party token-refresh failures, and makes OSV supply-chain fetches resilient with exponential backoff.
- Stops the release workflow from running on pull requests.

<sup>Written for commit b6141d95a4101aabee65c2201483e8402c554de4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

