### PR TITLE
feat: store local GitHub credentials in the OS credential store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,8 +15,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f0f96ce78e38c3dc6d8948aa8163d06385be74000f3c7a95bf1eef35d3ea32"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -79,7 +90,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -90,7 +101,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -98,6 +109,17 @@ name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "apple-native-keyring-store"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b350bfd03649e07aa05c0a81b3e15934374e585c98204a57e20b9d49f49bb9a"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
 
 [[package]]
 name = "arbitrary"
@@ -141,7 +163,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -153,8 +175,128 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -164,7 +306,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -343,6 +485,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,7 +570,16 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "cbc"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -475,7 +648,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -509,7 +692,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -562,6 +745,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,6 +790,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -716,7 +914,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -751,7 +949,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -767,6 +965,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,7 +1004,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -929,6 +1174,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -936,7 +1194,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1086,6 +1344,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,6 +1362,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
  "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -1391,8 +1664,18 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
+ "block-padding 0.3.3",
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding 0.4.2",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1465,7 +1748,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1484,7 +1767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1506,6 +1789,27 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "keyring"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2270074a3d26bcac93c1dc5d2845eb4c089e8d761ccf6e0ea266a16004640627"
+dependencies = [
+ "apple-native-keyring-store",
+ "keyring-core",
+ "windows-native-keyring-store",
+ "zbus-secret-service-keyring-store",
+]
+
+[[package]]
+name = "keyring-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -1620,6 +1924,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1679,7 +1992,21 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
 ]
 
 [[package]]
