### PR TITLE
fix: bind Results mutations to job tokens

### DIFF
--- a/crates/preloop-runner-server/src/auth.rs
+++ b/crates/preloop-runner-server/src/auth.rs
@@ -19,7 +19,7 @@ pub(crate) async fn require_protocol_bearer(
 
 pub(crate) async fn require_results_bearer(
     State(shared): State<Arc<SharedState>>,
-    request: Request,
+    mut request: Request,
     next: Next,
 ) -> Result<Response, ApiError> {
     let path = request.uri().path();
@@ -44,23 +44,16 @@ pub(crate) async fn require_results_bearer(
     if !path.starts_with("/twirp/") {
         return Ok(next.run(request).await);
     }
-    let authorized = bearer_token(&request).is_some_and(|token| {
-        token == shared.state.system_token
-            || shared
-                .state
-                .verify_local_jwt_claims(token)
-                .is_some_and(|claims| {
-                    claims
-                        .get("scp")
-                        .and_then(|value| value.as_str())
-                        .is_some_and(|scope| scope.starts_with("Actions.Results:"))
-                })
-    });
-    if authorized {
-        Ok(next.run(request).await)
-    } else {
-        Err(ApiError::unauthorized("results-service job token required"))
-    }
+    let Some(identity) =
+        bearer_token(&request).and_then(|token| results_identity(&shared.state, token))
+    else {
+        return Err(ApiError::unauthorized("results-service job token required"));
+    };
+    // The typed identity is authenticated before body extraction. Handlers
+    // then compare decoded plan/job ids against this same identity instead of
+    // re-parsing a bearer string independently.
+    request.extensions_mut().insert(identity);
+    Ok(next.run(request).await)
 }
 
 pub(crate) async fn require_test_api_token(
@@ -345,36 +338,80 @@ impl Clone for SocketSurface {
     }
 }
 
-/// Whether a caller may mint replay blob URLs for this exact plan/job pair.
+/// The authenticated identity carried by a Results bearer is used by every
+/// Results handler, including signed-URL minting and metadata mutation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ResultsJobIdentity {
+    pub(crate) plan_id: String,
+    pub(crate) job_id: uuid::Uuid,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ResultsIdentity {
+    /// The engine credential is allowed to address every Results target.
+    System,
+    /// A runtime credential is bound to one plan/job pair.
+    Job(ResultsJobIdentity),
+}
+
+/// Parse the Results bearer into the identity handlers must authorize against.
 ///
-/// The engine token may mint for any job (it is the administrator credential).
-/// A job runtime token is weaker — the runner exports it to steps as
-/// `ACTIONS_RUNTIME_TOKEN` — so it must only mint for the one job it names:
-/// both the subject and the `Actions.Results:{plan}:{job}` scope have to
-/// match the requested backend ids. Without this, workflow code holding its
-/// own runtime token could ask the mint handler for *another* job's signed
-/// URL and then overwrite that job's logs through it.
-pub(crate) fn results_token_binds_job(
-    state: &AppState,
-    bearer: Option<&str>,
+/// Requiring both the `sub` and the full Results scope to agree prevents a
+/// valid local JWT minted for one protocol surface from being repurposed as a
+/// different job's Results credential.
+pub(crate) fn results_identity(state: &AppState, bearer: &str) -> Option<ResultsIdentity> {
+    if bearer == state.system_token {
+        return Some(ResultsIdentity::System);
+    }
+
+    let claims = state.verify_local_jwt_claims(bearer)?;
+    let subject_job = claims
+        .get("sub")
+        .and_then(|value| value.as_str())
+        .and_then(|subject| subject.strip_prefix("preloop-job-"))
+        .and_then(|job| job.parse::<uuid::Uuid>().ok())?;
+    let scope = claims
+        .get("scp")
+        .and_then(|value| value.as_str())
+        .and_then(|scope| scope.strip_prefix("Actions.Results:"))?;
+    let (plan_id, scope_job) = scope.split_once(':')?;
+    if plan_id.is_empty() || scope_job.parse::<uuid::Uuid>().ok()? != subject_job {
+        return None;
+    }
+    Some(ResultsIdentity::Job(ResultsJobIdentity {
+        plan_id: plan_id.to_owned(),
+        job_id: subject_job,
+    }))
+}
+
+pub(crate) fn results_identity_binds_job(
+    identity: &ResultsIdentity,
     plan_id: &str,
     job_id: &str,
 ) -> bool {
-    match bearer {
-        Some(token) if token == state.system_token => true,
-        Some(token) => state.verify_local_jwt_claims(token).is_some_and(|claims| {
-            let subject_job = claims
-                .get("sub")
-                .and_then(|value| value.as_str())
-                .and_then(|subject| subject.strip_prefix("preloop-job-"))
-                .unwrap_or("");
-            let scope = claims
-                .get("scp")
-                .and_then(|value| value.as_str())
-                .unwrap_or("");
-            subject_job == job_id && scope == format!("Actions.Results:{plan_id}:{job_id}")
-        }),
-        None => false,
+    match identity {
+        ResultsIdentity::System => true,
+        ResultsIdentity::Job(identity) => {
+            identity.plan_id == plan_id
+                && job_id
+                    .parse::<uuid::Uuid>()
+                    .is_ok_and(|job| job == identity.job_id)
+        }
+    }
+}
+
+/// Require the typed Results identity to name the exact plan/job target.
+pub(crate) fn require_results_job(
+    identity: &ResultsIdentity,
+    plan_id: &str,
+    job_id: &str,
+) -> Result<(), ApiError> {
+    if results_identity_binds_job(identity, plan_id, job_id) {
+        Ok(())
+    } else {
+        Err(ApiError::forbidden(
+            "results-service token is not bound to that job",
+        ))
     }
 }
 

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -284,13 +284,13 @@ async fn sqlite_recovery_restores_post_restart_state() {
     let recovered = AppState::new(temp.path().to_path_buf()).await.unwrap();
     let recovered_inner = recovered.inner.lock().await;
 
-    // C1: session_keys restored.
+    // C1: \session_keys restored.
     assert!(
         recovered_inner.session_keys.contains_key(&session_id),
         "session_keys must survive restart"
     );
 
-    // C2: runner_rsa_public_keys restored.
+    // runner_rsa_public_keys restored.
     assert_eq!(
         recovered_inner
             .runner_rsa_public_keys
@@ -300,7 +300,7 @@ async fn sqlite_recovery_restores_post_restart_state() {
         "RSA public key must survive restart"
     );
 
-    // C5: cancellation of a queued job removes it from the queue and
+    // cancellation of a queued job removes it from the queue and
     // marks the run Cancelled. `cancellation_queue` is reserved for
     // in-progress jobs that need a JobCancellation message sent; a queued
     // job is simply dropped. Assert the run status is restored.
@@ -6413,7 +6413,7 @@ async fn twirp_metadata_routes_persist_log_metadata() {
                 "workflow_run_backend_id": "run-1",
                 "size": 321,
             }),
-            "summary:step-summary",
+            "results:run-1:job-1:summary:step-summary",
         ),
         (
             "/twirp/results.services.receiver.Receiver/CreateStepLogsMetadata",
@@ -6449,7 +6449,10 @@ async fn twirp_metadata_routes_persist_log_metadata() {
     }
 
     let inner = state.inner.lock().await;
-    let summary = inner.log_metadata.get("summary:step-summary").unwrap();
+    let summary = inner
+        .log_metadata
+        .get("results:run-1:job-1:summary:step-summary")
+        .unwrap();
     assert_eq!(summary.byte_count, 321);
     assert_eq!(summary.line_count, 0);
     let step = inner.log_metadata.get("step:step-logs").unwrap();
@@ -20508,6 +20511,286 @@ async fn replay_blob_urls_are_minted_only_for_the_callers_own_job() {
     .await
     .unwrap();
     assert_eq!(stored, "step one log");
+}
+
+#[tokio::test]
+async fn results_workflow_steps_require_the_calling_job() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, jobs) = two_job_run_for_log_filters(&app, &state).await;
+    let (_, plan_a, agent_a) = jobs[0].clone();
+    let (_, plan_b, agent_b) = jobs[1].clone();
+    let a_job = agent_a.parse::<uuid::Uuid>().unwrap();
+    let b_job = agent_b.parse::<uuid::Uuid>().unwrap();
+    let a_step = workflow_step_ids(&state, run_id, "build")
+        .await
+        .into_iter()
+        .next()
+        .expect("job A must have a workflow step");
+    let b_step = workflow_step_ids(&state, run_id, "test")
+        .await
+        .into_iter()
+        .next()
+        .expect("job B must have a workflow step");
+    let token_a = state.mint_runtime_token(&plan_a, &a_job);
+    let token_b = state.mint_runtime_token(&plan_b, &b_job);
+    let uri = "/twirp/github.actions.results.api.v1.WorkflowStepUpdateService/WorkflowStepsUpdate";
+
+    let before = get_run_json(&app, &run_id.to_string()).await;
+    let job_steps = |run: &Value, name: &str| {
+        run["jobs_list"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|job| job["job_id"] == name)
+            .unwrap()["steps"]
+            .clone()
+    };
+    let build_before = job_steps(&before, "build");
+    let test_before = job_steps(&before, "test");
+
+    assert_eq!(
+        status_with_bearer(
+            &app,
+            &token_a,
+            Method::POST,
+            uri,
+            json!({
+                "workflow_run_backend_id": plan_b,
+                "workflow_job_run_backend_id": agent_b,
+                "steps": [{
+                    "external_id": b_step,
+                    "number": 1,
+                    "name": "A must not rewrite B",
+                    "status": 6,
+                    "conclusion": 3
+                }]
+            }),
+        )
+        .await,
+        StatusCode::FORBIDDEN
+    );
+    assert_eq!(
+        status_with_bearer(
+            &app,
+            &token_b,
+            Method::POST,
+            uri,
+            json!({
+                "workflow_run_backend_id": plan_a,
+                "workflow_job_run_backend_id": agent_a,
+                "steps": [{
+                    "external_id": a_step,
+                    "number": 1,
+                    "name": "B must not rewrite A",
+                    "status": 6,
+                    "conclusion": 3
+                }]
+            }),
+        )
+        .await,
+        StatusCode::FORBIDDEN
+    );
+
+    let after_refused = get_run_json(&app, &run_id.to_string()).await;
+    assert_eq!(job_steps(&after_refused, "build"), build_before);
+    assert_eq!(job_steps(&after_refused, "test"), test_before);
+
+    assert_eq!(
+        status_with_bearer(
+            &app,
+            &token_a,
+            Method::POST,
+            uri,
+            json!({
+                "workflow_run_backend_id": plan_a,
+                "workflow_job_run_backend_id": agent_a,
+                "steps": [{
+                    "external_id": a_step,
+                    "number": 1,
+                    "name": "A owns this update",
+                    "status": 6,
+                    "conclusion": 2
+                }]
+            }),
+        )
+        .await,
+        StatusCode::OK
+    );
+    let after_own = get_run_json(&app, &run_id.to_string()).await;
+    assert_eq!(job_steps(&after_own, "test"), test_before);
+    assert_eq!(
+        job_steps(&after_own, "build")[0]["name"],
+        "A owns this update"
+    );
+}
+
+#[tokio::test]
+async fn results_metadata_requires_the_calling_job() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, jobs) = two_job_run_for_log_filters(&app, &state).await;
+    let (_, plan_a, agent_a) = jobs[0].clone();
+    let (_, plan_b, agent_b) = jobs[1].clone();
+    let a_job = agent_a.parse::<uuid::Uuid>().unwrap();
+    let b_step = workflow_step_ids(&state, run_id, "test")
+        .await
+        .into_iter()
+        .next()
+        .expect("job B must have a workflow step");
+    let token_a = state.mint_runtime_token(&plan_a, &a_job);
+    let keys = [
+        format!("results:{plan_b}:{agent_b}:summary:{b_step}"),
+        format!("results:{plan_b}:{agent_b}:step:{b_step}"),
+        format!("results:{plan_b}:{agent_b}:job:{agent_b}"),
+    ];
+    {
+        let mut inner = state.inner.lock().await;
+        for (index, key) in keys.iter().enumerate() {
+            inner.log_metadata.insert(
+                key.clone(),
+                LogMetadata {
+                    byte_count: index + 1,
+                    line_count: index + 10,
+                },
+            );
+        }
+    }
+    let metadata_before = {
+        let inner = state.inner.lock().await;
+        keys.iter()
+            .map(|key| {
+                inner
+                    .log_metadata
+                    .get(key)
+                    .map(|meta| (meta.byte_count, meta.line_count))
+            })
+            .collect::<Vec<_>>()
+    };
+
+    let requests = [
+        (
+            "/twirp/results.services.receiver.Receiver/CreateStepSummaryMetadata",
+            json!({
+                "step_backend_id": b_step,
+                "workflow_job_run_backend_id": agent_b,
+                "workflow_run_backend_id": plan_b,
+                "size": 999
+            }),
+        ),
+        (
+            "/twirp/results.services.receiver.Receiver/CreateStepLogsMetadata",
+            json!({
+                "step_backend_id": b_step,
+                "workflow_job_run_backend_id": agent_b,
+                "workflow_run_backend_id": plan_b,
+                "line_count": 999
+            }),
+        ),
+        (
+            "/twirp/results.services.receiver.Receiver/CreateJobLogsMetadata",
+            json!({
+                "workflow_job_run_backend_id": agent_b,
+                "workflow_run_backend_id": plan_b,
+                "line_count": 999
+            }),
+        ),
+    ];
+    for (uri, body) in requests {
+        assert_eq!(
+            status_with_bearer(&app, &token_a, Method::POST, uri, body).await,
+            StatusCode::FORBIDDEN,
+            "{uri}"
+        );
+    }
+
+    let metadata_after = {
+        let inner = state.inner.lock().await;
+        keys.iter()
+            .map(|key| {
+                inner
+                    .log_metadata
+                    .get(key)
+                    .map(|meta| (meta.byte_count, meta.line_count))
+            })
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(metadata_after, metadata_before);
+
+    let own_requests = [
+        (
+            "/twirp/results.services.receiver.Receiver/CreateStepSummaryMetadata",
+            json!({
+                "step_backend_id": b_step,
+                "workflow_job_run_backend_id": agent_a,
+                "workflow_run_backend_id": plan_a,
+                "size": 10
+            }),
+        ),
+        (
+            "/twirp/results.services.receiver.Receiver/CreateStepLogsMetadata",
+            json!({
+                "step_backend_id": b_step,
+                "workflow_job_run_backend_id": agent_a,
+                "workflow_run_backend_id": plan_a,
+                "line_count": 2
+            }),
+        ),
+        (
+            "/twirp/results.services.receiver.Receiver/CreateJobLogsMetadata",
+            json!({
+                "workflow_job_run_backend_id": agent_a,
+                "workflow_run_backend_id": plan_a,
+                "line_count": 3
+            }),
+        ),
+    ];
+    for (uri, body) in own_requests {
+        assert_eq!(
+            status_with_bearer(&app, &token_a, Method::POST, uri, body).await,
+            StatusCode::OK,
+            "{uri}"
+        );
+    }
+
+    let inner = state.inner.lock().await;
+    assert_eq!(
+        inner
+            .log_metadata
+            .get(&keys[0])
+            .map(|meta| (meta.byte_count, meta.line_count)),
+        Some((1, 10))
+    );
+    assert_eq!(
+        inner
+            .log_metadata
+            .get(&keys[1])
+            .map(|meta| (meta.byte_count, meta.line_count)),
+        Some((2, 11))
+    );
+    assert_eq!(
+        inner
+            .log_metadata
+            .get(&format!("results:{plan_a}:{agent_a}:summary:{b_step}"))
+            .map(|meta| (meta.byte_count, meta.line_count)),
+        Some((10, 0))
+    );
+    assert_eq!(
+        inner
+            .log_metadata
+            .get(&format!("results:{plan_a}:{agent_a}:step:{b_step}"))
+            .map(|meta| (meta.byte_count, meta.line_count)),
+        Some((160, 2))
+    );
+    assert_eq!(
+        inner
+            .log_metadata
+            .get(&format!("results:{plan_a}:{agent_a}:job:{agent_a}"))
+            .map(|meta| (meta.byte_count, meta.line_count)),
+        Some((240, 3))
+    );
 }
 
 #[tokio::test]

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -284,13 +284,13 @@ async fn sqlite_recovery_restores_post_restart_state() {
     let recovered = AppState::new(temp.path().to_path_buf()).await.unwrap();
     let recovered_inner = recovered.inner.lock().await;
 
-    // C1: \session_keys restored.
+    // C1: session_keys restored.
     assert!(
         recovered_inner.session_keys.contains_key(&session_id),
         "session_keys must survive restart"
     );
 
-    // runner_rsa_public_keys restored.
+    // C2: runner_rsa_public_keys restored.
     assert_eq!(
         recovered_inner
             .runner_rsa_public_keys
@@ -300,7 +300,7 @@ async fn sqlite_recovery_restores_post_restart_state() {
         "RSA public key must survive restart"
     );
 
-    // cancellation of a queued job removes it from the queue and
+    // C5: cancellation of a queued job removes it from the queue and
     // marks the run Cancelled. `cancellation_queue` is reserved for
     // in-progress jobs that need a JobCancellation message sent; a queued
     // job is simply dropped. Assert the run status is restored.
@@ -6455,12 +6455,10 @@ async fn twirp_metadata_routes_persist_log_metadata() {
         .unwrap();
     assert_eq!(summary.byte_count, 321);
     assert_eq!(summary.line_count, 0);
-    let step = inner.log_metadata.get("step:step-logs").unwrap();
-    assert_eq!(step.byte_count, 560);
-    assert_eq!(step.line_count, 7);
-    let job = inner.log_metadata.get("job:job-logs").unwrap();
-    assert_eq!(job.byte_count, 720);
-    assert_eq!(job.line_count, 9);
+    // Requests without plan/job identifiers succeed without writing: there is
+    // nothing to key or authorize against.
+    assert!(!inner.log_metadata.contains_key("step:step-logs"));
+    assert!(!inner.log_metadata.contains_key("job:job-logs"));
 }
 
 #[tokio::test]
@@ -20519,8 +20517,16 @@ async fn results_workflow_steps_require_the_calling_job() {
     let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
     let app = app(state.clone(), CancellationToken::new());
     let (run_id, jobs) = two_job_run_for_log_filters(&app, &state).await;
-    let (_, plan_a, agent_a) = jobs[0].clone();
-    let (_, plan_b, agent_b) = jobs[1].clone();
+    let (_, plan_a, agent_a) = jobs
+        .iter()
+        .find(|(job, _, _)| job == "build")
+        .cloned()
+        .expect("build job must be present");
+    let (_, plan_b, agent_b) = jobs
+        .iter()
+        .find(|(job, _, _)| job == "test")
+        .cloned()
+        .expect("test job must be present");
     let a_job = agent_a.parse::<uuid::Uuid>().unwrap();
     let b_job = agent_b.parse::<uuid::Uuid>().unwrap();
     let a_step = workflow_step_ids(&state, run_id, "build")
@@ -20632,8 +20638,16 @@ async fn results_metadata_requires_the_calling_job() {
     let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
     let app = app(state.clone(), CancellationToken::new());
     let (run_id, jobs) = two_job_run_for_log_filters(&app, &state).await;
-    let (_, plan_a, agent_a) = jobs[0].clone();
-    let (_, plan_b, agent_b) = jobs[1].clone();
+    let (_, plan_a, agent_a) = jobs
+        .iter()
+        .find(|(job, _, _)| job == "build")
+        .cloned()
+        .expect("build job must be present");
+    let (_, plan_b, agent_b) = jobs
+        .iter()
+        .find(|(job, _, _)| job == "test")
+        .cloned()
+        .expect("test job must be present");
     let a_job = agent_a.parse::<uuid::Uuid>().unwrap();
     let b_step = workflow_step_ids(&state, run_id, "test")
         .await

--- a/crates/preloop-runner-server/src/results_twirp.rs
+++ b/crates/preloop-runner-server/src/results_twirp.rs
@@ -24,14 +24,15 @@ pub(crate) struct StepLogsSignedBlobUrlRequest {
 /// numbering `--step` reads off the workflow.
 pub(crate) async fn twirp_workflow_steps_update(
     State(shared): State<Arc<SharedState>>,
+    axum::extract::Extension(identity): axum::extract::Extension<crate::auth::ResultsIdentity>,
     Json(payload): Json<serde_json::Value>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let mut inner = shared.state.inner.lock().await;
-
     let plan_id = payload["workflow_run_backend_id"].as_str().unwrap_or("");
     let agent_job_id_str = payload["workflow_job_run_backend_id"]
         .as_str()
         .unwrap_or("");
+    crate::auth::require_results_job(&identity, plan_id, agent_job_id_str)?;
+    let mut inner = shared.state.inner.lock().await;
 
     let (Some(plan_uuid), Some(job_uuid)) = (
         uuid::Uuid::parse_str(plan_id).ok(),
@@ -148,16 +149,15 @@ pub(crate) async fn twirp_workflow_steps_update(
 
 pub(crate) async fn twirp_get_job_logs_signed_blob_url(
     State(shared): State<Arc<SharedState>>,
-    headers: axum::http::HeaderMap,
+    axum::extract::Extension(identity): axum::extract::Extension<crate::auth::ResultsIdentity>,
     Json(request): Json<JobLogsSignedBlobUrlRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     // The signed URL is the upload credential for `/replay/results/*` — a
     // bearerless route reachable from inside every runner VM. Only mint for
     // the plan/job the caller's token actually names, or workflow code could
     // ask for another job's URL and overwrite its logs.
-    if !crate::auth::results_token_binds_job(
-        &shared.state,
-        crate::auth::bearer_from_headers(&headers),
+    if !crate::auth::results_identity_binds_job(
+        &identity,
         &request.workflow_run_backend_id,
         &request.workflow_job_run_backend_id,
     ) {
@@ -181,23 +181,28 @@ pub(crate) async fn twirp_get_job_logs_signed_blob_url(
 }
 
 pub(crate) async fn twirp_get_job_diag_logs_signed_blob_url(
-    Json(_request): Json<JobLogsSignedBlobUrlRequest>,
-) -> Json<serde_json::Value> {
+    axum::extract::Extension(identity): axum::extract::Extension<crate::auth::ResultsIdentity>,
+    Json(request): Json<JobLogsSignedBlobUrlRequest>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    crate::auth::require_results_job(
+        &identity,
+        &request.workflow_run_backend_id,
+        &request.workflow_job_run_backend_id,
+    )?;
     let token = uuid::Uuid::new_v4();
-    Json(json!({
+    Ok(Json(json!({
         "blob_storage_type": "BLOB_STORAGE_TYPE_AZURE",
         "diag_logs_url": format!("{}/twirp-blob/diag/{token}?sv=2021-08-06&se=2028-01-01T00%3A00%3A00Z&sr=c&sp=rw&sig=dummy", runner_base_url()),
-    }))
+    })))
 }
 
 pub(crate) async fn twirp_get_step_logs_signed_blob_url(
     State(shared): State<Arc<SharedState>>,
-    headers: axum::http::HeaderMap,
+    axum::extract::Extension(identity): axum::extract::Extension<crate::auth::ResultsIdentity>,
     Json(request): Json<StepLogsSignedBlobUrlRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    if !crate::auth::results_token_binds_job(
-        &shared.state,
-        crate::auth::bearer_from_headers(&headers),
+    if !crate::auth::results_identity_binds_job(
+        &identity,
         &request.workflow_run_backend_id,
         &request.workflow_job_run_backend_id,
     ) {
@@ -232,12 +237,11 @@ pub(crate) struct StepSummarySignedBlobUrlRequest {
 
 pub(crate) async fn twirp_get_step_summary_signed_blob_url(
     State(shared): State<Arc<SharedState>>,
-    headers: axum::http::HeaderMap,
+    axum::extract::Extension(identity): axum::extract::Extension<crate::auth::ResultsIdentity>,
     Json(request): Json<StepSummarySignedBlobUrlRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    if !crate::auth::results_token_binds_job(
-        &shared.state,
-        crate::auth::bearer_from_headers(&headers),
+    if !crate::auth::results_identity_binds_job(
+        &identity,
         &request.workflow_run_backend_id,
         &request.workflow_job_run_backend_id,
     ) {
@@ -263,15 +267,33 @@ pub(crate) async fn twirp_get_step_summary_signed_blob_url(
     })))
 }
 
+/// Results metadata keys are scoped to the authenticated plan/job whenever
+/// those identifiers are present. Step ids are minted by the runner for
+/// setup/cleanup records before the first step report arrives, so ownership
+/// cannot be inferred from the manifest at metadata-ingest time.
+fn results_metadata_key(
+    kind: &str,
+    plan_id: Option<&str>,
+    job_id: Option<&str>,
+    resource_id: Option<&str>,
+) -> String {
+    if let (Some(plan_id), Some(job_id)) = (plan_id, job_id) {
+        return match resource_id {
+            Some(resource_id) => format!("results:{plan_id}:{job_id}:{kind}:{resource_id}"),
+            None => format!("results:{plan_id}:{job_id}:{kind}"),
+        };
+    }
+    match resource_id {
+        Some(resource_id) => format!("{kind}:{resource_id}"),
+        None => kind.to_owned(),
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub(crate) struct StepSummaryMetadataRequest {
-    // serde: metadata is accepted for protocol compatibility; this identifies the summary.
+    // The backend identifiers identify the target job for Results authorization.
     pub(crate) step_backend_id: String,
-    // serde: metadata is accepted for protocol compatibility; field is not inspected.
-    #[allow(dead_code)]
     pub(crate) workflow_job_run_backend_id: String,
-    // serde: metadata is accepted for protocol compatibility; field is not inspected.
-    #[allow(dead_code)]
     pub(crate) workflow_run_backend_id: String,
     // serde: metadata is accepted for protocol compatibility; this records the summary size.
     pub(crate) size: Option<u64>,
@@ -282,12 +304,23 @@ pub(crate) struct StepSummaryMetadataRequest {
 
 pub(crate) async fn twirp_create_step_summary_metadata(
     State(shared): State<Arc<SharedState>>,
+    axum::extract::Extension(identity): axum::extract::Extension<crate::auth::ResultsIdentity>,
     Json(request): Json<StepSummaryMetadataRequest>,
-) -> Json<serde_json::Value> {
+) -> Result<Json<serde_json::Value>, ApiError> {
+    crate::auth::require_results_job(
+        &identity,
+        &request.workflow_run_backend_id,
+        &request.workflow_job_run_backend_id,
+    )?;
     let byte_count = request.size.unwrap_or_default().min(usize::MAX as u64) as usize;
     let mut inner = shared.state.inner.lock().await;
     inner.log_metadata.insert(
-        format!("summary:{}", request.step_backend_id),
+        results_metadata_key(
+            "summary",
+            Some(&request.workflow_run_backend_id),
+            Some(&request.workflow_job_run_backend_id),
+            Some(&request.step_backend_id),
+        ),
         LogMetadata {
             byte_count,
             line_count: 0,
@@ -298,18 +331,14 @@ pub(crate) async fn twirp_create_step_summary_metadata(
         tracing::warn!(?error, "failed to persist step summary metadata");
     }
 
-    Json(json!({"ok": true}))
+    Ok(Json(json!({"ok": true})))
 }
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct StepLogsMetadataRequest {
-    // serde: metadata is accepted for protocol compatibility; this identifies the step.
+    // The backend identifiers identify the target job for Results authorization.
     pub(crate) step_backend_id: Option<String>,
-    // serde: metadata is accepted for protocol compatibility; field is not inspected.
-    #[allow(dead_code)]
     pub(crate) workflow_job_run_backend_id: Option<String>,
-    // serde: metadata is accepted for protocol compatibility; field is not inspected.
-    #[allow(dead_code)]
     pub(crate) workflow_run_backend_id: Option<String>,
     // serde: metadata is accepted for protocol compatibility; field is not inspected.
     #[allow(dead_code)]
@@ -321,35 +350,38 @@ pub(crate) struct StepLogsMetadataRequest {
 /// POST CreateStepLogsMetadata — runner calls this after uploading step logs.
 pub(crate) async fn twirp_create_step_logs_metadata(
     State(shared): State<Arc<SharedState>>,
+    axum::extract::Extension(identity): axum::extract::Extension<crate::auth::ResultsIdentity>,
     Json(request): Json<StepLogsMetadataRequest>,
-) -> Json<serde_json::Value> {
-    if let Some(step_backend_id) = request.step_backend_id {
-        let line_count = request.line_count.unwrap_or_default();
-        let line_count_usize = line_count.min(usize::MAX as u64) as usize;
-        let byte_count = line_count.saturating_mul(80).min(usize::MAX as u64) as usize;
-        let mut inner = shared.state.inner.lock().await;
-        inner.log_metadata.insert(
-            format!("step:{step_backend_id}"),
-            LogMetadata {
-                byte_count,
-                line_count: line_count_usize,
-            },
-        );
-        let meta = crate::store::build_meta_snapshot(&inner);
-        if let Err(error) = shared.state.store.store_meta_only(&meta).await {
-            tracing::warn!(?error, "failed to persist step log metadata");
-        }
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let Some(step_backend_id) = request.step_backend_id else {
+        return Ok(Json(json!({"ok": true})));
+    };
+    let plan_id = request.workflow_run_backend_id.as_deref();
+    let job_id = request.workflow_job_run_backend_id.as_deref();
+    crate::auth::require_results_job(&identity, plan_id.unwrap_or(""), job_id.unwrap_or(""))?;
+    let line_count = request.line_count.unwrap_or_default();
+    let line_count_usize = line_count.min(usize::MAX as u64) as usize;
+    let byte_count = line_count.saturating_mul(80).min(usize::MAX as u64) as usize;
+    let mut inner = shared.state.inner.lock().await;
+    inner.log_metadata.insert(
+        results_metadata_key("step", plan_id, job_id, Some(&step_backend_id)),
+        LogMetadata {
+            byte_count,
+            line_count: line_count_usize,
+        },
+    );
+    let meta = crate::store::build_meta_snapshot(&inner);
+    if let Err(error) = shared.state.store.store_meta_only(&meta).await {
+        tracing::warn!(?error, "failed to persist step log metadata");
     }
 
-    Json(json!({"ok": true}))
+    Ok(Json(json!({"ok": true})))
 }
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct JobLogsMetadataRequest {
-    // serde: metadata is accepted for protocol compatibility; this identifies the job.
+    // The backend identifiers identify the target job for Results authorization.
     pub(crate) workflow_job_run_backend_id: Option<String>,
-    // serde: metadata is accepted for protocol compatibility; field is not inspected.
-    #[allow(dead_code)]
     pub(crate) workflow_run_backend_id: Option<String>,
     // serde: metadata is accepted for protocol compatibility; field is not inspected.
     #[allow(dead_code)]
@@ -358,30 +390,42 @@ pub(crate) struct JobLogsMetadataRequest {
     pub(crate) line_count: Option<u64>,
 }
 
-/// POST CreateJobLogsMetadata — runner calls this after uploading job logs.
 pub(crate) async fn twirp_create_job_logs_metadata(
     State(shared): State<Arc<SharedState>>,
+    axum::extract::Extension(identity): axum::extract::Extension<crate::auth::ResultsIdentity>,
     Json(request): Json<JobLogsMetadataRequest>,
-) -> Json<serde_json::Value> {
-    if let Some(workflow_job_run_backend_id) = request.workflow_job_run_backend_id {
-        let line_count = request.line_count.unwrap_or_default();
-        let line_count_usize = line_count.min(usize::MAX as u64) as usize;
-        let byte_count = line_count.saturating_mul(80).min(usize::MAX as u64) as usize;
-        let mut inner = shared.state.inner.lock().await;
-        inner.log_metadata.insert(
-            format!("job:{workflow_job_run_backend_id}"),
-            LogMetadata {
-                byte_count,
-                line_count: line_count_usize,
-            },
-        );
-        let meta = crate::store::build_meta_snapshot(&inner);
-        if let Err(error) = shared.state.store.store_meta_only(&meta).await {
-            tracing::warn!(?error, "failed to persist job log metadata");
-        }
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let Some(workflow_job_run_backend_id) = request.workflow_job_run_backend_id else {
+        return Ok(Json(json!({"ok": true})));
+    };
+    let plan_id = request.workflow_run_backend_id.as_deref();
+    crate::auth::require_results_job(
+        &identity,
+        plan_id.unwrap_or(""),
+        &workflow_job_run_backend_id,
+    )?;
+    let line_count = request.line_count.unwrap_or_default();
+    let line_count_usize = line_count.min(usize::MAX as u64) as usize;
+    let byte_count = line_count.saturating_mul(80).min(usize::MAX as u64) as usize;
+    let mut inner = shared.state.inner.lock().await;
+    inner.log_metadata.insert(
+        results_metadata_key(
+            "job",
+            plan_id,
+            Some(&workflow_job_run_backend_id),
+            Some(&workflow_job_run_backend_id),
+        ),
+        LogMetadata {
+            byte_count,
+            line_count: line_count_usize,
+        },
+    );
+    let meta = crate::store::build_meta_snapshot(&inner);
+    if let Err(error) = shared.state.store.store_meta_only(&meta).await {
+        tracing::warn!(?error, "failed to persist job log metadata");
     }
 
-    Json(json!({"ok": true}))
+    Ok(Json(json!({"ok": true})))
 }
 
 // ─── Cache v2 Twirp (github.actions.results.api.v1.CacheService) ─────────────

--- a/crates/preloop-runner-server/src/results_twirp.rs
+++ b/crates/preloop-runner-server/src/results_twirp.rs
@@ -356,15 +356,21 @@ pub(crate) async fn twirp_create_step_logs_metadata(
     let Some(step_backend_id) = request.step_backend_id else {
         return Ok(Json(json!({"ok": true})));
     };
-    let plan_id = request.workflow_run_backend_id.as_deref();
-    let job_id = request.workflow_job_run_backend_id.as_deref();
-    crate::auth::require_results_job(&identity, plan_id.unwrap_or(""), job_id.unwrap_or(""))?;
+    // Absent identifiers mean there is nothing to key or authorize against;
+    // stay compatible by succeeding without writing, as with a missing step id.
+    let (Some(plan_id), Some(job_id)) = (
+        request.workflow_run_backend_id.as_deref(),
+        request.workflow_job_run_backend_id.as_deref(),
+    ) else {
+        return Ok(Json(json!({"ok": true})));
+    };
+    crate::auth::require_results_job(&identity, plan_id, job_id)?;
     let line_count = request.line_count.unwrap_or_default();
     let line_count_usize = line_count.min(usize::MAX as u64) as usize;
     let byte_count = line_count.saturating_mul(80).min(usize::MAX as u64) as usize;
     let mut inner = shared.state.inner.lock().await;
     inner.log_metadata.insert(
-        results_metadata_key("step", plan_id, job_id, Some(&step_backend_id)),
+        results_metadata_key("step", Some(plan_id), Some(job_id), Some(&step_backend_id)),
         LogMetadata {
             byte_count,
             line_count: line_count_usize,
@@ -398,12 +404,12 @@ pub(crate) async fn twirp_create_job_logs_metadata(
     let Some(workflow_job_run_backend_id) = request.workflow_job_run_backend_id else {
         return Ok(Json(json!({"ok": true})));
     };
-    let plan_id = request.workflow_run_backend_id.as_deref();
-    crate::auth::require_results_job(
-        &identity,
-        plan_id.unwrap_or(""),
-        &workflow_job_run_backend_id,
-    )?;
+    // Absent plan means there is nothing to key or authorize against; stay
+    // compatible by succeeding without writing.
+    let Some(plan_id) = request.workflow_run_backend_id.as_deref() else {
+        return Ok(Json(json!({"ok": true})));
+    };
+    crate::auth::require_results_job(&identity, plan_id, &workflow_job_run_backend_id)?;
     let line_count = request.line_count.unwrap_or_default();
     let line_count_usize = line_count.min(usize::MAX as u64) as usize;
     let byte_count = line_count.saturating_mul(80).min(usize::MAX as u64) as usize;
@@ -411,7 +417,7 @@ pub(crate) async fn twirp_create_job_logs_metadata(
     inner.log_metadata.insert(
         results_metadata_key(
             "job",
-            plan_id,
+            Some(plan_id),
             Some(&workflow_job_run_backend_id),
             Some(&workflow_job_run_backend_id),
         ),


### PR DESCRIPTION
## Summary

- Parse Results credentials once into a typed plan/job identity.
- Bind WorkflowStepsUpdate, metadata mutations, and signed-URL minting to the caller's job.
- Scope metadata keys by plan and job while preserving synthetic runner step IDs.
- Add cross-job regression coverage.

## Verification

- Focused Results tests: 12 passed.
- Full workspace tests: 1,997 passed.
- cargo fmt and workspace Clippy with warnings denied passed.
- Live two-job reproduction: cross-job mutations and diagnostic URL minting returned 403 with unchanged state; same-job update returned 200.
- just test-ci reached pre-existing zizmor failures for dtolnay/rust-toolchain references in .github/workflows/ci.yml; formatting and Clippy passed.

## Review

Reviewed by an Opus 5 OMP agent through Orca against review.md after implementation: approve with concerns, no blockers. The remaining system-token/socket concern is pre-existing and tracked separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Results workflow-step updates and metadata mutations now enforce the caller’s plan/job binding, and diagnostic signed-URL minting requires authorization. Metadata keys now include the plan and job, so previously stored unscoped metadata no longer resolves.

- Parses each Results bearer once into a validated system-or-job identity and reuses it across handlers.
- Requests missing metadata plan or job identifiers still succeed without writing for protocol compatibility.
- Adds cross-job regression coverage for workflow steps, metadata, and same-job updates.

<sup>Written for commit eb7bd7f9ff986da701188ed163d517db8c24040f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Strengthened authentication for results callbacks and signed log URL endpoints.
  - Restricted workflow steps, job metadata, and log access to the authorized plan and job.
  - Diagnostic log URLs now require authorization and return clear errors when access is denied.

- **Bug Fixes**
  - Prevented jobs from updating or creating metadata for other jobs.
  - Standardized metadata keys with plan- and job-scoped naming to avoid collisions.
  - Added coverage for authorization checks across workflow steps and metadata operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->