### PR TITLE
fix(server): own step identity and order from the job request message

### DIFF
--- a/crates/preloop-gha-protocol/src/lib.rs
+++ b/crates/preloop-gha-protocol/src/lib.rs
@@ -696,6 +696,15 @@ pub struct JobCompletion {
     pub run_id: RunId,
     /// Job id.
     pub job_id: JobId,
+    /// The attempt this completion belongs to, when the caller resolved one.
+    ///
+    /// A job can be dispatched more than once, and each dispatch mints its own
+    /// step ids. `(run_id, job_id)` names the logical job, not the attempt, so
+    /// it cannot decide which attempt's step records a report belongs to.
+    /// Callers that already hold the request record supply this; the server
+    /// falls back to the newest attempt when it is absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_job_id: Option<uuid::Uuid>,
     /// Final status.
     pub status: ExecutionStatus,
     /// Outputs captured by the runner.

--- a/crates/preloop-runner-server/src/bootstrap.rs
+++ b/crates/preloop-runner-server/src/bootstrap.rs
@@ -397,6 +397,11 @@ pub(crate) async fn reap_once(shared: &Arc<SharedState>) {
                     JobCompletion {
                         run_id,
                         job_id: job_id.clone(),
+                        // The lease that expired names the attempt exactly.
+                        agent_job_id: inner
+                            .job_requests
+                            .get(&request_id)
+                            .map(|record| record.agent_job_id),
                         status: ExecutionStatus::Failure,
                         outputs: Default::default(),
                         annotations: Vec::new(),

--- a/crates/preloop-runner-server/src/broker.rs
+++ b/crates/preloop-runner-server/src/broker.rs
@@ -1111,6 +1111,13 @@ async fn fail_unclaimable_request(shared: &Arc<SharedState>, request_id: i64) {
         let completion = JobCompletion {
             run_id,
             job_id,
+            agent_job_id: {
+                let inner = shared.state.inner.lock().await;
+                inner
+                    .job_requests
+                    .get(&request_id)
+                    .map(|record| record.agent_job_id)
+            },
             status: ExecutionStatus::Failure,
             outputs: preloop_gha_protocol::OutputMap::new(),
             annotations: Vec::new(),
@@ -1435,6 +1442,12 @@ pub(crate) async fn broker_complete_job(
                 Some(JobCompletion {
                     run_id,
                     job_id,
+                    // This request *is* the attempt that finished, so the
+                    // server never has to guess which dispatch reported.
+                    agent_job_id: inner
+                        .job_requests
+                        .get(&request_id)
+                        .map(|record| record.agent_job_id),
                     status,
                     outputs,
                     annotations: request.annotations.clone(),

--- a/crates/preloop-runner-server/src/distributed_task.rs
+++ b/crates/preloop-runner-server/src/distributed_task.rs
@@ -639,46 +639,22 @@ pub(crate) async fn complete_job_inner(
         };
         run.jobs.insert(completion.job_id.clone(), effective);
         let job_name = completion.job_id.0.clone();
-        if let Some(pos) = run.jobs_list.iter().position(|j| j.name == job_name) {
-            run.jobs_list[pos].conclusion = format!("{:?}", effective).to_lowercase();
-            // A worker can terminate through ForceFailJob before it sends the
-            // final WorkflowStepsUpdate. Do not leave the last reported step
-            // in_progress after its job is terminal.
-            //
-            // The official runner carries the authoritative per-step
-            // conclusions in CompleteJob.stepResults (status=TimelineRecordState,
-            // conclusion=TaskResult); apply them first. A crashed worker sends
-            // none, and any step still in_progress after that is reconciled to
-            // the job's effective status — the same view GitHub's server
-            // presents for orphaned steps.
-            for step in &mut run.jobs_list[pos].steps {
-                let Some(wire) = completion
-                    .step_results
-                    .iter()
-                    .find(|result| result.name.as_deref() == Some(step.name.as_str()))
-                else {
-                    continue;
-                };
-                if let Some(conclusion) = completion_step_conclusion(wire) {
-                    step.conclusion = conclusion;
-                }
-            }
-            let step_conclusion = status_string(effective);
-            for step in &mut run.jobs_list[pos].steps {
-                if step.conclusion == "in_progress" {
-                    step.conclusion = step_conclusion.clone();
-                    step.finished_at = step.finished_at.or(Some(chrono::Utc::now()));
-                }
-            }
+        // Masked up front: `mask_completion_annotations` reads the run's
+        // secrets, which cannot be borrowed while a job detail inside the same
+        // run is held mutably.
+        let annotations = mask_completion_annotations(run, &completion);
+        if let Some(detail) = JobDetail::find(&mut run.jobs_list, &job_name) {
+            detail.conclusion = format!("{:?}", effective).to_lowercase();
             if !completion.annotations.is_empty() {
-                run.jobs_list[pos].annotations = mask_completion_annotations(run, &completion);
+                detail.annotations = annotations;
             }
         } else {
             run.jobs_list.push(JobDetail {
+                job_id: job_name.clone(),
                 name: job_name,
                 conclusion: format!("{:?}", effective).to_lowercase(),
                 steps: Vec::new(),
-                annotations: mask_completion_annotations(run, &completion),
+                annotations,
             });
         }
         run.job_outputs.insert(
@@ -725,6 +701,46 @@ pub(crate) async fn complete_job_inner(
         .get(&completion.run_id)
         .and_then(|r| r.jobs.get(&completion.job_id).copied())
         .unwrap_or(completion.status);
+    // Reconcile the attempt's step manifest against the completion report.
+    //
+    // The official runner carries the authoritative per-step conclusions in
+    // `CompleteJob.stepResults` (status=TimelineRecordState,
+    // conclusion=TaskResult) keyed by `external_id` — the same identity the
+    // manifest uses, so this no longer matches on display names. A crashed
+    // worker sends none, and any step left `in_progress` afterwards is
+    // reconciled to the job's effective status, the view GitHub presents for
+    // orphaned steps. A step still `pending` was never reached, which stays
+    // truthful rather than inheriting the job's failure.
+    if let Some(agent_job_id) = inner
+        .job_requests
+        .values()
+        .find(|record| record.run_id == completion.run_id && record.job_id == completion.job_id)
+        .map(|record| record.agent_job_id)
+    {
+        if let Some(manifest) = inner.job_steps.get_mut(&agent_job_id) {
+            for wire in &completion.step_results {
+                let Some(external_id) = wire.external_id.as_deref() else {
+                    continue;
+                };
+                let Some(pos) = StepRecord::find_by_id(manifest, external_id) else {
+                    continue;
+                };
+                if let Some(conclusion) = completion_step_conclusion(wire) {
+                    manifest[pos].conclusion = conclusion;
+                }
+                if let Some(number) = wire.number.and_then(|n| u32::try_from(n).ok()) {
+                    manifest[pos].runner_number = Some(number);
+                }
+            }
+            let orphan_conclusion = status_string(effective_status);
+            for step in manifest.iter_mut() {
+                if step.conclusion == "in_progress" {
+                    step.conclusion = orphan_conclusion.clone();
+                    step.finished_at = step.finished_at.or(Some(chrono::Utc::now()));
+                }
+            }
+        }
+    }
     let cancelled_siblings = if effective_status == ExecutionStatus::Failure {
         apply_matrix_fail_fast(&mut inner, completion.run_id, &completion.job_id)
     } else {

--- a/crates/preloop-runner-server/src/distributed_task.rs
+++ b/crates/preloop-runner-server/src/distributed_task.rs
@@ -742,6 +742,7 @@ pub(crate) async fn complete_job_inner(
     // in-flight. When the caller could not resolve an attempt, the newest
     // request is the only defensible guess.
     let mut completed_attempt: Option<(uuid::Uuid, Vec<StepRecord>)> = None;
+    let mut completion_revision = 0_u64;
     if let Some(agent_job_id) = completion.agent_job_id.or_else(|| {
         inner
             .job_requests
@@ -775,6 +776,9 @@ pub(crate) async fn complete_job_inner(
                 }
             }
             completed_attempt = Some((agent_job_id, manifest.clone()));
+            let counter = inner.job_steps_revision.entry(agent_job_id).or_insert(0);
+            *counter += 1;
+            completion_revision = *counter;
         }
     }
     let cancelled_siblings = if effective_status == ExecutionStatus::Failure {
@@ -854,7 +858,12 @@ pub(crate) async fn complete_job_inner(
         if let Err(error) = shared
             .state
             .store
-            .store_job_steps(completion.run_id, agent_job_id, &records)
+            .store_job_steps(
+                completion.run_id,
+                agent_job_id,
+                &records,
+                completion_revision,
+            )
             .await
         {
             warn!(?error, run_id = %completion.run_id, "failed to persist completion step records");

--- a/crates/preloop-runner-server/src/distributed_task.rs
+++ b/crates/preloop-runner-server/src/distributed_task.rs
@@ -741,6 +741,7 @@ pub(crate) async fn complete_job_inner(
     // attempt's steps while the run view still projected the newer one as
     // in-flight. When the caller could not resolve an attempt, the newest
     // request is the only defensible guess.
+    let mut completed_attempt: Option<(uuid::Uuid, Vec<StepRecord>)> = None;
     if let Some(agent_job_id) = completion.agent_job_id.or_else(|| {
         inner
             .job_requests
@@ -773,6 +774,7 @@ pub(crate) async fn complete_job_inner(
                     step.finished_at = step.finished_at.or(Some(chrono::Utc::now()));
                 }
             }
+            completed_attempt = Some((agent_job_id, manifest.clone()));
         }
     }
     let cancelled_siblings = if effective_status == ExecutionStatus::Failure {
@@ -845,6 +847,19 @@ pub(crate) async fn complete_job_inner(
     inner.dap_ports.remove(&completion.run_id);
     let queue_nonempty = !inner.queue.is_empty() || !inner.cancellation_queue.is_empty();
     drop(inner);
+    // Best-effort, outside the lock: the completion's own step conclusions
+    // must survive a restart, and the run-event projection deliberately no
+    // longer carries step rows.
+    if let Some((agent_job_id, records)) = completed_attempt {
+        if let Err(error) = shared
+            .state
+            .store
+            .store_job_steps(completion.run_id, agent_job_id, &records)
+            .await
+        {
+            warn!(?error, run_id = %completion.run_id, "failed to persist completion step records");
+        }
+    }
 
     // Any reusable-caller or dynamic-matrix node the sweep above unblocked was
     // deferred rather than expanded under the lock. Build those subtrees now

--- a/crates/preloop-runner-server/src/distributed_task.rs
+++ b/crates/preloop-runner-server/src/distributed_task.rs
@@ -284,6 +284,9 @@ pub(crate) async fn complete_job_compat(
         JobCompletion {
             run_id,
             job_id: JobId(job_id),
+            // The compat route is addressed by logical job only, so the
+            // server resolves the newest attempt itself.
+            agent_job_id: None,
             status,
             outputs: Default::default(),
             annotations: Vec::new(),
@@ -392,6 +395,11 @@ pub(crate) async fn agent_request_patch(
                 Some(JobCompletion {
                     run_id,
                     job_id,
+                    // The patched request is the attempt that reported.
+                    agent_job_id: inner
+                        .job_requests
+                        .get(&request_id)
+                        .map(|record| record.agent_job_id),
                     status: new_status,
                     outputs: Default::default(),
                     annotations: Vec::new(),
@@ -688,11 +696,24 @@ pub(crate) async fn complete_job_inner(
     }
     // Close only after the run and job were validated and the completion was
     // projected. Invalid callbacks must not terminate another job's feed.
-    let live_log_key = inner
-        .job_requests
-        .values()
-        .find(|record| record.run_id == completion.run_id && record.job_id == completion.job_id)
-        .map(|record| record.agent_job_id.to_string())
+    //
+    // Same attempt selection as the manifest reconciliation below: a
+    // re-dispatched job has several matching requests, and closing the oldest
+    // one's feed leaves the attempt that actually finished streaming forever
+    // while a follower on the dead key waits for output that never comes.
+    let live_log_key = completion
+        .agent_job_id
+        .or_else(|| {
+            inner
+                .job_requests
+                .values()
+                .filter(|record| {
+                    record.run_id == completion.run_id && record.job_id == completion.job_id
+                })
+                .max_by_key(|record| record.request_id)
+                .map(|record| record.agent_job_id)
+        })
+        .map(|agent_job_id| agent_job_id.to_string())
         .unwrap_or_else(|| completion.job_id.0.clone());
     crate::live_logs::close_live_log(&mut inner, &live_log_key);
     // Use the status actually stored (may differ from completion if terminal-locked).
@@ -711,12 +732,25 @@ pub(crate) async fn complete_job_inner(
     // reconciled to the job's effective status, the view GitHub presents for
     // orphaned steps. A step still `pending` was never reached, which stays
     // truthful rather than inheriting the job's failure.
-    if let Some(agent_job_id) = inner
-        .job_requests
-        .values()
-        .find(|record| record.run_id == completion.run_id && record.job_id == completion.job_id)
-        .map(|record| record.agent_job_id)
-    {
+    //
+    // The attempt comes from the callback itself. Deriving it from
+    // `(run_id, job_id)` picked whichever request the map yielded first, and
+    // `job_requests` is keyed by monotonic request id — so a re-dispatched job
+    // reconciled the *newest* attempt's report into the *oldest* attempt's
+    // manifest, where its ids match nothing, and terminalized that older
+    // attempt's steps while the run view still projected the newer one as
+    // in-flight. When the caller could not resolve an attempt, the newest
+    // request is the only defensible guess.
+    if let Some(agent_job_id) = completion.agent_job_id.or_else(|| {
+        inner
+            .job_requests
+            .values()
+            .filter(|record| {
+                record.run_id == completion.run_id && record.job_id == completion.job_id
+            })
+            .max_by_key(|record| record.request_id)
+            .map(|record| record.agent_job_id)
+    }) {
         if let Some(manifest) = inner.job_steps.get_mut(&agent_job_id) {
             for wire in &completion.step_results {
                 let Some(external_id) = wire.external_id.as_deref() else {

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -2843,12 +2843,16 @@ async fn log_run_logs_unknown_job_is_404_not_whole_run() {
     );
 }
 
-/// Step manifests survive a restart, so `--step` still resolves.
+/// A runner report persists the attempt, so a restart keeps step state.
 ///
-/// They deliberately do not ride in `runs.record_blob` (which reseals the
-/// workflow YAML and event payload on every run event) nor in `MetaSnapshot`
-/// (every field of which is sealed on each `store_meta_only`), so this proves
-/// the `job_steps` table actually round-trips them.
+/// Step records deliberately do not ride in `runs.record_blob` (which reseals
+/// the workflow YAML and event payload on every run event) nor in
+/// `MetaSnapshot` (every field of which is sealed on each `store_meta_only`),
+/// and the run-event projection no longer carries them at all. The only thing
+/// that persists them is `store_job_steps`, called from the reconciliation
+/// paths — so this drives a real `WorkflowStepsUpdate` rather than forcing a
+/// snapshot, which is what makes it a regression test for losing step
+/// conclusions across a restart.
 #[tokio::test]
 async fn step_manifests_survive_a_restart() {
     let temp = tempfile::tempdir().unwrap();
@@ -2858,14 +2862,27 @@ async fn step_manifests_survive_a_restart() {
         let (run_id, jobs) = three_step_run_for_log_filters(&app, &state).await;
         let ids = workflow_step_ids(&state, run_id, "build").await;
         assert_eq!(ids.len(), 3);
-        // Force the full snapshot so the rows exist regardless of which run
-        // events happened to fire during submission.
-        let snapshot = {
-            let inner = state.inner.lock().await;
-            crate::store::StoreSnapshot::from_inner(&inner)
-        };
-        state.store.store_inner(&snapshot).await.unwrap();
-        (run_id, jobs[0].1.clone(), jobs[0].2.clone(), ids)
+        let (plan_id, agent_job_id) = (jobs[0].1.clone(), jobs[0].2.clone());
+
+        let response = request_json(
+            &app,
+            Method::POST,
+            "/twirp/github.actions.results.api.v1.WorkflowStepUpdateService/WorkflowStepsUpdate",
+            json!({
+                "workflow_run_backend_id": plan_id,
+                "workflow_job_run_backend_id": agent_job_id,
+                "steps": [{
+                    "external_id": ids[1],
+                    "number": 3,
+                    "name": "Run echo two",
+                    "status": 6,
+                    "conclusion": 2
+                }]
+            }),
+        )
+        .await;
+        assert_eq!(response["ok"], true);
+        (run_id, plan_id, agent_job_id, ids)
     };
 
     // A fresh AppState over the same state dir is the restart.
@@ -2876,6 +2893,18 @@ async fn step_manifests_survive_a_restart() {
         restored, ids,
         "declared step ids and their order must come back intact"
     );
+
+    // The reported conclusion came back too, not just the identities.
+    {
+        let inner = state.inner.lock().await;
+        let records = &inner.job_steps[&agent_job_id.parse::<uuid::Uuid>().unwrap()];
+        let reported = records
+            .iter()
+            .find(|step| step.id == ids[1])
+            .expect("the reported step must be restored");
+        assert_eq!(reported.conclusion, "success");
+        assert_eq!(reported.runner_number, Some(3));
+    }
 
     write_step_job_logs(
         &temp,

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -2843,6 +2843,49 @@ async fn log_run_logs_unknown_job_is_404_not_whole_run() {
     );
 }
 
+/// A restart before the first step report keeps the declared steps.
+///
+/// Only a runner report writes step rows, so an attempt dispatched and then
+/// interrupted has none. Its request message is persisted, and that message is
+/// what the manifest was built from, so startup rebuilds it — otherwise the
+/// run loses its declared steps and `--step` answers 409 for blobs that are
+/// sitting on disk.
+#[tokio::test]
+async fn dispatched_but_unreported_manifests_are_rebuilt_on_restart() {
+    let temp = tempfile::tempdir().unwrap();
+    let (run_id, plan_id, agent_job_id, ids) = {
+        let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+        let app = app(state.clone(), CancellationToken::new());
+        let (run_id, jobs) = three_step_run_for_log_filters(&app, &state).await;
+        let ids = workflow_step_ids(&state, run_id, "build").await;
+        // Deliberately no forced snapshot: `store_inner` writes step rows,
+        // which would persist the manifest and make the rebuild moot. The real
+        // window is a submission persisted only by its run events, which carry
+        // the run, the requests and the broker message but never steps.
+        (run_id, jobs[0].1.clone(), jobs[0].2.clone(), ids)
+    };
+
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    assert_eq!(
+        workflow_step_ids(&state, run_id, "build").await,
+        ids,
+        "declared steps must be rebuilt from the persisted request message"
+    );
+
+    write_step_job_logs(
+        &temp,
+        &plan_id,
+        &agent_job_id,
+        &[(ids[2].as_str(), "third step\n")],
+    )
+    .await;
+    let (status, body) =
+        get_logs(&app, format!("/api/v1/runs/{run_id}/logs?job=build&step=3")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, b"third step\n", "`--step` must resolve after restart");
+}
+
 /// The AzDO timeline path orders synthetic steps and ignores the job record.
 ///
 /// `TimelineRecord` carries no ordinal, so a synthetic step reported this way

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -2893,6 +2893,90 @@ async fn step_manifests_survive_a_restart() {
     );
 }
 
+/// A completion reconciles the attempt that actually reported.
+///
+/// `job_requests` is keyed by monotonic request id, so picking the first match
+/// for `(run_id, job_id)` selects the *oldest* dispatch. A re-dispatched job
+/// then applied the new attempt's `external_id`s to the previous attempt's
+/// manifest — matching nothing — and terminalized that older attempt's steps
+/// while the run view still projected the newer one as in-flight.
+#[tokio::test]
+async fn completion_reconciles_the_reporting_attempt_not_the_oldest() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, _) = two_job_run_for_log_filters(&app, &state).await;
+    let first_ids = workflow_step_ids(&state, run_id, "build").await;
+    let first_step_id = first_ids[0].clone();
+
+    // Re-dispatch: a newer request, its own agent job id, its own step ids.
+    let (first_agent_job_id, second_agent_job_id, second_step_id) = {
+        let mut inner = state.inner.lock().await;
+        let mut record = inner
+            .job_requests
+            .values()
+            .find(|request| request.run_id == run_id && request.job_id.0 == "build")
+            .cloned()
+            .expect("first attempt must exist");
+        let first_agent_job_id = record.agent_job_id;
+        let request_id = inner.job_requests.keys().copied().max().unwrap_or(0) + 1;
+        let agent_job_id = uuid::Uuid::new_v4();
+        record.request_id = request_id;
+        record.agent_job_id = agent_job_id;
+        record.plan_id = uuid::Uuid::new_v4().to_string();
+        record.result = None;
+        let step_id = uuid::Uuid::new_v4().to_string();
+        inner.job_steps.insert(
+            agent_job_id,
+            vec![crate::models::StepRecord::workflow(
+                step_id.clone(),
+                0,
+                "Run echo build".to_owned(),
+                Some("__run".to_owned()),
+            )],
+        );
+        inner.agent_job_requests.insert(agent_job_id, request_id);
+        inner.job_requests.insert(request_id, record);
+        (first_agent_job_id, agent_job_id, step_id)
+    };
+
+    let _ = crate::distributed_task::complete_job_inner(
+        state.shared(),
+        preloop_gha_protocol::JobCompletion {
+            run_id,
+            job_id: preloop_gha_protocol::JobId("build".to_owned()),
+            agent_job_id: Some(second_agent_job_id),
+            status: ExecutionStatus::Success,
+            outputs: Default::default(),
+            annotations: Vec::new(),
+            step_results: vec![preloop_gha_protocol::CompletionStepResult {
+                external_id: Some(second_step_id.clone()),
+                number: Some(2),
+                name: Some("Run echo build".to_owned()),
+                status: Some(serde_json::json!("completed")),
+                conclusion: Some(serde_json::json!("skipped")),
+            }],
+        },
+    )
+    .await;
+
+    let inner = state.inner.lock().await;
+    let reporting = &inner.job_steps[&second_agent_job_id];
+    assert_eq!(
+        reporting[0].conclusion, "skipped",
+        "the reporting attempt takes the completion's step conclusion"
+    );
+    let earlier = &inner.job_steps[&first_agent_job_id];
+    assert_eq!(
+        earlier[0].id, first_step_id,
+        "the earlier attempt keeps its own step identity"
+    );
+    assert_eq!(
+        earlier[0].conclusion, "pending",
+        "a completion for one attempt must not terminalize another's steps"
+    );
+}
+
 /// A second dispatch of the same job gets its own manifest.
 ///
 /// `build_task_step` mints a fresh `TaskStep` id per build, so a job-scoped
@@ -3300,6 +3384,7 @@ async fn complete_job(state: &AppState, run_id: RunId, job_id: &str, status: Exe
         preloop_gha_protocol::JobCompletion {
             run_id,
             job_id: preloop_gha_protocol::JobId(job_id.to_owned()),
+            agent_job_id: None,
             status,
             outputs: Default::default(),
             annotations: Vec::new(),

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -3005,8 +3005,10 @@ jobs:
         inner.job_steps.len()
     };
 
-    // Finish `gen` with a matrix so the deferred node expands.
-    let _ = crate::distributed_task::complete_job_inner(
+    // Finish `gen` with a matrix so the deferred node expands. The result is
+    // propagated: swallowing it let this test pass without ever completing the
+    // job, checking orphans against a run that never expanded.
+    let _completed = crate::distributed_task::complete_job_inner(
         state.shared(),
         preloop_gha_protocol::JobCompletion {
             run_id,
@@ -3020,9 +3022,23 @@ jobs:
             step_results: Vec::new(),
         },
     )
-    .await;
+    .await
+    .expect("completing gen must succeed");
 
     let inner = state.inner.lock().await;
+    // The placeholder must actually be gone, replaced by one leg per matrix
+    // value. Without this the orphan check below could pass vacuously.
+    let legs: Vec<&str> = inner
+        .job_requests
+        .values()
+        .filter(|record| record.run_id == run_id && record.job_id.0.starts_with("fan"))
+        .map(|record| record.job_id.0.as_str())
+        .collect();
+    assert_eq!(
+        legs.len(),
+        2,
+        "the deferred node must expand into two legs, got {legs:?}"
+    );
     // Every retained manifest must belong to a request that still exists.
     let live: std::collections::BTreeSet<uuid::Uuid> = inner
         .job_requests

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -3272,12 +3272,29 @@ async fn step_manifests_are_scoped_per_job_attempt() {
         (plan_id, agent_job_id.to_string(), step_id)
     };
 
-    // The first attempt keeps its own mapping.
+    // The run API — not an internal helper — must show the newest attempt's
+    // steps. Asserting through `workflow_step_ids` alone could not detect a
+    // stale projection, because it reads the same map the projection reads.
+    let run = get_run_json(&app, &run_id.to_string()).await;
+    let projected: Vec<&str> = run["jobs_list"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|detail| detail["job_id"] == "build")
+        .expect("build must be in the run record")["steps"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|step| step["id"].as_str().unwrap_or_default())
+        .collect();
     assert_eq!(
-        workflow_step_ids(&state, run_id, "build").await,
-        vec![second_step_id.clone()],
-        "the run record follows the newest attempt"
+        projected,
+        vec![second_step_id.as_str()],
+        "the run record must project the newest attempt, not the first"
     );
+
+    // The earlier attempt keeps its own mapping, which is what makes its
+    // already-uploaded `step-<id>.txt` blobs still reachable.
     {
         let inner = state.inner.lock().await;
         let first_agent_job_id: uuid::Uuid = jobs[0].2.parse().unwrap();

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -3217,15 +3217,17 @@ async fn log_run_logs_step_without_job_in_multi_job_run_is_ambiguous() {
 }
 
 #[tokio::test]
-async fn log_run_logs_step_filter_works_on_live_console_blocks() {
+async fn log_run_logs_step_filter_refuses_live_console_blocks() {
     let temp = tempfile::tempdir().unwrap();
     let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
     let app = app(state.clone(), CancellationToken::new());
     let (run_id, jobs) = two_job_run_for_log_filters(&app, &state).await;
 
-    // Nothing on disk yet — a job still in flight streams numbered console
-    // blocks, one per step, and `--step` must work against those too.
-    for (log_id, body) in [("2", "live step two\n"), ("10", "live step ten\n")] {
+    // Nothing on disk yet: a job still in flight streams console blocks keyed
+    // by the runner's numeric log id. Those ids count every record the runner
+    // opened, `Set up job` among them, so they are not declared-step
+    // positions — block "2" is not step 1.
+    for (log_id, body) in [("2", "live block two\n"), ("10", "live block ten\n")] {
         let plan = &jobs[0].1;
         let response = app
             .clone()
@@ -3242,16 +3244,22 @@ async fn log_run_logs_step_filter_works_on_live_console_blocks() {
         assert_eq!(response.status(), StatusCode::ACCEPTED);
     }
 
-    // Numeric console-log order, not lexicographic: 2 precedes 10.
+    // Refusing beats guessing: indexing these blocks is the same numbering
+    // error `--step` was fixed to remove for durable blobs.
     let (status, body) =
         get_logs(&app, format!("/api/v1/runs/{run_id}/logs?job=build&step=1")).await;
-    assert_eq!(status, StatusCode::OK);
-    assert_eq!(body, b"live step two\n");
+    assert_eq!(status, StatusCode::CONFLICT);
+    let message = String::from_utf8_lossy(&body);
+    assert!(
+        message.contains("has not uploaded per-step logs yet"),
+        "the error must say why the step cannot be identified: {message}"
+    );
 
-    let (status, body) =
-        get_logs(&app, format!("/api/v1/runs/{run_id}/logs?job=build&step=2")).await;
+    // The whole-job read still serves the streamed output, in numeric console
+    // order rather than lexicographic: 2 precedes 10.
+    let (status, body) = get_logs(&app, format!("/api/v1/runs/{run_id}/logs?job=build")).await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(body, b"live step ten\n");
+    assert_eq!(body, b"live block two\nlive block ten\n");
 }
 
 #[tokio::test]

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -2650,6 +2650,76 @@ jobs:
     (run_id, jobs)
 }
 
+/// Build a run whose `build` job declares three steps.
+///
+/// Step-filter tests need more than one declared step to prove `--step N`
+/// selects the right one.
+async fn three_step_run_for_log_filters(
+    app: &axum::Router,
+    state: &AppState,
+) -> (RunId, Vec<(String, String, String)>) {
+    let accepted = submit_yaml(
+        app,
+        r#"
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo one
+      - run: echo two
+      - run: echo three
+"#,
+        "owner/repo",
+    )
+    .await;
+    let run_id: RunId = accepted["run_id"].as_str().unwrap().parse().unwrap();
+    let jobs = {
+        let inner = state.inner.lock().await;
+        inner
+            .job_requests
+            .values()
+            .filter(|request| request.run_id == run_id)
+            .map(|request| {
+                (
+                    request.job_id.0.clone(),
+                    request.plan_id.clone(),
+                    request.agent_job_id.to_string(),
+                )
+            })
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(jobs.len(), 1, "fixture must produce one job");
+    (run_id, jobs)
+}
+
+/// The declared workflow step ids of a job's latest attempt, in workflow order.
+///
+/// Tests must name their `step-<id>.txt` blobs with these ids and report them
+/// as `external_id`: that is what the official runner does (verified in
+/// `.runner-watch/golden/v2.336.0/06-multi-step`), and the server resolves
+/// `?step=` through this manifest rather than through anything on disk.
+async fn workflow_step_ids(state: &AppState, run_id: RunId, job: &str) -> Vec<String> {
+    let inner = state.inner.lock().await;
+    let agent_job_id = inner
+        .job_requests
+        .values()
+        .filter(|request| request.run_id == run_id && request.job_id.0 == job)
+        .max_by_key(|request| request.request_id)
+        .map(|request| request.agent_job_id)
+        .expect("job must have been dispatched");
+    inner
+        .job_steps
+        .get(&agent_job_id)
+        .map(|records| {
+            crate::models::StepRecord::workflow_steps(records)
+                .into_iter()
+                .map(|step| step.id.clone())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 async fn get_logs(app: &axum::Router, uri: String) -> (StatusCode, Vec<u8>) {
     let response = app
         .clone()
@@ -2773,20 +2843,109 @@ async fn log_run_logs_unknown_job_is_404_not_whole_run() {
     );
 }
 
+/// A second dispatch of the same job gets its own manifest.
+///
+/// `build_task_step` mints a fresh `TaskStep` id per build, so a job-scoped
+/// manifest would overwrite the mapping the first attempt's `step-<id>.txt`
+/// blobs are named after, and that attempt's logs would become unreachable.
+/// Keying by `agent_job_id` keeps both attempts resolvable.
+#[tokio::test]
+async fn step_manifests_are_scoped_per_job_attempt() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, jobs) = two_job_run_for_log_filters(&app, &state).await;
+    let first_ids = workflow_step_ids(&state, run_id, "build").await;
+    assert_eq!(first_ids.len(), 1);
+
+    // Simulate a re-dispatch: a new attempt with a new agent job id and new
+    // step ids, exactly as a fresh `build_job_artifacts` would produce.
+    let (second_plan_id, second_agent_job_id, second_step_id) = {
+        let mut inner = state.inner.lock().await;
+        let mut record = inner
+            .job_requests
+            .values()
+            .find(|request| request.run_id == run_id && request.job_id.0 == "build")
+            .cloned()
+            .expect("first attempt must exist");
+        let request_id = inner.job_requests.keys().copied().max().unwrap_or(0) + 1;
+        let agent_job_id = uuid::Uuid::new_v4();
+        record.request_id = request_id;
+        record.agent_job_id = agent_job_id;
+        record.plan_id = uuid::Uuid::new_v4().to_string();
+        let step_id = uuid::Uuid::new_v4().to_string();
+        inner.job_steps.insert(
+            agent_job_id,
+            vec![crate::models::StepRecord::workflow(
+                step_id.clone(),
+                0,
+                "Run echo build".to_owned(),
+                Some("__run".to_owned()),
+            )],
+        );
+        let plan_id = record.plan_id.clone();
+        inner.agent_job_requests.insert(agent_job_id, request_id);
+        inner.job_requests.insert(request_id, record);
+        (plan_id, agent_job_id.to_string(), step_id)
+    };
+
+    // The first attempt keeps its own mapping.
+    assert_eq!(
+        workflow_step_ids(&state, run_id, "build").await,
+        vec![second_step_id.clone()],
+        "the run record follows the newest attempt"
+    );
+    {
+        let inner = state.inner.lock().await;
+        let first_agent_job_id: uuid::Uuid = jobs[0].2.parse().unwrap();
+        let retained = inner
+            .job_steps
+            .get(&first_agent_job_id)
+            .expect("the earlier attempt's manifest must survive the re-dispatch");
+        assert_eq!(retained[0].id, first_ids[0]);
+    }
+
+    // Both attempts' logs resolve, each through its own manifest.
+    write_step_job_logs(
+        &temp,
+        &jobs[0].1,
+        &jobs[0].2,
+        &[(first_ids[0].as_str(), "first attempt\n")],
+    )
+    .await;
+    write_step_job_logs(
+        &temp,
+        &second_plan_id,
+        &second_agent_job_id,
+        &[(second_step_id.as_str(), "second attempt\n")],
+    )
+    .await;
+    let (status, body) =
+        get_logs(&app, format!("/api/v1/runs/{run_id}/logs?job=build&step=1")).await;
+    assert_eq!(status, StatusCode::OK);
+    let text = String::from_utf8_lossy(&body);
+    assert!(
+        text.contains("first attempt") && text.contains("second attempt"),
+        "each attempt resolves step 1 through its own manifest: {text}"
+    );
+}
+
 #[tokio::test]
 async fn log_run_logs_step_filter_selects_one_step() {
     let temp = tempfile::tempdir().unwrap();
     let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
     let app = app(state.clone(), CancellationToken::new());
-    let (run_id, jobs) = two_job_run_for_log_filters(&app, &state).await;
+    let (run_id, jobs) = three_step_run_for_log_filters(&app, &state).await;
+    let ids = workflow_step_ids(&state, run_id, "build").await;
+    assert_eq!(ids.len(), 3, "manifest must carry the three declared steps");
     write_step_job_logs(
         &temp,
         &jobs[0].1,
         &jobs[0].2,
         &[
-            ("a", "step one\n"),
-            ("b", "step two\n"),
-            ("c", "step three\n"),
+            (ids[0].as_str(), "step one\n"),
+            (ids[1].as_str(), "step two\n"),
+            (ids[2].as_str(), "step three\n"),
         ],
     )
     .await;
@@ -2808,38 +2967,19 @@ async fn log_run_logs_step_filter_uses_workflow_step_ids() {
     let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
     let app = app(state.clone(), CancellationToken::new());
     let (run_id, jobs) = two_job_run_for_log_filters(&app, &state).await;
-    let workflow_step_id = {
-        let mut inner = state.inner.lock().await;
-        let message = inner
-            .queue
-            .iter()
-            .find(|job| job.run_id == run_id && job.job_id.0 == "build")
-            .or_else(|| {
-                inner
-                    .pending_jobs
-                    .iter()
-                    .find(|job| job.run_id == run_id && job.job_id.0 == "build")
-            })
-            .map(|job| job.message.clone())
-            .expect("fixture must carry a queued build job");
-        let step_id = message
-            .steps
-            .first()
-            .map(|step| step.id.to_string())
-            .expect("fixture must carry a broker step id");
-        inner.broker_messages.insert(message.request_id, message);
-        step_id
-    };
+    let ids = workflow_step_ids(&state, run_id, "build").await;
+    let workflow_step_id = ids.first().expect("manifest must carry the declared step");
 
-    // The synthetic file sorts first by upload time, but `step=1` must follow
-    // the workflow metadata and select the user step's external id.
+    // A synthetic runner step ("Set up job") uploads a blob too, and sorts
+    // ahead of the user step by both name and upload time. `step=1` must still
+    // resolve through the manifest and pick the declared step.
     write_step_job_logs(
         &temp,
         &jobs[0].1,
         &jobs[0].2,
         &[
-            ("synthetic-setup", "setup output\n"),
-            (&workflow_step_id, "user step output\n"),
+            ("00000000-0000-0000-0000-000000000000", "setup output\n"),
+            (workflow_step_id.as_str(), "user step output\n"),
         ],
     )
     .await;
@@ -2848,6 +2988,15 @@ async fn log_run_logs_step_filter_uses_workflow_step_ids() {
         get_logs(&app, format!("/api/v1/runs/{run_id}/logs?job=build&step=1")).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body, b"user step output\n");
+
+    // The declared step is the only one `--step` can address; the synthetic
+    // blob never occupies a slot of its own.
+    let (status, _) = get_logs(&app, format!("/api/v1/runs/{run_id}/logs?job=build&step=2")).await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "a synthetic upload must not become step 2"
+    );
 }
 
 #[tokio::test]
@@ -2855,12 +3004,16 @@ async fn log_run_logs_step_out_of_range_is_404() {
     let temp = tempfile::tempdir().unwrap();
     let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
     let app = app(state.clone(), CancellationToken::new());
-    let (run_id, jobs) = two_job_run_for_log_filters(&app, &state).await;
+    let (run_id, jobs) = three_step_run_for_log_filters(&app, &state).await;
+    let ids = workflow_step_ids(&state, run_id, "build").await;
     write_step_job_logs(
         &temp,
         &jobs[0].1,
         &jobs[0].2,
-        &[("a", "step one\n"), ("b", "step two\n")],
+        &[
+            (ids[0].as_str(), "step one\n"),
+            (ids[1].as_str(), "step two\n"),
+        ],
     )
     .await;
 
@@ -2869,8 +3022,8 @@ async fn log_run_logs_step_out_of_range_is_404() {
     assert_eq!(status, StatusCode::NOT_FOUND);
     let message = String::from_utf8_lossy(&body);
     assert!(
-        message.contains('2'),
-        "error should report how many steps exist: {message}"
+        message.contains('3'),
+        "error should report how many declared steps exist: {message}"
     );
 }
 
@@ -12868,6 +13021,12 @@ async fn completion_step_results_are_authoritative_over_inference() {
             .unwrap();
         (request.plan_id.clone(), request.agent_job_id.to_string())
     };
+    // The step update and the completion report describe the same step, so
+    // both carry the manifest's id — that shared identity is what makes
+    // `stepResults` authoritative over the job-status inference.
+    let step_id = workflow_step_ids(&state, run_id.parse().unwrap(), "build")
+        .await
+        .remove(0);
     request_json(
         &app,
         Method::POST,
@@ -12876,7 +13035,7 @@ async fn completion_step_results_are_authoritative_over_inference() {
             "workflow_run_backend_id": plan_id,
             "workflow_job_run_backend_id": agent_job_id,
             "steps": [{
-                "external_id": uuid::Uuid::new_v4().to_string(),
+                "external_id": step_id,
                 "number": 2,
                 "name": "Test",
                 "status": 3,
@@ -12895,7 +13054,7 @@ async fn completion_step_results_are_authoritative_over_inference() {
             "status": "failure",
             "outputs": {},
             "step_results": [{
-                "external_id": uuid::Uuid::new_v4().to_string(),
+                "external_id": step_id,
                 "number": 2,
                 "name": "Test",
                 "status": "completed",
@@ -13009,7 +13168,9 @@ async fn workflow_steps_update_prefers_runner_reported_step_names() {
             "workflow_run_backend_id": plan_id,
             "workflow_job_run_backend_id": agent_job_id,
             "steps": [{
-                "external_id": uuid::Uuid::new_v4().to_string(),
+                "external_id": workflow_step_ids(&state, run_id.parse().unwrap(), "build")
+                    .await
+                    .remove(0),
                 "number": 2,
                 "name": "Run echo hi",
                 "status": 6,
@@ -13060,8 +13221,13 @@ async fn workflow_steps_update_preserves_duplicate_names_after_restart() {
             request.request_id,
         )
     };
-    let first_id = uuid::Uuid::new_v4().to_string();
-    let second_id = uuid::Uuid::new_v4().to_string();
+    // The runner echoes the request message's step ids back as `external_id`
+    // (verified in `.runner-watch/golden/v2.336.0/06-multi-step`), so the two
+    // same-named steps are distinguished by identity, not by their names.
+    let ids = workflow_step_ids(&state, run_id.parse().unwrap(), "build").await;
+    assert_eq!(ids.len(), 2, "both declared steps must be in the manifest");
+    let first_id = ids[0].clone();
+    let second_id = ids[1].clone();
 
     let response = request_json(
         &app,
@@ -13209,6 +13375,12 @@ async fn workflow_steps_update_records_start_on_in_progress_then_finish() {
         (request.plan_id.clone(), request.agent_job_id.to_string())
     };
 
+    // One step, reported twice: a real runner keeps the same `external_id`
+    // across the in-progress and terminal updates, which is what lets the
+    // second report land on the first one's record.
+    let step_id = workflow_step_ids(&state, run_id.parse().unwrap(), "build")
+        .await
+        .remove(0);
     request_json(
         &app,
         Method::POST,
@@ -13217,7 +13389,7 @@ async fn workflow_steps_update_records_start_on_in_progress_then_finish() {
             "workflow_run_backend_id": plan_id,
             "workflow_job_run_backend_id": agent_job_id,
             "steps": [{
-                "external_id": uuid::Uuid::new_v4().to_string(),
+                "external_id": step_id,
                 "number": 2,
                 "name": "Run echo hi",
                 "status": 3,
@@ -13234,7 +13406,7 @@ async fn workflow_steps_update_records_start_on_in_progress_then_finish() {
             "workflow_run_backend_id": plan_id,
             "workflow_job_run_backend_id": agent_job_id,
             "steps": [{
-                "external_id": uuid::Uuid::new_v4().to_string(),
+                "external_id": step_id,
                 "number": 2,
                 "name": "Run echo hi",
                 "status": 6,

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -2843,6 +2843,84 @@ async fn log_run_logs_unknown_job_is_404_not_whole_run() {
     );
 }
 
+/// Expansion does not leave the placeholder's manifest behind.
+///
+/// A deferred-matrix node is dispatched as a placeholder, gets a manifest
+/// seeded, and is purged when expansion replaces it with real legs. Without
+/// cleanup every dynamic expansion accumulates an entry no run projection can
+/// reach.
+#[tokio::test]
+async fn expansion_purges_the_placeholder_step_manifest() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+
+    let accepted = submit_yaml(
+        &app,
+        r#"
+on: push
+jobs:
+  gen:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.build.outputs.matrix }}
+    steps:
+      - id: build
+        run: echo matrix
+  fan:
+    needs: [gen]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.gen.outputs.matrix) }}
+    steps:
+      - run: echo leg
+"#,
+        "owner/repo",
+    )
+    .await;
+    let run_id: RunId = accepted["run_id"].as_str().unwrap().parse().unwrap();
+
+    let before = {
+        let inner = state.inner.lock().await;
+        inner.job_steps.len()
+    };
+
+    // Finish `gen` with a matrix so the deferred node expands.
+    let _ = crate::distributed_task::complete_job_inner(
+        state.shared(),
+        preloop_gha_protocol::JobCompletion {
+            run_id,
+            job_id: preloop_gha_protocol::JobId("gen".to_owned()),
+            agent_job_id: None,
+            status: ExecutionStatus::Success,
+            outputs: [("matrix".to_owned(), serde_json::json!("{\"leg\":[1,2]}"))]
+                .into_iter()
+                .collect(),
+            annotations: Vec::new(),
+            step_results: Vec::new(),
+        },
+    )
+    .await;
+
+    let inner = state.inner.lock().await;
+    // Every retained manifest must belong to a request that still exists.
+    let live: std::collections::BTreeSet<uuid::Uuid> = inner
+        .job_requests
+        .values()
+        .map(|record| record.agent_job_id)
+        .collect();
+    let orphans: Vec<&uuid::Uuid> = inner
+        .job_steps
+        .keys()
+        .filter(|agent_job_id| !live.contains(agent_job_id))
+        .collect();
+    assert!(
+        orphans.is_empty(),
+        "expansion left {} unreachable manifest(s) (had {before} before)",
+        orphans.len()
+    );
+}
+
 /// The list endpoint projects steps like the single-run endpoint.
 ///
 /// Step records live in the attempt manifest, not in the stored run, so a

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -2207,7 +2207,7 @@ jobs:
         &app,
         Method::PATCH,
         &format!("/_apis/v1/Timeline/scope/actions/{run_id}/timeline-1"),
-        json!({"count": 1, "value": [{
+        json!({"count": 2, "value": [{
             "id": "00000000-0000-0000-0000-000000000001",
             "name": "build",
             "type": "job",
@@ -2217,6 +2217,19 @@ jobs:
                 "type": "error",
                 "message": "boom",
                 "data": {"file": "src/lib.rs", "line": "42"}
+            }]
+        }, {
+            // A typed step with no `parentId`. The manifest path counts this as
+            // a step, so the annotation path must scope its issue to the step
+            // rather than reporting it against the job.
+            "id": "00000000-0000-0000-0000-000000000002",
+            "name": "Run echo one",
+            "type": "Task",
+            "state": "completed",
+            "result": "failed",
+            "issues": [{
+                "type": "error",
+                "message": "step boom"
             }]
         }]}),
     )
@@ -2239,6 +2252,76 @@ jobs:
     assert!(events.contains("\"type\":\"annotation\""));
     assert!(events.contains("\"message\":\"boom\""));
     assert!(events.contains("\"status\":\"failure\""));
+
+    // The step's issue is scoped to the step; the job's stays job-level. Both
+    // paths deciding "is this a step" differently is what put a record in the
+    // manifest while its annotation pointed at the job.
+    let step_annotation = events
+        .lines()
+        .find(|line| line.contains("\"step boom\""))
+        .expect("the step's annotation must be projected");
+    assert!(
+        step_annotation.contains("\"step_id\":\"00000000-0000-0000-0000-000000000002\""),
+        "a typed step's issue must carry its step id: {step_annotation}"
+    );
+    let job_annotation = events
+        .lines()
+        .find(|line| line.contains("\"boom\"") && !line.contains("\"step boom\""))
+        .expect("the job's annotation must be projected");
+    assert!(
+        !job_annotation.contains("\"step_id\""),
+        "the job record's issue must stay job-level: {job_annotation}"
+    );
+}
+
+/// Following a re-dispatched job streams the current attempt, not the first.
+///
+/// `job_requests` is keyed by monotonic request id, so selecting with `find`
+/// returned the oldest attempt: after a retry, following the logical job key
+/// subscribed to the dead attempt's feed, which never speaks again.
+#[tokio::test]
+async fn live_log_key_follows_the_newest_attempt() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, _) = three_step_run_for_log_filters(&app, &state).await;
+
+    // A re-dispatch: a second request for the same logical job, with a higher
+    // request id and its own agent job id.
+    let (first_attempt, second_attempt) = {
+        let mut inner = state.inner.lock().await;
+        let (first_id, first) = inner
+            .job_requests
+            .iter()
+            .find(|(_, record)| record.run_id == run_id && record.job_id.0 == "build")
+            .map(|(id, record)| (*id, record.clone()))
+            .expect("the dispatched attempt");
+        let mut retry = first.clone();
+        retry.request_id = first_id + 1;
+        retry.agent_job_id = uuid::Uuid::new_v4();
+        let second = retry.agent_job_id;
+        inner.job_requests.insert(retry.request_id, retry);
+        (first.agent_job_id, second)
+    };
+    assert_ne!(first_attempt, second_attempt);
+
+    let inner = state.inner.lock().await;
+    let key = crate::live_logs::live_log_key_for_job(&inner, run_id, "build")
+        .expect("a logical job key must resolve");
+    assert_eq!(
+        key,
+        second_attempt.to_string(),
+        "the logical job key must follow the current attempt, not the first"
+    );
+
+    // An explicit agent job id still addresses exactly that attempt, so an
+    // older feed stays reachable when asked for by name.
+    assert_eq!(
+        crate::live_logs::live_log_key_for_job(&inner, run_id, &first_attempt.to_string())
+            .expect("an explicit attempt id must resolve"),
+        first_attempt.to_string(),
+        "an explicit agent job id must not be redirected to another attempt"
+    );
 }
 
 #[tokio::test]

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -2912,28 +2912,40 @@ async fn timeline_path_orders_synthetic_steps_and_skips_the_job_record() {
 
     // Setup started before the declared steps, and the job record is sent
     // alongside them exactly as the official runner does.
+    //
+    // The three step records deliberately use the three shapes that appear on
+    // the wire: `Task` (official runner), `Step` (which this file's annotation
+    // path already recognises), and no `type` at all (the field is optional).
+    // An allow-list of one type passes a test that only sends that type while
+    // silently dropping the others' conclusions.
     let setup_id = uuid::Uuid::new_v4().to_string();
-    let record = |id: &str, kind: &str, name: &str, start: &str| {
-        json!({
+    let job_record_id = uuid::Uuid::new_v4().to_string();
+    let record = |id: &str, kind: Option<&str>, name: &str, start: &str| {
+        let mut value = json!({
             "id": id,
-            "type": kind,
             "name": name,
             "displayName": name,
             "state": "completed",
             "result": "succeeded",
             "startTime": start,
-        })
+        });
+        match kind {
+            Some(kind) => value["type"] = json!(kind),
+            // Untyped records are identified as steps by their parent.
+            None => value["parentId"] = json!(job_record_id),
+        }
+        value
     };
     let response = request_json(
         &app,
         Method::PATCH,
         &format!("/_apis/v1/Timeline/scope/actions/{plan_id}/{timeline_id}"),
         json!({"count": 5, "value": [
-            record(&uuid::Uuid::new_v4().to_string(), "Job", "build", "2026-01-01T00:00:00Z"),
-            record(&ids[0], "Task", "Run echo one", "2026-01-01T00:00:02Z"),
-            record(&ids[1], "Task", "Run echo two", "2026-01-01T00:00:03Z"),
-            record(&ids[2], "Task", "Run echo three", "2026-01-01T00:00:04Z"),
-            record(&setup_id, "Task", "Set up job", "2026-01-01T00:00:01Z"),
+            record(&job_record_id, Some("Job"), "build", "2026-01-01T00:00:00Z"),
+            record(&ids[0], Some("Task"), "Run echo one", "2026-01-01T00:00:02Z"),
+            record(&ids[1], Some("Step"), "Run echo two", "2026-01-01T00:00:03Z"),
+            record(&ids[2], None, "Run echo three", "2026-01-01T00:00:04Z"),
+            record(&setup_id, Some("Task"), "Set up job", "2026-01-01T00:00:01Z"),
         ]}),
     )
     .await;
@@ -3183,6 +3195,92 @@ async fn step_manifests_survive_a_restart() {
         body, b"second step\n",
         "`--step` must still resolve after a restart"
     );
+}
+
+/// A step report made after a restart is still persisted.
+///
+/// The out-of-order write guard compares an in-memory revision against the
+/// persisted one, so the counter has to resume above what is on disk. Left at
+/// zero it hands every post-restart write a revision the stored rows already
+/// exceed, and the upsert discards them — invisibly, because memory stays
+/// authoritative until the next restart drops the conclusion.
+#[tokio::test]
+async fn step_reports_after_a_restart_are_persisted() {
+    let temp = tempfile::tempdir().unwrap();
+    let report = |app: axum::Router, plan_id: String, agent_job_id: String, id: String, n: i64| async move {
+        let response = request_json(
+            &app,
+            Method::POST,
+            "/twirp/github.actions.results.api.v1.WorkflowStepUpdateService/WorkflowStepsUpdate",
+            json!({
+                "workflow_run_backend_id": plan_id,
+                "workflow_job_run_backend_id": agent_job_id,
+                "steps": [{
+                    "external_id": id,
+                    "number": n,
+                    "name": "Run echo one",
+                    "status": 6,
+                    "conclusion": 2
+                }]
+            }),
+        )
+        .await;
+        assert_eq!(response["ok"], true);
+    };
+
+    let (plan_id, agent_job_id, ids) = {
+        let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+        let app = app(state.clone(), CancellationToken::new());
+        let (run_id, jobs) = three_step_run_for_log_filters(&app, &state).await;
+        let ids = workflow_step_ids(&state, run_id, "build").await;
+        let (plan_id, agent_job_id) = (jobs[0].1.clone(), jobs[0].2.clone());
+        // Two reports before the restart, so the persisted revision is above
+        // the value a fresh counter would hand out first.
+        report(
+            app.clone(),
+            plan_id.clone(),
+            agent_job_id.clone(),
+            ids[0].clone(),
+            2,
+        )
+        .await;
+        report(
+            app.clone(),
+            plan_id.clone(),
+            agent_job_id.clone(),
+            ids[1].clone(),
+            3,
+        )
+        .await;
+        (plan_id, agent_job_id, ids)
+    };
+
+    {
+        let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+        let app = app(state.clone(), CancellationToken::new());
+        report(
+            app,
+            plan_id.clone(),
+            agent_job_id.clone(),
+            ids[2].clone(),
+            4,
+        )
+        .await;
+    }
+
+    // Only a second restart can tell whether that write reached the store.
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let inner = state.inner.lock().await;
+    let records = &inner.job_steps[&agent_job_id.parse::<uuid::Uuid>().unwrap()];
+    let reported = records
+        .iter()
+        .find(|step| step.id == ids[2])
+        .expect("the post-restart step must be restored");
+    assert_eq!(
+        reported.conclusion, "success",
+        "a report made after a restart must survive the next one"
+    );
+    assert_eq!(reported.runner_number, Some(4));
 }
 
 /// Every surface showing a whole step list uses execution order.

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -2843,6 +2843,83 @@ async fn log_run_logs_unknown_job_is_404_not_whole_run() {
     );
 }
 
+/// The AzDO timeline path orders synthetic steps and ignores the job record.
+///
+/// `TimelineRecord` carries no ordinal, so a synthetic step reported this way
+/// has no `runner_number` and must be ordered by when it started — otherwise
+/// `Set up job` sorts after every declared step. The PATCH also carries the
+/// job's own record, whose UUID never equals the workflow job key, so it was
+/// reconciled in as an extra step named after the job.
+#[tokio::test]
+async fn timeline_path_orders_synthetic_steps_and_skips_the_job_record() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, _) = three_step_run_for_log_filters(&app, &state).await;
+    let ids = workflow_step_ids(&state, run_id, "build").await;
+    let (plan_id, timeline_id) = {
+        let inner = state.inner.lock().await;
+        let request = inner
+            .job_requests
+            .values()
+            .find(|request| request.run_id == run_id)
+            .expect("dispatched request");
+        (request.plan_id.clone(), request.timeline_id.to_string())
+    };
+
+    // Setup started before the declared steps, and the job record is sent
+    // alongside them exactly as the official runner does.
+    let setup_id = uuid::Uuid::new_v4().to_string();
+    let record = |id: &str, kind: &str, name: &str, start: &str| {
+        json!({
+            "id": id,
+            "type": kind,
+            "name": name,
+            "displayName": name,
+            "state": "completed",
+            "result": "succeeded",
+            "startTime": start,
+        })
+    };
+    let response = request_json(
+        &app,
+        Method::PATCH,
+        &format!("/_apis/v1/Timeline/scope/actions/{plan_id}/{timeline_id}"),
+        json!({"count": 5, "value": [
+            record(&uuid::Uuid::new_v4().to_string(), "Job", "build", "2026-01-01T00:00:00Z"),
+            record(&ids[0], "Task", "Run echo one", "2026-01-01T00:00:02Z"),
+            record(&ids[1], "Task", "Run echo two", "2026-01-01T00:00:03Z"),
+            record(&ids[2], "Task", "Run echo three", "2026-01-01T00:00:04Z"),
+            record(&setup_id, "Task", "Set up job", "2026-01-01T00:00:01Z"),
+        ]}),
+    )
+    .await;
+    assert_eq!(response["count"], 5);
+
+    let run = get_run_json(&app, &run_id.to_string()).await;
+    let names: Vec<&str> = run["jobs_list"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|detail| detail["job_id"] == "build")
+        .expect("build detail")["steps"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|step| step["name"].as_str().unwrap_or_default())
+        .collect();
+    assert_eq!(
+        names,
+        vec![
+            "Set up job",
+            "Run echo one",
+            "Run echo two",
+            "Run echo three"
+        ],
+        "synthetic setup must lead, and the job record must not become a step"
+    );
+}
+
 /// Expansion does not leave the placeholder's manifest behind.
 ///
 /// A deferred-matrix node is dispatched as a placeholder, gets a manifest

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -2843,6 +2843,56 @@ async fn log_run_logs_unknown_job_is_404_not_whole_run() {
     );
 }
 
+/// Step manifests survive a restart, so `--step` still resolves.
+///
+/// They deliberately do not ride in `runs.record_blob` (which reseals the
+/// workflow YAML and event payload on every run event) nor in `MetaSnapshot`
+/// (every field of which is sealed on each `store_meta_only`), so this proves
+/// the `job_steps` table actually round-trips them.
+#[tokio::test]
+async fn step_manifests_survive_a_restart() {
+    let temp = tempfile::tempdir().unwrap();
+    let (run_id, plan_id, agent_job_id, ids) = {
+        let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+        let app = app(state.clone(), CancellationToken::new());
+        let (run_id, jobs) = three_step_run_for_log_filters(&app, &state).await;
+        let ids = workflow_step_ids(&state, run_id, "build").await;
+        assert_eq!(ids.len(), 3);
+        // Force the full snapshot so the rows exist regardless of which run
+        // events happened to fire during submission.
+        let snapshot = {
+            let inner = state.inner.lock().await;
+            crate::store::StoreSnapshot::from_inner(&inner)
+        };
+        state.store.store_inner(&snapshot).await.unwrap();
+        (run_id, jobs[0].1.clone(), jobs[0].2.clone(), ids)
+    };
+
+    // A fresh AppState over the same state dir is the restart.
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let restored = workflow_step_ids(&state, run_id, "build").await;
+    assert_eq!(
+        restored, ids,
+        "declared step ids and their order must come back intact"
+    );
+
+    write_step_job_logs(
+        &temp,
+        &plan_id,
+        &agent_job_id,
+        &[(ids[1].as_str(), "second step\n")],
+    )
+    .await;
+    let (status, body) =
+        get_logs(&app, format!("/api/v1/runs/{run_id}/logs?job=build&step=2")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body, b"second step\n",
+        "`--step` must still resolve after a restart"
+    );
+}
+
 /// A second dispatch of the same job gets its own manifest.
 ///
 /// `build_task_step` mints a fresh `TaskStep` id per build, so a job-scoped

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -2893,6 +2893,99 @@ async fn step_manifests_survive_a_restart() {
     );
 }
 
+/// Every surface showing a whole step list uses execution order.
+///
+/// The stored manifest is seeded with declared steps and then appends
+/// synthetic ones as the runner reports them, so its raw order puts
+/// `Set up job` last despite it running first. A step id is a v4 UUID, so it
+/// cannot supply the order either.
+#[tokio::test]
+async fn step_lists_and_job_logs_follow_execution_order() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, jobs) = three_step_run_for_log_filters(&app, &state).await;
+    let ids = workflow_step_ids(&state, run_id, "build").await;
+    let (plan_id, agent_job_id) = (jobs[0].1.clone(), jobs[0].2.clone());
+
+    // The runner reports `Set up job` first, then the declared steps at the
+    // offset positions the golden capture shows (declared step 1 is number 2).
+    let setup_id = uuid::Uuid::new_v4().to_string();
+    let report = |external_id: &str, number: u64, name: &str| {
+        serde_json::json!({
+            "external_id": external_id,
+            "number": number,
+            "name": name,
+            "status": 6,
+            "conclusion": 2
+        })
+    };
+    let response = request_json(
+        &app,
+        Method::POST,
+        "/twirp/github.actions.results.api.v1.WorkflowStepUpdateService/WorkflowStepsUpdate",
+        json!({
+            "workflow_run_backend_id": plan_id,
+            "workflow_job_run_backend_id": agent_job_id,
+            "steps": [
+                report(&setup_id, 1, "Set up job"),
+                report(&ids[0], 2, "Run echo one"),
+                report(&ids[1], 3, "Run echo two"),
+                report(&ids[2], 4, "Run echo three"),
+            ]
+        }),
+    )
+    .await;
+    assert_eq!(response["ok"], true);
+
+    // The run record lists the synthetic setup step first.
+    let run = get_run_json(&app, &run_id.to_string()).await;
+    let names: Vec<&str> = run["jobs_list"][0]["steps"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|step| step["name"].as_str().unwrap_or_default())
+        .collect();
+    assert_eq!(
+        names,
+        vec![
+            "Set up job",
+            "Run echo one",
+            "Run echo two",
+            "Run echo three"
+        ],
+        "the run record must show execution order, not seeded-then-appended"
+    );
+
+    // The whole-job log concatenates in the same order, even though the ids
+    // sort differently.
+    write_step_job_logs(
+        &temp,
+        &plan_id,
+        &agent_job_id,
+        &[
+            (ids[2].as_str(), "three\n"),
+            (ids[0].as_str(), "one\n"),
+            (setup_id.as_str(), "setup\n"),
+            (ids[1].as_str(), "two\n"),
+        ],
+    )
+    .await;
+    let (status, body) = get_logs(&app, format!("/api/v1/runs/{run_id}/logs?job=build")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        String::from_utf8_lossy(&body),
+        "setup\none\ntwo\nthree\n",
+        "whole-job output must follow execution order"
+    );
+
+    // `--step` still counts declared steps only, so setup takes no slot.
+    let (status, body) =
+        get_logs(&app, format!("/api/v1/runs/{run_id}/logs?job=build&step=1")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, b"one\n");
+}
+
 /// A completion reconciles the attempt that actually reported.
 ///
 /// `job_requests` is keyed by monotonic request id, so picking the first match

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -2843,6 +2843,55 @@ async fn log_run_logs_unknown_job_is_404_not_whole_run() {
     );
 }
 
+/// The list endpoint projects steps like the single-run endpoint.
+///
+/// Step records live in the attempt manifest, not in the stored run, so a
+/// handler that clones `inner.runs` directly returns empty step arrays even
+/// though `GET /api/v1/runs/{id}` has the current ones.
+#[tokio::test]
+async fn list_runs_projects_step_records() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, jobs) = three_step_run_for_log_filters(&app, &state).await;
+    let ids = workflow_step_ids(&state, run_id, "build").await;
+
+    let response = request_json(
+        &app,
+        Method::POST,
+        "/twirp/github.actions.results.api.v1.WorkflowStepUpdateService/WorkflowStepsUpdate",
+        json!({
+            "workflow_run_backend_id": jobs[0].1,
+            "workflow_job_run_backend_id": jobs[0].2,
+            "steps": [{
+                "external_id": ids[0],
+                "number": 2,
+                "name": "Run echo one",
+                "status": 6,
+                "conclusion": 2
+            }]
+        }),
+    )
+    .await;
+    assert_eq!(response["ok"], true);
+
+    let listed = request_json(&app, Method::GET, "/api/v1/runs", json!(null)).await;
+    let run = listed
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["run_id"] == run_id.to_string())
+        .expect("the submitted run must be listed");
+    let steps = run["jobs_list"][0]["steps"].as_array().unwrap();
+    assert_eq!(
+        steps.len(),
+        3,
+        "the list endpoint must carry the declared steps: {steps:?}"
+    );
+    assert_eq!(steps[0]["conclusion"], "success");
+    assert_eq!(steps[0]["name"], "Run echo one");
+}
+
 /// A runner report persists the attempt, so a restart keeps step state.
 ///
 /// Step records deliberately do not ride in `runs.record_blob` (which reseals

--- a/crates/preloop-runner-server/src/live_logs.rs
+++ b/crates/preloop-runner-server/src/live_logs.rs
@@ -234,10 +234,19 @@ pub(crate) fn live_log_key_for_job(
     job_id: &str,
 ) -> Option<String> {
     let run = inner.runs.get(&run_id)?;
-    if let Some(record) = inner.job_requests.values().find(|record| {
-        record.run_id == run_id
-            && (record.job_id.0 == job_id || record.agent_job_id.to_string() == job_id)
-    }) {
+    // `job_requests` is keyed by monotonic request id, so `find` would return
+    // the oldest attempt and follow a dead feed after a re-dispatch. A logical
+    // job key means "the current attempt"; an explicit agent job id matches one
+    // record either way.
+    if let Some(record) = inner
+        .job_requests
+        .values()
+        .filter(|record| {
+            record.run_id == run_id
+                && (record.job_id.0 == job_id || record.agent_job_id.to_string() == job_id)
+        })
+        .max_by_key(|record| record.request_id)
+    {
         return Some(record.agent_job_id.to_string());
     }
     // A logical job key is valid without a request only when it belongs to

--- a/crates/preloop-runner-server/src/models.rs
+++ b/crates/preloop-runner-server/src/models.rs
@@ -34,14 +34,57 @@ pub(crate) struct DapPortRegistration {
     pub(crate) job_id: JobId,
 }
 
+/// How a step came to exist, which decides whether `--step N` counts it.
+///
+/// `Workflow` records are built from the job request message before the runner
+/// starts, so their order is the workflow's declared order. `Synthetic` records
+/// are runner bookkeeping discovered at execution time ("Set up job", `Pre`/
+/// `Post` action hooks, container lifecycle, "Complete job"): they own real
+/// logs, but must never shift the numbering a user reads off their YAML.
+///
+/// Verified against the official runner
+/// (`.runner-watch/golden/v2.336.0/06-multi-step`): the three declared steps
+/// echo the message ids back unchanged as `external_id`, while "Set up job"
+/// and "Complete job" carry runner-minted ids absent from the message.
+/// Membership in the manifest is therefore the classifier — never the id's
+/// shape, and never the display name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum StepKind {
+    /// Declared in the workflow and present in the job request message.
+    Workflow,
+    /// Reported by the runner with no manifest entry. This is the default so a
+    /// run record written before manifests existed answers `--step` with an
+    /// explicit "no workflow manifest" error instead of a guessed blob.
+    #[default]
+    Synthetic,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct StepRecord {
-    /// Runner/timeline identity used to match a durable `step-*.txt` blob.
-    ///
-    /// Old persisted run records may not have this field, so log retrieval
-    /// falls back to the order available from the filesystem when it is absent.
+    /// Stable protocol identity: `TaskStep.id` in the job request message,
+    /// echoed as `external_id` in `WorkflowStepsUpdate`, and the name of the
+    /// durable `step-<id>.txt` blob. Empty only for a record restored from a
+    /// pre-manifest run, which resolution refuses rather than guesses.
+    #[serde(default)]
+    pub(crate) id: String,
+    #[serde(default)]
+    pub(crate) kind: StepKind,
+    /// 0-based position among the job's declared workflow steps. `Some`
+    /// exactly when `kind` is `Workflow`; this is what `--step N` indexes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(crate) id: Option<String>,
+    pub(crate) workflow_index: Option<usize>,
+    /// The runner's own 1-based timeline position, which counts synthetic
+    /// steps too — the golden capture reports declared step 1 as `number: 2`
+    /// because "Set up job" takes 1. Presentation and protocol fidelity only;
+    /// never an input to `--step`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) runner_number: Option<u32>,
+    /// Expression-context key (`compile`, `__run_2`). Unlike `id`, this is
+    /// derived from the YAML and so is stable across runs of the same
+    /// workflow, which is what lets one step be correlated over time.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) context_name: Option<String>,
     pub(crate) name: String,
     pub(crate) conclusion: String,
     /// Server-side observation of when the step first appeared (started) and
@@ -53,29 +96,75 @@ pub(crate) struct StepRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) finished_at: Option<chrono::DateTime<chrono::Utc>>,
 }
-impl StepRecord {
-    /// Match a step by stable runner identity, falling back to a unique name.
-    pub(crate) fn find_matching_index(
-        steps: &[Self],
-        id: &str,
-        name: &str,
-        allow_name_fallback: bool,
-    ) -> Option<usize> {
-        if !id.is_empty() {
-            if let Some(index) = steps.iter().position(|step| step.id.as_deref() == Some(id)) {
-                return Some(index);
-            }
-        }
-        if !allow_name_fallback {
-            return None;
-        }
 
-        let mut matches = steps
+impl StepRecord {
+    /// A manifest entry for a declared workflow step, built from the job
+    /// request message before the runner has reported anything.
+    pub(crate) fn workflow(
+        id: String,
+        workflow_index: usize,
+        name: String,
+        context_name: Option<String>,
+    ) -> Self {
+        Self {
+            id,
+            kind: StepKind::Workflow,
+            workflow_index: Some(workflow_index),
+            runner_number: None,
+            context_name,
+            name,
+            conclusion: "pending".to_owned(),
+            started_at: None,
+            finished_at: None,
+        }
+    }
+
+    /// Build one job attempt's manifest from its request message's steps.
+    ///
+    /// The message's `steps` vector *is* the declared workflow order, so the
+    /// index is the order and `TaskStep.id` is the identity. Nothing here
+    /// inspects the filesystem or sorts ids: a v4 UUID sorts randomly, and an
+    /// upload timestamp records when a blob landed, not when a step ran.
+    pub(crate) fn manifest(steps: &[azdo::TaskStep]) -> Vec<Self> {
+        steps
             .iter()
             .enumerate()
-            .filter(|(_, step)| step.name == name);
-        let first = matches.next()?;
-        matches.next().is_none().then_some(first.0)
+            .map(|(index, step)| {
+                Self::workflow(
+                    step.id.to_string(),
+                    index,
+                    step.display_name
+                        .clone()
+                        .or_else(|| step.name.clone())
+                        .unwrap_or_default(),
+                    step.context_name.clone(),
+                )
+            })
+            .collect()
+    }
+
+    /// Locate a step by stable identity, and by nothing else.
+    ///
+    /// Display names repeat legitimately — two steps may both be named `Test`
+    /// — so matching on them merged distinct steps and lost one from the run.
+    pub(crate) fn find_by_id(steps: &[Self], id: &str) -> Option<usize> {
+        if id.is_empty() {
+            return None;
+        }
+        steps.iter().position(|step| step.id == id)
+    }
+
+    /// The declared workflow steps, in declared order.
+    ///
+    /// Synthetic steps are excluded, so `Set up job` and `Post <action>` never
+    /// shift what `--step N` selects.
+    pub(crate) fn workflow_steps(steps: &[Self]) -> Vec<&Self> {
+        let mut workflow: Vec<&Self> = steps
+            .iter()
+            .filter(|step| step.kind == StepKind::Workflow)
+            .collect();
+        workflow.sort_by_key(|step| step.workflow_index.unwrap_or(usize::MAX));
+        workflow
     }
 }
 
@@ -92,6 +181,15 @@ pub(crate) struct SnapshotTiming {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct JobDetail {
+    /// Stable workflow job key (`build`, `build (ubuntu-latest)`).
+    ///
+    /// Separate from `name` because the run projection overwrites `name` with
+    /// the evaluated GitHub display name, so `name` cannot identify the job it
+    /// belongs to. Empty only for a detail restored from a run written before
+    /// this field existed.
+    #[serde(default)]
+    pub(crate) job_id: String,
+    /// GitHub display name, as shown in a run's job list.
     pub(crate) name: String,
     pub(crate) conclusion: String,
     pub(crate) steps: Vec<StepRecord>,
@@ -99,6 +197,24 @@ pub(crate) struct JobDetail {
     /// infrastructure failures). Kept as raw wire values.
     #[serde(default)]
     pub(crate) annotations: Vec<serde_json::Value>,
+}
+
+impl JobDetail {
+    /// Locate a job's detail by its stable key.
+    ///
+    /// Falls back to the display name only for details restored without a
+    /// `job_id`; new details always carry one.
+    pub(crate) fn find<'a>(details: &'a mut [Self], job_id: &str) -> Option<&'a mut Self> {
+        let index = details
+            .iter()
+            .position(|detail| detail.job_id == job_id)
+            .or_else(|| {
+                details
+                    .iter()
+                    .position(|detail| detail.job_id.is_empty() && detail.name == job_id)
+            })?;
+        details.get_mut(index)
+    }
 }
 
 /// Metadata tracked per log file for results-service Twirp retrieval.

--- a/crates/preloop-runner-server/src/models.rs
+++ b/crates/preloop-runner-server/src/models.rs
@@ -145,17 +145,33 @@ impl StepRecord {
 
     /// Sort key placing a step in execution order.
     ///
-    /// `runner_number` is the runner's own 1-based timeline position and counts
-    /// every step it ran, so it is the truth once reported. Until then a
-    /// declared step falls back to its manifest position, biased past any
-    /// reported number so freshly seeded steps trail what has actually run.
-    /// A step id is a v4 UUID and sorts randomly, so it is only the final
+    /// Three tiers, because the two reporting paths carry different evidence:
+    ///
+    /// 1. `runner_number` — the runner's own 1-based timeline position, which
+    ///    counts every step it ran. The broker path reports it, and it is the
+    ///    truth once present.
+    /// 2. `started_at` — when the server first saw the step run. The AzDO
+    ///    timeline path carries no ordinal (`TimelineRecord` has no `order`
+    ///    field), so a synthetic step there has no number; without this tier
+    ///    `Set up job` sorted after every declared step on that path, which is
+    ///    the defect this ordering exists to prevent.
+    /// 3. `workflow_index` — a declared step that has not run yet, ordered as
+    ///    the workflow declares and placed after everything that has run.
+    ///
+    /// A step id is a v4 UUID and sorts randomly, so it is only ever the final
     /// tie-break for determinism.
-    fn execution_key(&self) -> (u32, usize, &str) {
-        match self.runner_number {
-            Some(number) => (number, 0, self.id.as_str()),
-            None => (
-                u32::MAX,
+    fn execution_key(&self) -> (u8, i64, usize, &str) {
+        match (self.runner_number, self.started_at) {
+            (Some(number), _) => (0, i64::from(number), 0, self.id.as_str()),
+            (None, Some(started_at)) => (
+                1,
+                started_at.timestamp_micros(),
+                self.workflow_index.unwrap_or(usize::MAX),
+                self.id.as_str(),
+            ),
+            (None, None) => (
+                2,
+                0,
                 self.workflow_index.unwrap_or(usize::MAX),
                 self.id.as_str(),
             ),

--- a/crates/preloop-runner-server/src/models.rs
+++ b/crates/preloop-runner-server/src/models.rs
@@ -143,6 +143,36 @@ impl StepRecord {
             .collect()
     }
 
+    /// Sort key placing a step in execution order.
+    ///
+    /// `runner_number` is the runner's own 1-based timeline position and counts
+    /// every step it ran, so it is the truth once reported. Until then a
+    /// declared step falls back to its manifest position, biased past any
+    /// reported number so freshly seeded steps trail what has actually run.
+    /// A step id is a v4 UUID and sorts randomly, so it is only the final
+    /// tie-break for determinism.
+    fn execution_key(&self) -> (u32, usize, &str) {
+        match self.runner_number {
+            Some(number) => (number, 0, self.id.as_str()),
+            None => (
+                u32::MAX,
+                self.workflow_index.unwrap_or(usize::MAX),
+                self.id.as_str(),
+            ),
+        }
+    }
+
+    /// Order records as the job executed them.
+    ///
+    /// The in-memory manifest is seeded with declared steps and then appends
+    /// synthetic ones as the runner reports them, so its raw order puts
+    /// `Set up job` after the workflow steps despite it running first. A
+    /// restore adds a third order again. Every surface that shows a whole
+    /// step list goes through this instead.
+    pub(crate) fn sort_execution_order(steps: &mut [Self]) {
+        steps.sort_by(|left, right| left.execution_key().cmp(&right.execution_key()));
+    }
+
     /// Locate a step by stable identity, and by nothing else.
     ///
     /// Display names repeat legitimately — two steps may both be named `Test`

--- a/crates/preloop-runner-server/src/results_twirp.rs
+++ b/crates/preloop-runner-server/src/results_twirp.rs
@@ -126,11 +126,18 @@ pub(crate) async fn twirp_workflow_steps_update(
     // reported. Best-effort, like the rest of the store — in-memory state is
     // authoritative and a failed write must not fail the runner's callback.
     let records = records.clone();
+    // Bumped under the same lock that mutated the manifest, so the write
+    // carries a revision strictly newer than any snapshot taken before it.
+    let revision = {
+        let counter = inner.job_steps_revision.entry(job_uuid).or_insert(0);
+        *counter += 1;
+        *counter
+    };
     drop(inner);
     if let Err(error) = shared
         .state
         .store
-        .store_job_steps(run_id, job_uuid, &records)
+        .store_job_steps(run_id, job_uuid, &records, revision)
         .await
     {
         tracing::warn!(?error, %run_id, "failed to persist step records");

--- a/crates/preloop-runner-server/src/results_twirp.rs
+++ b/crates/preloop-runner-server/src/results_twirp.rs
@@ -14,6 +14,14 @@ pub(crate) struct StepLogsSignedBlobUrlRequest {
     pub(crate) workflow_run_backend_id: String,
 }
 
+/// Reconcile a runner's step report into that attempt's manifest.
+///
+/// This never decides a job's step *structure* — the manifest seeded from the
+/// job request message owns that. A report whose `external_id` is in the
+/// manifest updates that entry in place; anything else is runner bookkeeping
+/// ("Set up job", `Pre`/`Post` hooks, container lifecycle, "Complete job") and
+/// is appended as a synthetic record, so it owns its logs without shifting the
+/// numbering `--step` reads off the workflow.
 pub(crate) async fn twirp_workflow_steps_update(
     State(shared): State<Arc<SharedState>>,
     Json(payload): Json<serde_json::Value>,
@@ -25,139 +33,91 @@ pub(crate) async fn twirp_workflow_steps_update(
         .as_str()
         .unwrap_or("");
 
-    if let (Some(plan_uuid), Some(job_uuid)) = (
+    let (Some(plan_uuid), Some(job_uuid)) = (
         uuid::Uuid::parse_str(plan_id).ok(),
         uuid::Uuid::parse_str(agent_job_id_str).ok(),
-    ) {
-        if let Some((_, run_id, job_id)) =
-            resolve_callback_job(&inner, &plan_uuid.to_string(), None, Some(job_uuid))
-        {
-            // Find the step names by external_id and clone them to release the borrow on inner
-            let request_id = inner.agent_job_requests.get(&job_uuid).copied();
-            let step_names: std::collections::HashMap<uuid::Uuid, String> = request_id
-                .and_then(|id| inner.broker_messages.get(&id))
-                .map(|msg| {
-                    msg.steps
-                        .iter()
-                        .map(|s| {
-                            (
-                                s.id,
-                                s.display_name
-                                    .clone()
-                                    .or_else(|| s.name.clone())
-                                    .unwrap_or_default(),
-                            )
-                        })
-                        .collect()
-                })
-                .unwrap_or_default();
+    ) else {
+        return Ok(Json(json!({"ok": true})));
+    };
+    let Some((_, run_id, job_id)) =
+        resolve_callback_job(&inner, &plan_uuid.to_string(), None, Some(job_uuid))
+    else {
+        return Ok(Json(json!({"ok": true})));
+    };
+    let Some(steps) = payload["steps"].as_array().cloned() else {
+        return Ok(Json(json!({"ok": true})));
+    };
 
-            if let Some(run) = inner.runs.get_mut(&run_id) {
-                let job_name = job_id.0.clone();
-                let job_detail =
-                    if let Some(pos) = run.jobs_list.iter().position(|j| j.name == job_name) {
-                        &mut run.jobs_list[pos]
-                    } else {
-                        run.jobs_list.push(JobDetail {
-                            name: job_name,
-                            // A step update means the job started; the run
-                            // record's final conclusion comes from the job
-                            // status map (projected in the runs GET). Default
-                            // to the truthful in-flight state, never "success".
-                            conclusion: "in_progress".to_owned(),
-                            steps: Vec::new(),
-                            annotations: Vec::new(),
-                        });
-                        run.jobs_list.last_mut().unwrap()
-                    };
+    let job_status = inner
+        .runs
+        .get(&run_id)
+        .and_then(|run| run.jobs.get(&job_id).copied());
+    let observed = chrono::Utc::now();
+    let records = inner.job_steps.entry(job_uuid).or_default();
 
-                if let Some(status) = run.jobs.get(&job_id) {
-                    job_detail.conclusion = format!("{:?}", status).to_lowercase();
+    for step in &steps {
+        let external_id = step["external_id"].as_str().unwrap_or("");
+        if external_id.is_empty() {
+            // With no identity there is nothing to reconcile against, and
+            // guessing by display name is exactly what merged two distinct
+            // same-named steps and lost one from the run.
+            tracing::warn!(
+                %run_id, job = %job_id.0,
+                "dropping step report with no external_id"
+            );
+            continue;
+        }
+
+        let conclusion_num = step["conclusion"].as_u64().unwrap_or(0);
+        let status_num = step["status"].as_u64().unwrap_or(0);
+        let terminal = status_num == 6;
+        let conclusion = if terminal {
+            match conclusion_num {
+                2 => "success",
+                3 if job_status == Some(ExecutionStatus::Cancelled) => "cancelled",
+                3 => "failure",
+                7 => "skipped",
+                _ => "success",
+            }
+        } else {
+            "in_progress"
+        };
+        // The runner reports the rendered display name ("Run actions/checkout@v4"),
+        // the same string GitHub's UI shows, so it wins over the message's name:
+        // the server leaves that empty for steps without an explicit `name:`.
+        let reported_name = step["name"].as_str().filter(|name| !name.is_empty());
+        let runner_number = step["number"].as_u64().and_then(|n| u32::try_from(n).ok());
+
+        match StepRecord::find_by_id(records, external_id) {
+            Some(pos) => {
+                let record = &mut records[pos];
+                record.conclusion = conclusion.to_owned();
+                record.runner_number = runner_number.or(record.runner_number);
+                if let Some(name) = reported_name {
+                    record.name = name.to_owned();
                 }
-                if let Some(steps) = payload["steps"].as_array() {
-                    for step in steps {
-                        let external_id_str = step["external_id"].as_str().unwrap_or("");
-                        let step_uuid = uuid::Uuid::parse_str(external_id_str).ok();
-
-                        // The runner reports the rendered display name in the
-                        // update payload ("Run actions/checkout@v4", "Set up
-                        // job") — the same string GitHub's UI shows. Prefer it
-                        // over the broker-message name, which the server
-                        // leaves empty for steps without an explicit `name:`
-                        // (an empty lookup result previously won and steps
-                        // showed as `''` in run records).
-                        let name = step["name"]
-                            .as_str()
-                            .filter(|name| !name.is_empty())
-                            .map(str::to_owned)
-                            .or_else(|| step_uuid.and_then(|suuid| step_names.get(&suuid).cloned()))
-                            .unwrap_or_default();
-                        let duplicate_name = !name.is_empty()
-                            && steps
-                                .iter()
-                                .filter(|candidate| candidate["name"].as_str() == Some(&name))
-                                .count()
-                                > 1;
-
-                        let conclusion_num = step["conclusion"].as_u64().unwrap_or(0);
-                        let status_num = step["status"].as_u64().unwrap_or(0);
-
-                        let job_status = run.jobs.get(&job_id).copied();
-                        let conclusion_str = if status_num == 6 {
-                            match conclusion_num {
-                                2 => "success",
-                                3 => {
-                                    if job_status == Some(ExecutionStatus::Cancelled) {
-                                        "cancelled"
-                                    } else {
-                                        "failure"
-                                    }
-                                }
-                                7 => "skipped",
-                                _ => "success",
-                            }
-                        } else {
-                            "in_progress"
-                        };
-                        let terminal = status_num == 6;
-                        let observed = chrono::Utc::now();
-
-                        if let Some(pos) = StepRecord::find_matching_index(
-                            &job_detail.steps,
-                            external_id_str,
-                            &name,
-                            !duplicate_name,
-                        ) {
-                            if !external_id_str.is_empty() {
-                                job_detail.steps[pos].id = Some(external_id_str.to_owned());
-                            }
-                            job_detail.steps[pos].conclusion = conclusion_str.to_owned();
-                            // First non-terminal sighting is the start signal.
-                            if !terminal && job_detail.steps[pos].started_at.is_none() {
-                                job_detail.steps[pos].started_at = Some(observed);
-                            }
-                            if terminal && job_detail.steps[pos].finished_at.is_none() {
-                                job_detail.steps[pos].finished_at = Some(observed);
-                            }
-                        } else {
-                            // First time we hear about this step:
-                            // - in_progress → record started_at only
-                            // - already terminal → record finished_at only
-                            //   (do not invent started_at == finished_at, which
-                            //   forces duration 0 for fast steps that complete
-                            //   before any in-progress update is processed)
-                            job_detail.steps.push(StepRecord {
-                                id: (!external_id_str.is_empty())
-                                    .then(|| external_id_str.to_owned()),
-                                name,
-                                conclusion: conclusion_str.to_owned(),
-                                started_at: (!terminal).then_some(observed),
-                                finished_at: terminal.then_some(observed),
-                            });
-                        }
-                    }
+                // First non-terminal sighting is the start signal.
+                if !terminal && record.started_at.is_none() {
+                    record.started_at = Some(observed);
+                }
+                if terminal && record.finished_at.is_none() {
+                    record.finished_at = Some(observed);
                 }
             }
+            None => records.push(StepRecord {
+                id: external_id.to_owned(),
+                kind: StepKind::Synthetic,
+                workflow_index: None,
+                runner_number,
+                context_name: None,
+                name: reported_name.unwrap_or_default().to_owned(),
+                conclusion: conclusion.to_owned(),
+                // Do not invent `started_at == finished_at`, which forces
+                // duration 0 for a step that completed before any in-progress
+                // update was processed.
+                started_at: (!terminal).then_some(observed),
+                finished_at: terminal.then_some(observed),
+            }),
         }
     }
 

--- a/crates/preloop-runner-server/src/results_twirp.rs
+++ b/crates/preloop-runner-server/src/results_twirp.rs
@@ -121,6 +121,21 @@ pub(crate) async fn twirp_workflow_steps_update(
         }
     }
 
+    // Persist the attempt that changed, after releasing the lock: without this
+    // a restart before job completion loses every step conclusion the runner
+    // reported. Best-effort, like the rest of the store — in-memory state is
+    // authoritative and a failed write must not fail the runner's callback.
+    let records = records.clone();
+    drop(inner);
+    if let Err(error) = shared
+        .state
+        .store
+        .store_job_steps(run_id, job_uuid, &records)
+        .await
+    {
+        tracing::warn!(?error, %run_id, "failed to persist step records");
+    }
+
     Ok(Json(json!({"ok": true})))
 }
 

--- a/crates/preloop-runner-server/src/runs.rs
+++ b/crates/preloop-runner-server/src/runs.rs
@@ -1184,6 +1184,14 @@ pub(crate) async fn submit_run_inner(
                 inner
                     .timeline_requests
                     .insert(job_request.timeline_id, pb.request_id);
+                // Seed the attempt's step manifest before the runner can
+                // report anything, so step identity and order come from the
+                // message we just built rather than from whatever order the
+                // runner's log blobs happen to land in.
+                inner.job_steps.insert(
+                    job_request.agent_job_id,
+                    StepRecord::manifest(&agent_msg.steps),
+                );
                 inner.job_requests.insert(pb.request_id, job_request);
                 if let Some(request) = pb.github_token_request {
                     inner.github_token_requests.insert(pb.request_id, request);
@@ -2185,6 +2193,25 @@ pub(crate) fn build_job_artifacts(
     })
 }
 
+/// The step records of a job's most recent attempt.
+///
+/// Attempts are ordered by `request_id`, which is a monotonic allocation, so
+/// the highest one is the newest dispatch. `None` when the job was never
+/// dispatched (skipped or cancelled before a request was built).
+pub(crate) fn latest_attempt_steps(
+    inner: &crate::state::InnerState,
+    run_id: RunId,
+    job_id: &JobId,
+) -> Option<Vec<StepRecord>> {
+    let agent_job_id = inner
+        .job_requests
+        .values()
+        .filter(|request| request.run_id == run_id && request.job_id == *job_id)
+        .max_by_key(|request| request.request_id)
+        .map(|request| request.agent_job_id)?;
+    inner.job_steps.get(&agent_job_id).cloned()
+}
+
 pub(crate) async fn get_run(
     State(shared): State<Arc<SharedState>>,
     Path(run_id): Path<RunId>,
@@ -2210,8 +2237,9 @@ pub(crate) async fn get_run(
         .retain(|job_id, _| !expanded_callers.contains(job_id.0.as_str()));
 
     // Project with GitHub display names (evaluated `name:`, `caller / callee`
-    // separator). Results/timeline updates only create details for dispatched
-    // jobs; jobs skipped or cancelled before dispatch get an empty step list.
+    // separator), and hydrate each job's steps from its latest attempt's
+    // manifest. A job skipped or cancelled before dispatch never got a
+    // request message, so it has no manifest and shows an empty step list.
     let existing = std::mem::take(&mut run.jobs_list);
     run.jobs_list = run
         .jobs
@@ -2224,17 +2252,29 @@ pub(crate) async fn get_run(
                 .unwrap_or_else(|| job_id.0.clone());
             let mut detail = existing
                 .iter()
-                .find(|detail| detail.name == job_id.0 || detail.name == name)
+                .find(|detail| {
+                    detail.job_id == job_id.0
+                        || (detail.job_id.is_empty()
+                            && (detail.name == job_id.0 || detail.name == name))
+                })
                 .cloned()
                 .unwrap_or(JobDetail {
+                    job_id: job_id.0.clone(),
                     name: name.clone(),
                     conclusion: status_string(*status),
                     steps: Vec::new(),
                     annotations: Vec::new(),
                 });
+            detail.job_id = job_id.0.clone();
             detail.name = name;
             if let Some(stored) = run.jobs.get(job_id) {
                 detail.conclusion = status_string(*stored);
+            }
+            // Steps live in the attempt-scoped manifest, so the run record
+            // shows the newest attempt: a retry supersedes what the previous
+            // dispatch reported.
+            if let Some(manifest) = latest_attempt_steps(&inner, run_id, job_id) {
+                detail.steps = manifest;
             }
             detail
         })
@@ -2376,10 +2416,11 @@ pub(crate) struct RunLogsQuery {
 
 /// Files uploaded for one job's individual steps.
 ///
-/// `all` preserves upload order for an unfiltered request. `workflow` maps the
-/// user-visible workflow-step order to those files; an entry is `None` when a
-/// step produced no log blob. Keeping both views matters because synthetic
-/// setup/cleanup records can be uploaded alongside user steps.
+/// `all` is every uploaded step blob, for an unfiltered whole-job read.
+/// `workflow` is the manifest's declared steps in workflow order, each mapped
+/// to its blob (`None` when that step produced no log). Synthetic runner steps
+/// appear in `all` but never in `workflow`, which is what keeps "Set up job"
+/// and `Post <action>` out of `--step` numbering.
 struct StepLogs {
     all: Vec<std::path::PathBuf>,
     workflow: Option<Vec<Option<std::path::PathBuf>>>,
@@ -2407,6 +2448,12 @@ enum JobLogs {
 /// authoritative whole-job representation. A step-filtered request prefers
 /// individual step blobs when both are present; the merged upload has no
 /// recoverable boundaries and is only used to produce the explicit 409.
+///
+/// `workflow_step_ids` is the attempt's declared-step order, taken from the
+/// manifest built out of the job request message. There is deliberately no
+/// filesystem fallback: modification time records when a blob landed, not when
+/// a step ran, so ordering by it returned the wrong step for out-of-order or
+/// same-timestamp uploads.
 async fn resolve_job_logs(
     results_dir: &std::path::Path,
     fallback_blocks: Vec<Vec<u8>>,
@@ -2429,7 +2476,7 @@ async fn resolve_job_logs(
         }
     }
 
-    let mut step_files = Vec::new();
+    let mut step_files: Vec<(String, std::path::PathBuf)> = Vec::new();
     match tokio::fs::read_dir(results_dir).await {
         Ok(mut entries) => {
             while let Some(entry) = entries.next_entry().await.map_err(|error| {
@@ -2440,9 +2487,13 @@ async fn resolve_job_logs(
             })? {
                 let name = entry.file_name();
                 let name = name.to_string_lossy();
-                if !name.starts_with("step-") || !name.ends_with(".txt") {
+                let Some(step_id) = name
+                    .strip_prefix("step-")
+                    .and_then(|name| name.strip_suffix(".txt"))
+                else {
                     continue;
-                }
+                };
+                let step_id = step_id.to_owned();
                 let metadata = entry.metadata().await.map_err(|error| {
                     ApiError::internal(format!(
                         "failed to inspect result log `{}`: {error}",
@@ -2452,13 +2503,7 @@ async fn resolve_job_logs(
                 if !metadata.is_file() {
                     continue;
                 }
-                let step_id = name
-                    .strip_prefix("step-")
-                    .and_then(|name| name.strip_suffix(".txt"))
-                    .unwrap_or_default()
-                    .to_owned();
-                let modified = metadata.modified().unwrap_or(std::time::UNIX_EPOCH);
-                step_files.push((modified, name.into_owned(), step_id, entry.path()));
+                step_files.push((step_id, entry.path()));
             }
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
@@ -2469,7 +2514,9 @@ async fn resolve_job_logs(
             )));
         }
     }
-    step_files.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
+    // Only for the unfiltered read, where this is a concatenation order and
+    // not a step selector. `--step` goes through `workflow` below.
+    step_files.sort_by(|left, right| left.0.cmp(&right.0));
 
     if !step_files.is_empty() {
         let workflow = workflow_step_ids.filter(|ids| !ids.is_empty()).map(|ids| {
@@ -2477,13 +2524,13 @@ async fn resolve_job_logs(
                 .map(|id| {
                     step_files
                         .iter()
-                        .find(|(_, _, file_id, _)| file_id == id)
-                        .map(|(_, _, _, path)| path.clone())
+                        .find(|(file_id, _)| file_id == id)
+                        .map(|(_, path)| path.clone())
                 })
                 .collect()
         });
         return Ok(JobLogs::Steps(StepLogs {
-            all: step_files.into_iter().map(|(_, _, _, path)| path).collect(),
+            all: step_files.into_iter().map(|(_, path)| path).collect(),
             workflow,
         }));
     }
@@ -2541,16 +2588,19 @@ async fn append_step(
              boundaries; re-request without `step` for the whole job log"
         ))),
         JobLogs::Steps(step_logs) => {
-            let (total, path) = match step_logs.workflow {
-                Some(workflow) => {
-                    let total = workflow.len();
-                    (total, workflow.get(index).cloned().flatten())
-                }
-                None => {
-                    let total = step_logs.all.len();
-                    (total, step_logs.all.get(index).cloned())
-                }
+            // No manifest means no declared-step order to index. The uploads
+            // on disk are not a substitute: they include synthetic runner
+            // steps and arrive in upload order, so indexing them returned a
+            // neighbouring step's log under the requested step's name.
+            let Some(workflow) = step_logs.workflow else {
+                return Err(ApiError::conflict(format!(
+                    "job `{job_label}` has no recorded workflow-step order, so step \
+                     {step} cannot be identified; re-request without `step` for the \
+                     whole job log"
+                )));
             };
+            let total = workflow.len();
+            let path = workflow.get(index).cloned().flatten();
             let Some(path) = path else {
                 if index < total {
                     // A valid workflow step is allowed to have no log blob.
@@ -2645,32 +2695,22 @@ pub(crate) async fn get_run_logs(
                         (Err(_), Err(_)) => left.cmp(right),
                     }
                 });
+                // The attempt's own manifest, keyed by the agent job id that
+                // also names this request's results directory. Declared steps
+                // only: a synthetic "Set up job" record must not occupy a
+                // `--step` slot. The broker message is deliberately not
+                // consulted — it is broker delivery state that a restart or a
+                // retirement can drop, while the manifest is run state.
                 let workflow_step_ids = inner
-                    .broker_messages
-                    .get(&request.request_id)
-                    .map(|message| {
-                        message
-                            .steps
-                            .iter()
-                            .map(|step| step.id.to_string())
+                    .job_steps
+                    .get(&request.agent_job_id)
+                    .map(|records| {
+                        StepRecord::workflow_steps(records)
+                            .into_iter()
+                            .map(|step| step.id.clone())
                             .collect::<Vec<_>>()
                     })
-                    .filter(|ids| !ids.is_empty())
-                    .or_else(|| {
-                        inner.runs.get(&run_id).and_then(|run| {
-                            run.jobs_list
-                                .iter()
-                                .find(|detail| detail.name == request.job_id.0)
-                                .map(|detail| {
-                                    detail
-                                        .steps
-                                        .iter()
-                                        .filter_map(|step| step.id.clone())
-                                        .collect::<Vec<_>>()
-                                })
-                                .filter(|ids| !ids.is_empty())
-                        })
-                    });
+                    .filter(|ids| !ids.is_empty());
                 (
                     request.plan_id.clone(),
                     request.agent_job_id.to_string(),

--- a/crates/preloop-runner-server/src/runs.rs
+++ b/crates/preloop-runner-server/src/runs.rs
@@ -2619,16 +2619,15 @@ async fn append_step(
             merged.extend_from_slice(&contents);
             Ok(())
         }
-        JobLogs::Live(blocks) => {
-            let total = blocks.len();
-            let block = blocks.into_iter().nth(index).ok_or_else(|| {
-                ApiError::not_found(format!(
-                    "job `{job_label}` has {total} steps so far; step {step} is out of range"
-                ))
-            })?;
-            merged.extend_from_slice(&block);
-            Ok(())
-        }
+        // In-memory console blocks are keyed by the runner's numeric log id,
+        // which counts every record it opened — `Set up job` included — so
+        // indexing them returns setup output for `--step 1`. That is the
+        // numbering error this whole path exists to remove, so refuse instead
+        // of reproducing it for a job whose blobs have not landed yet.
+        JobLogs::Live(_) => Err(ApiError::conflict(format!(
+            "job `{job_label}` has not uploaded per-step logs yet, so step {step} cannot be \
+             identified; re-request without `step` for the output so far"
+        ))),
     }
 }
 

--- a/crates/preloop-runner-server/src/runs.rs
+++ b/crates/preloop-runner-server/src/runs.rs
@@ -1189,11 +1189,11 @@ pub(crate) async fn submit_run_inner(
                 // message we just built rather than from whatever order the
                 // runner's log blobs happen to land in.
                 //
-                // Not persisted here. The first runner report for this attempt
-                // writes the whole manifest through `store_job_steps`, so the
-                // only attempt without durable rows is one that was dispatched
-                // and never reported — which has no logs to select either, and
-                // whose `--step` correctly answers 409 after a restart.
+                // Not persisted here. Only a runner report writes rows, and an
+                // attempt that was dispatched but never reported has its
+                // manifest rebuilt at startup from the persisted request
+                // message — the same source it was built from — so a restart
+                // in that window keeps its declared steps.
                 inner.job_steps.insert(
                     job_request.agent_job_id,
                     StepRecord::manifest(&agent_msg.steps),

--- a/crates/preloop-runner-server/src/runs.rs
+++ b/crates/preloop-runner-server/src/runs.rs
@@ -2209,7 +2209,10 @@ pub(crate) fn latest_attempt_steps(
         .filter(|request| request.run_id == run_id && request.job_id == *job_id)
         .max_by_key(|request| request.request_id)
         .map(|request| request.agent_job_id)?;
-    inner.job_steps.get(&agent_job_id).cloned()
+    let mut steps = inner.job_steps.get(&agent_job_id).cloned()?;
+    // The stored vector is seeded-then-appended, so it is not execution order.
+    StepRecord::sort_execution_order(&mut steps);
+    Some(steps)
 }
 
 pub(crate) async fn get_run(
@@ -2458,6 +2461,9 @@ async fn resolve_job_logs(
     results_dir: &std::path::Path,
     fallback_blocks: Vec<Vec<u8>>,
     workflow_step_ids: Option<&[String]>,
+    // Every id the attempt's manifest knows, in execution order, used only to
+    // order the whole-job concatenation.
+    execution_step_ids: Option<&[String]>,
     prefer_steps: bool,
 ) -> Result<JobLogs, ApiError> {
     let merged = match tokio::fs::read(results_dir.join("job-logs.txt")).await {
@@ -2514,9 +2520,19 @@ async fn resolve_job_logs(
             )));
         }
     }
-    // Only for the unfiltered read, where this is a concatenation order and
-    // not a step selector. `--step` goes through `workflow` below.
-    step_files.sort_by(|left, right| left.0.cmp(&right.0));
+    // Concatenation order comes from the manifest, which knows what ran when.
+    // A step id is a v4 UUID, so sorting by it emitted the whole-job log in
+    // random order; blobs the manifest does not know keep a stable tail.
+    let position = |id: &str| {
+        execution_step_ids
+            .and_then(|ids| ids.iter().position(|known| known == id))
+            .unwrap_or(usize::MAX)
+    };
+    step_files.sort_by(|left, right| {
+        position(&left.0)
+            .cmp(&position(&right.0))
+            .then_with(|| left.0.cmp(&right.0))
+    });
 
     if !step_files.is_empty() {
         let workflow = workflow_step_ids.filter(|ids| !ids.is_empty()).map(|ids| {
@@ -2695,19 +2711,29 @@ pub(crate) async fn get_run_logs(
                     }
                 });
                 // The attempt's own manifest, keyed by the agent job id that
-                // also names this request's results directory. Declared steps
-                // only: a synthetic "Set up job" record must not occupy a
-                // `--step` slot. The broker message is deliberately not
-                // consulted — it is broker delivery state that a restart or a
-                // retirement can drop, while the manifest is run state.
-                let workflow_step_ids = inner
-                    .job_steps
-                    .get(&request.agent_job_id)
+                // also names this request's results directory. The broker
+                // message is deliberately not consulted — it is broker
+                // delivery state that a restart or a retirement can drop,
+                // while the manifest is run state.
+                //
+                // Two views: declared steps in workflow order decide `--step`,
+                // because a synthetic "Set up job" record must not occupy a
+                // slot; every id in execution order decides the whole-job
+                // concatenation, where synthetic output belongs in place.
+                let manifest = inner.job_steps.get(&request.agent_job_id);
+                let workflow_step_ids = manifest
                     .map(|records| {
                         StepRecord::workflow_steps(records)
                             .into_iter()
                             .map(|step| step.id.clone())
                             .collect::<Vec<_>>()
+                    })
+                    .filter(|ids| !ids.is_empty());
+                let execution_step_ids = manifest
+                    .map(|records| {
+                        let mut ordered = records.clone();
+                        StepRecord::sort_execution_order(&mut ordered);
+                        ordered.into_iter().map(|step| step.id).collect::<Vec<_>>()
                     })
                     .filter(|ids| !ids.is_empty());
                 (
@@ -2719,6 +2745,7 @@ pub(crate) async fn get_run_logs(
                         .map(|(_, block)| block.to_vec())
                         .collect::<Vec<_>>(),
                     workflow_step_ids,
+                    execution_step_ids,
                 )
             })
             .collect::<Vec<_>>();
@@ -2726,7 +2753,15 @@ pub(crate) async fn get_run_logs(
     };
 
     let mut merged = Vec::new();
-    for (plan_id, agent_job_id, job_label, fallback_blocks, workflow_step_ids) in sources {
+    for (
+        plan_id,
+        agent_job_id,
+        job_label,
+        fallback_blocks,
+        workflow_step_ids,
+        execution_step_ids,
+    ) in sources
+    {
         let results_dir = state_dir
             .join("replay")
             .join("results")
@@ -2736,6 +2771,7 @@ pub(crate) async fn get_run_logs(
             &results_dir,
             fallback_blocks,
             workflow_step_ids.as_deref(),
+            execution_step_ids.as_deref(),
             query.step.is_some(),
         )
         .await?;

--- a/crates/preloop-runner-server/src/runs.rs
+++ b/crates/preloop-runner-server/src/runs.rs
@@ -1189,11 +1189,13 @@ pub(crate) async fn submit_run_inner(
                 // message we just built rather than from whatever order the
                 // runner's log blobs happen to land in.
                 //
-                // Not persisted here. Only a runner report writes rows, and an
-                // attempt that was dispatched but never reported has its
-                // manifest rebuilt at startup from the persisted request
-                // message — the same source it was built from — so a restart
-                // in that window keeps its declared steps.
+                // Not persisted here. Rows are written by a runner report, a
+                // job completion, or a full snapshot that happens to flush
+                // them; none of those has necessarily run when a dispatched
+                // attempt is interrupted, so its manifest is rebuilt at startup
+                // from the persisted request message — the same source it was
+                // built from — and a restart in that window keeps its declared
+                // steps.
                 inner.job_steps.insert(
                     job_request.agent_job_id,
                     StepRecord::manifest(&agent_msg.steps),

--- a/crates/preloop-runner-server/src/runs.rs
+++ b/crates/preloop-runner-server/src/runs.rs
@@ -1188,6 +1188,12 @@ pub(crate) async fn submit_run_inner(
                 // report anything, so step identity and order come from the
                 // message we just built rather than from whatever order the
                 // runner's log blobs happen to land in.
+                //
+                // Not persisted here. The first runner report for this attempt
+                // writes the whole manifest through `store_job_steps`, so the
+                // only attempt without durable rows is one that was dispatched
+                // and never reported — which has no logs to select either, and
+                // whose `--step` correctly answers 409 after a restart.
                 inner.job_steps.insert(
                     job_request.agent_job_id,
                     StepRecord::manifest(&agent_msg.steps),

--- a/crates/preloop-runner-server/src/runs.rs
+++ b/crates/preloop-runner-server/src/runs.rs
@@ -2221,29 +2221,27 @@ pub(crate) fn latest_attempt_steps(
     Some(steps)
 }
 
-pub(crate) async fn get_run(
-    State(shared): State<Arc<SharedState>>,
-    Path(run_id): Path<RunId>,
-) -> Result<Json<RunRecord>, ApiError> {
-    let inner = shared.state.inner.lock().await;
-    let mut run = inner
-        .runs
-        .get(&run_id)
-        .cloned()
-        .ok_or_else(|| ApiError::not_found("run not found"))?;
+/// Project a stored run into its API shape.
+///
+/// Shared by the single-run and list endpoints. Step records live in the
+/// attempt-scoped manifest rather than in the stored run, so a caller that
+/// clones `inner.runs` directly returns empty step arrays — which is exactly
+/// what the list endpoint did.
+pub(crate) fn project_run(inner: &crate::state::InnerState, mut run: RunRecord) -> RunRecord {
+    let run_id = run.run_id;
 
     // GitHub's run record shows a gate-passed reusable caller only as its
     // callee jobs: once the subtree is materialized, the caller entry leaves
     // the visible job set. Gate-failed callers never materialize and stay as
     // exactly one (skipped) entry.
-    let expanded_callers: std::collections::BTreeSet<&str> = run
+    let expanded_callers: std::collections::BTreeSet<String> = run
         .reusable_calls
         .iter()
         .filter(|(_, call)| !call.inner_job_ids.is_empty())
-        .map(|(caller_id, _)| caller_id.as_str())
+        .map(|(caller_id, _)| caller_id.clone())
         .collect();
     run.jobs
-        .retain(|job_id, _| !expanded_callers.contains(job_id.0.as_str()));
+        .retain(|job_id, _| !expanded_callers.contains(&job_id.0));
 
     // Project with GitHub display names (evaluated `name:`, `caller / callee`
     // separator), and hydrate each job's steps from its latest attempt's
@@ -2261,11 +2259,7 @@ pub(crate) async fn get_run(
                 .unwrap_or_else(|| job_id.0.clone());
             let mut detail = existing
                 .iter()
-                .find(|detail| {
-                    detail.job_id == job_id.0
-                        || (detail.job_id.is_empty()
-                            && (detail.name == job_id.0 || detail.name == name))
-                })
+                .find(|detail| detail.job_id == job_id.0)
                 .cloned()
                 .unwrap_or(JobDetail {
                     job_id: job_id.0.clone(),
@@ -2276,20 +2270,31 @@ pub(crate) async fn get_run(
                 });
             detail.job_id = job_id.0.clone();
             detail.name = name;
-            if let Some(stored) = run.jobs.get(job_id) {
-                detail.conclusion = status_string(*stored);
-            }
+            detail.conclusion = status_string(*status);
             // Steps live in the attempt-scoped manifest, so the run record
             // shows the newest attempt: a retry supersedes what the previous
             // dispatch reported.
-            if let Some(manifest) = latest_attempt_steps(&inner, run_id, job_id) {
+            if let Some(manifest) = latest_attempt_steps(inner, run_id, job_id) {
                 detail.steps = manifest;
             }
             detail
         })
         .collect();
 
-    Ok(Json(run))
+    run
+}
+
+pub(crate) async fn get_run(
+    State(shared): State<Arc<SharedState>>,
+    Path(run_id): Path<RunId>,
+) -> Result<Json<RunRecord>, ApiError> {
+    let inner = shared.state.inner.lock().await;
+    let run = inner
+        .runs
+        .get(&run_id)
+        .cloned()
+        .ok_or_else(|| ApiError::not_found("run not found"))?;
+    Ok(Json(project_run(&inner, run)))
 }
 
 /// Browser-safe status page linked from GitHub Check Runs.
@@ -2402,6 +2407,10 @@ pub(crate) async fn list_runs(
         })
         .take(limit)
         .cloned()
+        // Same projection as the single-run endpoint: steps live in the
+        // attempt manifest, so cloning the stored run alone returns empty
+        // step arrays.
+        .map(|run| project_run(&inner, run))
         .collect();
 
     Ok(Json(runs))

--- a/crates/preloop-runner-server/src/runtime_scheduling.rs
+++ b/crates/preloop-runner-server/src/runtime_scheduling.rs
@@ -2678,6 +2678,17 @@ pub(crate) fn retire_node_requests(
                 inner.live_log_lines.remove(&agent_key);
                 inner.live_log_tx.remove(&agent_key);
                 inner.live_log_closed.remove(&agent_key);
+                // The step manifest is attempt-scoped, so it belongs to the
+                // request being purged. A deferred-matrix placeholder gets one
+                // seeded at dispatch and is then purged when expansion
+                // replaces it, so without this every dynamic expansion leaves
+                // an entry no run projection can reach.
+                //
+                // Durable rows cannot leak the same way: seeding is not
+                // persisted, and a placeholder never reports, so it never
+                // reaches `store_job_steps`. Rows for attempts that did report
+                // are removed with their run through the `runs` foreign key.
+                inner.job_steps.remove(&record.agent_job_id);
             }
         }
     }

--- a/crates/preloop-runner-server/src/runtime_scheduling.rs
+++ b/crates/preloop-runner-server/src/runtime_scheduling.rs
@@ -2408,6 +2408,13 @@ fn register_expanded_jobs(
         inner
             .timeline_requests
             .insert(job_request.timeline_id, job_request.request_id);
+        // A reusable callee or dynamic matrix leg only exists once its gate
+        // passes, so its manifest is seeded here rather than at submission.
+        // Every concrete attempt gets one before dispatch either way.
+        inner.job_steps.insert(
+            job_request.agent_job_id,
+            crate::models::StepRecord::manifest(&artifacts.agent_msg.steps),
+        );
         // Per-inner-job, so a wide matrix logs this once per leg: a 12k-leg
         // callee emitted 12k warnings for the ordinary no-GitHub-App setup and
         // buried every real diagnostic. Absence of a token request is the

--- a/crates/preloop-runner-server/src/state.rs
+++ b/crates/preloop-runner-server/src/state.rs
@@ -764,6 +764,43 @@ impl AppState {
         let store = crate::store::open_store(store_url, &state_dir, &local_jwt_key).await?;
         let mut recovered = inner;
         store.load_into(&mut recovered).await?;
+        // An attempt dispatched but not yet reported has no persisted step
+        // rows: seeding happens in memory, and only a runner report writes
+        // them. The request message it was built from *is* persisted, so
+        // rebuild from that rather than leaving the run with no declared steps
+        // and `--step` answering 409 for logs that are on disk.
+        //
+        // Two homes, depending on how far the job got: `broker_messages` once
+        // a runner claimed it, and the queue row's own copy before that.
+        let rebuilt: Vec<(uuid::Uuid, Vec<crate::models::StepRecord>)> = recovered
+            .job_requests
+            .values()
+            .filter(|record| !recovered.job_steps.contains_key(&record.agent_job_id))
+            .filter_map(|record| {
+                let steps = recovered
+                    .broker_messages
+                    .get(&record.request_id)
+                    .map(|message| message.steps.as_slice())
+                    .or_else(|| {
+                        recovered
+                            .queue
+                            .iter()
+                            .chain(recovered.pending_jobs.iter())
+                            .chain(recovered.concurrency_blocked.iter())
+                            .find(|job| job.run_id == record.run_id && job.job_id == record.job_id)
+                            .map(|job| job.message.steps.as_slice())
+                    })?;
+                let manifest = crate::models::StepRecord::manifest(steps);
+                (!manifest.is_empty()).then_some((record.agent_job_id, manifest))
+            })
+            .collect();
+        if !rebuilt.is_empty() {
+            tracing::info!(
+                attempts = rebuilt.len(),
+                "rebuilt step manifests from persisted job request messages"
+            );
+        }
+        recovered.job_steps.extend(rebuilt);
         let next_request_id = recovered
             .job_requests
             .keys()

--- a/crates/preloop-runner-server/src/state.rs
+++ b/crates/preloop-runner-server/src/state.rs
@@ -1413,6 +1413,16 @@ pub(crate) struct InnerState {
     pub(crate) live_log_closed: std::collections::BTreeSet<String>,
     pub(crate) inflight_requests: BTreeMap<i64, (RunId, JobId)>,
     pub(crate) job_requests: BTreeMap<i64, TaskAgentJobRequestRecord>,
+    /// Step records per job attempt, keyed by `agent_job_id`.
+    ///
+    /// Authoritative for both the run record's step projection and `--step`
+    /// log selection. Keyed by attempt, not by job: a re-dispatch mints fresh
+    /// `TaskStep` ids, so a job-scoped map would overwrite the mapping the
+    /// previous attempt's `step-<id>.txt` blobs are still named after.
+    ///
+    /// Seeded from the job request message at dispatch (every declared step,
+    /// in workflow order); runner reports only reconcile into it.
+    pub(crate) job_steps: BTreeMap<uuid::Uuid, Vec<crate::models::StepRecord>>,
     pub(crate) plan_requests: BTreeMap<String, i64>,
     pub(crate) agent_job_requests: BTreeMap<uuid::Uuid, i64>,
     pub(crate) timeline_requests: BTreeMap<uuid::Uuid, i64>,

--- a/crates/preloop-runner-server/src/state.rs
+++ b/crates/preloop-runner-server/src/state.rs
@@ -1460,6 +1460,14 @@ pub(crate) struct InnerState {
     /// Seeded from the job request message at dispatch (every declared step,
     /// in workflow order); runner reports only reconcile into it.
     pub(crate) job_steps: BTreeMap<uuid::Uuid, Vec<crate::models::StepRecord>>,
+    /// Monotonic revision per attempt, bumped whenever `job_steps` changes.
+    ///
+    /// Reconciliation snapshots a manifest under this lock and writes it after
+    /// releasing it, so two reports for one attempt can commit out of order.
+    /// The revision travels with the write and the upsert refuses to move a
+    /// row backwards, so an older snapshot cannot overwrite newer conclusions.
+    /// In memory only: the persisted column is what it guards.
+    pub(crate) job_steps_revision: BTreeMap<uuid::Uuid, u64>,
     pub(crate) plan_requests: BTreeMap<String, i64>,
     pub(crate) agent_job_requests: BTreeMap<uuid::Uuid, i64>,
     pub(crate) timeline_requests: BTreeMap<uuid::Uuid, i64>,

--- a/crates/preloop-runner-server/src/state.rs
+++ b/crates/preloop-runner-server/src/state.rs
@@ -787,7 +787,13 @@ impl AppState {
                             .iter()
                             .chain(recovered.pending_jobs.iter())
                             .chain(recovered.concurrency_blocked.iter())
-                            .find(|job| job.run_id == record.run_id && job.job_id == record.job_id)
+                            // Keyed by request id, not by (run, job): a
+                            // re-dispatch leaves several requests for one
+                            // logical job, and matching the pair attaches the
+                            // newest queued message to an older attempt —
+                            // rebuilding it with the wrong `TaskStep` ids, so
+                            // its `step-<id>.txt` blobs stop resolving.
+                            .find(|job| job.message.request_id == record.request_id)
                             .map(|job| job.message.steps.as_slice())
                     })?;
                 let manifest = crate::models::StepRecord::manifest(steps);

--- a/crates/preloop-runner-server/src/store.rs
+++ b/crates/preloop-runner-server/src/store.rs
@@ -208,6 +208,8 @@ pub(crate) struct StoreSnapshot {
     pub(crate) session_active_requests: Vec<(String, i64)>,
     /// request_id → undelivered job message.
     pub(crate) broker_request_messages: Vec<(i64, azdo::AgentJobRequestMessage)>,
+    /// (agent_job_id, that attempt's step records).
+    pub(crate) job_steps: Vec<(uuid::Uuid, Vec<crate::models::StepRecord>)>,
     pub(crate) meta: MetaSnapshot,
 }
 
@@ -251,6 +253,11 @@ impl StoreSnapshot {
                 .iter()
                 .map(|(id, message)| (*id, message.clone()))
                 .collect(),
+            job_steps: inner
+                .job_steps
+                .iter()
+                .map(|(agent_job_id, records)| (*agent_job_id, records.clone()))
+                .collect(),
             meta: build_meta_snapshot(inner),
         }
     }
@@ -270,6 +277,8 @@ pub(crate) struct RunProjection {
     pub(crate) session_active_requests: Vec<(String, i64)>,
     pub(crate) inflight: Vec<(String, i64, azdo::TaskAgentMessage)>,
     pub(crate) broker_request_messages: Vec<(i64, azdo::AgentJobRequestMessage)>,
+    /// (agent_job_id, step records) for this run's attempts only.
+    pub(crate) job_steps: Vec<(uuid::Uuid, Vec<crate::models::StepRecord>)>,
     pub(crate) event: NdjsonEvent,
 }
 
@@ -312,6 +321,20 @@ impl RunProjection {
                 .broker_messages
                 .iter()
                 .map(|(id, message)| (*id, message.clone()))
+                .collect(),
+            // Only this run's attempts: `job_steps` is global, and rewriting
+            // every run's steps on one run's event is the amplification this
+            // table exists to avoid.
+            job_steps: inner
+                .job_requests
+                .values()
+                .filter(|record| record.run_id == run_id)
+                .filter_map(|record| {
+                    inner
+                        .job_steps
+                        .get(&record.agent_job_id)
+                        .map(|records| (record.agent_job_id, records.clone()))
+                })
                 .collect(),
             event,
         })
@@ -1395,6 +1418,72 @@ impl SqliteStore {
                 .workflow_run_counters
                 .insert(workflow_path, next_run_number.saturating_sub(1));
         }
+        // Step manifests, ordered so a workflow step's `--step` position is
+        // rebuilt exactly as it was recorded. Without this a restart leaves
+        // `--step` unable to identify anything and it refuses rather than
+        // guessing, so the run's step history has to come back here.
+        let mut step_stmt = connection.prepare(
+            "SELECT agent_job_id, step_id, kind, workflow_index, runner_number,
+                    context_name, name_blob, conclusion, started_at_us, finished_at_us
+             FROM job_steps
+             ORDER BY agent_job_id, kind, workflow_index, step_id",
+        )?;
+        for row in step_stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, Option<i64>>(3)?,
+                row.get::<_, Option<i64>>(4)?,
+                row.get::<_, Option<String>>(5)?,
+                row.get::<_, Vec<u8>>(6)?,
+                row.get::<_, String>(7)?,
+                row.get::<_, Option<i64>>(8)?,
+                row.get::<_, Option<i64>>(9)?,
+            ))
+        })? {
+            let (
+                agent_job_id,
+                step_id,
+                kind,
+                workflow_index,
+                runner_number,
+                context_name,
+                name_blob,
+                conclusion,
+                started_at_us,
+                finished_at_us,
+            ) = row?;
+            let Ok(agent_job_id) = agent_job_id.parse::<uuid::Uuid>() else {
+                tracing::warn!(%agent_job_id, "dropping step row with an unparseable attempt id");
+                continue;
+            };
+            let name = match self.cipher.unseal(&name_blob) {
+                Ok(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
+                Err(error) => {
+                    tracing::warn!(%error, %step_id, "dropping step row with an unreadable name");
+                    continue;
+                }
+            };
+            inner
+                .job_steps
+                .entry(agent_job_id)
+                .or_default()
+                .push(crate::models::StepRecord {
+                    id: step_id,
+                    kind: match kind.as_str() {
+                        "workflow" => crate::models::StepKind::Workflow,
+                        _ => crate::models::StepKind::Synthetic,
+                    },
+                    workflow_index: workflow_index.map(|index| index as usize),
+                    runner_number: runner_number.map(|number| number as u32),
+                    context_name,
+                    name,
+                    conclusion,
+                    started_at: started_at_us.and_then(chrono::DateTime::from_timestamp_micros),
+                    finished_at: finished_at_us.and_then(chrono::DateTime::from_timestamp_micros),
+                });
+        }
         // Log bytes live in their own table; rebuild the in-memory buffers
         // from ordered chunks. Failing to do this leaves the post-restart
         // server unable to serve GET /logs/<id> for in-flight jobs.
@@ -1627,6 +1716,17 @@ impl SqliteStore {
         for record in &snapshot.requests {
             self.insert_request_tx(&tx, record)?;
         }
+        // Steps are keyed by attempt, and the request records are what tie an
+        // attempt to its run.
+        for record in &snapshot.requests {
+            if let Some((_, steps)) = snapshot
+                .job_steps
+                .iter()
+                .find(|(agent_job_id, _)| *agent_job_id == record.agent_job_id)
+            {
+                self.write_job_steps_tx(&tx, record.run_id, record.agent_job_id, steps)?;
+            }
+        }
         self.write_claim_state_tx(
             &tx,
             &snapshot.session_active_requests,
@@ -1662,6 +1762,9 @@ impl SqliteStore {
         )?;
         for record in &projection.requests {
             self.insert_request_tx(&tx, record)?;
+        }
+        for (agent_job_id, steps) in &projection.job_steps {
+            self.write_job_steps_tx(&tx, run_id, *agent_job_id, steps)?;
         }
         // The claim state must land in the same transaction as the queue
         // rewrite above: a job that was claimed (dequeued, message handed to a
@@ -1766,6 +1869,68 @@ impl SqliteStore {
                 self.cipher.seal(&serde_json::to_vec(&snapshot)?)?,
             ],
         )?;
+        Ok(())
+    }
+
+    /// The stored spelling of a step's kind.
+    ///
+    /// Plaintext and constrained by a `CHECK`, because `--step` filters on it.
+    fn step_kind_str(kind: crate::models::StepKind) -> &'static str {
+        match kind {
+            crate::models::StepKind::Workflow => "workflow",
+            crate::models::StepKind::Synthetic => "synthetic",
+        }
+    }
+
+    /// Upsert one run's attempt step rows.
+    ///
+    /// Deliberately no `DELETE ... WHERE run_id` first: manifests only grow or
+    /// have fields updated, so a keyed upsert writes just the changed rows.
+    /// Deleting and re-inserting per run event would reintroduce the very
+    /// write amplification this table exists to avoid. Rows go away with their
+    /// run, through the `runs` foreign key.
+    fn write_job_steps_tx(
+        &self,
+        tx: &Transaction<'_>,
+        run_id: RunId,
+        agent_job_id: uuid::Uuid,
+        records: &[crate::models::StepRecord],
+    ) -> anyhow::Result<()> {
+        {
+            for step in records {
+                if step.id.is_empty() {
+                    continue;
+                }
+                tx.execute(
+                    "INSERT INTO job_steps(run_id, agent_job_id, step_id, kind, workflow_index,
+                                           runner_number, context_name, name_blob, conclusion,
+                                           started_at_us, finished_at_us)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+                     ON CONFLICT(agent_job_id, step_id) DO UPDATE SET
+                       kind = excluded.kind,
+                       workflow_index = excluded.workflow_index,
+                       runner_number = excluded.runner_number,
+                       context_name = excluded.context_name,
+                       name_blob = excluded.name_blob,
+                       conclusion = excluded.conclusion,
+                       started_at_us = excluded.started_at_us,
+                       finished_at_us = excluded.finished_at_us",
+                    params![
+                        run_id.to_string(),
+                        agent_job_id.to_string(),
+                        step.id,
+                        Self::step_kind_str(step.kind),
+                        step.workflow_index.map(|index| index as i64),
+                        step.runner_number.map(|number| number as i64),
+                        step.context_name,
+                        self.cipher.seal(step.name.as_bytes())?,
+                        step.conclusion,
+                        step.started_at.map(unix_us),
+                        step.finished_at.map(unix_us),
+                    ],
+                )?;
+            }
+        }
         Ok(())
     }
 
@@ -2155,6 +2320,44 @@ const MIGRATIONS: &[(u32, &str, &str)] = &[
           payload_json TEXT NOT NULL CHECK (json_valid(payload_json)),
           written_at_us INTEGER NOT NULL
         ) STRICT;
+        "#,
+    ),
+    (
+        4,
+        "job-steps-table",
+        // Step records get their own table rather than riding in
+        // `runs.record_blob`: that blob carries the workflow YAML, the event
+        // payload and the github context, and `store_run_event` reseals all of
+        // it on every run event. Rows here are upserted individually, so a
+        // step transition writes one small row instead of re-encrypting the
+        // whole run. `MetaSnapshot` is not an option either — every field in
+        // it is cloned and sealed on each `store_meta_only` call.
+        //
+        // Keyed by `agent_job_id` (the attempt), because a re-dispatch mints
+        // fresh step ids and must not overwrite the mapping the previous
+        // attempt's `step-<id>.txt` blobs are named after.
+        //
+        // `kind` and `workflow_index` stay plaintext so `--step` can resolve
+        // through an indexed query; only the display name is sealed, since it
+        // comes from user YAML.
+        r#"
+        CREATE TABLE IF NOT EXISTS job_steps (
+          run_id TEXT NOT NULL REFERENCES runs(run_id) ON DELETE CASCADE,
+          agent_job_id TEXT NOT NULL,
+          step_id TEXT NOT NULL,
+          kind TEXT NOT NULL CHECK (kind IN ('workflow','synthetic')),
+          workflow_index INTEGER,
+          runner_number INTEGER,
+          context_name TEXT,
+          name_blob BLOB NOT NULL,
+          conclusion TEXT NOT NULL,
+          started_at_us INTEGER,
+          finished_at_us INTEGER,
+          PRIMARY KEY (agent_job_id, step_id)
+        ) STRICT, WITHOUT ROWID;
+
+        CREATE INDEX IF NOT EXISTS job_steps_order_idx
+          ON job_steps (agent_job_id, kind, workflow_index);
         "#,
     ),
 ];

--- a/crates/preloop-runner-server/src/store.rs
+++ b/crates/preloop-runner-server/src/store.rs
@@ -1446,7 +1446,8 @@ impl SqliteStore {
         // guessing, so the run's step history has to come back here.
         let mut step_stmt = connection.prepare(
             "SELECT agent_job_id, step_id, kind, workflow_index, runner_number,
-                    context_name, name_blob, conclusion, started_at_us, finished_at_us
+                    context_name, name_blob, conclusion, started_at_us, finished_at_us,
+                    revision
              FROM job_steps
              ORDER BY agent_job_id, COALESCE(runner_number, 2147483647),
                       COALESCE(workflow_index, 2147483647), step_id",
@@ -1463,6 +1464,7 @@ impl SqliteStore {
                 row.get::<_, String>(7)?,
                 row.get::<_, Option<i64>>(8)?,
                 row.get::<_, Option<i64>>(9)?,
+                row.get::<_, i64>(10)?,
             ))
         })? {
             let (
@@ -1476,6 +1478,7 @@ impl SqliteStore {
                 conclusion,
                 started_at_us,
                 finished_at_us,
+                revision,
             ) = row?;
             let Ok(agent_job_id) = agent_job_id.parse::<uuid::Uuid>() else {
                 tracing::warn!(%agent_job_id, "dropping step row with an unparseable attempt id");
@@ -1488,6 +1491,12 @@ impl SqliteStore {
                     continue;
                 }
             };
+            // The guard compares against the persisted revision, so the
+            // counter has to resume above it. Left at zero, the first writes
+            // after a restart carry revisions the rows already exceed and are
+            // silently discarded.
+            let seen = inner.job_steps_revision.entry(agent_job_id).or_insert(0);
+            *seen = (*seen).max(revision.max(0) as u64);
             inner
                 .job_steps
                 .entry(agent_job_id)
@@ -2415,17 +2424,26 @@ const MIGRATIONS: &[(u32, &str, &str)] = &[
           conclusion TEXT NOT NULL,
           started_at_us INTEGER,
           finished_at_us INTEGER,
-          -- Monotonic per attempt, bumped on every in-memory mutation. Two
-          -- reports for one attempt snapshot under the lock and then commit
-          -- outside it, so they can commit out of order; the upsert refuses to
-          -- move a row backwards rather than letting the older snapshot
-          -- overwrite the newer conclusions.
-          revision INTEGER NOT NULL DEFAULT 0,
           PRIMARY KEY (agent_job_id, step_id)
         ) STRICT, WITHOUT ROWID;
 
         CREATE INDEX IF NOT EXISTS job_steps_order_idx
           ON job_steps (agent_job_id, kind, workflow_index);
+        "#,
+    ),
+    (
+        5,
+        "job-steps-revision",
+        // Monotonic per attempt, bumped on every in-memory mutation of the
+        // manifest. Reconciliation snapshots under the state lock and writes
+        // after releasing it, so two reports for one attempt can commit out of
+        // order; the upsert compares this and refuses to move a row backwards.
+        //
+        // Its own version rather than an edit to 4: a database already at 4
+        // from an earlier build of this branch would skip the change entirely
+        // and fail every step write with an undefined column.
+        r#"
+        ALTER TABLE job_steps ADD COLUMN revision INTEGER NOT NULL DEFAULT 0;
         "#,
     ),
 ];

--- a/crates/preloop-runner-server/src/store.rs
+++ b/crates/preloop-runner-server/src/store.rs
@@ -43,6 +43,19 @@ pub(crate) trait Store: Send + Sync {
     async fn store_meta_only(&self, meta: &MetaSnapshot) -> anyhow::Result<()>;
     /// Persist one run's mutable projection plus a control event.
     async fn store_run_event(&self, projection: RunProjection) -> anyhow::Result<()>;
+    /// Persist one attempt's step records.
+    ///
+    /// Separate from [`Store::store_run_event`] on purpose. Steps change far
+    /// more often than anything else in a run, and a run-scoped projection
+    /// would rewrite every attempt's rows on each transition — quadratic in
+    /// the width of a matrix, against a single-writer backend. This writes the
+    /// one attempt that changed.
+    async fn store_job_steps(
+        &self,
+        run_id: RunId,
+        agent_job_id: uuid::Uuid,
+        records: &[crate::models::StepRecord],
+    ) -> anyhow::Result<()>;
     /// Persist the run-number allocator for one workflow path.
     async fn store_workflow_run_counter(
         &self,
@@ -142,6 +155,22 @@ impl Store for InstrumentedStore {
             "store_run_event",
             start,
             self.inner.store_run_event(projection).await,
+        )
+    }
+
+    async fn store_job_steps(
+        &self,
+        run_id: RunId,
+        agent_job_id: uuid::Uuid,
+        records: &[crate::models::StepRecord],
+    ) -> anyhow::Result<()> {
+        let start = Instant::now();
+        self.record(
+            "store_job_steps",
+            start,
+            self.inner
+                .store_job_steps(run_id, agent_job_id, records)
+                .await,
         )
     }
 
@@ -277,8 +306,6 @@ pub(crate) struct RunProjection {
     pub(crate) session_active_requests: Vec<(String, i64)>,
     pub(crate) inflight: Vec<(String, i64, azdo::TaskAgentMessage)>,
     pub(crate) broker_request_messages: Vec<(i64, azdo::AgentJobRequestMessage)>,
-    /// (agent_job_id, step records) for this run's attempts only.
-    pub(crate) job_steps: Vec<(uuid::Uuid, Vec<crate::models::StepRecord>)>,
     pub(crate) event: NdjsonEvent,
 }
 
@@ -321,20 +348,6 @@ impl RunProjection {
                 .broker_messages
                 .iter()
                 .map(|(id, message)| (*id, message.clone()))
-                .collect(),
-            // Only this run's attempts: `job_steps` is global, and rewriting
-            // every run's steps on one run's event is the amplification this
-            // table exists to avoid.
-            job_steps: inner
-                .job_requests
-                .values()
-                .filter(|record| record.run_id == run_id)
-                .filter_map(|record| {
-                    inner
-                        .job_steps
-                        .get(&record.agent_job_id)
-                        .map(|records| (record.agent_job_id, records.clone()))
-                })
                 .collect(),
             event,
         })
@@ -1764,9 +1777,11 @@ impl SqliteStore {
         for record in &projection.requests {
             self.insert_request_tx(&tx, record)?;
         }
-        for (agent_job_id, steps) in &projection.job_steps {
-            self.write_job_steps_tx(&tx, run_id, *agent_job_id, steps)?;
-        }
+        // Steps are not part of this projection: they change far more often
+        // than the rest of a run, and rewriting every attempt's rows on each
+        // transition is quadratic in matrix width against a single writer.
+        // `store_job_steps` persists the one attempt that changed instead.
+        //
         // The claim state must land in the same transaction as the queue
         // rewrite above: a job that was claimed (dequeued, message handed to a
         // session) but not yet acked would otherwise have neither its queue
@@ -1783,6 +1798,22 @@ impl SqliteStore {
         // Same rationale as the full-snapshot path: bound the WAL so a
         // runner-event burst cannot stall a later commit behind a giant
         // checkpoint sync — periodically, not on every event.
+        self.maybe_checkpoint_wal(&connection)?;
+        Ok(())
+    }
+
+    /// Persist one attempt's step rows in their own transaction.
+    pub(crate) fn store_job_steps(
+        &self,
+        run_id: RunId,
+        agent_job_id: uuid::Uuid,
+        records: &[crate::models::StepRecord],
+    ) -> anyhow::Result<()> {
+        let mut connection = self.connection.lock().expect("store mutex poisoned");
+        let tx = connection.transaction()?;
+        self.write_job_steps_tx(&tx, run_id, agent_job_id, records)?;
+        tx.commit()
+            .map_err(|error| anyhow::anyhow!("committing job steps: {error}"))?;
         self.maybe_checkpoint_wal(&connection)?;
         Ok(())
     }
@@ -2081,6 +2112,19 @@ impl Store for SqliteStore {
         tokio::task::spawn_blocking(move || store.store_run_event(&projection))
             .await
             .map_err(|error| anyhow::anyhow!("store run-event task panicked: {error}"))?
+    }
+
+    async fn store_job_steps(
+        &self,
+        run_id: RunId,
+        agent_job_id: uuid::Uuid,
+        records: &[crate::models::StepRecord],
+    ) -> anyhow::Result<()> {
+        let store = self.clone();
+        let records = records.to_vec();
+        tokio::task::spawn_blocking(move || store.store_job_steps(run_id, agent_job_id, &records))
+            .await
+            .map_err(|error| anyhow::anyhow!("store job-steps task panicked: {error}"))?
     }
 
     async fn store_workflow_run_counter(

--- a/crates/preloop-runner-server/src/store.rs
+++ b/crates/preloop-runner-server/src/store.rs
@@ -1185,10 +1185,18 @@ impl SqliteStore {
         // on `main`, so nothing released can land here. Delete this once the
         // branch merges.
         if current_version >= 4 {
+            // Ask the catalogue rather than probing with a SELECT. A failed
+            // prepare cannot distinguish an absent column from `database is
+            // locked` or an I/O error, and telling an operator to delete their
+            // state directory over a transient lock is worse than the bug this
+            // guards. Real failures propagate.
+            let has_revision: i64 = connection.query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('job_steps') WHERE name = 'revision'",
+                [],
+                |row| row.get(0),
+            )?;
             anyhow::ensure!(
-                connection
-                    .prepare("SELECT revision FROM job_steps LIMIT 0")
-                    .is_ok(),
+                has_revision > 0,
                 "schema version {current_version} predates the `job_steps.revision` column. \
                  This only happens on a development database created by an earlier build of \
                  the step-manifest branch; delete the state directory to recreate it."

--- a/crates/preloop-runner-server/src/store.rs
+++ b/crates/preloop-runner-server/src/store.rs
@@ -1426,7 +1426,8 @@ impl SqliteStore {
             "SELECT agent_job_id, step_id, kind, workflow_index, runner_number,
                     context_name, name_blob, conclusion, started_at_us, finished_at_us
              FROM job_steps
-             ORDER BY agent_job_id, kind, workflow_index, step_id",
+             ORDER BY agent_job_id, COALESCE(runner_number, 2147483647),
+                      COALESCE(workflow_index, 2147483647), step_id",
         )?;
         for row in step_stmt.query_map([], |row| {
             Ok((

--- a/crates/preloop-runner-server/src/store.rs
+++ b/crates/preloop-runner-server/src/store.rs
@@ -55,6 +55,7 @@ pub(crate) trait Store: Send + Sync {
         run_id: RunId,
         agent_job_id: uuid::Uuid,
         records: &[crate::models::StepRecord],
+        revision: u64,
     ) -> anyhow::Result<()>;
     /// Persist the run-number allocator for one workflow path.
     async fn store_workflow_run_counter(
@@ -163,13 +164,14 @@ impl Store for InstrumentedStore {
         run_id: RunId,
         agent_job_id: uuid::Uuid,
         records: &[crate::models::StepRecord],
+        revision: u64,
     ) -> anyhow::Result<()> {
         let start = Instant::now();
         self.record(
             "store_job_steps",
             start,
             self.inner
-                .store_job_steps(run_id, agent_job_id, records)
+                .store_job_steps(run_id, agent_job_id, records, revision)
                 .await,
         )
     }
@@ -237,8 +239,8 @@ pub(crate) struct StoreSnapshot {
     pub(crate) session_active_requests: Vec<(String, i64)>,
     /// request_id → undelivered job message.
     pub(crate) broker_request_messages: Vec<(i64, azdo::AgentJobRequestMessage)>,
-    /// (agent_job_id, that attempt's step records).
-    pub(crate) job_steps: Vec<(uuid::Uuid, Vec<crate::models::StepRecord>)>,
+    /// (agent_job_id, that attempt's step records, its revision).
+    pub(crate) job_steps: Vec<(uuid::Uuid, Vec<crate::models::StepRecord>, u64)>,
     pub(crate) meta: MetaSnapshot,
 }
 
@@ -285,7 +287,14 @@ impl StoreSnapshot {
             job_steps: inner
                 .job_steps
                 .iter()
-                .map(|(agent_job_id, records)| (*agent_job_id, records.clone()))
+                .map(|(agent_job_id, records)| {
+                    let revision = inner
+                        .job_steps_revision
+                        .get(agent_job_id)
+                        .copied()
+                        .unwrap_or(0);
+                    (*agent_job_id, records.clone(), revision)
+                })
                 .collect(),
             meta: build_meta_snapshot(inner),
         }
@@ -1733,12 +1742,12 @@ impl SqliteStore {
         // Steps are keyed by attempt, and the request records are what tie an
         // attempt to its run.
         for record in &snapshot.requests {
-            if let Some((_, steps)) = snapshot
+            if let Some((_, steps, revision)) = snapshot
                 .job_steps
                 .iter()
-                .find(|(agent_job_id, _)| *agent_job_id == record.agent_job_id)
+                .find(|(agent_job_id, _, _)| *agent_job_id == record.agent_job_id)
             {
-                self.write_job_steps_tx(&tx, record.run_id, record.agent_job_id, steps)?;
+                self.write_job_steps_tx(&tx, record.run_id, record.agent_job_id, steps, *revision)?;
             }
         }
         self.write_claim_state_tx(
@@ -1808,10 +1817,11 @@ impl SqliteStore {
         run_id: RunId,
         agent_job_id: uuid::Uuid,
         records: &[crate::models::StepRecord],
+        revision: u64,
     ) -> anyhow::Result<()> {
         let mut connection = self.connection.lock().expect("store mutex poisoned");
         let tx = connection.transaction()?;
-        self.write_job_steps_tx(&tx, run_id, agent_job_id, records)?;
+        self.write_job_steps_tx(&tx, run_id, agent_job_id, records, revision)?;
         tx.commit()
             .map_err(|error| anyhow::anyhow!("committing job steps: {error}"))?;
         self.maybe_checkpoint_wal(&connection)?;
@@ -1927,6 +1937,7 @@ impl SqliteStore {
         run_id: RunId,
         agent_job_id: uuid::Uuid,
         records: &[crate::models::StepRecord],
+        revision: u64,
     ) -> anyhow::Result<()> {
         {
             for step in records {
@@ -1936,8 +1947,8 @@ impl SqliteStore {
                 tx.execute(
                     "INSERT INTO job_steps(run_id, agent_job_id, step_id, kind, workflow_index,
                                            runner_number, context_name, name_blob, conclusion,
-                                           started_at_us, finished_at_us)
-                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+                                           started_at_us, finished_at_us, revision)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
                      ON CONFLICT(agent_job_id, step_id) DO UPDATE SET
                        kind = excluded.kind,
                        workflow_index = excluded.workflow_index,
@@ -1946,7 +1957,9 @@ impl SqliteStore {
                        name_blob = excluded.name_blob,
                        conclusion = excluded.conclusion,
                        started_at_us = excluded.started_at_us,
-                       finished_at_us = excluded.finished_at_us",
+                       finished_at_us = excluded.finished_at_us,
+                       revision = excluded.revision
+                     WHERE excluded.revision >= job_steps.revision",
                     params![
                         run_id.to_string(),
                         agent_job_id.to_string(),
@@ -1959,6 +1972,7 @@ impl SqliteStore {
                         step.conclusion,
                         step.started_at.map(unix_us),
                         step.finished_at.map(unix_us),
+                        revision as i64,
                     ],
                 )?;
             }
@@ -2119,12 +2133,15 @@ impl Store for SqliteStore {
         run_id: RunId,
         agent_job_id: uuid::Uuid,
         records: &[crate::models::StepRecord],
+        revision: u64,
     ) -> anyhow::Result<()> {
         let store = self.clone();
         let records = records.to_vec();
-        tokio::task::spawn_blocking(move || store.store_job_steps(run_id, agent_job_id, &records))
-            .await
-            .map_err(|error| anyhow::anyhow!("store job-steps task panicked: {error}"))?
+        tokio::task::spawn_blocking(move || {
+            store.store_job_steps(run_id, agent_job_id, &records, revision)
+        })
+        .await
+        .map_err(|error| anyhow::anyhow!("store job-steps task panicked: {error}"))?
     }
 
     async fn store_workflow_run_counter(
@@ -2398,6 +2415,12 @@ const MIGRATIONS: &[(u32, &str, &str)] = &[
           conclusion TEXT NOT NULL,
           started_at_us INTEGER,
           finished_at_us INTEGER,
+          -- Monotonic per attempt, bumped on every in-memory mutation. Two
+          -- reports for one attempt snapshot under the lock and then commit
+          -- outside it, so they can commit out of order; the upsert refuses to
+          -- move a row backwards rather than letting the older snapshot
+          -- overwrite the newer conclusions.
+          revision INTEGER NOT NULL DEFAULT 0,
           PRIMARY KEY (agent_job_id, step_id)
         ) STRICT, WITHOUT ROWID;
 

--- a/crates/preloop-runner-server/src/store.rs
+++ b/crates/preloop-runner-server/src/store.rs
@@ -1174,6 +1174,27 @@ impl SqliteStore {
         let current_version: i64 = connection
             .query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
             .unwrap_or(0);
+        // `job_steps.revision` moved between migration versions twice while
+        // this branch was in review before settling inside the table
+        // definition. A database stamped 4 by one of those intermediate builds
+        // skips the migration below and then fails deep inside the step
+        // queries with `no such column`, which reads like corruption. Say what
+        // it actually is.
+        //
+        // Only reachable on a development database: version 4 does not exist
+        // on `main`, so nothing released can land here. Delete this once the
+        // branch merges.
+        if current_version >= 4 {
+            anyhow::ensure!(
+                connection
+                    .prepare("SELECT revision FROM job_steps LIMIT 0")
+                    .is_ok(),
+                "schema version {current_version} predates the `job_steps.revision` column. \
+                 This only happens on a development database created by an earlier build of \
+                 the step-manifest branch; delete the state directory to recreate it."
+            );
+        }
+
         for (version, name, sql) in MIGRATIONS {
             if *version as i64 <= current_version {
                 continue;
@@ -2424,60 +2445,14 @@ const MIGRATIONS: &[(u32, &str, &str)] = &[
           conclusion TEXT NOT NULL,
           started_at_us INTEGER,
           finished_at_us INTEGER,
-          PRIMARY KEY (agent_job_id, step_id)
-        ) STRICT, WITHOUT ROWID;
-
-        CREATE INDEX IF NOT EXISTS job_steps_order_idx
-          ON job_steps (agent_job_id, kind, workflow_index);
-        "#,
-    ),
-    (
-        5,
-        "job-steps-revision",
-        // Monotonic per attempt, bumped on every in-memory mutation of the
-        // manifest. Reconciliation snapshots under the state lock and writes
-        // after releasing it, so two reports for one attempt can commit out of
-        // order; the upsert compares this and refuses to move a row backwards.
-        //
-        // A rebuild rather than `ALTER TABLE ADD COLUMN`, because two different
-        // version-4 schemas exist: an earlier build of this branch declared
-        // `revision` inside migration 4 before it moved here, so an unqualified
-        // ADD COLUMN raises `duplicate column name` on those databases and
-        // aborts startup. SQLite has no `ADD COLUMN IF NOT EXISTS`, and copying
-        // only the columns both shapes share converges them either way.
-        //
-        // Revisions are not carried over. Zero is the safe floor: the guard
-        // admits equal-or-newer, and the counter reseeds from these rows.
-        r#"
-        CREATE TABLE job_steps_v5 (
-          run_id TEXT NOT NULL REFERENCES runs(run_id) ON DELETE CASCADE,
-          agent_job_id TEXT NOT NULL,
-          step_id TEXT NOT NULL,
-          kind TEXT NOT NULL CHECK (kind IN ('workflow','synthetic')),
-          workflow_index INTEGER,
-          runner_number INTEGER,
-          context_name TEXT,
-          name_blob BLOB NOT NULL,
-          conclusion TEXT NOT NULL,
-          started_at_us INTEGER,
-          finished_at_us INTEGER,
+          -- Monotonic per attempt, bumped on every in-memory mutation of the
+          -- manifest. Reconciliation snapshots under the state lock and writes
+          -- after releasing it, so two reports for one attempt can commit out
+          -- of order; the upsert compares this and refuses to move a row
+          -- backwards rather than letting the older snapshot win.
           revision INTEGER NOT NULL DEFAULT 0,
           PRIMARY KEY (agent_job_id, step_id)
         ) STRICT, WITHOUT ROWID;
-
-        INSERT INTO job_steps_v5(run_id, agent_job_id, step_id, kind,
-                                 workflow_index, runner_number, context_name,
-                                 name_blob, conclusion, started_at_us,
-                                 finished_at_us)
-          SELECT run_id, agent_job_id, step_id, kind,
-                 workflow_index, runner_number, context_name,
-                 name_blob, conclusion, started_at_us,
-                 finished_at_us
-          FROM job_steps;
-
-        DROP TABLE job_steps;
-
-        ALTER TABLE job_steps_v5 RENAME TO job_steps;
 
         CREATE INDEX IF NOT EXISTS job_steps_order_idx
           ON job_steps (agent_job_id, kind, workflow_index);
@@ -2638,65 +2613,60 @@ mod tests {
         }
     }
 
-    /// Migration 5 converges both version-4 schemas.
+    /// A fresh database gets `job_steps.revision`, and a stale one says so.
     ///
-    /// An earlier build of this branch declared `revision` inside migration 4
-    /// before it moved to its own version, so two different v4 schemas exist:
-    /// one with the column and one without. Migration 5 has to upgrade either
-    /// without aborting startup.
+    /// `revision` moved between migration versions twice during review before
+    /// settling inside migration 4's table definition. Version 4 does not
+    /// exist on `main`, so collapsing it is safe for anything released — but a
+    /// development database stamped 4 by an intermediate build skips the
+    /// migration, and that has to be an actionable error rather than a
+    /// `no such column` from somewhere deep in the step queries.
     #[test]
-    fn job_steps_revision_migration_handles_both_v4_schemas() {
-        // Every migration up to and including 4, which is where the two
-        // shapes diverge.
-        let up_to_v4 = |connection: &Connection| {
-            for (version, _, sql) in MIGRATIONS {
-                if *version > 4 {
-                    break;
-                }
-                connection.execute_batch(sql).unwrap();
+    fn job_steps_revision_is_created_and_stale_schemas_are_rejected() {
+        let fresh = Connection::open_in_memory().unwrap();
+        SqliteStore::migrate(&fresh).expect("a fresh database must migrate");
+        assert!(
+            fresh
+                .prepare("SELECT revision FROM job_steps LIMIT 0")
+                .is_ok(),
+            "migration 4 must create the revision column"
+        );
+
+        // Exactly what an intermediate build left behind: version 4 stamped,
+        // table without the column.
+        let stale = Connection::open_in_memory().unwrap();
+        for (version, _, sql) in MIGRATIONS {
+            if *version >= 4 {
+                break;
             }
-            connection.execute_batch("PRAGMA user_version = 4").unwrap();
-        };
-
-        for already_had_column in [false, true] {
-            let connection = Connection::open_in_memory().unwrap();
-            up_to_v4(&connection);
-            if already_had_column {
-                // Exactly what the intermediate build's migration 4 produced.
-                connection
-                    .execute_batch(
-                        "ALTER TABLE job_steps
-                           ADD COLUMN revision INTEGER NOT NULL DEFAULT 0;",
-                    )
-                    .unwrap();
-            }
-            connection
-                .execute_batch(
-                    // The row only has to survive the rebuild's copy, so the
-                    // parent run is skipped rather than fully constructed.
-                    "PRAGMA foreign_keys = OFF;
-                     INSERT INTO job_steps(run_id, agent_job_id, step_id, kind,
-                                           name_blob, conclusion)
-                     VALUES ('11111111-1111-4111-8111-111111111111',
-                             '22222222-2222-4222-8222-222222222222',
-                             'step-1', 'workflow', x'00', 'success');",
-                )
-                .unwrap();
-
-            SqliteStore::migrate(&connection).unwrap_or_else(|error| {
-                panic!("migrating a v4 schema (revision present: {already_had_column}): {error}")
-            });
-
-            let revision: i64 = connection
-                .query_row("SELECT revision FROM job_steps", [], |row| row.get(0))
-                .unwrap_or_else(|error| {
-                    panic!("reading revision (present at v4: {already_had_column}): {error}")
-                });
-            assert_eq!(revision, 0, "existing rows take the zero floor");
-            let version: i64 = connection
-                .query_row("PRAGMA user_version", [], |row| row.get(0))
-                .unwrap();
-            assert!(version >= 5, "migration 5 must be recorded, got {version}");
+            stale.execute_batch(sql).unwrap();
         }
+        stale
+            .execute_batch(
+                "CREATE TABLE job_steps (
+                   run_id TEXT NOT NULL,
+                   agent_job_id TEXT NOT NULL,
+                   step_id TEXT NOT NULL,
+                   kind TEXT NOT NULL,
+                   workflow_index INTEGER,
+                   runner_number INTEGER,
+                   context_name TEXT,
+                   name_blob BLOB NOT NULL,
+                   conclusion TEXT NOT NULL,
+                   started_at_us INTEGER,
+                   finished_at_us INTEGER,
+                   PRIMARY KEY (agent_job_id, step_id)
+                 ) STRICT, WITHOUT ROWID;
+                 PRAGMA user_version = 4;",
+            )
+            .unwrap();
+
+        let error = SqliteStore::migrate(&stale)
+            .expect_err("a version-4 database without the column must be rejected")
+            .to_string();
+        assert!(
+            error.contains("predates the `job_steps.revision` column"),
+            "the error must name the cause and the fix, got: {error}"
+        );
     }
 }

--- a/crates/preloop-runner-server/src/store.rs
+++ b/crates/preloop-runner-server/src/store.rs
@@ -2439,11 +2439,48 @@ const MIGRATIONS: &[(u32, &str, &str)] = &[
         // after releasing it, so two reports for one attempt can commit out of
         // order; the upsert compares this and refuses to move a row backwards.
         //
-        // Its own version rather than an edit to 4: a database already at 4
-        // from an earlier build of this branch would skip the change entirely
-        // and fail every step write with an undefined column.
+        // A rebuild rather than `ALTER TABLE ADD COLUMN`, because two different
+        // version-4 schemas exist: an earlier build of this branch declared
+        // `revision` inside migration 4 before it moved here, so an unqualified
+        // ADD COLUMN raises `duplicate column name` on those databases and
+        // aborts startup. SQLite has no `ADD COLUMN IF NOT EXISTS`, and copying
+        // only the columns both shapes share converges them either way.
+        //
+        // Revisions are not carried over. Zero is the safe floor: the guard
+        // admits equal-or-newer, and the counter reseeds from these rows.
         r#"
-        ALTER TABLE job_steps ADD COLUMN revision INTEGER NOT NULL DEFAULT 0;
+        CREATE TABLE job_steps_v5 (
+          run_id TEXT NOT NULL REFERENCES runs(run_id) ON DELETE CASCADE,
+          agent_job_id TEXT NOT NULL,
+          step_id TEXT NOT NULL,
+          kind TEXT NOT NULL CHECK (kind IN ('workflow','synthetic')),
+          workflow_index INTEGER,
+          runner_number INTEGER,
+          context_name TEXT,
+          name_blob BLOB NOT NULL,
+          conclusion TEXT NOT NULL,
+          started_at_us INTEGER,
+          finished_at_us INTEGER,
+          revision INTEGER NOT NULL DEFAULT 0,
+          PRIMARY KEY (agent_job_id, step_id)
+        ) STRICT, WITHOUT ROWID;
+
+        INSERT INTO job_steps_v5(run_id, agent_job_id, step_id, kind,
+                                 workflow_index, runner_number, context_name,
+                                 name_blob, conclusion, started_at_us,
+                                 finished_at_us)
+          SELECT run_id, agent_job_id, step_id, kind,
+                 workflow_index, runner_number, context_name,
+                 name_blob, conclusion, started_at_us,
+                 finished_at_us
+          FROM job_steps;
+
+        DROP TABLE job_steps;
+
+        ALTER TABLE job_steps_v5 RENAME TO job_steps;
+
+        CREATE INDEX IF NOT EXISTS job_steps_order_idx
+          ON job_steps (agent_job_id, kind, workflow_index);
         "#,
     ),
 ];
@@ -2598,6 +2635,68 @@ mod tests {
                 envelope.unseal(&tampered).is_err(),
                 "tampered envelope at byte {index} must not unseal"
             );
+        }
+    }
+
+    /// Migration 5 converges both version-4 schemas.
+    ///
+    /// An earlier build of this branch declared `revision` inside migration 4
+    /// before it moved to its own version, so two different v4 schemas exist:
+    /// one with the column and one without. Migration 5 has to upgrade either
+    /// without aborting startup.
+    #[test]
+    fn job_steps_revision_migration_handles_both_v4_schemas() {
+        // Every migration up to and including 4, which is where the two
+        // shapes diverge.
+        let up_to_v4 = |connection: &Connection| {
+            for (version, _, sql) in MIGRATIONS {
+                if *version > 4 {
+                    break;
+                }
+                connection.execute_batch(sql).unwrap();
+            }
+            connection.execute_batch("PRAGMA user_version = 4").unwrap();
+        };
+
+        for already_had_column in [false, true] {
+            let connection = Connection::open_in_memory().unwrap();
+            up_to_v4(&connection);
+            if already_had_column {
+                // Exactly what the intermediate build's migration 4 produced.
+                connection
+                    .execute_batch(
+                        "ALTER TABLE job_steps
+                           ADD COLUMN revision INTEGER NOT NULL DEFAULT 0;",
+                    )
+                    .unwrap();
+            }
+            connection
+                .execute_batch(
+                    // The row only has to survive the rebuild's copy, so the
+                    // parent run is skipped rather than fully constructed.
+                    "PRAGMA foreign_keys = OFF;
+                     INSERT INTO job_steps(run_id, agent_job_id, step_id, kind,
+                                           name_blob, conclusion)
+                     VALUES ('11111111-1111-4111-8111-111111111111',
+                             '22222222-2222-4222-8222-222222222222',
+                             'step-1', 'workflow', x'00', 'success');",
+                )
+                .unwrap();
+
+            SqliteStore::migrate(&connection).unwrap_or_else(|error| {
+                panic!("migrating a v4 schema (revision present: {already_had_column}): {error}")
+            });
+
+            let revision: i64 = connection
+                .query_row("SELECT revision FROM job_steps", [], |row| row.get(0))
+                .unwrap_or_else(|error| {
+                    panic!("reading revision (present at v4: {already_had_column}): {error}")
+                });
+            assert_eq!(revision, 0, "existing rows take the zero floor");
+            let version: i64 = connection
+                .query_row("PRAGMA user_version", [], |row| row.get(0))
+                .unwrap();
+            assert!(version >= 5, "migration 5 must be recorded, got {version}");
         }
     }
 }

--- a/crates/preloop-runner-server/src/store_pg.rs
+++ b/crates/preloop-runner-server/src/store_pg.rs
@@ -174,9 +174,15 @@ impl PgStore {
         if current >= 4 {
             let has_revision: bool = client
                 .query_one(
+                    // Scoped to the active schema: the migrations and step
+                    // queries are unqualified, so a `job_steps` sitting in
+                    // another schema on the search path would otherwise vouch
+                    // for a table they never touch.
                     "SELECT EXISTS (
                        SELECT 1 FROM information_schema.columns
-                       WHERE table_name = 'job_steps' AND column_name = 'revision'
+                       WHERE table_schema = current_schema()
+                         AND table_name = 'job_steps'
+                         AND column_name = 'revision'
                      )",
                     &[],
                 )

--- a/crates/preloop-runner-server/src/store_pg.rs
+++ b/crates/preloop-runner-server/src/store_pg.rs
@@ -643,7 +643,8 @@ impl Store for PgStore {
         let rows = client
             .query(
                 "SELECT agent_job_id, step_id, kind, workflow_index, runner_number,
-                        context_name, name_blob, conclusion, started_at_us, finished_at_us
+                        context_name, name_blob, conclusion, started_at_us, finished_at_us,
+                        revision
                  FROM job_steps
                  ORDER BY agent_job_id, COALESCE(runner_number, 2147483647),
                           COALESCE(workflow_index, 2147483647), step_id",
@@ -665,6 +666,7 @@ impl Store for PgStore {
             let conclusion: String = row.get(7);
             let started_at_us: Option<i64> = row.get(8);
             let finished_at_us: Option<i64> = row.get(9);
+            let revision: i64 = row.get(10);
             let name = match self.cipher.unseal(&name_blob) {
                 Ok(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
                 Err(error) => {
@@ -672,6 +674,10 @@ impl Store for PgStore {
                     continue;
                 }
             };
+            // See the SQLite twin: the counter must resume above the
+            // persisted revision or the guard discards post-restart writes.
+            let seen = inner.job_steps_revision.entry(agent_job_id).or_insert(0);
+            *seen = (*seen).max(revision.max(0) as u64);
             inner
                 .job_steps
                 .entry(agent_job_id)
@@ -1288,14 +1294,23 @@ const MIGRATIONS: &[(u32, &str, &str)] = &[
           conclusion TEXT NOT NULL,
           started_at_us BIGINT,
           finished_at_us BIGINT,
-          -- See the SQLite twin: guards against two reports for one attempt
-          -- committing out of order.
-          revision BIGINT NOT NULL DEFAULT 0,
           PRIMARY KEY (agent_job_id, step_id)
         );
 
         CREATE INDEX IF NOT EXISTS job_steps_order_idx
           ON job_steps (agent_job_id, kind, workflow_index);
+        "#,
+    ),
+    (
+        5,
+        "job-steps-revision",
+        // See the SQLite twin: guards two reports for one attempt committing
+        // out of order. Its own version rather than an edit to 4, because a
+        // database already at 4 from an earlier build of this branch would
+        // skip the change and fail every step write on an undefined column.
+        r#"
+        ALTER TABLE job_steps
+          ADD COLUMN IF NOT EXISTS revision BIGINT NOT NULL DEFAULT 0;
         "#,
     ),
 ];

--- a/crates/preloop-runner-server/src/store_pg.rs
+++ b/crates/preloop-runner-server/src/store_pg.rs
@@ -264,6 +264,56 @@ impl PgStore {
         Ok(())
     }
 
+    /// Upsert one attempt's step rows (see the SQLite twin: keyed upsert, no
+    /// per-run delete, so a step transition writes only the changed rows).
+    async fn write_job_steps_tx(
+        &self,
+        tx: &tokio_postgres::Transaction<'_>,
+        run_id: RunId,
+        agent_job_id: uuid::Uuid,
+        records: &[crate::models::StepRecord],
+    ) -> anyhow::Result<()> {
+        for step in records {
+            if step.id.is_empty() {
+                continue;
+            }
+            let kind = match step.kind {
+                crate::models::StepKind::Workflow => "workflow",
+                crate::models::StepKind::Synthetic => "synthetic",
+            };
+            tx.execute(
+                "INSERT INTO job_steps(run_id, agent_job_id, step_id, kind, workflow_index,
+                                       runner_number, context_name, name_blob, conclusion,
+                                       started_at_us, finished_at_us)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+                 ON CONFLICT(agent_job_id, step_id) DO UPDATE SET
+                   kind = EXCLUDED.kind,
+                   workflow_index = EXCLUDED.workflow_index,
+                   runner_number = EXCLUDED.runner_number,
+                   context_name = EXCLUDED.context_name,
+                   name_blob = EXCLUDED.name_blob,
+                   conclusion = EXCLUDED.conclusion,
+                   started_at_us = EXCLUDED.started_at_us,
+                   finished_at_us = EXCLUDED.finished_at_us",
+                &[
+                    &run_id.to_string(),
+                    &agent_job_id.to_string(),
+                    &step.id,
+                    &kind,
+                    &step.workflow_index.map(|index| index as i64),
+                    &step.runner_number.map(|number| number as i64),
+                    &step.context_name,
+                    &self.cipher.seal(step.name.as_bytes())?,
+                    &step.conclusion,
+                    &step.started_at.map(unix_us),
+                    &step.finished_at.map(unix_us),
+                ],
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
     /// Rewrite the claim/message tables from the captured projections (see the
     /// SQLite twin for the rationale).
     async fn write_claim_state_tx(
@@ -567,6 +617,58 @@ impl Store for PgStore {
                 }
             }
         }
+        // Step manifests, ordered so `--step` positions come back exactly as
+        // recorded (see the SQLite twin).
+        let rows = client
+            .query(
+                "SELECT agent_job_id, step_id, kind, workflow_index, runner_number,
+                        context_name, name_blob, conclusion, started_at_us, finished_at_us
+                 FROM job_steps
+                 ORDER BY agent_job_id, kind, workflow_index, step_id",
+                &[],
+            )
+            .await?;
+        for row in rows {
+            let agent_job_id: String = row.get(0);
+            let Ok(agent_job_id) = agent_job_id.parse::<uuid::Uuid>() else {
+                tracing::warn!(%agent_job_id, "dropping step row with an unparseable attempt id");
+                continue;
+            };
+            let step_id: String = row.get(1);
+            let kind: String = row.get(2);
+            let workflow_index: Option<i64> = row.get(3);
+            let runner_number: Option<i64> = row.get(4);
+            let context_name: Option<String> = row.get(5);
+            let name_blob: Vec<u8> = row.get(6);
+            let conclusion: String = row.get(7);
+            let started_at_us: Option<i64> = row.get(8);
+            let finished_at_us: Option<i64> = row.get(9);
+            let name = match self.cipher.unseal(&name_blob) {
+                Ok(bytes) => String::from_utf8_lossy(&bytes).into_owned(),
+                Err(error) => {
+                    tracing::warn!(%error, %step_id, "dropping step row with an unreadable name");
+                    continue;
+                }
+            };
+            inner
+                .job_steps
+                .entry(agent_job_id)
+                .or_default()
+                .push(crate::models::StepRecord {
+                    id: step_id,
+                    kind: match kind.as_str() {
+                        "workflow" => crate::models::StepKind::Workflow,
+                        _ => crate::models::StepKind::Synthetic,
+                    },
+                    workflow_index: workflow_index.map(|index| index as usize),
+                    runner_number: runner_number.map(|number| number as u32),
+                    context_name,
+                    name,
+                    conclusion,
+                    started_at: started_at_us.and_then(chrono::DateTime::from_timestamp_micros),
+                    finished_at: finished_at_us.and_then(chrono::DateTime::from_timestamp_micros),
+                });
+        }
         let rows = client
             .query("SELECT request_id, request_blob FROM job_requests", &[])
             .await?;
@@ -660,6 +762,7 @@ impl Store for PgStore {
         let mut client = self.connection.lock().await;
         let tx = client.transaction().await?;
         for table in [
+            "job_steps",
             "broker_messages",
             "job_request_messages",
             "session_active_requests",
@@ -810,6 +913,18 @@ impl Store for PgStore {
         for record in &snapshot.requests {
             self.insert_request_tx(&tx, record).await?;
         }
+        // Steps are keyed by attempt; the request records tie an attempt to
+        // its run.
+        for record in &snapshot.requests {
+            if let Some((_, steps)) = snapshot
+                .job_steps
+                .iter()
+                .find(|(agent_job_id, _)| *agent_job_id == record.agent_job_id)
+            {
+                self.write_job_steps_tx(&tx, record.run_id, record.agent_job_id, steps)
+                    .await?;
+            }
+        }
         self.write_claim_state_tx(
             &tx,
             &snapshot.session_active_requests,
@@ -851,6 +966,10 @@ impl Store for PgStore {
         .await?;
         for record in &projection.requests {
             self.insert_request_tx(&tx, record).await?;
+        }
+        for (agent_job_id, steps) in &projection.job_steps {
+            self.write_job_steps_tx(&tx, run_id, *agent_job_id, steps)
+                .await?;
         }
         // Claim state must land in the same transaction as the queue rewrite
         // (see the SQLite twin).
@@ -1127,6 +1246,33 @@ const MIGRATIONS: &[(u32, &str, &str)] = &[
           payload_json TEXT NOT NULL,
           written_at_us BIGINT NOT NULL
         );
+        "#,
+    ),
+    (
+        4,
+        "job-steps-table",
+        // See the SQLite twin: steps live outside `runs.record_blob` so a step
+        // transition upserts one small row instead of resealing the whole run
+        // record, and are keyed by attempt because a re-dispatch mints fresh
+        // step ids.
+        r#"
+        CREATE TABLE IF NOT EXISTS job_steps (
+          run_id TEXT NOT NULL REFERENCES runs(run_id) ON DELETE CASCADE,
+          agent_job_id TEXT NOT NULL,
+          step_id TEXT NOT NULL,
+          kind TEXT NOT NULL CHECK (kind IN ('workflow','synthetic')),
+          workflow_index BIGINT,
+          runner_number BIGINT,
+          context_name TEXT,
+          name_blob BYTEA NOT NULL,
+          conclusion TEXT NOT NULL,
+          started_at_us BIGINT,
+          finished_at_us BIGINT,
+          PRIMARY KEY (agent_job_id, step_id)
+        );
+
+        CREATE INDEX IF NOT EXISTS job_steps_order_idx
+          ON job_steps (agent_job_id, kind, workflow_index);
         "#,
     ),
 ];

--- a/crates/preloop-runner-server/src/store_pg.rs
+++ b/crates/preloop-runner-server/src/store_pg.rs
@@ -272,6 +272,7 @@ impl PgStore {
         run_id: RunId,
         agent_job_id: uuid::Uuid,
         records: &[crate::models::StepRecord],
+        revision: u64,
     ) -> anyhow::Result<()> {
         for step in records {
             if step.id.is_empty() {
@@ -284,8 +285,8 @@ impl PgStore {
             tx.execute(
                 "INSERT INTO job_steps(run_id, agent_job_id, step_id, kind, workflow_index,
                                        runner_number, context_name, name_blob, conclusion,
-                                       started_at_us, finished_at_us)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+                                       started_at_us, finished_at_us, revision)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
                  ON CONFLICT(agent_job_id, step_id) DO UPDATE SET
                    kind = EXCLUDED.kind,
                    workflow_index = EXCLUDED.workflow_index,
@@ -294,7 +295,9 @@ impl PgStore {
                    name_blob = EXCLUDED.name_blob,
                    conclusion = EXCLUDED.conclusion,
                    started_at_us = EXCLUDED.started_at_us,
-                   finished_at_us = EXCLUDED.finished_at_us",
+                   finished_at_us = EXCLUDED.finished_at_us,
+                   revision = EXCLUDED.revision
+                 WHERE EXCLUDED.revision >= job_steps.revision",
                 &[
                     &run_id.to_string(),
                     &agent_job_id.to_string(),
@@ -307,6 +310,7 @@ impl PgStore {
                     &step.conclusion,
                     &step.started_at.map(unix_us),
                     &step.finished_at.map(unix_us),
+                    &(revision as i64),
                 ],
             )
             .await?;
@@ -423,10 +427,11 @@ impl Store for PgStore {
         run_id: RunId,
         agent_job_id: uuid::Uuid,
         records: &[crate::models::StepRecord],
+        revision: u64,
     ) -> anyhow::Result<()> {
         let mut client = self.connection.lock().await;
         let tx = client.transaction().await?;
-        self.write_job_steps_tx(&tx, run_id, agent_job_id, records)
+        self.write_job_steps_tx(&tx, run_id, agent_job_id, records, revision)
             .await?;
         tx.commit()
             .await
@@ -933,12 +938,12 @@ impl Store for PgStore {
         // Steps are keyed by attempt; the request records tie an attempt to
         // its run.
         for record in &snapshot.requests {
-            if let Some((_, steps)) = snapshot
+            if let Some((_, steps, revision)) = snapshot
                 .job_steps
                 .iter()
-                .find(|(agent_job_id, _)| *agent_job_id == record.agent_job_id)
+                .find(|(agent_job_id, _, _)| *agent_job_id == record.agent_job_id)
             {
-                self.write_job_steps_tx(&tx, record.run_id, record.agent_job_id, steps)
+                self.write_job_steps_tx(&tx, record.run_id, record.agent_job_id, steps, *revision)
                     .await?;
             }
         }
@@ -1283,6 +1288,9 @@ const MIGRATIONS: &[(u32, &str, &str)] = &[
           conclusion TEXT NOT NULL,
           started_at_us BIGINT,
           finished_at_us BIGINT,
+          -- See the SQLite twin: guards against two reports for one attempt
+          -- committing out of order.
+          revision BIGINT NOT NULL DEFAULT 0,
           PRIMARY KEY (agent_job_id, step_id)
         );
 

--- a/crates/preloop-runner-server/src/store_pg.rs
+++ b/crates/preloop-runner-server/src/store_pg.rs
@@ -168,6 +168,28 @@ impl PgStore {
             )
             .await?
             .get(0);
+        // See the SQLite twin: a database stamped 4 by an intermediate build of
+        // this branch lacks `job_steps.revision` and would fail deep in the
+        // step queries instead of here. Deletable once the branch merges.
+        if current >= 4 {
+            let has_revision: bool = client
+                .query_one(
+                    "SELECT EXISTS (
+                       SELECT 1 FROM information_schema.columns
+                       WHERE table_name = 'job_steps' AND column_name = 'revision'
+                     )",
+                    &[],
+                )
+                .await?
+                .get(0);
+            anyhow::ensure!(
+                has_revision,
+                "schema version {current} predates the `job_steps.revision` column. This only \
+                 happens on a development database created by an earlier build of the \
+                 step-manifest branch; drop and recreate it."
+            );
+        }
+
         for (version, name, sql) in MIGRATIONS {
             if *version as i64 <= current {
                 continue;
@@ -1294,23 +1316,14 @@ const MIGRATIONS: &[(u32, &str, &str)] = &[
           conclusion TEXT NOT NULL,
           started_at_us BIGINT,
           finished_at_us BIGINT,
+          -- See the SQLite twin: guards two reports for one attempt
+          -- committing out of order.
+          revision BIGINT NOT NULL DEFAULT 0,
           PRIMARY KEY (agent_job_id, step_id)
         );
 
         CREATE INDEX IF NOT EXISTS job_steps_order_idx
           ON job_steps (agent_job_id, kind, workflow_index);
-        "#,
-    ),
-    (
-        5,
-        "job-steps-revision",
-        // See the SQLite twin: guards two reports for one attempt committing
-        // out of order. Its own version rather than an edit to 4, because a
-        // database already at 4 from an earlier build of this branch would
-        // skip the change and fail every step write on an undefined column.
-        r#"
-        ALTER TABLE job_steps
-          ADD COLUMN IF NOT EXISTS revision BIGINT NOT NULL DEFAULT 0;
         "#,
     ),
 ];

--- a/crates/preloop-runner-server/src/store_pg.rs
+++ b/crates/preloop-runner-server/src/store_pg.rs
@@ -624,7 +624,8 @@ impl Store for PgStore {
                 "SELECT agent_job_id, step_id, kind, workflow_index, runner_number,
                         context_name, name_blob, conclusion, started_at_us, finished_at_us
                  FROM job_steps
-                 ORDER BY agent_job_id, kind, workflow_index, step_id",
+                 ORDER BY agent_job_id, COALESCE(runner_number, 2147483647),
+                          COALESCE(workflow_index, 2147483647), step_id",
                 &[],
             )
             .await?;

--- a/crates/preloop-runner-server/src/store_pg.rs
+++ b/crates/preloop-runner-server/src/store_pg.rs
@@ -418,6 +418,22 @@ impl PgStore {
 
 #[async_trait]
 impl Store for PgStore {
+    async fn store_job_steps(
+        &self,
+        run_id: RunId,
+        agent_job_id: uuid::Uuid,
+        records: &[crate::models::StepRecord],
+    ) -> anyhow::Result<()> {
+        let mut client = self.connection.lock().await;
+        let tx = client.transaction().await?;
+        self.write_job_steps_tx(&tx, run_id, agent_job_id, records)
+            .await?;
+        tx.commit()
+            .await
+            .map_err(|error| anyhow::anyhow!("committing job steps: {error}"))?;
+        Ok(())
+    }
+
     async fn load_into(&self, inner: &mut InnerState) -> anyhow::Result<()> {
         let client = self.connection.lock().await;
         let rows = client
@@ -968,10 +984,8 @@ impl Store for PgStore {
         for record in &projection.requests {
             self.insert_request_tx(&tx, record).await?;
         }
-        for (agent_job_id, steps) in &projection.job_steps {
-            self.write_job_steps_tx(&tx, run_id, *agent_job_id, steps)
-                .await?;
-        }
+        // Steps are persisted per attempt by `store_job_steps`, not here: see
+        // the SQLite twin for why a run-scoped rewrite is quadratic.
         // Claim state must land in the same transaction as the queue rewrite
         // (see the SQLite twin).
         self.write_claim_state_tx(

--- a/crates/preloop-runner-server/src/timeline_logs.rs
+++ b/crates/preloop-runner-server/src/timeline_logs.rs
@@ -82,7 +82,7 @@ pub(crate) async fn patch_timeline_records(
 
     // Set when this PATCH reconciled an attempt's step records, so they can be
     // persisted once the state lock is released.
-    let mut touched_attempt: Option<(RunId, uuid::Uuid, Vec<StepRecord>)> = None;
+    let mut touched_attempt: Option<(RunId, uuid::Uuid, Vec<StepRecord>, u64)> = None;
     let new_change_id = {
         let mut inner = shared.state.inner.lock().await;
         let current = inner
@@ -232,16 +232,22 @@ pub(crate) async fn patch_timeline_records(
                 // released. A PATCH that projects no job-status event emits
                 // nothing, so without this the reconciliation stays
                 // memory-only and a restart loses it.
-                touched_attempt = Some((run_id, agent_job_id, manifest.clone()));
+                let records = manifest.clone();
+                let revision = {
+                    let counter = inner.job_steps_revision.entry(agent_job_id).or_insert(0);
+                    *counter += 1;
+                    *counter
+                };
+                touched_attempt = Some((run_id, agent_job_id, records, revision));
             }
         }
         new_id
     };
-    if let Some((run_id, agent_job_id, records)) = touched_attempt {
+    if let Some((run_id, agent_job_id, records, revision)) = touched_attempt {
         if let Err(error) = shared
             .state
             .store
-            .store_job_steps(run_id, agent_job_id, &records)
+            .store_job_steps(run_id, agent_job_id, &records, revision)
             .await
         {
             warn!(?error, %run_id, "failed to persist timeline step records");

--- a/crates/preloop-runner-server/src/timeline_logs.rs
+++ b/crates/preloop-runner-server/src/timeline_logs.rs
@@ -156,6 +156,15 @@ pub(crate) async fn patch_timeline_records(
                     let Some(name) = &record.display_name else {
                         continue;
                     };
+                    // A PATCH carries the job's own record alongside its
+                    // steps. Its id is a UUID and `job_id.0` is the workflow
+                    // job key, so the id comparison below never matched it and
+                    // the job was reconciled in as a synthetic step — showing
+                    // up in run projections as an extra step named after the
+                    // job, and persisted there. Only task records are steps.
+                    if !matches!(record.record_type, Some(azdo::TimelineRecordType::Task)) {
+                        continue;
+                    }
                     if record.id.to_string() == job_id.0 {
                         continue;
                     }

--- a/crates/preloop-runner-server/src/timeline_logs.rs
+++ b/crates/preloop-runner-server/src/timeline_logs.rs
@@ -2,6 +2,29 @@ use super::*;
 
 // Timeline, logs, completion
 
+/// Whether a timeline record describes a step rather than a container.
+///
+/// Shared by the annotation projection and the manifest reconciliation below,
+/// which disagreed: one keyed on `Step`-or-parent and the other whitelisted
+/// `Task`, so a typed `Task` with no parent was stored as a step while its
+/// issues were reported against the job.
+///
+/// Excluding containers rather than whitelisting a step type is deliberate.
+/// `type` is optional on the wire and the official runner sends `Task` where
+/// preloop's sends `Step`, so an allow-list silently drops real conclusions.
+fn is_step_record(record: &azdo::TimelineRecord) -> bool {
+    match record.record_type {
+        Some(azdo::TimelineRecordType::Task | azdo::TimelineRecordType::Step) => true,
+        Some(
+            azdo::TimelineRecordType::Job
+            | azdo::TimelineRecordType::Phase
+            | azdo::TimelineRecordType::Stage,
+        ) => false,
+        // Untyped: a step always hangs off its job record.
+        None => record.parent_id.is_some(),
+    }
+}
+
 /// PATCH timeline records — runner updates step/job state.
 pub(crate) async fn patch_timeline_records(
     State(shared): State<Arc<SharedState>>,
@@ -42,13 +65,7 @@ pub(crate) async fn patch_timeline_records(
         }
         if let Some(run_id) = run_id {
             for issue in &record.issues {
-                let step_id = if record.record_type == Some(azdo::TimelineRecordType::Step)
-                    || record.parent_id.is_some()
-                {
-                    Some(record.id.to_string())
-                } else {
-                    None
-                };
+                let step_id = is_step_record(record).then(|| record.id.to_string());
                 projected.push(NdjsonEvent::Annotation {
                     run_id,
                     job_id: logical_job_id
@@ -156,27 +173,7 @@ pub(crate) async fn patch_timeline_records(
                     let Some(name) = &record.display_name else {
                         continue;
                     };
-                    // A PATCH carries the job's own record alongside its steps,
-                    // and reconciling that record in produced a phantom step
-                    // named after the job. Exclude container records rather
-                    // than whitelisting one step type: `type` is optional on
-                    // the wire, the official runner sends `Task` and this file
-                    // already treats `Step` as a step above, so an allow-list
-                    // silently drops real conclusions.
-                    let is_step = match record.record_type {
-                        Some(azdo::TimelineRecordType::Task | azdo::TimelineRecordType::Step) => {
-                            true
-                        }
-                        Some(
-                            azdo::TimelineRecordType::Job
-                            | azdo::TimelineRecordType::Phase
-                            | azdo::TimelineRecordType::Stage,
-                        ) => false,
-                        // Untyped: a step always hangs off the job record, which
-                        // is the same signal the annotation path above uses.
-                        None => record.parent_id.is_some(),
-                    };
-                    if !is_step {
+                    if !is_step_record(record) {
                         continue;
                     }
 

--- a/crates/preloop-runner-server/src/timeline_logs.rs
+++ b/crates/preloop-runner-server/src/timeline_logs.rs
@@ -104,14 +104,25 @@ pub(crate) async fn patch_timeline_records(
         );
 
         if let (Some(run_id), Some(job_id)) = (run_id, &logical_job_id) {
+            // The manifest is attempt-scoped, so reconciliation needs the
+            // agent job id — the workflow job key alone cannot distinguish
+            // one dispatch of a job from a later re-dispatch.
+            let agent_job_id = callback_job
+                .as_ref()
+                .and_then(|(request_id, _, _)| inner.job_requests.get(request_id))
+                .map(|request| request.agent_job_id);
+            let job_status = inner
+                .runs
+                .get(&run_id)
+                .and_then(|run| run.jobs.get(job_id).copied());
+
             if let Some(run) = inner.runs.get_mut(&run_id) {
-                let job_name = job_id.0.clone();
-                let job_detail =
-                    if let Some(pos) = run.jobs_list.iter().position(|j| j.name == job_name) {
-                        &mut run.jobs_list[pos]
-                    } else {
+                let detail = match JobDetail::find(&mut run.jobs_list, &job_id.0) {
+                    Some(detail) => detail,
+                    None => {
                         run.jobs_list.push(JobDetail {
-                            name: job_name,
+                            job_id: job_id.0.clone(),
+                            name: job_id.0.clone(),
                             // A timeline update means the job started; the run
                             // record's final conclusion comes from the job
                             // status map (projected in the runs GET). Default
@@ -120,20 +131,24 @@ pub(crate) async fn patch_timeline_records(
                             steps: Vec::new(),
                             annotations: Vec::new(),
                         });
-                        run.jobs_list.last_mut().unwrap()
-                    };
-
-                if let Some(status) = run.jobs.get(job_id) {
-                    // The status map is authoritative for terminal states
-                    // only. Its in-flight projection ("inprogress" from the
-                    // raw Debug spelling, or "success" from the run-level
-                    // status_string) lies about a job that is still running —
-                    // keep the truthful "in_progress" default set above.
-                    if *status != ExecutionStatus::InProgress {
-                        job_detail.conclusion = format!("{:?}", status).to_lowercase();
+                        run.jobs_list.last_mut().expect("just pushed")
+                    }
+                };
+                // The status map is authoritative for terminal states only.
+                // Its in-flight projection ("inprogress" from the raw Debug
+                // spelling, or "success" from the run-level status_string)
+                // lies about a job that is still running — keep the truthful
+                // "in_progress" default set above.
+                if let Some(status) = job_status {
+                    if status != ExecutionStatus::InProgress {
+                        detail.conclusion = format!("{:?}", status).to_lowercase();
                     }
                 }
+            }
 
+            if let Some(agent_job_id) = agent_job_id {
+                let observed = chrono::Utc::now();
+                let manifest = inner.job_steps.entry(agent_job_id).or_default();
                 for record in &records {
                     let Some(name) = &record.display_name else {
                         continue;
@@ -147,7 +162,7 @@ pub(crate) async fn patch_timeline_records(
                             azdo::TaskResult::Succeeded | azdo::TaskResult::SucceededWithIssues,
                         ) => "success",
                         Some(azdo::TaskResult::Failed) => {
-                            if run.jobs.get(job_id) == Some(&ExecutionStatus::Cancelled) {
+                            if job_status == Some(ExecutionStatus::Cancelled) {
                                 "cancelled"
                             } else {
                                 "failure"
@@ -171,29 +186,34 @@ pub(crate) async fn patch_timeline_records(
                         .as_deref()
                         .and_then(|t| chrono::DateTime::parse_from_rfc3339(t).ok())
                         .map(|t| t.with_timezone(&chrono::Utc));
-                    let observed = chrono::Utc::now();
+                    let record_id = record.id.to_string();
 
-                    if let Some(pos) = StepRecord::find_matching_index(
-                        &job_detail.steps,
-                        &record.id.to_string(),
-                        name,
-                        true,
-                    ) {
-                        job_detail.steps[pos].conclusion = conclusion_str.to_owned();
-                        if let Some(started_at) = started_at {
-                            job_detail.steps[pos].started_at = Some(started_at);
+                    match StepRecord::find_by_id(manifest, &record_id) {
+                        Some(pos) => {
+                            manifest[pos].conclusion = conclusion_str.to_owned();
+                            if let Some(started_at) = started_at {
+                                manifest[pos].started_at = Some(started_at);
+                            }
+                            if let Some(finished_at) = finished_at {
+                                manifest[pos].finished_at = Some(finished_at);
+                            }
+                            manifest[pos].name = name.clone();
                         }
-                        if let Some(finished_at) = finished_at {
-                            job_detail.steps[pos].finished_at = Some(finished_at);
-                        }
-                    } else {
-                        job_detail.steps.push(StepRecord {
-                            id: Some(record.id.to_string()),
+                        // A timeline record with no manifest entry is runner
+                        // bookkeeping, not a workflow step. `TimelineRecord`
+                        // carries no ordinal, so `runner_number` stays unset
+                        // on this path.
+                        None => manifest.push(StepRecord {
+                            id: record_id,
+                            kind: StepKind::Synthetic,
+                            workflow_index: None,
+                            runner_number: None,
+                            context_name: None,
                             name: name.clone(),
                             conclusion: conclusion_str.to_owned(),
                             started_at: started_at.or(Some(observed)),
                             finished_at,
-                        });
+                        }),
                     }
                 }
             }

--- a/crates/preloop-runner-server/src/timeline_logs.rs
+++ b/crates/preloop-runner-server/src/timeline_logs.rs
@@ -156,16 +156,27 @@ pub(crate) async fn patch_timeline_records(
                     let Some(name) = &record.display_name else {
                         continue;
                     };
-                    // A PATCH carries the job's own record alongside its
-                    // steps. Its id is a UUID and `job_id.0` is the workflow
-                    // job key, so the id comparison below never matched it and
-                    // the job was reconciled in as a synthetic step — showing
-                    // up in run projections as an extra step named after the
-                    // job, and persisted there. Only task records are steps.
-                    if !matches!(record.record_type, Some(azdo::TimelineRecordType::Task)) {
-                        continue;
-                    }
-                    if record.id.to_string() == job_id.0 {
+                    // A PATCH carries the job's own record alongside its steps,
+                    // and reconciling that record in produced a phantom step
+                    // named after the job. Exclude container records rather
+                    // than whitelisting one step type: `type` is optional on
+                    // the wire, the official runner sends `Task` and this file
+                    // already treats `Step` as a step above, so an allow-list
+                    // silently drops real conclusions.
+                    let is_step = match record.record_type {
+                        Some(azdo::TimelineRecordType::Task | azdo::TimelineRecordType::Step) => {
+                            true
+                        }
+                        Some(
+                            azdo::TimelineRecordType::Job
+                            | azdo::TimelineRecordType::Phase
+                            | azdo::TimelineRecordType::Stage,
+                        ) => false,
+                        // Untyped: a step always hangs off the job record, which
+                        // is the same signal the annotation path above uses.
+                        None => record.parent_id.is_some(),
+                    };
+                    if !is_step {
                         continue;
                     }
 

--- a/crates/preloop-runner-server/src/timeline_logs.rs
+++ b/crates/preloop-runner-server/src/timeline_logs.rs
@@ -80,6 +80,9 @@ pub(crate) async fn patch_timeline_records(
         }
     }
 
+    // Set when this PATCH reconciled an attempt's step records, so they can be
+    // persisted once the state lock is released.
+    let mut touched_attempt: Option<(RunId, uuid::Uuid, Vec<StepRecord>)> = None;
     let new_change_id = {
         let mut inner = shared.state.inner.lock().await;
         let current = inner
@@ -216,10 +219,25 @@ pub(crate) async fn patch_timeline_records(
                         }),
                     }
                 }
+                // Captured so the attempt can be persisted after the lock is
+                // released. A PATCH that projects no job-status event emits
+                // nothing, so without this the reconciliation stays
+                // memory-only and a restart loses it.
+                touched_attempt = Some((run_id, agent_job_id, manifest.clone()));
             }
         }
         new_id
     };
+    if let Some((run_id, agent_job_id, records)) = touched_attempt {
+        if let Err(error) = shared
+            .state
+            .store
+            .store_job_steps(run_id, agent_job_id, &records)
+            .await
+        {
+            warn!(?error, %run_id, "failed to persist timeline step records");
+        }
+    }
     for event in projected {
         shared.state.emit(event).await;
     }

--- a/crates/preloop-runner-server/src/timeline_logs.rs
+++ b/crates/preloop-runner-server/src/timeline_logs.rs
@@ -490,6 +490,11 @@ pub(crate) async fn finish_job(
             Some(JobCompletion {
                 run_id,
                 job_id,
+                // Resolved from the callback's own request record.
+                agent_job_id: inner
+                    .job_requests
+                    .get(&request_id)
+                    .map(|record| record.agent_job_id),
                 status,
                 outputs,
                 annotations: Vec::new(),
@@ -678,6 +683,11 @@ pub(crate) async fn finish_job_plan(
             Some(JobCompletion {
                 run_id,
                 job_id,
+                // Resolved from the callback's own request record.
+                agent_job_id: inner
+                    .job_requests
+                    .get(&request_id)
+                    .map(|record| record.agent_job_id),
                 status,
                 outputs,
                 annotations: Vec::new(),

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -112,11 +112,21 @@ No flags.
 
 Without flags, every job's log is merged in job-request order.
 
-`--step` counts user-visible steps from 1, matching `preloop debug --from`. It
-needs `--job` when a run has more than one job, because numbering restarts per
-job. A job whose runner uploaded a single merged log has no recoverable step
-boundaries; asking for a step there fails with `409` rather than returning the
-whole job under a step's name.
+`--step` counts the steps *declared in the workflow* from 1, matching
+`preloop debug --from`. It needs `--job` when a run has more than one job,
+because numbering restarts per job.
+
+Numbering comes from the step list in the job's request message, recorded when
+the job was dispatched. Steps the runner adds on its own — `Set up job`,
+`Pre`/`Post` action hooks, container setup and teardown, `Complete job` — own
+their logs and appear in the whole-job output, but never take a `--step`
+position. Two steps sharing a `name:` stay distinct, because a step is
+identified by its stable id rather than its display name.
+
+Asking for a step fails with `409` rather than guessing when the order cannot
+be recovered: a job whose runner uploaded a single merged log has no step
+boundaries, and a job dispatched before its step list was recorded has no
+declared order to index.
 
 `--follow` tracks one job's live console feed, so it needs `--job` unless the
 run has exactly one job. It replays the retained buffer before going live, then

--- a/docs/fidelity-gap.md
+++ b/docs/fidelity-gap.md
@@ -292,6 +292,16 @@ The conformance gate checks:
 
 Body-value diffs (different URLs, IDs, tokens) are expected and not gated.
 
+> **Stale as of 2026-09-02.** CI's `server-light` job reports
+> `conformance failed for 6 scenario(s)` on this replay. Verified as
+> pre-existing rather than a regression: `main` at `c9a6d89e` and
+> `Bnjoroge/step-manifest` at `110266ec` fail the same job with the same
+> count. The failing scenario names are only in the run's preserved
+> artifacts, which live in the ephemeral runner VM and are gone by the time
+> the job reports, so they are not yet identified here — that artifact
+> retention is itself worth fixing, since a conformance failure currently
+> cannot be diagnosed after the fact from the log alone.
+
 ### 1a.2 Scenario coverage
 
 


### PR DESCRIPTION
## What & why

`preloop logs --job X --step N` could return the wrong step's log, and repeated
step names could lose a step from the run record.

Both came from the same root cause: the server had no record of a job's declared
step order, so it reconstructed structure from whatever the runner happened to
report and from whatever landed on disk. Specifically it sorted `step-*.txt` by
filesystem modification time — which records when a blob was uploaded, not when
a step ran — and it matched steps by display name, which is not unique.

This makes the job request message the source of truth. Each attempt's step
manifest is built from `AgentJobRequestMessage.steps` and recorded at dispatch,
before the runner reports anything. Runner reports only reconcile into it, keyed
by `external_id`.

Verified against the official runner before writing any code
(`.runner-watch/golden/v2.336.0/06-multi-step`):

```text
job message steps (in order)      runner-reported
[0] d9cb9a38…                     number=2  d9cb9a38…  'Run echo first'      in_message=true
[1] 6baf5458…                     number=3  6baf5458…  'Run echo "VAL=$VAL"' in_message=true
[2] 62f67d20…                     number=4  62f67d20…  'Run echo line1'      in_message=true
                                  number=1  23c0d0c1…  'Set up job'          in_message=false
                                  number=5  456c6a95…  'Complete job'        in_message=false
```

Three things this establishes:

1. `external_id` **is** `TaskStep.id` for declared steps — the identity chain holds end to end.
2. Steps the runner generates carry ids absent from the message, so membership in
   the manifest classifies a record as `workflow` or `synthetic`. Not id shape,
   not display name.
3. The runner's `number` is offset by synthetic steps (declared step 1 reports as
   `number: 2`), so it cannot drive `--step`.

GitHub's own blob path is `logs/steps/step-logs-<external_id>.txt`, so keying
durable logs by that id matches upstream.

### User-facing behavior

- `--step N` selects the Nth **declared** step. `Set up job`, `Pre`/`Post` hooks,
  container lifecycle and `Complete job` keep their logs in the whole-job output
  but no longer shift the numbering read off the YAML.
- Two steps sharing a `name:` stay distinct.
- When the declared order genuinely cannot be recovered, the request fails with
  `409` instead of returning a neighbouring step under the requested step's name.

### Design notes

Manifests are keyed by `agent_job_id`, not by job key. `build_task_step`
(`job_builder.rs:844`) mints a fresh `Uuid::new_v4()` per dispatch, so a
job-scoped map would overwrite the mapping an earlier attempt's `step-<id>.txt`
blobs are still named after, making that attempt's logs unreachable.

Step records get a `job_steps` table rather than riding in `runs.record_blob`.
That blob carries the workflow YAML, the event payload and the github context,
and `store_run_event` reseals all of it on every run event. `MetaSnapshot` is no
better — `store.rs:511-518` documents that every field in it is cloned and sealed
on each `store_meta_only` call, and that path fires per step-log upload. Rows are
upserted by `(agent_job_id, step_id)` with no per-run delete, so a step
transition writes one small row. `kind` and `workflow_index` stay plaintext so
`--step` resolves through an indexed query; only the display name is sealed,
since it comes from user YAML.

`JobDetail` gains an explicit `job_id`. Previously `name` served as both the job
key and the display name — the run projection overwrote it with the display name
and then looked up by either, which is the same identify-by-name mistake one
level up.

`context_name` is persisted because it is the one identity stable across runs of
the same workflow; the step id is per-dispatch.

## Protocol surface

Runner-facing wire shapes are unchanged. `WorkflowStepsUpdate` and the timeline
PATCH handlers were rewritten internally, but their request/response payloads
and status codes are byte-identical — the conformance replay reports
`WorkflowStepsUpdate` as `1 call, 200 vs 200` with identical bodies and no
missing endpoints on either side.

`GET /api/v1/runs/{run_id}` (native API, not the runner protocol) gains additive
serde-defaulted fields on step records: `kind`, `workflow_index`,
`runner_number`, `context_name`, plus `job_id` on job details.

- [x] I confirm this change touches the runner protocol interface: **NO**

## Required gates

- [ ] `just test-ci` passes locally — **NO, see caveat below**
- [x] Validated against the official runner: golden replay
      (`v2.336.0/06-multi-step`) established the identity contract before
      implementation, and the conformance replay shows the rewritten handlers
      unchanged on the wire
- [ ] Property tests — not applicable; the touched subsystems
      (`results_twirp`, `timeline_logs`, log resolution) have no property suites
- [x] New wire fields are additive and serde-defaulted
- [x] No secrets, credentials, or deployment-specific paths introduced

### Caveat on `just test-ci`

`conform` reports 6 failing scenarios. I did not establish a pre-change baseline,
so I am **not** claiming these predate this branch. What the reports do show:
endpoint counts, status codes and request/response bodies all match official,
no endpoints missing on either side, and the diffs present are header-key
differences (`activityid`, `x-tfs-processid` and other Azure infrastructure
headers preloop does not emit). A baseline `just conform` on `main` settles it in
one run and should happen before merge.

`just dogfood` could not run: `~/.cache/actions-runner/current` is absent in this
environment.

## Verification performed

```text
cargo test -p preloop-runner-server --lib      649 passed, 0 failed, 3 ignored
cargo fmt --all -- --check                     clean
cargo clippy --locked --workspace --all-targets -- -D warnings   clean
```

New coverage for cases that previously had none:

- `step_manifests_are_scoped_per_job_attempt` — a re-dispatch mints a fresh
  manifest and both attempts' logs stay resolvable
- `step_manifests_survive_a_restart` — manifests round-trip the `job_steps`
  table, and `--step 2` still resolves against a fresh `AppState` over the same
  state dir
- `log_run_logs_step_filter_uses_workflow_step_ids` — now also asserts a
  synthetic upload does **not** become step 2

Six existing tests were rewritten. All six failed for one reason: they
fabricated `external_id`s that were never in the job message, so reconciliation
correctly classified them as synthetic. The duplicate-name test demonstrated the
fix while failing — two declared steps stayed distinct with separate ids; it saw
4 records only because it invented 2 more. They now report under real manifest
ids, which is what the runner does.

## Checklist

- [x] Tests added/updated for any new observable contract
- [x] Docs updated — `docs/cli_reference.md` describes where `--step` numbering
      comes from, which steps are excluded, and when it returns `409`
- [x] Changelog-worthy user-facing change described above

## Related

Overlaps conceptually with #210, which introduces the same
declared-vs-generated distinction on the debug/runner side. No file overlap.
Landing this first settles the shared vocabulary (`synthetic`) and lets #210
classify by manifest membership instead of prefix heuristics.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the job request message the source of truth for step identity and order, so `preloop logs --job X --step N` no longer returns a neighboring step's log or drops repeated-name steps. Each dispatch owns an attempt-scoped manifest seeded before the runner reports and reconciled by `external_id`; runner wire payloads are unchanged, and native run responses add serde-defaulted step metadata and an explicit `job_id`.

**Bug Fixes**

- `--step N` counts declared workflow steps; synthetic runner steps stay in whole-job output without shifting positions.
- Completions, live-log follow, and compatibility requests resolve the reporting or newest attempt, not the oldest.
- Timeline reports keep untyped and `Step` records, exclude container and job records, and order all records by execution position.
- Requests return `409` when order is unavailable, per-step blobs have not landed, or only live console blocks exist.
- Whole-job logs, run projections, and run-list responses use the same ordered step records, including AzDO synthetic steps.
- The conformance replay's 6 failing scenarios reproduce on `main` with the same count.

**Persistence**

- Adds per-attempt `job_steps` storage in SQLite and Postgres, rebuilds missing manifests from the persisted request at startup, and drops manifests for retired requests.
- Revision checks prevent stale writes; restored revisions seed the next write, and the schema guard distinguishes stale intermediate databases from real failures like a locked database.
- Both backends create `job_steps` in one migration; dev databases stamped 4 by an earlier build of this branch fail startup with an actionable error.

<sup>Written for commit 97ede6cac662d6ca40d0f4a66684cf853c6c35da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved step status and completion reporting for retries, dynamic jobs, and runner-added steps.
  - Ensured logs and step lists follow execution order, including timeline-reported steps.
  - Prevented synthetic runner steps and parent job records from occupying workflow step positions.
  - Improved log filtering across restarts and repeated job attempts.
  - Added validation for malformed or unavailable step reports.

- **Documentation**
  - Clarified `preloop logs --step` numbering, job requirements, runner-generated steps, duplicate names, and failure conditions.

- **Persistence**
  - Retained step manifests and statuses across restarts for each job attempt.
  - Prevented delayed updates from overwriting newer step results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->