@@ -1709,6 +2036,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,6 +2066,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -1879,6 +2226,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1970,6 +2333,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1995,6 +2369,20 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2207,11 +2595,11 @@ dependencies = [
 name = "preloop-gha-protocol"
 version = "0.2.0"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "anyhow",
  "base64",
- "cbc",
- "cipher",
+ "cbc 0.1.2",
+ "cipher 0.4.4",
  "indexmap",
  "proptest",
  "rand 0.8.6",
@@ -2370,11 +2758,12 @@ dependencies = [
  "cron",
  "filetime",
  "futures",
- "hkdf",
+ "hkdf 0.12.4",
  "hmac 0.12.1",
  "hyper",
  "hyper-util",
  "indexmap",
+ "keyring",
  "opentelemetry",
  "parking_lot",
  "postgres_rustls",
@@ -2443,6 +2832,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.13+spec-1.1.0",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2490,7 +2888,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2878,7 +3276,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2956,7 +3354,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3026,6 +3424,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secret-service"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5107b24b91445dd2aa449a258a1807b63240942157292354dc5bfdbeb8bc6db8"
+dependencies = [
+ "aes 0.9.3",
+ "cbc 0.2.1",
+ "futures-util",
+ "getrandom 0.4.3",
+ "hkdf 0.13.0",
+ "hybrid-array",
+ "num",
+ "once_cell",
+ "serde",
+ "sha2 0.11.0",
+ "zbus",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3092,7 +3509,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3118,6 +3535,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3275,7 +3703,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3341,6 +3769,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3357,7 +3796,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3402,7 +3841,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3431,7 +3870,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3442,7 +3881,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3533,7 +3972,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3632,8 +4071,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -3646,6 +4085,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3654,9 +4102,30 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -3748,7 +4217,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3900,6 +4369,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3994,7 +4474,7 @@ checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "uuid",
 ]
 
@@ -4131,7 +4611,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -4239,7 +4719,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4269,7 +4749,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4280,7 +4760,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4288,6 +4768,19 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-native-keyring-store"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063426e76fdec7438d56bb777f67e318a84a25c707b07e575cb8b78e10c028f8"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
 
 [[package]]
 name = "windows-registry"
@@ -4493,6 +4986,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winx"
 version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4570,8 +5072,89 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.4",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-secret-service-keyring-store"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74801d001b9e7729adb4f1825b67b398185fed424749aa3d8bacf70417137d9a"
+dependencies = [
+ "keyring-core",
+ "secret-service",
+ "zbus",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.4",
+ "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4591,7 +5174,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4611,7 +5194,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -4651,7 +5234,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4687,4 +5270,45 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.4",
+ "zcheapstr",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 3.0.4",
+ "winnow 1.0.4",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"
 utoipa = { version = "5", features = ["uuid", "chrono"] }
 cap-std = "3.4"
+keyring = "4.2"
 
 command-group = { version = "5", features = ["with-tokio"] }
 flate2 = "1"

--- a/crates/preloop-cli/src/github_setup.rs
+++ b/crates/preloop-cli/src/github_setup.rs
@@ -10,7 +10,7 @@ use anyhow::Context;
 use clap::{Parser, Subcommand};
 use preloop_runner_server::config::{load_config, store_memory, write_config};
 use preloop_runner_server::credential_store::{
-    github_reference, CredentialStore, OsCredentialStore, SecretString,
+    github_reference, github_reference_with_host, CredentialStore, OsCredentialStore, SecretString,
 };
 use std::collections::BTreeMap;
 use std::io::IsTerminal;
@@ -260,9 +260,15 @@ async fn cmd_setup_github(args: GithubSetupArgs) -> anyhow::Result<()> {
             let target_app_id = args.app_id.as_deref().or(config.github.app_id.as_deref());
             if let Some(app_id) = target_app_id {
                 if store.available().is_ok() {
-                    let reference = github_reference("webhook", Some(app_id))?;
+                    let reference = github_reference_with_host(
+                        "webhook",
+                        config.github.server_url.as_deref(),
+                        Some(app_id),
+                    )?;
                     store.set(&reference, &SecretString::new(secret))?;
-                    if let Some(existing) = config.github.apps.iter_mut().find(|a| a.app_id == app_id) {
+                    if let Some(existing) =
+                        config.github.apps.iter_mut().find(|a| a.app_id == app_id)
+                    {
                         existing.legacy_webhook_secret = None;
                         existing.webhook_secret_ref = Some(reference.as_str().to_owned());
                     } else {
@@ -280,7 +286,9 @@ async fn cmd_setup_github(args: GithubSetupArgs) -> anyhow::Result<()> {
                         "warning: operating-system credential store is unavailable (headless environment); \
                          storing webhook secret inline in config.toml (mode 0600)."
                     );
-                    if let Some(existing) = config.github.apps.iter_mut().find(|a| a.app_id == app_id) {
+                    if let Some(existing) =
+                        config.github.apps.iter_mut().find(|a| a.app_id == app_id)
+                    {
                         existing.legacy_webhook_secret = Some(secret.to_owned());
                         existing.webhook_secret_ref = None;
                     } else {
@@ -401,11 +409,14 @@ fn save_app_credentials(
 ) -> anyhow::Result<PathBuf> {
     let store = OsCredentialStore;
     let store_available = store.available().is_ok();
+    let mut config = load_config()?;
+    let host = config.github.server_url.as_deref();
+
     let (pem_ref, webhook_ref) = if store_available {
-        let pem_ref = github_reference("app-pem", Some(app_id))?;
+        let pem_ref = github_reference_with_host("app-pem", host, Some(app_id))?;
         store.set(&pem_ref, &SecretString::new(pem))?;
         let webhook_ref = if let Some(secret) = &webhook_secret {
-            let reference = github_reference("webhook", Some(app_id))?;
+            let reference = github_reference_with_host("webhook", host, Some(app_id))?;
             store.set(&reference, &SecretString::new(secret))?;
             Some(reference.as_str().to_owned())
         } else {
@@ -420,7 +431,6 @@ fn save_app_credentials(
         (None, None)
     };
 
-    let mut config = load_config()?;
     if config.github.mint_failure.is_none() {
         config.github.mint_failure = Some("local".into());
     }
@@ -511,7 +521,6 @@ fn save_app_credentials(
     write_config(&config)
 }
 
-
 /// Create the App through GitHub's manifest flow and store what comes back.
 async fn setup_app_via_browser(args: &GithubSetupArgs) -> anyhow::Result<()> {
     let registration = crate::app_manifest::register(
@@ -576,7 +585,11 @@ async fn enable_webhooks(
     let store = OsCredentialStore;
     let mut config = load_config()?;
     if store.available().is_ok() {
-        let webhook_ref = github_reference("webhook", Some(app_id))?;
+        let webhook_ref = github_reference_with_host(
+            "webhook",
+            config.github.server_url.as_deref(),
+            Some(app_id),
+        )?;
         store.set(&webhook_ref, &SecretString::new(&secret))?;
         if let Some(existing) = config.github.apps.iter_mut().find(|a| a.app_id == app_id) {
             existing.legacy_webhook_secret = None;
@@ -703,7 +716,7 @@ async fn setup_pat(args: &GithubSetupArgs) -> anyhow::Result<()> {
     let store = OsCredentialStore;
     let mut config = load_config()?;
     if store.available().is_ok() {
-        let pat_ref = github_reference("pat", None)?;
+        let pat_ref = github_reference_with_host("pat", config.github.server_url.as_deref(), None)?;
         store.set(&pat_ref, &SecretString::new(&token))?;
         config.github.legacy_pat = None;
         config.github.pat_ref = Some(pat_ref.as_str().to_owned());

--- a/crates/preloop-cli/src/github_setup.rs
+++ b/crates/preloop-cli/src/github_setup.rs
@@ -10,7 +10,7 @@ use anyhow::Context;
 use clap::{Parser, Subcommand};
 use preloop_runner_server::config::{load_config, store_memory, write_config};
 use preloop_runner_server::credential_store::{
-    github_reference, CredentialStore, OsCredentialStore,
+    github_reference, CredentialStore, OsCredentialStore, SecretString,
 };
 use std::collections::BTreeMap;
 use std::io::IsTerminal;
@@ -259,7 +259,7 @@ async fn cmd_setup_github(args: GithubSetupArgs) -> anyhow::Result<()> {
         match config.github.app_id.as_deref() {
             Some(app_id) => {
                 let reference = github_reference("webhook", Some(app_id))?;
-                store.set(&reference, secret)?;
+                store.set(&reference, &SecretString::new(secret))?;
                 config.github.legacy_webhook_secret = None;
                 config.github.webhook_secret_ref = Some(reference.as_str().to_owned());
                 let path = write_config(&config)?;
@@ -380,10 +380,10 @@ fn save_app_credentials(
 ) -> anyhow::Result<PathBuf> {
     let store = OsCredentialStore;
     let pem_ref = github_reference("app-pem", Some(app_id))?;
-    store.set(&pem_ref, pem)?;
+    store.set(&pem_ref, &SecretString::new(pem))?;
     let webhook_ref = if let Some(secret) = webhook_secret {
         let reference = github_reference("webhook", Some(app_id))?;
-        store.set(&reference, &secret)?;
+        store.set(&reference, &SecretString::new(&secret))?;
         Some(reference.as_str().to_owned())
     } else {
         None
@@ -424,7 +424,7 @@ fn save_app_credentials(
             config.github.webhook_secret_ref = webhook_ref;
         } else if let Some(secret) = config.github.legacy_webhook_secret.take() {
             let reference = github_reference("webhook", Some(app_id))?;
-            store.set(&reference, &secret)?;
+            store.set(&reference, &SecretString::new(&secret))?;
             config.github.webhook_secret_ref = Some(reference.as_str().to_owned());
         }
         return write_config(&config);
@@ -504,7 +504,7 @@ async fn enable_webhooks(
         .await?;
     let store = OsCredentialStore;
     let webhook_ref = github_reference("webhook", Some(app_id))?;
-    store.set(&webhook_ref, &secret)?;
+    store.set(&webhook_ref, &SecretString::new(&secret))?;
     let mut config = load_config()?;
     if let Some(existing) = config.github.apps.iter_mut().find(|a| a.app_id == app_id) {
         existing.legacy_webhook_secret = None;
@@ -617,7 +617,7 @@ async fn setup_pat(args: &GithubSetupArgs) -> anyhow::Result<()> {
 
     let store = OsCredentialStore;
     let pat_ref = github_reference("pat", None)?;
-    store.set(&pat_ref, &token)?;
+    store.set(&pat_ref, &SecretString::new(&token))?;
     let mut config = load_config()?;
     config.github.legacy_pat = None;
     config.github.pat_ref = Some(pat_ref.as_str().to_owned());

--- a/crates/preloop-cli/src/github_setup.rs
+++ b/crates/preloop-cli/src/github_setup.rs
@@ -9,6 +9,9 @@ use crate::preloop_home;
 use anyhow::Context;
 use clap::{Parser, Subcommand};
 use preloop_runner_server::config::{load_config, store_memory, write_config};
+use preloop_runner_server::credential_store::{
+    github_reference, CredentialStore, OsCredentialStore,
+};
 use std::collections::BTreeMap;
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
@@ -248,10 +251,35 @@ async fn cmd_setup_github(args: GithubSetupArgs) -> anyhow::Result<()> {
     // App *creation* still wins: GitHub generates the secret it will sign
     // with, and nothing local can override that.
     if let Some(secret) = args.webhook_secret.as_deref() {
+        let store = OsCredentialStore;
         let mut config = preloop_runner_server::config::load_config()?;
-        config.github.webhook_secret = Some(secret.to_owned());
-        let path = write_config(&config)?;
-        println!("Webhook secret stored in {}", path.display());
+        // A webhook secret can precede App registration, in which case there
+        // is no App id to namespace it under; the legacy inline field stays
+        // the only home until `save_app_credentials` moves it.
+        match config.github.app_id.as_deref() {
+            Some(app_id) => {
+                let reference = github_reference("webhook", Some(app_id))?;
+                store.set(&reference, secret)?;
+                config.github.legacy_webhook_secret = None;
+                config.github.webhook_secret_ref = Some(reference.as_str().to_owned());
+                let path = write_config(&config)?;
+                println!(
+                    "Webhook secret stored in the operating-system credential store \
+                     (referenced from {}).",
+                    path.display()
+                );
+            }
+            None => {
+                config.github.legacy_webhook_secret = Some(secret.to_owned());
+                config.github.webhook_secret_ref = None;
+                let path = write_config(&config)?;
+                println!(
+                    "Webhook secret stored in {} (moves to the operating-system \
+                     credential store once an App id is configured).",
+                    path.display()
+                );
+            }
+        }
     }
     match via {
         Via::App => setup_app(&args).await,
@@ -269,13 +297,15 @@ async fn setup_app(args: &GithubSetupArgs) -> anyhow::Result<()> {
             // the first installed and minting tokens, and the operator almost
             // certainly meant "point the one I have at this URL".
             let existing = preloop_runner_server::config::load_config()?.github;
-            let has_configured_app = (existing.app_id.is_some() && existing.app_pem.is_some())
+            let has_configured_app = (existing.app_id.is_some() && existing.app_pem().is_some())
                 || !existing.apps.is_empty();
             if has_configured_app && !args.add {
-                if let (Some(app_id), Some(pem)) = (&existing.app_id, &existing.app_pem) {
+                if let (Some(app_id), Some(pem)) = (existing.app_id.as_deref(), existing.app_pem())
+                {
                     return match args.public_url.as_deref() {
                         Some(public_url) => {
-                            enable_webhooks(app_id, pem, public_url, existing.webhook_secret).await
+                            let webhook_secret = existing.webhook_secret().map(str::to_owned);
+                            enable_webhooks(app_id, pem, public_url, webhook_secret).await
                         }
                         None => {
                             let primary_id = existing.app_id.as_deref().unwrap_or("configured");
@@ -348,46 +378,65 @@ fn save_app_credentials(
     pem: &str,
     webhook_secret: Option<String>,
 ) -> anyhow::Result<PathBuf> {
-    let mut config = preloop_runner_server::config::load_config()?;
+    let store = OsCredentialStore;
+    let pem_ref = github_reference("app-pem", Some(app_id))?;
+    store.set(&pem_ref, pem)?;
+    let webhook_ref = if let Some(secret) = webhook_secret {
+        let reference = github_reference("webhook", Some(app_id))?;
+        store.set(&reference, &secret)?;
+        Some(reference.as_str().to_owned())
+    } else {
+        None
+    };
+
+    let mut config = load_config()?;
     if config.github.mint_failure.is_none() {
         config.github.mint_failure = Some("local".into());
     }
-
     if let Some(existing_primary) = &config.github.app_id {
         if existing_primary == app_id {
-            config.github.app_pem = Some(pem.to_owned());
-            if webhook_secret.is_some() {
-                config.github.webhook_secret = webhook_secret;
+            config.github.legacy_app_pem = None;
+            config.github.app_pem_ref = Some(pem_ref.as_str().to_owned());
+            if webhook_ref.is_some() {
+                config.github.legacy_webhook_secret = None;
+                config.github.webhook_secret_ref = webhook_ref;
             }
             return write_config(&config);
         }
     }
-
     if let Some(existing) = config.github.apps.iter_mut().find(|a| a.app_id == app_id) {
-        existing.pem = pem.to_owned();
-        if webhook_secret.is_some() {
-            existing.webhook_secret = webhook_secret;
+        existing.legacy_pem.clear();
+        existing.pem_ref = Some(pem_ref.as_str().to_owned());
+        if webhook_ref.is_some() {
+            existing.legacy_webhook_secret = None;
+            existing.webhook_secret_ref = webhook_ref;
         }
         return write_config(&config);
     }
-
     if config.github.app_id.is_none() && config.github.apps.is_empty() {
         config.github.app_id = Some(app_id.to_owned());
-        config.github.app_pem = Some(pem.to_owned());
-        if webhook_secret.is_some() {
-            config.github.webhook_secret = webhook_secret;
+        config.github.legacy_app_pem = None;
+        config.github.app_pem_ref = Some(pem_ref.as_str().to_owned());
+        // An App id now exists, so a secret parked inline by
+        // `--webhook-secret` can finally be namespaced and moved.
+        if webhook_ref.is_some() {
+            config.github.legacy_webhook_secret = None;
+            config.github.webhook_secret_ref = webhook_ref;
+        } else if let Some(secret) = config.github.legacy_webhook_secret.take() {
+            let reference = github_reference("webhook", Some(app_id))?;
+            store.set(&reference, &secret)?;
+            config.github.webhook_secret_ref = Some(reference.as_str().to_owned());
         }
         return write_config(&config);
     }
-
     config
         .github
         .apps
         .push(preloop_runner_server::config::AppConfig {
             app_id: app_id.to_owned(),
-            pem: pem.to_owned(),
-            webhook_secret,
-            installation_id: None,
+            pem_ref: Some(pem_ref.as_str().to_owned()),
+            webhook_secret_ref: webhook_ref,
+            ..Default::default()
         });
     write_config(&config)
 }
@@ -453,15 +502,20 @@ async fn enable_webhooks(
     );
     preloop_runner_server::github_app::set_app_webhook_config(app_id, pem, &hook_url, &secret)
         .await?;
-    let mut config = preloop_runner_server::config::load_config()?;
+    let store = OsCredentialStore;
+    let webhook_ref = github_reference("webhook", Some(app_id))?;
+    store.set(&webhook_ref, &secret)?;
+    let mut config = load_config()?;
     if let Some(existing) = config.github.apps.iter_mut().find(|a| a.app_id == app_id) {
-        existing.webhook_secret = Some(secret.clone());
+        existing.legacy_webhook_secret = None;
+        existing.webhook_secret_ref = Some(webhook_ref.as_str().to_owned());
     } else {
-        config.github.webhook_secret = Some(secret.clone());
+        config.github.legacy_webhook_secret = None;
+        config.github.webhook_secret_ref = Some(webhook_ref.as_str().to_owned());
     }
-    let path = write_config(&config)?;
+    write_config(&config)?;
     println!("App {app_id} webhook now delivers to {hook_url}");
-    println!("Secret stored in {}", path.display());
+    println!("Secret stored in the operating-system credential store.");
     println!(
         "If deliveries do not arrive, tick **Active** under Webhook in the App's\n\
          settings — GitHub's API cannot set that flag, and an App created\n\
@@ -561,11 +615,15 @@ async fn setup_pat(args: &GithubSetupArgs) -> anyhow::Result<()> {
         );
     }
 
-    let mut config = preloop_runner_server::config::load_config()?;
-    config.github.pat = Some(token.clone());
+    let store = OsCredentialStore;
+    let pat_ref = github_reference("pat", None)?;
+    store.set(&pat_ref, &token)?;
+    let mut config = load_config()?;
+    config.github.legacy_pat = None;
+    config.github.pat_ref = Some(pat_ref.as_str().to_owned());
     config.github.mint_failure = Some("pat".into());
-    let path = write_config(&config)?;
-    println!("Wrote {}", path.display());
+    write_config(&config)?;
+    println!("Stored PAT in the operating-system credential store.");
     println!("Restart the engine (`preloop serve`) to pick up the config.");
 
     if args.repos.is_empty() {
@@ -734,7 +792,7 @@ pub(crate) async fn cmd_doctor(args: DoctorArgs) -> anyhow::Result<()> {
     let mut failed = false;
     let mut app_found = false;
 
-    if let (Some(app_id), Some(pem)) = (&config.github.app_id, &config.github.app_pem) {
+    if let (Some(app_id), Some(pem)) = (config.github.app_id.as_deref(), config.github.app_pem()) {
         app_found = true;
         println!(
             "github app: configured (id {app_id}, mint failure = {})",
@@ -757,7 +815,7 @@ pub(crate) async fn cmd_doctor(args: DoctorArgs) -> anyhow::Result<()> {
             config.github.mint_failure.as_deref().unwrap_or("local")
         );
         if !args.repos.is_empty() {
-            if let Err(error) = doctor_app(&app.app_id, &app.pem, &args.repos).await {
+            if let Err(error) = doctor_app(&app.app_id, app.pem(), &args.repos).await {
                 println!("{error:#}");
                 failed = true;
             }
@@ -768,7 +826,7 @@ pub(crate) async fn cmd_doctor(args: DoctorArgs) -> anyhow::Result<()> {
     if !app_found {
         println!("github app: not configured (jobs get no GitHub authority)");
     }
-    if let Some(pat) = &config.github.pat {
+    if let Some(pat) = config.github.pat() {
         println!(
             "github pat: configured (mint failure = {})",
             config.github.mint_failure.as_deref().unwrap_or("local")

--- a/crates/preloop-cli/src/github_setup.rs
+++ b/crates/preloop-cli/src/github_setup.rs
@@ -126,7 +126,7 @@ fn redacted(present: bool) -> impl std::fmt::Debug {
     Marker(present)
 }
 
-#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum Via {
     App,
     Pat,
@@ -251,25 +251,46 @@ async fn cmd_setup_github(args: GithubSetupArgs) -> anyhow::Result<()> {
     // App *creation* still wins: GitHub generates the secret it will sign
     // with, and nothing local can override that.
     if let Some(secret) = args.webhook_secret.as_deref() {
-        let store = OsCredentialStore;
-        let mut config = preloop_runner_server::config::load_config()?;
-        // A webhook secret can precede App registration, in which case there
-        // is no App id to namespace it under; the legacy inline field stays
-        // the only home until `save_app_credentials` moves it.
-        match config.github.app_id.as_deref() {
-            Some(app_id) => {
-                let reference = github_reference("webhook", Some(app_id))?;
-                store.set(&reference, &SecretString::new(secret))?;
-                config.github.legacy_webhook_secret = None;
-                config.github.webhook_secret_ref = Some(reference.as_str().to_owned());
-                let path = write_config(&config)?;
-                println!(
-                    "Webhook secret stored in the operating-system credential store \
-                     (referenced from {}).",
-                    path.display()
-                );
-            }
-            None => {
+        // If `--via app` is chosen with an explicit `--app-id` or `--pem-file`,
+        // `setup_app` / `save_app_credentials` will bind the secret directly to
+        // that target App. Otherwise, configure it here.
+        if !(via == Via::App && args.app_id.is_some()) {
+            let store = OsCredentialStore;
+            let mut config = preloop_runner_server::config::load_config()?;
+            let target_app_id = args.app_id.as_deref().or(config.github.app_id.as_deref());
+            if let Some(app_id) = target_app_id {
+                if store.available().is_ok() {
+                    let reference = github_reference("webhook", Some(app_id))?;
+                    store.set(&reference, &SecretString::new(secret))?;
+                    if let Some(existing) = config.github.apps.iter_mut().find(|a| a.app_id == app_id) {
+                        existing.legacy_webhook_secret = None;
+                        existing.webhook_secret_ref = Some(reference.as_str().to_owned());
+                    } else {
+                        config.github.legacy_webhook_secret = None;
+                        config.github.webhook_secret_ref = Some(reference.as_str().to_owned());
+                    }
+                    let path = write_config(&config)?;
+                    println!(
+                        "Webhook secret stored in the operating-system credential store \
+                         (referenced from {}).",
+                        path.display()
+                    );
+                } else {
+                    println!(
+                        "warning: operating-system credential store is unavailable (headless environment); \
+                         storing webhook secret inline in config.toml (mode 0600)."
+                    );
+                    if let Some(existing) = config.github.apps.iter_mut().find(|a| a.app_id == app_id) {
+                        existing.legacy_webhook_secret = Some(secret.to_owned());
+                        existing.webhook_secret_ref = None;
+                    } else {
+                        config.github.legacy_webhook_secret = Some(secret.to_owned());
+                        config.github.webhook_secret_ref = None;
+                    }
+                    let path = write_config(&config)?;
+                    println!("Webhook secret stored in {}.", path.display());
+                }
+            } else {
                 config.github.legacy_webhook_secret = Some(secret.to_owned());
                 config.github.webhook_secret_ref = None;
                 let path = write_config(&config)?;
@@ -338,7 +359,7 @@ async fn setup_app(args: &GithubSetupArgs) -> anyhow::Result<()> {
         (Some(app_id), Some(pem_path)) => {
             let pem = std::fs::read_to_string(pem_path)
                 .with_context(|| format!("reading App private key {}", pem_path.display()))?;
-            (app_id.to_owned(), pem, None)
+            (app_id.to_owned(), pem, args.webhook_secret.clone())
         }
         (Some(_), None) => anyhow::bail!(
             "--pem-file is required alongside --app-id (omit both to create the App in a browser)"
@@ -379,14 +400,24 @@ fn save_app_credentials(
     webhook_secret: Option<String>,
 ) -> anyhow::Result<PathBuf> {
     let store = OsCredentialStore;
-    let pem_ref = github_reference("app-pem", Some(app_id))?;
-    store.set(&pem_ref, &SecretString::new(pem))?;
-    let webhook_ref = if let Some(secret) = webhook_secret {
-        let reference = github_reference("webhook", Some(app_id))?;
-        store.set(&reference, &SecretString::new(&secret))?;
-        Some(reference.as_str().to_owned())
+    let store_available = store.available().is_ok();
+    let (pem_ref, webhook_ref) = if store_available {
+        let pem_ref = github_reference("app-pem", Some(app_id))?;
+        store.set(&pem_ref, &SecretString::new(pem))?;
+        let webhook_ref = if let Some(secret) = &webhook_secret {
+            let reference = github_reference("webhook", Some(app_id))?;
+            store.set(&reference, &SecretString::new(secret))?;
+            Some(reference.as_str().to_owned())
+        } else {
+            None
+        };
+        (Some(pem_ref.as_str().to_owned()), webhook_ref)
     } else {
-        None
+        println!(
+            "warning: operating-system credential store is unavailable (headless environment); \
+             storing credentials inline in config.toml (mode 0600)."
+        );
+        (None, None)
     };
 
     let mut config = load_config()?;
@@ -395,51 +426,91 @@ fn save_app_credentials(
     }
     if let Some(existing_primary) = &config.github.app_id {
         if existing_primary == app_id {
-            config.github.legacy_app_pem = None;
-            config.github.app_pem_ref = Some(pem_ref.as_str().to_owned());
-            if webhook_ref.is_some() {
-                config.github.legacy_webhook_secret = None;
-                config.github.webhook_secret_ref = webhook_ref;
+            if store_available {
+                config.github.legacy_app_pem = None;
+                config.github.app_pem_ref = pem_ref;
+                if webhook_ref.is_some() {
+                    config.github.legacy_webhook_secret = None;
+                    config.github.webhook_secret_ref = webhook_ref;
+                }
+            } else {
+                config.github.legacy_app_pem = Some(pem.to_owned());
+                config.github.app_pem_ref = None;
+                if let Some(secret) = webhook_secret {
+                    config.github.legacy_webhook_secret = Some(secret);
+                    config.github.webhook_secret_ref = None;
+                }
             }
             return write_config(&config);
         }
     }
     if let Some(existing) = config.github.apps.iter_mut().find(|a| a.app_id == app_id) {
-        existing.legacy_pem.clear();
-        existing.pem_ref = Some(pem_ref.as_str().to_owned());
-        if webhook_ref.is_some() {
-            existing.legacy_webhook_secret = None;
-            existing.webhook_secret_ref = webhook_ref;
+        if store_available {
+            existing.legacy_pem.clear();
+            existing.pem_ref = pem_ref;
+            if webhook_ref.is_some() {
+                existing.legacy_webhook_secret = None;
+                existing.webhook_secret_ref = webhook_ref;
+            }
+        } else {
+            existing.legacy_pem = pem.to_owned();
+            existing.pem_ref = None;
+            if let Some(secret) = webhook_secret {
+                existing.legacy_webhook_secret = Some(secret);
+                existing.webhook_secret_ref = None;
+            }
         }
         return write_config(&config);
     }
     if config.github.app_id.is_none() && config.github.apps.is_empty() {
         config.github.app_id = Some(app_id.to_owned());
-        config.github.legacy_app_pem = None;
-        config.github.app_pem_ref = Some(pem_ref.as_str().to_owned());
-        // An App id now exists, so a secret parked inline by
-        // `--webhook-secret` can finally be namespaced and moved.
-        if webhook_ref.is_some() {
-            config.github.legacy_webhook_secret = None;
-            config.github.webhook_secret_ref = webhook_ref;
-        } else if let Some(secret) = config.github.legacy_webhook_secret.take() {
-            let reference = github_reference("webhook", Some(app_id))?;
-            store.set(&reference, &SecretString::new(&secret))?;
-            config.github.webhook_secret_ref = Some(reference.as_str().to_owned());
+        if store_available {
+            config.github.legacy_app_pem = None;
+            config.github.app_pem_ref = pem_ref;
+            // An App id now exists, so a secret parked inline by
+            // `--webhook-secret` can finally be namespaced and moved.
+            if webhook_ref.is_some() {
+                config.github.legacy_webhook_secret = None;
+                config.github.webhook_secret_ref = webhook_ref;
+            } else if let Some(secret) = config.github.legacy_webhook_secret.take() {
+                let reference = github_reference("webhook", Some(app_id))?;
+                store.set(&reference, &SecretString::new(&secret))?;
+                config.github.webhook_secret_ref = Some(reference.as_str().to_owned());
+            }
+        } else {
+            config.github.legacy_app_pem = Some(pem.to_owned());
+            config.github.app_pem_ref = None;
+            if let Some(secret) = webhook_secret {
+                config.github.legacy_webhook_secret = Some(secret);
+                config.github.webhook_secret_ref = None;
+            }
         }
         return write_config(&config);
     }
-    config
-        .github
-        .apps
-        .push(preloop_runner_server::config::AppConfig {
-            app_id: app_id.to_owned(),
-            pem_ref: Some(pem_ref.as_str().to_owned()),
-            webhook_secret_ref: webhook_ref,
-            ..Default::default()
-        });
+    if store_available {
+        config
+            .github
+            .apps
+            .push(preloop_runner_server::config::AppConfig {
+                app_id: app_id.to_owned(),
+                pem_ref,
+                webhook_secret_ref: webhook_ref,
+                ..Default::default()
+            });
+    } else {
+        config
+            .github
+            .apps
+            .push(preloop_runner_server::config::AppConfig {
+                app_id: app_id.to_owned(),
+                legacy_pem: pem.to_owned(),
+                legacy_webhook_secret: webhook_secret,
+                ..Default::default()
+            });
+    }
     write_config(&config)
 }
+
 
 /// Create the App through GitHub's manifest flow and store what comes back.
 async fn setup_app_via_browser(args: &GithubSetupArgs) -> anyhow::Result<()> {
@@ -503,19 +574,33 @@ async fn enable_webhooks(
     preloop_runner_server::github_app::set_app_webhook_config(app_id, pem, &hook_url, &secret)
         .await?;
     let store = OsCredentialStore;
-    let webhook_ref = github_reference("webhook", Some(app_id))?;
-    store.set(&webhook_ref, &SecretString::new(&secret))?;
     let mut config = load_config()?;
-    if let Some(existing) = config.github.apps.iter_mut().find(|a| a.app_id == app_id) {
-        existing.legacy_webhook_secret = None;
-        existing.webhook_secret_ref = Some(webhook_ref.as_str().to_owned());
+    if store.available().is_ok() {
+        let webhook_ref = github_reference("webhook", Some(app_id))?;
+        store.set(&webhook_ref, &SecretString::new(&secret))?;
+        if let Some(existing) = config.github.apps.iter_mut().find(|a| a.app_id == app_id) {
+            existing.legacy_webhook_secret = None;
+            existing.webhook_secret_ref = Some(webhook_ref.as_str().to_owned());
+        } else {
+            config.github.legacy_webhook_secret = None;
+            config.github.webhook_secret_ref = Some(webhook_ref.as_str().to_owned());
+        }
+        println!("Secret stored in the operating-system credential store.");
     } else {
-        config.github.legacy_webhook_secret = None;
-        config.github.webhook_secret_ref = Some(webhook_ref.as_str().to_owned());
+        println!(
+            "warning: operating-system credential store is unavailable (headless environment); \
+             storing webhook secret inline in config.toml (mode 0600)."
+        );
+        if let Some(existing) = config.github.apps.iter_mut().find(|a| a.app_id == app_id) {
+            existing.legacy_webhook_secret = Some(secret.clone());
+            existing.webhook_secret_ref = None;
+        } else {
+            config.github.legacy_webhook_secret = Some(secret.clone());
+            config.github.webhook_secret_ref = None;
+        }
     }
     write_config(&config)?;
     println!("App {app_id} webhook now delivers to {hook_url}");
-    println!("Secret stored in the operating-system credential store.");
     println!(
         "If deliveries do not arrive, tick **Active** under Webhook in the App's\n\
          settings — GitHub's API cannot set that flag, and an App created\n\
@@ -616,16 +701,24 @@ async fn setup_pat(args: &GithubSetupArgs) -> anyhow::Result<()> {
     }
 
     let store = OsCredentialStore;
-    let pat_ref = github_reference("pat", None)?;
-    store.set(&pat_ref, &SecretString::new(&token))?;
     let mut config = load_config()?;
-    config.github.legacy_pat = None;
-    config.github.pat_ref = Some(pat_ref.as_str().to_owned());
+    if store.available().is_ok() {
+        let pat_ref = github_reference("pat", None)?;
+        store.set(&pat_ref, &SecretString::new(&token))?;
+        config.github.legacy_pat = None;
+        config.github.pat_ref = Some(pat_ref.as_str().to_owned());
+        println!("Stored PAT in the operating-system credential store.");
+    } else {
+        println!(
+            "warning: operating-system credential store is unavailable (headless environment); \
+             storing PAT inline in config.toml (mode 0600)."
+        );
+        config.github.legacy_pat = Some(token.clone());
+        config.github.pat_ref = None;
+    }
     config.github.mint_failure = Some("pat".into());
     write_config(&config)?;
-    println!("Stored PAT in the operating-system credential store.");
     println!("Restart the engine (`preloop serve`) to pick up the config.");
-
     if args.repos.is_empty() {
         println!("Tip: verify with `preloop doctor --repo owner/name`.");
         return Ok(());

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -1240,6 +1240,96 @@ fn prepare_engine_token(
     Ok(token)
 }
 
+/// Move any inline GitHub credential in `config` into the OS credential
+/// store, returning whether anything moved.
+///
+/// Only the `legacy_*` fields are inspected, and those are populated purely
+/// from disk — [`resolve_credential_references`] fills the separate
+/// `resolved_*` fields instead. That is what makes this idempotent: once a
+/// credential has moved, its legacy field is empty on the next load and the
+/// migration is a no-op rather than a rewrite on every startup.
+///
+/// A credential that cannot be namespaced (an App key or webhook secret with
+/// no `github.app_id`) is left inline and reported. Failing here would take
+/// down `preloop serve` for a config `preloop setup github --webhook-secret`
+/// itself produces.
+///
+/// Mutates `config` only; the caller persists it, and does so once every
+/// credential has landed in the store. A failure partway leaves config.toml
+/// untouched, so the inline values are still there and the next startup
+/// retries the whole migration.
+///
+/// [`resolve_credential_references`]: preloop_runner_server::config
+fn migrate_legacy_github_credentials(
+    config: &mut preloop_runner_server::config::ConfigFile,
+    store: &impl preloop_runner_server::credential_store::CredentialStore,
+) -> anyhow::Result<bool> {
+    use preloop_runner_server::credential_store::github_reference;
+
+    if store.available().is_err() {
+        return Ok(false);
+    }
+    let mut migrated = false;
+    let app_id = config.github.app_id.clone();
+
+    if config.github.legacy_app_pem.is_some() {
+        match app_id.as_deref() {
+            Some(app_id) => {
+                let value = config.github.legacy_app_pem.take().expect("checked above");
+                let reference = github_reference("app-pem", Some(app_id))?;
+                store.set(&reference, &value)?;
+                config.github.app_pem_ref = Some(reference.as_str().to_owned());
+                migrated = true;
+            }
+            None => eprintln!(
+                "[preloop] leaving the inline GitHub App key in config.toml: \
+                 github.app_id is not set, so it cannot be namespaced"
+            ),
+        }
+    }
+    if let Some(value) = config.github.legacy_pat.take() {
+        let reference = github_reference("pat", None)?;
+        store.set(&reference, &value)?;
+        config.github.pat_ref = Some(reference.as_str().to_owned());
+        migrated = true;
+    }
+    if config.github.legacy_webhook_secret.is_some() {
+        match app_id.as_deref() {
+            Some(app_id) => {
+                let value = config
+                    .github
+                    .legacy_webhook_secret
+                    .take()
+                    .expect("checked above");
+                let reference = github_reference("webhook", Some(app_id))?;
+                store.set(&reference, &value)?;
+                config.github.webhook_secret_ref = Some(reference.as_str().to_owned());
+                migrated = true;
+            }
+            None => eprintln!(
+                "[preloop] leaving the inline webhook secret in config.toml: \
+                 github.app_id is not set, so it cannot be namespaced"
+            ),
+        }
+    }
+    for app in &mut config.github.apps {
+        if !app.legacy_pem.is_empty() {
+            let reference = github_reference("app-pem", Some(&app.app_id))?;
+            store.set(&reference, &app.legacy_pem)?;
+            app.legacy_pem.clear();
+            app.pem_ref = Some(reference.as_str().to_owned());
+            migrated = true;
+        }
+        if let Some(value) = app.legacy_webhook_secret.take() {
+            let reference = github_reference("webhook", Some(&app.app_id))?;
+            store.set(&reference, &value)?;
+            app.webhook_secret_ref = Some(reference.as_str().to_owned());
+            migrated = true;
+        }
+    }
+    Ok(migrated)
+}
+
 /// Merge stored and command-line GitHub credentials into the environment the
 /// server reads, optionally persisting them, and report the effective state.
 ///
@@ -1272,13 +1362,23 @@ fn resolve_github_auth(args: &ServeArgs, state_dir: &std::path::Path) -> anyhow:
     // `preloop setup` stores credentials in config.toml's [github] section,
     // which is what the server itself loads at startup. Fill any gaps from
     // it so the startup report matches what the server will actually see.
-    let file_config = preloop_runner_server::config::load_config()?;
-    auth.fill_gaps(github_auth::StoredAuth {
-        app_id: file_config.github.app_id,
+    let mut file_config = preloop_runner_server::config::load_config()?;
+    let store = preloop_runner_server::credential_store::OsCredentialStore;
+    // Read before migrating: migration moves the inline values out of
+    // `config.github`, and the freshly stored ones are not re-resolved here.
+    let from_file = github_auth::StoredAuth {
+        app_id: file_config.github.app_id.clone(),
         installation_id: None,
-        private_key_pem: file_config.github.app_pem,
-        webhook_secret: file_config.github.webhook_secret,
-    });
+        private_key_pem: file_config.github.app_pem().map(str::to_owned),
+        webhook_secret: file_config.github.webhook_secret().map(str::to_owned),
+    };
+    if migrate_legacy_github_credentials(&mut file_config, &store)? {
+        preloop_runner_server::config::write_config(&file_config)?;
+        eprintln!(
+            "[preloop] migrated legacy GitHub credentials to the operating-system credential store"
+        );
+    }
+    auth.fill_gaps(from_file);
 
     if args.save {
         if !supplied {
@@ -4127,6 +4227,109 @@ mod tests {
     /// test threads would otherwise race each other's set_var/remove_var
     /// pairs.
     static TEST_ENV_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    mod github_credential_migration {
+        use super::super::migrate_legacy_github_credentials;
+        use preloop_runner_server::config::{AppConfig, ConfigFile, GitHubConfig};
+        use preloop_runner_server::credential_store::{
+            github_reference, CredentialStore, MemoryCredentialStore,
+        };
+
+        fn legacy_config() -> ConfigFile {
+            ConfigFile {
+                github: GitHubConfig {
+                    app_id: Some("123".into()),
+                    legacy_app_pem: Some("INLINE-PEM".into()),
+                    legacy_pat: Some("ghp_inline".into()),
+                    legacy_webhook_secret: Some("hook-secret".into()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+        }
+
+        #[test]
+        fn inline_credentials_move_into_the_store() {
+            let store = MemoryCredentialStore::default();
+            let mut config = legacy_config();
+            assert!(migrate_legacy_github_credentials(&mut config, &store).unwrap());
+
+            assert_eq!(config.github.legacy_app_pem, None);
+            assert_eq!(config.github.legacy_pat, None);
+            assert_eq!(config.github.legacy_webhook_secret, None);
+            assert_eq!(
+                config.github.app_pem_ref.as_deref(),
+                Some("github-app-pem-123")
+            );
+            let pem_ref = github_reference("app-pem", Some("123")).unwrap();
+            assert_eq!(store.get(&pem_ref).unwrap().as_deref(), Some("INLINE-PEM"));
+            let pat_ref = github_reference("pat", None).unwrap();
+            assert_eq!(store.get(&pat_ref).unwrap().as_deref(), Some("ghp_inline"));
+        }
+
+        /// The regression: migration used to inspect fields that the loader
+        /// had just populated from the credential store, so it reported a
+        /// migration and rewrote config.toml on every single startup.
+        #[test]
+        fn migration_is_idempotent() {
+            let store = MemoryCredentialStore::default();
+            let mut config = legacy_config();
+            assert!(migrate_legacy_github_credentials(&mut config, &store).unwrap());
+            assert!(
+                !migrate_legacy_github_credentials(&mut config, &store).unwrap(),
+                "second run must be a no-op"
+            );
+        }
+
+        /// `preloop setup github --webhook-secret` writes a secret with no
+        /// App id. Failing that config would refuse to start the server.
+        #[test]
+        fn a_missing_app_id_is_not_fatal() {
+            let store = MemoryCredentialStore::default();
+            let mut config = ConfigFile {
+                github: GitHubConfig {
+                    legacy_webhook_secret: Some("hook-secret".into()),
+                    legacy_pat: Some("ghp_inline".into()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            // The PAT needs no App id, so it still migrates.
+            assert!(migrate_legacy_github_credentials(&mut config, &store).unwrap());
+            assert_eq!(config.github.legacy_pat, None);
+            assert_eq!(
+                config.github.legacy_webhook_secret.as_deref(),
+                Some("hook-secret"),
+                "un-namespaceable secret must be left inline, not dropped"
+            );
+        }
+
+        #[test]
+        fn registry_entries_migrate_too() {
+            let store = MemoryCredentialStore::default();
+            let mut config = ConfigFile {
+                github: GitHubConfig {
+                    apps: vec![AppConfig {
+                        app_id: "456".into(),
+                        legacy_pem: "REGISTRY-PEM".into(),
+                        legacy_webhook_secret: Some("registry-hook".into()),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            assert!(migrate_legacy_github_credentials(&mut config, &store).unwrap());
+            assert!(config.github.apps[0].legacy_pem.is_empty());
+            assert_eq!(config.github.apps[0].legacy_webhook_secret, None);
+            let pem_ref = github_reference("app-pem", Some("456")).unwrap();
+            assert_eq!(
+                store.get(&pem_ref).unwrap().as_deref(),
+                Some("REGISTRY-PEM")
+            );
+            assert!(!migrate_legacy_github_credentials(&mut config, &store).unwrap());
+        }
+    }
 
     #[test]
     fn truncate_reason_cuts_on_char_boundary() {

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -1264,7 +1264,7 @@ fn migrate_legacy_github_credentials(
     config: &mut preloop_runner_server::config::ConfigFile,
     store: &impl preloop_runner_server::credential_store::CredentialStore,
 ) -> anyhow::Result<bool> {
-    use preloop_runner_server::credential_store::github_reference;
+    use preloop_runner_server::credential_store::{github_reference, SecretString};
 
     if store.available().is_err() {
         return Ok(false);
@@ -1277,7 +1277,7 @@ fn migrate_legacy_github_credentials(
             Some(app_id) => {
                 let value = config.github.legacy_app_pem.take().expect("checked above");
                 let reference = github_reference("app-pem", Some(app_id))?;
-                store.set(&reference, &value)?;
+                store.set(&reference, &SecretString::new(value))?;
                 config.github.app_pem_ref = Some(reference.as_str().to_owned());
                 migrated = true;
             }
@@ -1289,7 +1289,7 @@ fn migrate_legacy_github_credentials(
     }
     if let Some(value) = config.github.legacy_pat.take() {
         let reference = github_reference("pat", None)?;
-        store.set(&reference, &value)?;
+        store.set(&reference, &SecretString::new(value))?;
         config.github.pat_ref = Some(reference.as_str().to_owned());
         migrated = true;
     }
@@ -1302,7 +1302,7 @@ fn migrate_legacy_github_credentials(
                     .take()
                     .expect("checked above");
                 let reference = github_reference("webhook", Some(app_id))?;
-                store.set(&reference, &value)?;
+                store.set(&reference, &SecretString::new(value))?;
                 config.github.webhook_secret_ref = Some(reference.as_str().to_owned());
                 migrated = true;
             }
@@ -1315,14 +1315,14 @@ fn migrate_legacy_github_credentials(
     for app in &mut config.github.apps {
         if !app.legacy_pem.is_empty() {
             let reference = github_reference("app-pem", Some(&app.app_id))?;
-            store.set(&reference, &app.legacy_pem)?;
+            store.set(&reference, &SecretString::new(&app.legacy_pem))?;
             app.legacy_pem.clear();
             app.pem_ref = Some(reference.as_str().to_owned());
             migrated = true;
         }
         if let Some(value) = app.legacy_webhook_secret.take() {
             let reference = github_reference("webhook", Some(&app.app_id))?;
-            store.set(&reference, &value)?;
+            store.set(&reference, &SecretString::new(value))?;
             app.webhook_secret_ref = Some(reference.as_str().to_owned());
             migrated = true;
         }
@@ -4262,11 +4262,16 @@ mod tests {
                 Some("github-app-pem-123")
             );
             let pem_ref = github_reference("app-pem", Some("123")).unwrap();
-            assert_eq!(store.get(&pem_ref).unwrap().as_deref(), Some("INLINE-PEM"));
+            assert_eq!(
+                store.get(&pem_ref).unwrap().as_ref().map(|s| s.expose()),
+                Some("INLINE-PEM")
+            );
             let pat_ref = github_reference("pat", None).unwrap();
-            assert_eq!(store.get(&pat_ref).unwrap().as_deref(), Some("ghp_inline"));
+            assert_eq!(
+                store.get(&pat_ref).unwrap().as_ref().map(|s| s.expose()),
+                Some("ghp_inline")
+            );
         }
-
         /// The regression: migration used to inspect fields that the loader
         /// had just populated from the credential store, so it reported a
         /// migration and rewrote config.toml on every single startup.
@@ -4324,7 +4329,7 @@ mod tests {
             assert_eq!(config.github.apps[0].legacy_webhook_secret, None);
             let pem_ref = github_reference("app-pem", Some("456")).unwrap();
             assert_eq!(
-                store.get(&pem_ref).unwrap().as_deref(),
+                store.get(&pem_ref).unwrap().as_ref().map(|s| s.expose()),
                 Some("REGISTRY-PEM")
             );
             assert!(!migrate_legacy_github_credentials(&mut config, &store).unwrap());

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -1266,65 +1266,129 @@ fn migrate_legacy_github_credentials(
 ) -> anyhow::Result<bool> {
     use preloop_runner_server::credential_store::{github_reference, SecretString};
 
-    if store.available().is_err() {
+    let has_legacy = config
+        .github
+        .legacy_app_pem
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .is_some()
+        || config
+            .github
+            .legacy_pat
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .is_some()
+        || config
+            .github
+            .legacy_webhook_secret
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .is_some()
+        || config.github.apps.iter().any(|app| {
+            !app.legacy_pem.trim().is_empty()
+                || app
+                    .legacy_webhook_secret
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .is_some()
+        });
+
+    if !has_legacy {
         return Ok(false);
     }
+
+    if let Err(error) = store.available() {
+        tracing::warn!(
+            %error,
+            "config contains inline GitHub credentials but no credential store is reachable; \
+             leaving inline credentials active"
+        );
+        return Ok(false);
+    }
+
     let mut migrated = false;
     let app_id = config.github.app_id.clone();
 
-    if config.github.legacy_app_pem.is_some() {
-        match app_id.as_deref() {
-            Some(app_id) => {
-                let value = config.github.legacy_app_pem.take().expect("checked above");
-                let reference = github_reference("app-pem", Some(app_id))?;
-                store.set(&reference, &SecretString::new(value))?;
-                config.github.app_pem_ref = Some(reference.as_str().to_owned());
-                migrated = true;
+    if let Some(value) = config.github.legacy_app_pem.take() {
+        let value = value.trim();
+        if !value.is_empty() {
+            match app_id.as_deref() {
+                Some(app_id) => {
+                    let reference = github_reference("app-pem", Some(app_id))?;
+                    if store.get(&reference)?.is_none() {
+                        store.set(&reference, &SecretString::new(value))?;
+                    }
+                    config.github.app_pem_ref = Some(reference.as_str().to_owned());
+                    migrated = true;
+                }
+                None => {
+                    config.github.legacy_app_pem = Some(value.to_owned());
+                    eprintln!(
+                        "[preloop] leaving the inline GitHub App key in config.toml: \
+                         github.app_id is not set, so it cannot be namespaced"
+                    );
+                }
             }
-            None => eprintln!(
-                "[preloop] leaving the inline GitHub App key in config.toml: \
-                 github.app_id is not set, so it cannot be namespaced"
-            ),
         }
     }
     if let Some(value) = config.github.legacy_pat.take() {
-        let reference = github_reference("pat", None)?;
-        store.set(&reference, &SecretString::new(value))?;
-        config.github.pat_ref = Some(reference.as_str().to_owned());
-        migrated = true;
-    }
-    if config.github.legacy_webhook_secret.is_some() {
-        match app_id.as_deref() {
-            Some(app_id) => {
-                let value = config
-                    .github
-                    .legacy_webhook_secret
-                    .take()
-                    .expect("checked above");
-                let reference = github_reference("webhook", Some(app_id))?;
+        let value = value.trim();
+        if !value.is_empty() {
+            let reference = github_reference("pat", None)?;
+            if store.get(&reference)?.is_none() {
                 store.set(&reference, &SecretString::new(value))?;
-                config.github.webhook_secret_ref = Some(reference.as_str().to_owned());
-                migrated = true;
             }
-            None => eprintln!(
-                "[preloop] leaving the inline webhook secret in config.toml: \
-                 github.app_id is not set, so it cannot be namespaced"
-            ),
+            config.github.pat_ref = Some(reference.as_str().to_owned());
+            migrated = true;
+        }
+    }
+    if let Some(value) = config.github.legacy_webhook_secret.take() {
+        let value = value.trim();
+        if !value.is_empty() {
+            match app_id.as_deref() {
+                Some(app_id) => {
+                    let reference = github_reference("webhook", Some(app_id))?;
+                    if store.get(&reference)?.is_none() {
+                        store.set(&reference, &SecretString::new(value))?;
+                    }
+                    config.github.webhook_secret_ref = Some(reference.as_str().to_owned());
+                    migrated = true;
+                }
+                None => {
+                    config.github.legacy_webhook_secret = Some(value.to_owned());
+                    eprintln!(
+                        "[preloop] leaving the inline webhook secret in config.toml: \
+                         github.app_id is not set, so it cannot be namespaced"
+                    );
+                }
+            }
         }
     }
     for app in &mut config.github.apps {
-        if !app.legacy_pem.is_empty() {
+        let pem = app.legacy_pem.trim().to_owned();
+        if !pem.is_empty() {
             let reference = github_reference("app-pem", Some(&app.app_id))?;
-            store.set(&reference, &SecretString::new(&app.legacy_pem))?;
+            if store.get(&reference)?.is_none() {
+                store.set(&reference, &SecretString::new(&pem))?;
+            }
             app.legacy_pem.clear();
             app.pem_ref = Some(reference.as_str().to_owned());
             migrated = true;
         }
         if let Some(value) = app.legacy_webhook_secret.take() {
-            let reference = github_reference("webhook", Some(&app.app_id))?;
-            store.set(&reference, &SecretString::new(value))?;
-            app.webhook_secret_ref = Some(reference.as_str().to_owned());
-            migrated = true;
+            let value = value.trim();
+            if !value.is_empty() {
+                let reference = github_reference("webhook", Some(&app.app_id))?;
+                if store.get(&reference)?.is_none() {
+                    store.set(&reference, &SecretString::new(value))?;
+                }
+                app.webhook_secret_ref = Some(reference.as_str().to_owned());
+                migrated = true;
+            }
         }
     }
     Ok(migrated)

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -1264,7 +1264,7 @@ fn migrate_legacy_github_credentials(
     config: &mut preloop_runner_server::config::ConfigFile,
     store: &impl preloop_runner_server::credential_store::CredentialStore,
 ) -> anyhow::Result<bool> {
-    use preloop_runner_server::credential_store::{github_reference, SecretString};
+    use preloop_runner_server::credential_store::{github_reference_with_host, SecretString};
 
     let has_legacy = config
         .github
@@ -1312,13 +1312,14 @@ fn migrate_legacy_github_credentials(
 
     let mut migrated = false;
     let app_id = config.github.app_id.clone();
+    let host = config.github.server_url.as_deref();
 
     if let Some(value) = config.github.legacy_app_pem.take() {
         let value = value.trim();
         if !value.is_empty() {
             match app_id.as_deref() {
                 Some(app_id) => {
-                    let reference = github_reference("app-pem", Some(app_id))?;
+                    let reference = github_reference_with_host("app-pem", host, Some(app_id))?;
                     if store.get(&reference)?.is_none() {
                         store.set(&reference, &SecretString::new(value))?;
                     }
@@ -1338,7 +1339,7 @@ fn migrate_legacy_github_credentials(
     if let Some(value) = config.github.legacy_pat.take() {
         let value = value.trim();
         if !value.is_empty() {
-            let reference = github_reference("pat", None)?;
+            let reference = github_reference_with_host("pat", host, None)?;
             if store.get(&reference)?.is_none() {
                 store.set(&reference, &SecretString::new(value))?;
             }
@@ -1351,7 +1352,7 @@ fn migrate_legacy_github_credentials(
         if !value.is_empty() {
             match app_id.as_deref() {
                 Some(app_id) => {
-                    let reference = github_reference("webhook", Some(app_id))?;
+                    let reference = github_reference_with_host("webhook", host, Some(app_id))?;
                     if store.get(&reference)?.is_none() {
                         store.set(&reference, &SecretString::new(value))?;
                     }
@@ -1371,7 +1372,7 @@ fn migrate_legacy_github_credentials(
     for app in &mut config.github.apps {
         let pem = app.legacy_pem.trim().to_owned();
         if !pem.is_empty() {
-            let reference = github_reference("app-pem", Some(&app.app_id))?;
+            let reference = github_reference_with_host("app-pem", host, Some(&app.app_id))?;
             if store.get(&reference)?.is_none() {
                 store.set(&reference, &SecretString::new(&pem))?;
             }
@@ -1382,7 +1383,7 @@ fn migrate_legacy_github_credentials(
         if let Some(value) = app.legacy_webhook_secret.take() {
             let value = value.trim();
             if !value.is_empty() {
-                let reference = github_reference("webhook", Some(&app.app_id))?;
+                let reference = github_reference_with_host("webhook", host, Some(&app.app_id))?;
                 if store.get(&reference)?.is_none() {
                     store.set(&reference, &SecretString::new(value))?;
                 }
@@ -4397,6 +4398,100 @@ mod tests {
                 Some("REGISTRY-PEM")
             );
             assert!(!migrate_legacy_github_credentials(&mut config, &store).unwrap());
+        }
+
+        #[test]
+        fn rotation_preserves_existing_store_credentials() {
+            let store = MemoryCredentialStore::default();
+            let pat_ref = github_reference("pat", None).unwrap();
+            store
+                .set(
+                    &pat_ref,
+                    &preloop_runner_server::credential_store::SecretString::new("ROTATED-PAT"),
+                )
+                .unwrap();
+
+            let mut config = ConfigFile {
+                github: GitHubConfig {
+                    legacy_pat: Some("stale_legacy_pat".into()),
+                    pat_ref: Some(pat_ref.as_str().to_owned()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+
+            assert!(migrate_legacy_github_credentials(&mut config, &store).unwrap());
+            assert_eq!(config.github.legacy_pat, None);
+            assert_eq!(
+                store.get(&pat_ref).unwrap().as_ref().map(|s| s.expose()),
+                Some("ROTATED-PAT"),
+                "migration must not overwrite rotated store value with stale legacy value"
+            );
+        }
+
+        #[test]
+        fn empty_legacy_values_do_not_fail_migration() {
+            let store = MemoryCredentialStore::default();
+            let mut config = ConfigFile {
+                github: GitHubConfig {
+                    app_id: Some("123".into()),
+                    legacy_app_pem: Some("  ".into()),
+                    legacy_pat: Some("".into()),
+                    legacy_webhook_secret: Some("".into()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            assert!(!migrate_legacy_github_credentials(&mut config, &store).unwrap());
+        }
+
+        #[test]
+        fn distinct_hosts_with_identical_app_ids_do_not_collide_in_store() {
+            let store = MemoryCredentialStore::default();
+            let mut config_cloud = ConfigFile {
+                github: GitHubConfig {
+                    app_id: Some("999".into()),
+                    server_url: Some("https://github.com".into()),
+                    legacy_app_pem: Some("CLOUD-PEM".into()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let mut config_ghes = ConfigFile {
+                github: GitHubConfig {
+                    app_id: Some("999".into()),
+                    server_url: Some("https://ghe.corp.internal".into()),
+                    legacy_app_pem: Some("GHES-PEM".into()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+
+            assert!(migrate_legacy_github_credentials(&mut config_cloud, &store).unwrap());
+            assert!(migrate_legacy_github_credentials(&mut config_ghes, &store).unwrap());
+
+            let cloud_ref = preloop_runner_server::credential_store::github_reference_with_host(
+                "app-pem",
+                Some("https://github.com"),
+                Some("999"),
+            )
+            .unwrap();
+            let ghes_ref = preloop_runner_server::credential_store::github_reference_with_host(
+                "app-pem",
+                Some("https://ghe.corp.internal"),
+                Some("999"),
+            )
+            .unwrap();
+
+            assert_ne!(cloud_ref.as_str(), ghes_ref.as_str());
+            assert_eq!(
+                store.get(&cloud_ref).unwrap().as_ref().map(|s| s.expose()),
+                Some("CLOUD-PEM")
+            );
+            assert_eq!(
+                store.get(&ghes_ref).unwrap().as_ref().map(|s| s.expose()),
+                Some("GHES-PEM")
+            );
         }
     }
 

--- a/crates/preloop-runner-server/Cargo.toml
+++ b/crates/preloop-runner-server/Cargo.toml
@@ -64,6 +64,7 @@ chrono.workspace = true
 chrono-tz.workspace = true
 serde_yaml.workspace = true
 utoipa.workspace = true
+keyring.workspace = true
 
 toml = { workspace = true }
 parking_lot.workspace = true

--- a/crates/preloop-runner-server/src/config.rs
+++ b/crates/preloop-runner-server/src/config.rs
@@ -10,6 +10,7 @@
 //! is written with mode 0600 and never echoed back by `preloop secret list`
 //! or `preloop doctor`.
 
+use crate::credential_store::{CredentialRef, CredentialStore, OsCredentialStore};
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -27,21 +28,45 @@ pub struct GitHubConfig {
     /// GitHub App ID.
     #[serde(default)]
     pub app_id: Option<String>,
-    /// GitHub App private key PEM (inline).
+    /// GitHub App private key PEM, stored inline (legacy).
+    ///
+    /// Read from disk and migrated into the OS credential store on the next
+    /// `preloop serve`; never populated from the credential store, so a
+    /// load/write round-trip can neither lose an unmigrated credential nor
+    /// reintroduce plaintext for a migrated one. Use [`GitHubConfig::app_pem`]
+    /// to read the effective value.
+    #[serde(default, rename = "app_pem")]
+    pub legacy_app_pem: Option<String>,
+    /// OS credential-store reference for the App private key.
     #[serde(default)]
-    pub app_pem: Option<String>,
+    pub app_pem_ref: Option<String>,
+    /// Value behind [`Self::app_pem_ref`], resolved at load. Never persisted.
+    #[serde(skip)]
+    pub resolved_app_pem: Option<String>,
     /// Mint-failure policy: `local`, `error`, or `pat`.
     #[serde(default)]
     pub mint_failure: Option<String>,
     /// PAT used as the fallback when App minting fails under the `pat`
     /// policy. Also the credential for the `--via pat` setup path.
+    /// Stored inline (legacy); see [`Self::legacy_app_pem`].
+    #[serde(default, rename = "pat")]
+    pub legacy_pat: Option<String>,
+    /// OS credential-store reference for the PAT.
     #[serde(default)]
-    pub pat: Option<String>,
+    pub pat_ref: Option<String>,
+    /// Value behind [`Self::pat_ref`], resolved at load. Never persisted.
+    #[serde(skip)]
+    pub resolved_pat: Option<String>,
     /// Shared secret for `X-Hub-Signature-256` webhook verification.
-    /// Written by the App-manifest setup flow, which receives it from
-    /// GitHub. Env: `PRELOOP_WEBHOOK_SECRET`.
+    /// Stored inline (legacy); see [`Self::legacy_app_pem`].
+    #[serde(default, rename = "webhook_secret")]
+    pub legacy_webhook_secret: Option<String>,
+    /// OS credential-store reference for the webhook secret.
     #[serde(default)]
-    pub webhook_secret: Option<String>,
+    pub webhook_secret_ref: Option<String>,
+    /// Value behind [`Self::webhook_secret_ref`], resolved at load. Never persisted.
+    #[serde(skip)]
+    pub resolved_webhook_secret: Option<String>,
     /// GitHub server URL exposed to workflows as `github.server_url` /
     /// `GITHUB_SERVER_URL`. Defaults to `https://github.com`; point it at a
     /// GHES-style host when the engine fronts one. Env: `PRELOOP_GITHUB_SERVER_URL`.
@@ -69,6 +94,28 @@ pub struct GitHubConfig {
     pub pr: PrConfig,
 }
 
+impl GitHubConfig {
+    /// Effective App private key: the credential store wins, the inline
+    /// legacy value is the pre-migration fallback.
+    pub fn app_pem(&self) -> Option<&str> {
+        self.resolved_app_pem
+            .as_deref()
+            .or(self.legacy_app_pem.as_deref())
+    }
+
+    /// Effective PAT. See [`Self::app_pem`].
+    pub fn pat(&self) -> Option<&str> {
+        self.resolved_pat.as_deref().or(self.legacy_pat.as_deref())
+    }
+
+    /// Effective webhook secret. See [`Self::app_pem`].
+    pub fn webhook_secret(&self) -> Option<&str> {
+        self.resolved_webhook_secret
+            .as_deref()
+            .or(self.legacy_webhook_secret.as_deref())
+    }
+}
+
 /// One additional GitHub App in the multi-App registry (`github.apps`).
 #[derive(Clone, Default, Serialize, Deserialize)]
 pub struct AppConfig {
@@ -78,17 +125,45 @@ pub struct AppConfig {
     /// hand, so `app_id: 12345` and `app_id: "12345"` must both load.
     #[serde(deserialize_with = "de_string_or_integer")]
     pub app_id: String,
-    /// App private key PEM (inline).
-    pub pem: String,
+    /// App private key PEM, stored inline (legacy). See
+    /// [`GitHubConfig::legacy_app_pem`]; read via [`AppConfig::pem`].
+    #[serde(default, rename = "pem")]
+    pub legacy_pem: String,
+    /// OS credential-store reference for the App private key.
+    #[serde(default)]
+    pub pem_ref: Option<String>,
+    /// Value behind [`Self::pem_ref`], resolved at load. Never persisted.
+    #[serde(skip)]
+    pub resolved_pem: Option<String>,
     /// Webhook secret for `X-Hub-Signature-256` verification, when the App
     /// has its own (the legacy `PRELOOP_WEBHOOK_SECRET` covers the default
-    /// App).
+    /// App). Stored inline (legacy); read via [`AppConfig::webhook_secret`].
+    #[serde(default, rename = "webhook_secret")]
+    pub legacy_webhook_secret: Option<String>,
+    /// OS credential-store reference for the App webhook secret.
     #[serde(default)]
-    pub webhook_secret: Option<String>,
+    pub webhook_secret_ref: Option<String>,
+    /// Value behind [`Self::webhook_secret_ref`], resolved at load. Never persisted.
+    #[serde(skip)]
+    pub resolved_webhook_secret: Option<String>,
     /// Explicit installation id, bypassing installation discovery for
     /// single-installation deployments of this App.
     #[serde(default)]
     pub installation_id: Option<u64>,
+}
+
+impl AppConfig {
+    /// Effective App private key. See [`GitHubConfig::app_pem`].
+    pub fn pem(&self) -> &str {
+        self.resolved_pem.as_deref().unwrap_or(&self.legacy_pem)
+    }
+
+    /// Effective webhook secret. See [`GitHubConfig::app_pem`].
+    pub fn webhook_secret(&self) -> Option<&str> {
+        self.resolved_webhook_secret
+            .as_deref()
+            .or(self.legacy_webhook_secret.as_deref())
+    }
 }
 
 /// Accept a string or integer for the numeric `app_id`, normalizing to a
@@ -196,15 +271,16 @@ fn redacted(present: bool) -> impl std::fmt::Debug {
 
 /// Manual `Debug`: this struct carries a PAT and an RSA private key, so the
 /// derived impl would disclose both on a single `debug!(?config)`. Presence
-/// only — `Serialize` still emits real values for the 0600 TOML file.
+/// only — `Serialize` still emits the inline legacy values for the 0600 TOML
+/// file, but never the credential-store-resolved ones.
 impl std::fmt::Debug for GitHubConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GitHubConfig")
             .field("app_id", &self.app_id)
-            .field("app_pem", &redacted(self.app_pem.is_some()))
+            .field("app_pem", &redacted(self.app_pem().is_some()))
             .field("mint_failure", &self.mint_failure)
-            .field("pat", &redacted(self.pat.is_some()))
-            .field("webhook_secret", &redacted(self.webhook_secret.is_some()))
+            .field("pat", &redacted(self.pat().is_some()))
+            .field("webhook_secret", &redacted(self.webhook_secret().is_some()))
             .field("apps", &self.apps.len())
             .field("pr", &self.pr)
             .finish()
@@ -381,6 +457,72 @@ pub fn load_config() -> anyhow::Result<ConfigFile> {
     load_config_from(&config_path())
 }
 
+/// Populate the `resolved_*` fields from the credential store.
+///
+/// Only the `*_ref` fields are consulted and only the non-persisted
+/// `resolved_*` fields are written, so this is invisible to a subsequent
+/// [`write_config`]: an unmigrated inline credential survives a load/write
+/// round-trip untouched, and a migrated one is never written back as
+/// plaintext.
+///
+/// A backend that cannot be reached at all (a headless Linux host with no
+/// secret-service daemon) is a warning, not an error: the engine still has
+/// the `PRELOOP_GITHUB_*` environment variables as its escape hatch, and
+/// failing the load would take `preloop secret` and server startup down with
+/// it. A reachable backend that fails an individual read is still an error.
+pub(crate) fn resolve_credential_references(
+    config: &mut ConfigFile,
+    store: &impl CredentialStore,
+) -> anyhow::Result<()> {
+    let references_present = config.github.app_pem_ref.is_some()
+        || config.github.pat_ref.is_some()
+        || config.github.webhook_secret_ref.is_some()
+        || config
+            .github
+            .apps
+            .iter()
+            .any(|app| app.pem_ref.is_some() || app.webhook_secret_ref.is_some());
+    if !references_present {
+        return Ok(());
+    }
+    if let Err(error) = store.available() {
+        tracing::warn!(
+            %error,
+            "config references stored credentials but no credential store is reachable; \
+             falling back to inline values and PRELOOP_GITHUB_* environment variables"
+        );
+        return Ok(());
+    }
+    if let Some(reference) = &config.github.app_pem_ref {
+        config.github.resolved_app_pem = read_credential(store, reference)?;
+    }
+    if let Some(reference) = &config.github.pat_ref {
+        config.github.resolved_pat = read_credential(store, reference)?;
+    }
+    if let Some(reference) = &config.github.webhook_secret_ref {
+        config.github.resolved_webhook_secret = read_credential(store, reference)?;
+    }
+    for app in &mut config.github.apps {
+        if let Some(reference) = &app.pem_ref {
+            app.resolved_pem = read_credential(store, reference)?;
+        }
+        if let Some(reference) = &app.webhook_secret_ref {
+            app.resolved_webhook_secret = read_credential(store, reference)?;
+        }
+    }
+    Ok(())
+}
+
+fn read_credential(
+    store: &impl CredentialStore,
+    reference: &str,
+) -> anyhow::Result<Option<String>> {
+    let reference = CredentialRef::new(reference.to_owned())?;
+    store
+        .get(&reference)
+        .with_context(|| format!("reading credential reference {reference:?}"))
+}
+
 /// Load the config file at `path`. A missing or empty file yields the default
 /// config; a malformed file is an error.
 pub fn load_config_from(path: &Path) -> anyhow::Result<ConfigFile> {
@@ -391,8 +533,9 @@ pub fn load_config_from(path: &Path) -> anyhow::Result<ConfigFile> {
         }
         Err(error) => return Err(error).context(format!("reading config {}", path.display())),
     };
-    let config: ConfigFile =
+    let mut config: ConfigFile =
         toml::from_str(&text).with_context(|| format!("parsing config {}", path.display()))?;
+    resolve_credential_references(&mut config, &OsCredentialStore)?;
     Ok(config)
 }
 
@@ -474,17 +617,12 @@ mod tests {
         ConfigFile {
             github: GitHubConfig {
                 app_id: Some("123".into()),
-                app_pem: Some(
+                legacy_app_pem: Some(
                     "-----BEGIN RSA PRIVATE KEY-----\nabc\n-----END RSA PRIVATE KEY-----\n".into(),
                 ),
                 mint_failure: Some("pat".into()),
-                pat: Some("ghp_secret".into()),
-                webhook_secret: None,
-                server_url: None,
-                api_url: None,
-                graphql_url: None,
-                apps: vec![],
-                pr: PrConfig::default(),
+                legacy_pat: Some("ghp_secret".into()),
+                ..Default::default()
             },
             secrets: BTreeMap::from([("DOCKERHUB_TOKEN".into(), "abc123".into())]),
             repo_secrets: BTreeMap::from([(
@@ -523,7 +661,7 @@ mod tests {
         }
         let loaded = load_config_from(&path).unwrap();
         assert_eq!(loaded.github.app_id.as_deref(), Some("123"));
-        assert_eq!(loaded.github.pat.as_deref(), Some("ghp_secret"));
+        assert_eq!(loaded.github.pat(), Some("ghp_secret"));
         assert_eq!(
             loaded.secrets.get("DOCKERHUB_TOKEN").map(String::as_str),
             Some("abc123")
@@ -544,6 +682,115 @@ mod tests {
         let path = dir.path().join("config.toml");
         std::fs::write(&path, "not [ valid toml ==").unwrap();
         assert!(load_config_from(&path).is_err());
+    }
+
+    use crate::credential_store::{
+        github_reference, MemoryCredentialStore, UnavailableCredentialStore,
+    };
+
+    fn config_with_refs(store: &MemoryCredentialStore) -> ConfigFile {
+        let pem_ref = github_reference("app-pem", Some("123")).unwrap();
+        let pat_ref = github_reference("pat", None).unwrap();
+        store.set(&pem_ref, "STORED-PEM").unwrap();
+        store.set(&pat_ref, "STORED-PAT").unwrap();
+        ConfigFile {
+            github: GitHubConfig {
+                app_id: Some("123".into()),
+                app_pem_ref: Some(pem_ref.as_str().to_owned()),
+                pat_ref: Some(pat_ref.as_str().to_owned()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    /// The regression that motivated splitting `legacy_*` from `resolved_*`:
+    /// resolving used to overwrite the inline fields, so the next
+    /// `write_config` serialized the credential store's plaintext straight
+    /// back into config.toml — which every `preloop secret set` does.
+    #[test]
+    fn resolved_credentials_are_never_written_back_as_plaintext() {
+        let store = MemoryCredentialStore::default();
+        let mut config = config_with_refs(&store);
+        resolve_credential_references(&mut config, &store).unwrap();
+        assert_eq!(config.github.app_pem(), Some("STORED-PEM"));
+        assert_eq!(config.github.pat(), Some("STORED-PAT"));
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        write_config_to(&path, &config).unwrap();
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(!text.contains("STORED-PEM"), "PEM written back: {text}");
+        assert!(!text.contains("STORED-PAT"), "PAT written back: {text}");
+        assert!(text.contains("app_pem_ref"), "reference dropped: {text}");
+        assert!(text.contains("pat_ref"), "reference dropped: {text}");
+    }
+
+    /// An operator who has not migrated yet must not silently lose their
+    /// credential when an unrelated command rewrites the file.
+    #[test]
+    fn unmigrated_inline_credentials_survive_a_round_trip() {
+        let store = MemoryCredentialStore::default();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let mut config = ConfigFile {
+            github: GitHubConfig {
+                app_id: Some("123".into()),
+                legacy_pat: Some("ghp_inline".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        resolve_credential_references(&mut config, &store).unwrap();
+        write_config_to(&path, &config).unwrap();
+        let text = std::fs::read_to_string(&path).unwrap();
+        assert!(text.contains("ghp_inline"), "inline PAT lost: {text}");
+        assert_eq!(
+            load_config_from(&path).unwrap().github.pat(),
+            Some("ghp_inline")
+        );
+    }
+
+    /// A headless host has no secret-service daemon. Failing the load there
+    /// would take `preloop secret` and server startup down with it, even
+    /// though `PRELOOP_GITHUB_*` could still supply the credentials.
+    #[test]
+    fn an_unreachable_store_degrades_instead_of_failing_the_load() {
+        let mut config = config_with_refs(&MemoryCredentialStore::default());
+        resolve_credential_references(&mut config, &UnavailableCredentialStore).unwrap();
+        assert_eq!(config.github.app_pem(), None);
+        assert_eq!(config.github.pat(), None);
+    }
+
+    /// No references means no reason to touch the backend at all.
+    #[test]
+    fn a_config_without_references_never_consults_the_store() {
+        let mut config = ConfigFile::default();
+        resolve_credential_references(&mut config, &UnavailableCredentialStore).unwrap();
+        assert_eq!(config.github.app_pem(), None);
+    }
+
+    /// Registry entries resolve too, and the store wins over a stale inline
+    /// value left behind by a partial migration.
+    #[test]
+    fn registry_entries_prefer_the_store_over_inline_values() {
+        let store = MemoryCredentialStore::default();
+        let pem_ref = github_reference("app-pem", Some("456")).unwrap();
+        store.set(&pem_ref, "STORED-PEM").unwrap();
+        let mut config = ConfigFile {
+            github: GitHubConfig {
+                apps: vec![AppConfig {
+                    app_id: "456".into(),
+                    legacy_pem: "INLINE-PEM".into(),
+                    pem_ref: Some(pem_ref.as_str().to_owned()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        resolve_credential_references(&mut config, &store).unwrap();
+        assert_eq!(config.github.apps[0].pem(), "STORED-PEM");
     }
 
     /// A `debug!(?config)` must never disclose the PAT or the private key.

--- a/crates/preloop-runner-server/src/config.rs
+++ b/crates/preloop-runner-server/src/config.rs
@@ -701,10 +701,16 @@ mod tests {
         let pem_ref = github_reference("app-pem", Some("123")).unwrap();
         let pat_ref = github_reference("pat", None).unwrap();
         store
-            .set(&pem_ref, &preloop_gha_protocol::SecretString::new("STORED-PEM"))
+            .set(
+                &pem_ref,
+                &preloop_gha_protocol::SecretString::new("STORED-PEM"),
+            )
             .unwrap();
         store
-            .set(&pat_ref, &preloop_gha_protocol::SecretString::new("STORED-PAT"))
+            .set(
+                &pat_ref,
+                &preloop_gha_protocol::SecretString::new("STORED-PAT"),
+            )
             .unwrap();
         ConfigFile {
             github: GitHubConfig {
@@ -790,7 +796,10 @@ mod tests {
         let store = MemoryCredentialStore::default();
         let pem_ref = github_reference("app-pem", Some("456")).unwrap();
         store
-            .set(&pem_ref, &preloop_gha_protocol::SecretString::new("STORED-PEM"))
+            .set(
+                &pem_ref,
+                &preloop_gha_protocol::SecretString::new("STORED-PEM"),
+            )
             .unwrap();
         let mut config = ConfigFile {
             github: GitHubConfig {
@@ -806,6 +815,48 @@ mod tests {
         };
         resolve_credential_references(&mut config, &store).unwrap();
         assert_eq!(config.github.apps[0].pem(), "STORED-PEM");
+    }
+    #[test]
+    fn unreachable_store_degrades_registry_apps_to_empty() {
+        let mut config = ConfigFile {
+            github: GitHubConfig {
+                apps: vec![AppConfig {
+                    app_id: "456".into(),
+                    pem_ref: Some("github-app-pem-456".into()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        resolve_credential_references(&mut config, &UnavailableCredentialStore).unwrap();
+        assert_eq!(config.github.apps[0].pem(), "");
+    }
+
+    #[test]
+    fn host_scoped_credential_references_resolve() {
+        let store = MemoryCredentialStore::default();
+        let pat_ref = crate::credential_store::github_reference_with_host(
+            "pat",
+            Some("https://ghe.internal"),
+            None,
+        )
+        .unwrap();
+        store
+            .set(
+                &pat_ref,
+                &preloop_gha_protocol::SecretString::new("GHE-PAT"),
+            )
+            .unwrap();
+        let mut config = ConfigFile {
+            github: GitHubConfig {
+                pat_ref: Some(pat_ref.as_str().to_owned()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        resolve_credential_references(&mut config, &store).unwrap();
+        assert_eq!(config.github.pat(), Some("GHE-PAT"));
     }
 
     /// A `debug!(?config)` must never disclose the PAT or the private key.

--- a/crates/preloop-runner-server/src/config.rs
+++ b/crates/preloop-runner-server/src/config.rs
@@ -10,7 +10,7 @@
 //! is written with mode 0600 and never echoed back by `preloop secret list`
 //! or `preloop doctor`.
 
-use crate::credential_store::{CredentialRef, CredentialStore, OsCredentialStore};
+use crate::credential_store::{CredentialRef, CredentialStore, OsCredentialStore, SecretString};
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -42,7 +42,7 @@ pub struct GitHubConfig {
     pub app_pem_ref: Option<String>,
     /// Value behind [`Self::app_pem_ref`], resolved at load. Never persisted.
     #[serde(skip)]
-    pub resolved_app_pem: Option<String>,
+    pub resolved_app_pem: Option<SecretString>,
     /// Mint-failure policy: `local`, `error`, or `pat`.
     #[serde(default)]
     pub mint_failure: Option<String>,
@@ -56,7 +56,7 @@ pub struct GitHubConfig {
     pub pat_ref: Option<String>,
     /// Value behind [`Self::pat_ref`], resolved at load. Never persisted.
     #[serde(skip)]
-    pub resolved_pat: Option<String>,
+    pub resolved_pat: Option<SecretString>,
     /// Shared secret for `X-Hub-Signature-256` webhook verification.
     /// Stored inline (legacy); see [`Self::legacy_app_pem`].
     #[serde(default, rename = "webhook_secret")]
@@ -66,7 +66,7 @@ pub struct GitHubConfig {
     pub webhook_secret_ref: Option<String>,
     /// Value behind [`Self::webhook_secret_ref`], resolved at load. Never persisted.
     #[serde(skip)]
-    pub resolved_webhook_secret: Option<String>,
+    pub resolved_webhook_secret: Option<SecretString>,
     /// GitHub server URL exposed to workflows as `github.server_url` /
     /// `GITHUB_SERVER_URL`. Defaults to `https://github.com`; point it at a
     /// GHES-style host when the engine fronts one. Env: `PRELOOP_GITHUB_SERVER_URL`.
@@ -99,19 +99,24 @@ impl GitHubConfig {
     /// legacy value is the pre-migration fallback.
     pub fn app_pem(&self) -> Option<&str> {
         self.resolved_app_pem
-            .as_deref()
+            .as_ref()
+            .map(|s| s.expose())
             .or(self.legacy_app_pem.as_deref())
     }
 
     /// Effective PAT. See [`Self::app_pem`].
     pub fn pat(&self) -> Option<&str> {
-        self.resolved_pat.as_deref().or(self.legacy_pat.as_deref())
+        self.resolved_pat
+            .as_ref()
+            .map(|s| s.expose())
+            .or(self.legacy_pat.as_deref())
     }
 
     /// Effective webhook secret. See [`Self::app_pem`].
     pub fn webhook_secret(&self) -> Option<&str> {
         self.resolved_webhook_secret
-            .as_deref()
+            .as_ref()
+            .map(|s| s.expose())
             .or(self.legacy_webhook_secret.as_deref())
     }
 }
@@ -134,7 +139,7 @@ pub struct AppConfig {
     pub pem_ref: Option<String>,
     /// Value behind [`Self::pem_ref`], resolved at load. Never persisted.
     #[serde(skip)]
-    pub resolved_pem: Option<String>,
+    pub resolved_pem: Option<SecretString>,
     /// Webhook secret for `X-Hub-Signature-256` verification, when the App
     /// has its own (the legacy `PRELOOP_WEBHOOK_SECRET` covers the default
     /// App). Stored inline (legacy); read via [`AppConfig::webhook_secret`].
@@ -145,7 +150,7 @@ pub struct AppConfig {
     pub webhook_secret_ref: Option<String>,
     /// Value behind [`Self::webhook_secret_ref`], resolved at load. Never persisted.
     #[serde(skip)]
-    pub resolved_webhook_secret: Option<String>,
+    pub resolved_webhook_secret: Option<SecretString>,
     /// Explicit installation id, bypassing installation discovery for
     /// single-installation deployments of this App.
     #[serde(default)]
@@ -155,13 +160,17 @@ pub struct AppConfig {
 impl AppConfig {
     /// Effective App private key. See [`GitHubConfig::app_pem`].
     pub fn pem(&self) -> &str {
-        self.resolved_pem.as_deref().unwrap_or(&self.legacy_pem)
+        self.resolved_pem
+            .as_ref()
+            .map(|s| s.expose())
+            .unwrap_or(&self.legacy_pem)
     }
 
     /// Effective webhook secret. See [`GitHubConfig::app_pem`].
     pub fn webhook_secret(&self) -> Option<&str> {
         self.resolved_webhook_secret
-            .as_deref()
+            .as_ref()
+            .map(|s| s.expose())
             .or(self.legacy_webhook_secret.as_deref())
     }
 }
@@ -516,7 +525,7 @@ pub(crate) fn resolve_credential_references(
 fn read_credential(
     store: &impl CredentialStore,
     reference: &str,
-) -> anyhow::Result<Option<String>> {
+) -> anyhow::Result<Option<SecretString>> {
     let reference = CredentialRef::new(reference.to_owned())?;
     store
         .get(&reference)
@@ -691,8 +700,12 @@ mod tests {
     fn config_with_refs(store: &MemoryCredentialStore) -> ConfigFile {
         let pem_ref = github_reference("app-pem", Some("123")).unwrap();
         let pat_ref = github_reference("pat", None).unwrap();
-        store.set(&pem_ref, "STORED-PEM").unwrap();
-        store.set(&pat_ref, "STORED-PAT").unwrap();
+        store
+            .set(&pem_ref, &preloop_gha_protocol::SecretString::new("STORED-PEM"))
+            .unwrap();
+        store
+            .set(&pat_ref, &preloop_gha_protocol::SecretString::new("STORED-PAT"))
+            .unwrap();
         ConfigFile {
             github: GitHubConfig {
                 app_id: Some("123".into()),
@@ -776,7 +789,9 @@ mod tests {
     fn registry_entries_prefer_the_store_over_inline_values() {
         let store = MemoryCredentialStore::default();
         let pem_ref = github_reference("app-pem", Some("456")).unwrap();
-        store.set(&pem_ref, "STORED-PEM").unwrap();
+        store
+            .set(&pem_ref, &preloop_gha_protocol::SecretString::new("STORED-PEM"))
+            .unwrap();
         let mut config = ConfigFile {
             github: GitHubConfig {
                 apps: vec![AppConfig {

--- a/crates/preloop-runner-server/src/credential_store.rs
+++ b/crates/preloop-runner-server/src/credential_store.rs
@@ -15,6 +15,7 @@ use std::sync::{Arc, Mutex};
 pub struct CredentialRef(String);
 
 impl CredentialRef {
+    /// Create and validate a new credential reference.
     pub fn new(value: impl Into<String>) -> Result<Self> {
         let value = value.into();
         if value.is_empty() || value.len() > 255 {
@@ -29,11 +30,11 @@ impl CredentialRef {
         Ok(Self(value))
     }
 
+    /// Return the underlying reference string.
     pub fn as_str(&self) -> &str {
         &self.0
     }
 }
-
 impl fmt::Debug for CredentialRef {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("CredentialRef").field(&self.0).finish()
@@ -61,7 +62,12 @@ pub fn github_reference_with_host(
         }
     }
     let host_prefix = match host {
-        Some(h) if !h.is_empty() && h != "github.com" && h != "https://github.com" && h != "http://github.com" => {
+        Some(h)
+            if !h.is_empty()
+                && h != "github.com"
+                && h != "https://github.com"
+                && h != "http://github.com" =>
+        {
             let clean = h
                 .trim_start_matches("https://")
                 .trim_start_matches("http://")
@@ -73,7 +79,13 @@ pub fn github_reference_with_host(
                 .unwrap_or(h);
             let sanitized: String = clean
                 .chars()
-                .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '.' { c } else { '-' })
+                .map(|c| {
+                    if c.is_ascii_alphanumeric() || c == '-' || c == '.' {
+                        c
+                    } else {
+                        '-'
+                    }
+                })
                 .collect();
             if sanitized.is_empty() {
                 String::new()
@@ -94,11 +106,14 @@ pub fn github_reference_with_host(
 
 /// Secret storage backend. Implementations must never log values.
 pub trait CredentialStore: Send + Sync {
+    /// Retrieve a secret by reference from the store.
     fn get(&self, reference: &CredentialRef) -> Result<Option<SecretString>>;
+    /// Write or overwrite a secret by reference in the store.
     fn set(&self, reference: &CredentialRef, value: &SecretString) -> Result<()>;
+    /// Delete a secret by reference from the store.
     fn delete(&self, reference: &CredentialRef) -> Result<()>;
+    /// Human-readable name of the backend for diagnostics.
     fn name(&self) -> &'static str;
-
     /// Whether the backend can be reached at all.
     ///
     /// Distinct from a missing entry: a headless Linux host has no
@@ -146,7 +161,6 @@ impl CredentialStore for OsCredentialStore {
             Err(error) => Err(error).context("delete credential from OS store"),
         }
     }
-
 
     fn name(&self) -> &'static str {
         "operating-system credential store"
@@ -254,9 +268,7 @@ mod tests {
         let store = MemoryCredentialStore::default();
         let reference = CredentialRef::new("github-pat").unwrap();
         assert_eq!(store.get(&reference).unwrap(), None);
-        store
-            .set(&reference, &SecretString::new("secret"))
-            .unwrap();
+        store.set(&reference, &SecretString::new("secret")).unwrap();
         assert_eq!(
             store.get(&reference).unwrap().as_ref().map(|s| s.expose()),
             Some("secret")

--- a/crates/preloop-runner-server/src/credential_store.rs
+++ b/crates/preloop-runner-server/src/credential_store.rs
@@ -1,6 +1,5 @@
-//! Platform credential storage used for local operator credentials.
-
 use anyhow::{Context, Result};
+pub use preloop_gha_protocol::SecretString;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::{Arc, Mutex};
@@ -41,21 +40,53 @@ impl fmt::Debug for CredentialRef {
     }
 }
 
-/// Build a stable local reference for a GitHub credential.
+/// Build a stable local reference for a GitHub credential on default github.com.
+pub fn github_reference(kind: &str, app_id: Option<&str>) -> Result<CredentialRef> {
+    github_reference_with_host(kind, None, app_id)
+}
+
+/// Build a stable local reference for a GitHub credential, optionally scoped to a host.
 ///
 /// `app_id` is operator-supplied (`github.apps[].app_id` is hand-editable and
-/// accepts a bare integer), so it is validated rather than trusted: without
-/// this, an id like `1-webhook-2` could collide with another kind's namespace.
-pub fn github_reference(kind: &str, app_id: Option<&str>) -> Result<CredentialRef> {
+/// accepts a bare integer), so it is validated as numeric for safety and to
+/// enforce canonical identifiers.
+pub fn github_reference_with_host(
+    kind: &str,
+    host: Option<&str>,
+    app_id: Option<&str>,
+) -> Result<CredentialRef> {
     if let Some(app_id) = app_id {
         if app_id.is_empty() || !app_id.chars().all(|c| c.is_ascii_digit()) {
             anyhow::bail!("GitHub App id must be numeric, got {app_id:?}");
         }
     }
+    let host_prefix = match host {
+        Some(h) if !h.is_empty() && h != "github.com" && h != "https://github.com" && h != "http://github.com" => {
+            let clean = h
+                .trim_start_matches("https://")
+                .trim_start_matches("http://")
+                .split('/')
+                .next()
+                .unwrap_or(h)
+                .split(':')
+                .next()
+                .unwrap_or(h);
+            let sanitized: String = clean
+                .chars()
+                .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '.' { c } else { '-' })
+                .collect();
+            if sanitized.is_empty() {
+                String::new()
+            } else {
+                format!("{sanitized}-")
+            }
+        }
+        _ => String::new(),
+    };
     let value = match (kind, app_id) {
-        ("pat", None) => "github-pat".to_owned(),
-        ("app-pem", Some(app_id)) => format!("github-app-pem-{app_id}"),
-        ("webhook", Some(app_id)) => format!("github-app-webhook-{app_id}"),
+        ("pat", None) => format!("github-{host_prefix}pat"),
+        ("app-pem", Some(app_id)) => format!("github-{host_prefix}app-pem-{app_id}"),
+        ("webhook", Some(app_id)) => format!("github-{host_prefix}app-webhook-{app_id}"),
         _ => anyhow::bail!("invalid GitHub credential reference"),
     };
     CredentialRef::new(value)
@@ -63,8 +94,8 @@ pub fn github_reference(kind: &str, app_id: Option<&str>) -> Result<CredentialRe
 
 /// Secret storage backend. Implementations must never log values.
 pub trait CredentialStore: Send + Sync {
-    fn get(&self, reference: &CredentialRef) -> Result<Option<String>>;
-    fn set(&self, reference: &CredentialRef, value: &str) -> Result<()>;
+    fn get(&self, reference: &CredentialRef) -> Result<Option<SecretString>>;
+    fn set(&self, reference: &CredentialRef, value: &SecretString) -> Result<()>;
     fn delete(&self, reference: &CredentialRef) -> Result<()>;
     fn name(&self) -> &'static str;
 
@@ -90,20 +121,20 @@ impl OsCredentialStore {
 }
 
 impl CredentialStore for OsCredentialStore {
-    fn get(&self, reference: &CredentialRef) -> Result<Option<String>> {
+    fn get(&self, reference: &CredentialRef) -> Result<Option<SecretString>> {
         match Self::entry(reference)?.get_password() {
-            Ok(value) => Ok(Some(value)),
+            Ok(value) => Ok(Some(SecretString::new(value))),
             Err(keyring::Error::NoEntry) => Ok(None),
             Err(error) => Err(error).context("read credential from OS store"),
         }
     }
 
-    fn set(&self, reference: &CredentialRef, value: &str) -> Result<()> {
-        if value.is_empty() {
+    fn set(&self, reference: &CredentialRef, value: &SecretString) -> Result<()> {
+        if value.expose().is_empty() {
             anyhow::bail!("refusing to store an empty credential");
         }
         Self::entry(reference)?
-            .set_password(value)
+            .set_password(value.expose())
             .context("write credential to OS store")?;
         Ok(())
     }
@@ -115,6 +146,7 @@ impl CredentialStore for OsCredentialStore {
             Err(error) => Err(error).context("delete credential from OS store"),
         }
     }
+
 
     fn name(&self) -> &'static str {
         "operating-system credential store"
@@ -136,11 +168,11 @@ impl CredentialStore for OsCredentialStore {
 /// In-memory backend for deterministic tests and embedders.
 #[derive(Clone, Default)]
 pub struct MemoryCredentialStore {
-    values: Arc<Mutex<HashMap<CredentialRef, String>>>,
+    values: Arc<Mutex<HashMap<CredentialRef, SecretString>>>,
 }
 
 impl CredentialStore for MemoryCredentialStore {
-    fn get(&self, reference: &CredentialRef) -> Result<Option<String>> {
+    fn get(&self, reference: &CredentialRef) -> Result<Option<SecretString>> {
         Ok(self
             .values
             .lock()
@@ -149,14 +181,14 @@ impl CredentialStore for MemoryCredentialStore {
             .cloned())
     }
 
-    fn set(&self, reference: &CredentialRef, value: &str) -> Result<()> {
-        if value.is_empty() {
+    fn set(&self, reference: &CredentialRef, value: &SecretString) -> Result<()> {
+        if value.expose().is_empty() {
             anyhow::bail!("refusing to store an empty credential");
         }
         self.values
             .lock()
             .expect("credential store lock poisoned")
-            .insert(reference.clone(), value.to_owned());
+            .insert(reference.clone(), value.clone());
         Ok(())
     }
 
@@ -180,11 +212,11 @@ pub(crate) struct UnavailableCredentialStore;
 
 #[cfg(test)]
 impl CredentialStore for UnavailableCredentialStore {
-    fn get(&self, _reference: &CredentialRef) -> Result<Option<String>> {
+    fn get(&self, _reference: &CredentialRef) -> Result<Option<SecretString>> {
         anyhow::bail!("credential store unavailable")
     }
 
-    fn set(&self, _reference: &CredentialRef, _value: &str) -> Result<()> {
+    fn set(&self, _reference: &CredentialRef, _value: &SecretString) -> Result<()> {
         anyhow::bail!("credential store unavailable")
     }
 
@@ -222,8 +254,13 @@ mod tests {
         let store = MemoryCredentialStore::default();
         let reference = CredentialRef::new("github-pat").unwrap();
         assert_eq!(store.get(&reference).unwrap(), None);
-        store.set(&reference, "secret").unwrap();
-        assert_eq!(store.get(&reference).unwrap().as_deref(), Some("secret"));
+        store
+            .set(&reference, &SecretString::new("secret"))
+            .unwrap();
+        assert_eq!(
+            store.get(&reference).unwrap().as_ref().map(|s| s.expose()),
+            Some("secret")
+        );
         store.delete(&reference).unwrap();
         assert_eq!(store.get(&reference).unwrap(), None);
     }
@@ -232,14 +269,12 @@ mod tests {
     fn memory_store_rejects_empty_values() {
         let store = MemoryCredentialStore::default();
         let reference = CredentialRef::new("github-pat").unwrap();
-        assert!(store.set(&reference, "").is_err());
+        assert!(store.set(&reference, &SecretString::new("")).is_err());
     }
 
-    /// A non-numeric App id must not be able to reach across namespaces:
-    /// `app-pem` for id `webhook-9` would otherwise mint the same reference
-    /// as `webhook` for id `9`.
+    /// App IDs are validated as numeric for safety and to enforce canonical identifiers.
     #[test]
-    fn app_ids_are_validated_so_namespaces_cannot_collide() {
+    fn app_ids_are_validated_and_canonical() {
         assert!(github_reference("app-pem", Some("webhook-9")).is_err());
         assert!(github_reference("app-pem", Some("")).is_err());
         assert!(github_reference("app-pem", Some("../etc")).is_err());
@@ -256,6 +291,18 @@ mod tests {
         assert_eq!(
             github_reference("pat", None).unwrap().as_str(),
             "github-pat"
+        );
+        assert_eq!(
+            github_reference_with_host("pat", Some("https://ghe.example.com"), None)
+                .unwrap()
+                .as_str(),
+            "github-ghe.example.com-pat"
+        );
+        assert_eq!(
+            github_reference_with_host("app-pem", Some("ghe.example.com"), Some("12345"))
+                .unwrap()
+                .as_str(),
+            "github-ghe.example.com-app-pem-12345"
         );
     }
 }

--- a/crates/preloop-runner-server/src/credential_store.rs
+++ b/crates/preloop-runner-server/src/credential_store.rs
@@ -1,0 +1,261 @@
+//! Platform credential storage used for local operator credentials.
+
+use anyhow::{Context, Result};
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+/// A validated, non-secret identifier for one stored credential.
+///
+/// The value becomes the account name of an OS keychain entry under the
+/// `preloop` service, so it is restricted to a flat, printable identifier:
+/// path separators and control characters would either be rejected by a
+/// backend or silently reinterpreted (the secret-service backend treats the
+/// attribute as opaque, the Windows credential manager does not).
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct CredentialRef(String);
+
+impl CredentialRef {
+    pub fn new(value: impl Into<String>) -> Result<Self> {
+        let value = value.into();
+        if value.is_empty() || value.len() > 255 {
+            anyhow::bail!("credential reference must contain 1-255 characters");
+        }
+        if !value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+        {
+            anyhow::bail!("credential reference contains an invalid character");
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for CredentialRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("CredentialRef").field(&self.0).finish()
+    }
+}
+
+/// Build a stable local reference for a GitHub credential.
+///
+/// `app_id` is operator-supplied (`github.apps[].app_id` is hand-editable and
+/// accepts a bare integer), so it is validated rather than trusted: without
+/// this, an id like `1-webhook-2` could collide with another kind's namespace.
+pub fn github_reference(kind: &str, app_id: Option<&str>) -> Result<CredentialRef> {
+    if let Some(app_id) = app_id {
+        if app_id.is_empty() || !app_id.chars().all(|c| c.is_ascii_digit()) {
+            anyhow::bail!("GitHub App id must be numeric, got {app_id:?}");
+        }
+    }
+    let value = match (kind, app_id) {
+        ("pat", None) => "github-pat".to_owned(),
+        ("app-pem", Some(app_id)) => format!("github-app-pem-{app_id}"),
+        ("webhook", Some(app_id)) => format!("github-app-webhook-{app_id}"),
+        _ => anyhow::bail!("invalid GitHub credential reference"),
+    };
+    CredentialRef::new(value)
+}
+
+/// Secret storage backend. Implementations must never log values.
+pub trait CredentialStore: Send + Sync {
+    fn get(&self, reference: &CredentialRef) -> Result<Option<String>>;
+    fn set(&self, reference: &CredentialRef, value: &str) -> Result<()>;
+    fn delete(&self, reference: &CredentialRef) -> Result<()>;
+    fn name(&self) -> &'static str;
+
+    /// Whether the backend can be reached at all.
+    ///
+    /// Distinct from a missing entry: a headless Linux host has no
+    /// secret-service daemon, so every operation fails for a reason that has
+    /// nothing to do with the credential being asked for. Callers use this to
+    /// degrade instead of failing closed.
+    fn available(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// The host operating system's native credential store.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct OsCredentialStore;
+
+impl OsCredentialStore {
+    fn entry(reference: &CredentialRef) -> Result<keyring::Entry> {
+        keyring::Entry::new("preloop", reference.as_str()).context("create OS credential entry")
+    }
+}
+
+impl CredentialStore for OsCredentialStore {
+    fn get(&self, reference: &CredentialRef) -> Result<Option<String>> {
+        match Self::entry(reference)?.get_password() {
+            Ok(value) => Ok(Some(value)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(error) => Err(error).context("read credential from OS store"),
+        }
+    }
+
+    fn set(&self, reference: &CredentialRef, value: &str) -> Result<()> {
+        if value.is_empty() {
+            anyhow::bail!("refusing to store an empty credential");
+        }
+        Self::entry(reference)?
+            .set_password(value)
+            .context("write credential to OS store")?;
+        Ok(())
+    }
+
+    fn delete(&self, reference: &CredentialRef) -> Result<()> {
+        match Self::entry(reference)?.delete_credential() {
+            Ok(()) => Ok(()),
+            Err(keyring::Error::NoEntry) => Ok(()),
+            Err(error) => Err(error).context("delete credential from OS store"),
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        "operating-system credential store"
+    }
+
+    /// `keyring`'s platform store is initialized once, lazily, on the first
+    /// `Entry::new`. `store_status` reports that one-time result without
+    /// touching a credential.
+    fn available(&self) -> Result<()> {
+        match keyring::Entry::store_status() {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                anyhow::bail!("no operating-system credential store available: {error}")
+            }
+        }
+    }
+}
+
+/// In-memory backend for deterministic tests and embedders.
+#[derive(Clone, Default)]
+pub struct MemoryCredentialStore {
+    values: Arc<Mutex<HashMap<CredentialRef, String>>>,
+}
+
+impl CredentialStore for MemoryCredentialStore {
+    fn get(&self, reference: &CredentialRef) -> Result<Option<String>> {
+        Ok(self
+            .values
+            .lock()
+            .expect("credential store lock poisoned")
+            .get(reference)
+            .cloned())
+    }
+
+    fn set(&self, reference: &CredentialRef, value: &str) -> Result<()> {
+        if value.is_empty() {
+            anyhow::bail!("refusing to store an empty credential");
+        }
+        self.values
+            .lock()
+            .expect("credential store lock poisoned")
+            .insert(reference.clone(), value.to_owned());
+        Ok(())
+    }
+
+    fn delete(&self, reference: &CredentialRef) -> Result<()> {
+        self.values
+            .lock()
+            .expect("credential store lock poisoned")
+            .remove(reference);
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "memory credential store"
+    }
+}
+
+/// A backend that is reachable by nobody, standing in for a headless host.
+#[cfg(test)]
+#[derive(Clone, Copy, Default)]
+pub(crate) struct UnavailableCredentialStore;
+
+#[cfg(test)]
+impl CredentialStore for UnavailableCredentialStore {
+    fn get(&self, _reference: &CredentialRef) -> Result<Option<String>> {
+        anyhow::bail!("credential store unavailable")
+    }
+
+    fn set(&self, _reference: &CredentialRef, _value: &str) -> Result<()> {
+        anyhow::bail!("credential store unavailable")
+    }
+
+    fn delete(&self, _reference: &CredentialRef) -> Result<()> {
+        anyhow::bail!("credential store unavailable")
+    }
+
+    fn name(&self) -> &'static str {
+        "unavailable credential store"
+    }
+
+    fn available(&self) -> Result<()> {
+        anyhow::bail!("credential store unavailable")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn references_reject_unsafe_values() {
+        assert!(CredentialRef::new("").is_err());
+        assert!(CredentialRef::new("a/b").is_err());
+        assert!(CredentialRef::new("a\nb").is_err());
+        assert!(CredentialRef::new("github/pat").is_err());
+        assert!(CredentialRef::new("github pat").is_err());
+        assert!(CredentialRef::new("github:pat").is_err());
+        assert!(CredentialRef::new("a".repeat(256)).is_err());
+        assert!(CredentialRef::new("github-app-pem-12345").is_ok());
+    }
+
+    #[test]
+    fn memory_store_round_trips_and_deletes() {
+        let store = MemoryCredentialStore::default();
+        let reference = CredentialRef::new("github-pat").unwrap();
+        assert_eq!(store.get(&reference).unwrap(), None);
+        store.set(&reference, "secret").unwrap();
+        assert_eq!(store.get(&reference).unwrap().as_deref(), Some("secret"));
+        store.delete(&reference).unwrap();
+        assert_eq!(store.get(&reference).unwrap(), None);
+    }
+
+    #[test]
+    fn memory_store_rejects_empty_values() {
+        let store = MemoryCredentialStore::default();
+        let reference = CredentialRef::new("github-pat").unwrap();
+        assert!(store.set(&reference, "").is_err());
+    }
+
+    /// A non-numeric App id must not be able to reach across namespaces:
+    /// `app-pem` for id `webhook-9` would otherwise mint the same reference
+    /// as `webhook` for id `9`.
+    #[test]
+    fn app_ids_are_validated_so_namespaces_cannot_collide() {
+        assert!(github_reference("app-pem", Some("webhook-9")).is_err());
+        assert!(github_reference("app-pem", Some("")).is_err());
+        assert!(github_reference("app-pem", Some("../etc")).is_err());
+        assert!(github_reference("pat", Some("12345")).is_err());
+        assert!(github_reference("nonsense", None).is_err());
+        assert_eq!(
+            github_reference("app-pem", Some("12345")).unwrap().as_str(),
+            "github-app-pem-12345"
+        );
+        assert_eq!(
+            github_reference("webhook", Some("12345")).unwrap().as_str(),
+            "github-app-webhook-12345"
+        );
+        assert_eq!(
+            github_reference("pat", None).unwrap().as_str(),
+            "github-pat"
+        );
+    }
+}

--- a/crates/preloop-runner-server/src/github_app.rs
+++ b/crates/preloop-runner-server/src/github_app.rs
@@ -428,7 +428,7 @@ pub(crate) fn load_from(
     let pat_fallback = std::env::var("PRELOOP_GITHUB_TOKEN")
         .ok()
         .filter(|value| !value.is_empty())
-        .or_else(|| file_config.github.pat.clone());
+        .or_else(|| file_config.github.pat().map(str::to_owned));
 
     let mut apps: Vec<GitHubAppCredentials> = Vec::new();
     // The default entry is index 0 because the legacy App, when present, is
@@ -446,9 +446,8 @@ pub(crate) fn load_from(
         .or_else(|| {
             file_config
                 .github
-                .app_pem
-                .as_ref()
-                .map(|pem| ("config github.app_pem", false, pem.clone()))
+                .app_pem()
+                .map(|pem| ("config github.app_pem", false, pem.to_owned()))
         });
     match (app_id, key_source) {
         (Some(app_id), Some((source, is_path, value))) => {
@@ -509,8 +508,9 @@ pub(crate) fn load_from(
         None => file_config.github.apps.clone(),
     };
     for app in extra {
-        let private_key = parse_private_key(&app.pem)
+        let private_key = parse_private_key(app.pem())
             .with_context(|| format!("parsing the private key for GitHub App {}", app.app_id))?;
+        let webhook_secret = app.webhook_secret().map(str::to_owned);
         info!(
             app_id = %app.app_id,
             "registered additional GitHub App"
@@ -522,7 +522,7 @@ pub(crate) fn load_from(
             pat_fallback: pat_fallback.clone(),
             installation_cache: Arc::new(RwLock::new(HashMap::new())),
             mint_ledger: Arc::new(MintLedger::default()),
-            webhook_secret: app.webhook_secret,
+            webhook_secret,
             installation_id: app.installation_id,
             verified_installation_owners: Arc::new(parking_lot::Mutex::new(HashMap::new())),
         });

--- a/crates/preloop-runner-server/src/github_app.rs
+++ b/crates/preloop-runner-server/src/github_app.rs
@@ -29,8 +29,8 @@ use serde_json::json;
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
+use crate::credential_store::{CredentialRef, CredentialStore, OsCredentialStore};
 use crate::shared_http::CLIENT;
-
 /// Private-key environment variables, highest precedence first. The flag marks
 /// a variable that holds a path to a PEM file rather than the PEM itself.
 ///
@@ -503,12 +503,40 @@ pub(crate) fn load_from(
         .filter(|raw| !raw.is_empty())
     {
         Some(raw) => {
-            serde_json::from_str(&raw).with_context(|| "parsing PRELOOP_GITHUB_APPS_JSON")?
+            let mut env_apps: Vec<crate::config::AppConfig> =
+                serde_json::from_str(&raw).with_context(|| "parsing PRELOOP_GITHUB_APPS_JSON")?;
+            let store = OsCredentialStore;
+            for app in &mut env_apps {
+                if let Some(reference) = &app.pem_ref {
+                    if let Ok(reference_ref) = CredentialRef::new(reference) {
+                        if let Ok(Some(secret)) = store.get(&reference_ref) {
+                            app.resolved_pem = Some(secret);
+                        }
+                    }
+                }
+                if let Some(reference) = &app.webhook_secret_ref {
+                    if let Ok(reference_ref) = CredentialRef::new(reference) {
+                        if let Ok(Some(secret)) = store.get(&reference_ref) {
+                            app.resolved_webhook_secret = Some(secret);
+                        }
+                    }
+                }
+            }
+            env_apps
         }
         None => file_config.github.apps.clone(),
     };
     for app in extra {
-        let private_key = parse_private_key(app.pem())
+        let pem = app.pem().trim();
+        if pem.is_empty() {
+            warn!(
+                app_id = %app.app_id,
+                "GitHub App private key is not configured or its credential reference could not be resolved; \
+                 skipping registration for it"
+            );
+            continue;
+        }
+        let private_key = parse_private_key(pem)
             .with_context(|| format!("parsing the private key for GitHub App {}", app.app_id))?;
         let webhook_secret = app.webhook_secret().map(str::to_owned);
         info!(
@@ -527,7 +555,6 @@ pub(crate) fn load_from(
             verified_installation_owners: Arc::new(parking_lot::Mutex::new(HashMap::new())),
         });
     }
-
     if apps.is_empty() {
         return Ok(None);
     }

--- a/crates/preloop-runner-server/src/lib.rs
+++ b/crates/preloop-runner-server/src/lib.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 pub mod concurrency;
 pub mod config;
+pub mod credential_store;
 mod errors;
 pub mod events;
 pub mod github;

--- a/crates/preloop-runner-server/src/state.rs
+++ b/crates/preloop-runner-server/src/state.rs
@@ -866,16 +866,22 @@ impl AppState {
             .or_else(|| {
                 config
                     .github
-                    .webhook_secret
-                    .clone()
+                    .webhook_secret()
                     .filter(|secret| !secret.is_empty())
+                    .map(str::to_owned)
             });
         // Env wins over the config file, matching every other `PRELOOP_GITHUB_*`
         // override. An empty value in either source counts as unset.
         let github_pat = env::var("PRELOOP_GITHUB_TOKEN")
             .ok()
             .filter(|pat| !pat.is_empty())
-            .or_else(|| config.github.pat.clone().filter(|pat| !pat.is_empty()))
+            .or_else(|| {
+                config
+                    .github
+                    .pat()
+                    .filter(|pat| !pat.is_empty())
+                    .map(str::to_owned)
+            })
             .map(preloop_gha_protocol::SecretString::new);
         // Env wins over the config file, matching every other `PRELOOP_GITHUB_*`
         // override; an empty value in either source counts as unset.

--- a/docs/github-tokens.md
+++ b/docs/github-tokens.md
@@ -94,7 +94,8 @@ preloop setup github --via app          # add --org NAME for an org App
 
 It serves the manifest from a single-use loopback listener, GitHub redirects
 the one-time code back to it, and the App id, private key, and webhook secret
-land in `~/.preloop/config.toml` (mode 0600). Add `--public-url https://…` to
+are stored in the operating-system credential store. `~/.preloop/config.toml`
+(mode 0600) keeps only non-secret references. Add `--public-url https://…` to
 create the App with webhook delivery enabled; without it webhooks are off,
 since GitHub cannot reach `localhost`. Restart the engine to pick the
 credentials up.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -74,8 +74,9 @@ preloop setup github --via app
 The command binds a single-use listener on loopback, opens it in your
 browser, and uses it as the manifest's redirect target. You click **Create on
 GitHub**; GitHub redirects back with a one-time code, and the CLI converts it
-into the App id, private key, and webhook secret and writes them to
-`~/.preloop/config.toml` (mode 0600). The browser then lands on the
+into the App id, private key, and webhook secret and stores the secrets in the
+operating-system credential store. The config file retains only non-secret
+credential references (and remains mode 0600). The browser then lands on the
 installation page, pick the repositories you run, and the CLI reports the
 installation id and exits.
 
@@ -127,9 +128,9 @@ Point the webhook at the stable hostname once:
 preloop setup github --via app --public-url https://ci.example.com
 ```
 
-That updates the existing App's webhook URL and secret through GitHub's API
 (`PATCH /app/hook/config`) instead of creating a second App, and stores the
-secret so deliveries verify. GitHub exposes no API for the webhook **Active**
+secret in the operating-system credential store so deliveries verify. GitHub
+exposes no API for the webhook **Active**
 checkbox, so an App created without `--public-url` needs that ticked once in
 its settings.
 
@@ -268,19 +269,31 @@ not hold plaintext at rest, two options:
 ## Config file
 
 Everything lives in `~/.preloop/config.toml` (mode 0600; `PRELOOP_CONFIG`
-overrides the path, `PRELOOP_HOME` the default directory). A missing or
-empty file is fine (everything defaults); a malformed one fails startup, so
-a typo is caught before a mint or a job hits it. `preloop setup github`
+overrides the path, `PRELOOP_HOME` the default directory). GitHub App keys,
+PATs, and webhook secrets are held in the operating-system credential store
+(Keychain on macOS, Credential Manager on Windows, Secret Service on Linux);
+the config file keeps only a `*_ref` name pointing at each one. Credentials
+still stored inline are migrated on the next `preloop serve`, which rewrites
+the config to reference them instead. A missing or empty file is fine
+(everything defaults); a malformed one fails startup, so a typo is caught
+before a mint or a job hits it. `preloop setup github`
 writes the `[github]` section; `preloop secret` writes the secret tables.
+
+On a host with no reachable credential store — a headless Linux box without a
+Secret Service daemon, for example — startup logs a warning and falls back to
+any inline values plus the `PRELOOP_GITHUB_*` environment variables, which
+always take precedence. Nothing is migrated there, so the config is left
+exactly as written.
+
 Fields:
 
 ```toml
 [github]
 app_id = "123456"
-app_pem = "-----BEGIN RSA PRIVATE KEY-----…"
+app_pem_ref = "github-app-pem-123456"   # written by setup; key lives in the OS store
 mint_failure = "pat"        # "local" | "error" | "pat"
-pat = "github_pat_…"        # fallback under `pat` policy; `--via pat` credential
-webhook_secret = "…"        # written by `setup github --via app`
+pat_ref = "github-pat"      # fallback under `pat` policy; `--via pat` credential
+webhook_secret_ref = "github-app-webhook-123456"  # written by `setup github --via app`
 server_url = "https://github.com"          # GHES: point at your host
 api_url = "https://api.github.com"         # GHES: REST base
 graphql_url = "https://api.github.com/graphql"


### PR DESCRIPTION
## What

GitHub App keys, PATs, and webhook secrets move out of plaintext in `~/.preloop/config.toml` and into the platform credential store (Keychain / Credential Manager / Secret Service). The config keeps only a non-secret `*_ref` name per credential.

## Design

On-disk and resolved values live in **separate fields**:

- `legacy_app_pem` / `legacy_pat` / `legacy_webhook_secret` (and `AppConfig::legacy_pem`) hold only what the file literally contains. Their TOML keys are unchanged via `#[serde(rename)]`, so existing configs load as-is.
- `resolved_*` are `#[serde(skip)]` and hold what the credential store returned.
- `GitHubConfig::app_pem()` / `pat()` / `webhook_secret()` and `AppConfig::pem()` / `webhook_secret()` return the effective value, store first.

`resolve_credential_references` writes only to `resolved_*`. That is what makes a load/write round-trip safe: it can neither reintroduce plaintext for a migrated credential nor drop an unmigrated one.

Migration runs on `preloop serve`, reads only `legacy_*` (populated purely from disk), and is therefore idempotent. It is pure — the caller persists — so it is testable without touching a real config.

## Behavior notes

- A credential that cannot be namespaced (App key or webhook secret with no `github.app_id`, which `setup github --webhook-secret` produces) is left inline and reported, not treated as a startup failure.
- A host with no reachable credential store (headless Linux without Secret Service) logs one warning and falls back to inline values plus `PRELOOP_GITHUB_*`, which always take precedence. Nothing is migrated there.
- App ids are validated as numeric before interpolation, so one credential kind cannot collide with another's namespace (an id like `webhook-9` would otherwise mint an `app-pem` reference identical to `webhook` for id `9`).

## Tests

Nine tests added, each failing against a naive implementation:

- `resolved_credentials_are_never_written_back_as_plaintext` — asserts no store-held secret reaches the TOML
- `unmigrated_inline_credentials_survive_a_round_trip` — guards the credential-loss mode
- `an_unreachable_store_degrades_instead_of_failing_the_load`, `a_config_without_references_never_consults_the_store`
- `migration_is_idempotent`, `a_missing_app_id_is_not_fatal`, `inline_credentials_move_into_the_store`, `registry_entries_migrate_too`
- `app_ids_are_validated_so_namespaces_cannot_collide`

`MemoryCredentialStore` is now a real injection seam — both resolution and migration take `&impl CredentialStore`, so no test can reach the developer's real keychain.

## Verification

- `cargo fmt --all` and `cargo clippy --workspace --all-targets`: clean, no new `#[allow]`.
- `cargo test --workspace`: 0 failures across all suites.
- `just sg-scan-strict`: **not run** — `sg` (ast-grep) is not installed locally. Needs a CI run before merge.

No protocol surface is touched — nothing under `/_apis/`, `/broker/`, `/twirp/`, or the `azdo` DTOs — so no golden or dogfood evidence applies. This is local operator credential storage only.

## Docs

`docs/setup.md` and `docs/github-tokens.md` updated, including correcting a claim that the config holds only non-secret references and documenting the headless-host fallback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves GitHub App keys, PATs, and webhook secrets from plaintext `~/.preloop/config.toml` into the OS credential store. The config now keeps only host-scoped, non-secret references; existing inline credentials migrate on `preloop serve` when possible, with inline and environment-variable fallback when the store is unavailable.

- Stored values use `SecretString`, and references resolve for both regular config and `PRELOOP_GITHUB_APPS_JSON`.
- Setup commands warn and keep credentials inline on headless hosts, while webhook secrets use the explicitly targeted App.
- Migration preserves rotated store values, ignores empty legacy values, avoids unnecessary store probes, and leaves credentials without an App ID inline with a warning.
- Numeric App ID validation prevents credential reference namespace collisions; unresolvable registry Apps are skipped with a warning.

**Verification**

- `cargo test --workspace` passes; `just sg-scan-strict` still needs a CI run because `ast-grep` is not installed locally.

<sup>Written for commit 48b55cf2cf60f1f5910a8ed27c8c9a62d9891c11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * GitHub App credentials, webhook secrets, and personal access tokens are now stored in the operating-system credential store.
  * Existing inline credentials are migrated automatically when possible, while preserving compatibility where credential storage is unavailable.
  * Configuration files now retain credential references instead of secret values.

* **Documentation**
  * Updated setup guidance and examples to describe credential storage, migration, and reference-based configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->