### PR TITLE
security: persist per-engine admin token

### DIFF
--- a/.github/workflows/runner-sync.yml
+++ b/.github/workflows/runner-sync.yml
@@ -191,10 +191,15 @@ jobs:
           SERVER_LOG="$STATE_DIR/server.log"
           REPLAY_PORT="$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')"
           REPLAY_URL="http://127.0.0.1:$REPLAY_PORT"
+          if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
+            export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+          fi
+
           SERVER_PID=""
           cleanup() { [ -n "$SERVER_PID" ] && kill "$SERVER_PID" >/dev/null 2>&1 || true; }
           trap cleanup EXIT
           PRELOOP_PUBLIC_URL="$REPLAY_URL" \
+            PRELOOP_SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN" \
             PRELOOP_CONFIG="$STATE_DIR/config.toml" \
             PRELOOP_REGISTRATION_POLICY="permissive" \
             ./target/debug/preloop-server serve --listen "127.0.0.1:$REPLAY_PORT" \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2736,6 +2736,7 @@ dependencies = [
  "clap",
  "preloop-gha-parser",
  "preloop-gha-protocol",
+ "preloop-runner-server",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,6 +2531,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
+ "uuid",
  "walkdir",
 ]
 

--- a/benchmarks/conformance/run.sh
+++ b/benchmarks/conformance/run.sh
@@ -13,6 +13,10 @@ REPLAY_PORT="$(
   python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()'
 )"
 REPLAY_URL="http://127.0.0.1:$REPLAY_PORT"
+if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
+  export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+fi
+
 
 cleanup() {
   local status=$?
@@ -45,6 +49,7 @@ cargo build --quiet -p preloop-runner-server
 # policy — the same sanctioned exception `preloop-conformance` uses. Without
 # it every scenario 401s on /api/v3/actions/runner-registration.
 PRELOOP_PUBLIC_URL="$REPLAY_URL" \
+  PRELOOP_SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN" \
   PRELOOP_CONFIG="$STATE_DIR/config.toml" \
   PRELOOP_REGISTRATION_POLICY="permissive" \
   ./target/debug/preloop-server serve --listen "127.0.0.1:$REPLAY_PORT" \

--- a/benchmarks/preloop-perf/src/main.rs
+++ b/benchmarks/preloop-perf/src/main.rs
@@ -49,7 +49,7 @@ use tower::ServiceExt;
 
 // ── constants ───────────────────────────────────────────────────────────────
 
-const SYSTEM_TOKEN: &str = "preloop-system-token";
+const SYSTEM_TOKEN: &str = "preloop-benchmark-explicit-token";
 
 const SIMPLE_WORKFLOW: &str = r#"
 on: push
@@ -1089,10 +1089,14 @@ fn emit_run_provenance(cfg: BenchConfig) -> Result<()> {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    if std::env::var_os("PRELOOP_SYSTEM_TOKEN").is_none() {
+        // This benchmark uses an explicit in-process client; it does not
+        // exercise engine-token discovery.
+        std::env::set_var("PRELOOP_SYSTEM_TOKEN", SYSTEM_TOKEN);
+    }
     let args: Vec<String> = std::env::args().collect();
     let subcommand = args.get(1).map(String::as_str).unwrap_or("all");
     let cfg = BenchConfig::from_env()?;
-
     emit_run_provenance(cfg)?;
 
     match subcommand {

--- a/benchmarks/real-world/bench-real-world.sh
+++ b/benchmarks/real-world/bench-real-world.sh
@@ -13,6 +13,10 @@ REPO_DIR="/tmp/bench-repos/$REPO"
 BENCH_DIR="$(dirname "$(readlink -f "$0")")"
 RESULTS="/tmp/bench-results"
 AKSH="${AKSH:-/usr/local/bin}"
+if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
+  export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+fi
+
 OFFICIAL="$HOME/actions-runner"
 
 mkdir -p "$RESULTS"
@@ -41,7 +45,7 @@ start_fresh_server() {
   sleep 0.3
   export PRELOOP_PUBLIC_URL="http://127.0.0.1:$PORT"
   local t0=$(ms)
-  RUST_LOG=info "$AKSH/preloop-server" serve --listen "127.0.0.1:$PORT" \
+  RUST_LOG=info PRELOOP_SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN" "$AKSH/preloop-server" serve --listen "127.0.0.1:$PORT" \
     --state-dir "/tmp/bench-state-$$" > /tmp/bench-server.log 2>&1 &
   SERVER_PID=$!
   local ok=0

--- a/benchmarks/real-world/conformance-4repos/conformance-4repos.sh
+++ b/benchmarks/real-world/conformance-4repos/conformance-4repos.sh
@@ -24,7 +24,10 @@ SERVER_BIN="$REPO_ROOT/target/debug/preloop-server"
 PRELOOP_RUNNER="$REPO_ROOT/target/debug/preloop-runner"
 PORT_B="${PORT_B:-9191}"
 PORT_C="${PORT_C:-9193}"
-TOKEN="preloop-system-token"
+if [ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]; then
+  export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+fi
+TOKEN="$PRELOOP_SYSTEM_TOKEN"
 mkdir -p "$OUT_ROOT"
 
 # repo -> (workspace dir, workflow path, event, git_ref)
@@ -94,7 +97,7 @@ start_server() {
   sleep 0.5
   rm -rf "$state"
   local public_port="${RUNNER_PORT:-$port}"
-  PRELOOP_GITHUB_TOKEN="$(gh auth token)" PRELOOP_PUBLIC_URL="http://127.0.0.1:$public_port" \
+  PRELOOP_SYSTEM_TOKEN="$TOKEN" PRELOOP_GITHUB_TOKEN="$(gh auth token)" PRELOOP_PUBLIC_URL="http://127.0.0.1:$public_port" \
     RUST_LOG=info,preloop=info "$SERVER_BIN" serve --listen "127.0.0.1:$port" --state-dir "$state" \
     > "$log" 2>&1 &
   local pid=$!

--- a/benchmarks/real-world/conformance-4repos/run-host-cell.sh
+++ b/benchmarks/real-world/conformance-4repos/run-host-cell.sh
@@ -19,7 +19,7 @@ RESULT_DIR=benchmarks/real-world/results/conformance-4repos/$OUT/c
 RUNNER_ROOT=/tmp/conformance-host-runner
 export PRELOOP_URL="http://$ENGINE_PORT"
 
-TOKEN=$(cat ~/.preloop/engine.token)
+TOKEN="${PRELOOP_SYSTEM_TOKEN:?set PRELOOP_SYSTEM_TOKEN to the engine administrator token}"
 
 # Configure the host runner once (labels match the rewritten runs-on).
 if [ ! -f "$RUNNER_ROOT/.runner" ]; then

--- a/benchmarks/real-world/conformance-4repos/run-preloop-cell.sh
+++ b/benchmarks/real-world/conformance-4repos/run-preloop-cell.sh
@@ -28,6 +28,9 @@ PRELOOP=${PRELOOP:-$HOME/preloop/target/debug/preloop}
 ENGINE_PORT=${PRELOOP_LISTEN:-127.0.0.1:9091}
 RESULT_DIR=benchmarks/real-world/results/conformance-4repos/$OUT/c
 
+# The native API token is deliberately explicit for this separate client.
+TOKEN="${PRELOOP_SYSTEM_TOKEN:?set PRELOOP_SYSTEM_TOKEN to the engine administrator token}"
+export PRELOOP_SYSTEM_TOKEN
 # The CLI otherwise falls back to its configured endpoint (unix socket or the
 # default port), where /api/v1/* is gated off and submission 404s.
 export PRELOOP_URL="http://$ENGINE_PORT"
@@ -52,7 +55,6 @@ fi
 RUN_ID=$(echo "$RUN_LINE" | grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}')
 echo "run: $RUN_ID"
 
-TOKEN=$(cat ~/.preloop/engine.token)
 for _ in $(seq 1 120); do
   sleep 15
   STATUS=$(curl -sf -H "Authorization: Bearer $TOKEN" \

--- a/benchmarks/real-world/conformance-5repos.sh
+++ b/benchmarks/real-world/conformance-5repos.sh
@@ -27,7 +27,9 @@ TIMEOUT_SECONDS="${CONFORMANCE_TIMEOUT_SECONDS:-7200}"
 POOL_SIZE="${PRELOOP_RUNNER_POOL_SIZE:-1}"
 HOST_HOME="${HOME:-}"
 SMOLVM_PROCESS_HOME="${CONFORMANCE_SMOLVM_HOME:-$CAMPAIGN_HOME/smolvm-home}"
-export PRELOOP_SYSTEM_TOKEN="${PRELOOP_SYSTEM_TOKEN:-preloop-system-token}"
+if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
+  export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+fi
 export PRELOOP_CLIENT_TIMEOUT_SECONDS="${PRELOOP_CLIENT_TIMEOUT_SECONDS:-3600}"
 
 SERVER_BIN="${PRELOOP_BIN:-$ROOT/target/debug/preloop}"
@@ -270,7 +272,7 @@ trap 'cleanup; exit 143' TERM
 run_status() {
   # --max-time keeps a stalled status request from masking the deadline; a
   # dead server then surfaces as `unknown` and wait_run fails fast instead.
-  curl -fsS --max-time 15 -H "Authorization: Bearer ${PRELOOP_SYSTEM_TOKEN:-preloop-system-token}" \
+  curl -fsS --max-time 15 -H "Authorization: Bearer $PRELOOP_SYSTEM_TOKEN" \
     "http://127.0.0.1:$PORT/api/v1/runs/$1" 2>/dev/null \
     | python3 -c 'import json,sys; r=json.load(sys.stdin); print(r.get("status", "unknown"))' \
     || echo unknown
@@ -278,7 +280,7 @@ run_status() {
 
 run_snapshot() {
   local run_id="$1" output="$2"
-  curl -fsS --max-time 15 -H "Authorization: Bearer ${PRELOOP_SYSTEM_TOKEN:-preloop-system-token}" \
+  curl -fsS --max-time 15 -H "Authorization: Bearer $PRELOOP_SYSTEM_TOKEN" \
     "http://127.0.0.1:$PORT/api/v1/runs/$run_id" >"$output" 2>/dev/null || printf '%s\n' '{}' >"$output"
 }
 

--- a/benchmarks/real-world/conformance-new5repos.sh
+++ b/benchmarks/real-world/conformance-new5repos.sh
@@ -21,7 +21,9 @@ TIMEOUT_SECONDS="${CONFORMANCE_TIMEOUT_SECONDS:-7200}"
 POOL_SIZE="${PRELOOP_RUNNER_POOL_SIZE:-1}"
 HOST_HOME="${HOME:-}"
 SMOLVM_PROCESS_HOME="${CONFORMANCE_SMOLVM_HOME:-$CAMPAIGN_HOME/smolvm-home}"
-export PRELOOP_SYSTEM_TOKEN="${PRELOOP_SYSTEM_TOKEN:-preloop-system-token}"
+if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
+  export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+fi
 export PRELOOP_CLIENT_TIMEOUT_SECONDS="${PRELOOP_CLIENT_TIMEOUT_SECONDS:-3600}"
 SERVER_BIN="${PRELOOP_BIN:-$ROOT/target/debug/preloop}"
 CLIENT_BIN="${PRELOOP_CLIENT_BIN:-$ROOT/target/debug/preloop-runner-client}"
@@ -184,12 +186,12 @@ trap 'cleanup; exit 130' INT
 trap 'cleanup; exit 143' TERM
 run_status() {
   local run_id="$1"
-  curl -fsS --max-time 15 -H "Authorization: Bearer ${PRELOOP_SYSTEM_TOKEN:-preloop-system-token}" \
+  curl -fsS --max-time 15 -H "Authorization: Bearer $PRELOOP_SYSTEM_TOKEN" \
     "http://127.0.0.1:$PORT/api/v1/runs/$run_id" 2>/dev/null | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("status","unknown"))' 2>/dev/null || echo "unknown"
 }
 run_snapshot() {
   local run_id="$1" output="$2"
-  curl -fsS --max-time 15 -H "Authorization: Bearer ${PRELOOP_SYSTEM_TOKEN:-preloop-system-token}" \
+  curl -fsS --max-time 15 -H "Authorization: Bearer $PRELOOP_SYSTEM_TOKEN" \
     "http://127.0.0.1:$PORT/api/v1/runs/$run_id" >"$output" 2>/dev/null || printf '%s\n' '{}' >"$output"
 }
 write_push_payload() {

--- a/benchmarks/real-world/e2e-per-job-smolvm-bench.sh
+++ b/benchmarks/real-world/e2e-per-job-smolvm-bench.sh
@@ -14,6 +14,10 @@
 #
 # Workflows: serde | axum | bat | all
 set -euo pipefail
+if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
+  export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+fi
+
 
 # ── Config ──────────────────────────────────────────────────────────
 MODE="${1:?Usage: $0 <github-official|github-preloop|preloop-server> <serde|axum|bat|all>}"
@@ -216,7 +220,7 @@ run_preloop_server_mode() {
 
   # Start preloop-server on localhost only
   log "Starting preloop-server on 127.0.0.1:${server_internal_port}..."
-  PRELOOP_PUBLIC_URL="$server_url" RUST_LOG=info "$server_bin" serve \
+  PRELOOP_PUBLIC_URL="$server_url" PRELOOP_SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN" RUST_LOG=info "$server_bin" serve \
     --listen "127.0.0.1:${server_internal_port}" \
     --state-dir "$TMP_DIR/preloop-state" \
     > "$TMP_DIR/preloop-server.log" 2>&1 &

--- a/benchmarks/real-world/e2e-smolvm-bench.sh
+++ b/benchmarks/real-world/e2e-smolvm-bench.sh
@@ -15,6 +15,12 @@ HOST_CLIENT="$HOME/cachingv4/target/release/preloop-runner-client"
 GH_REPO="preloopdev/preloop-conformance-sample"
 RESULTS_DIR="$HOME/cachingv4/benchmarks/real-world/results"
 mkdir -p "$RESULTS_DIR"
+if [[ "$MODE" == "preloop" ]]; then
+  if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
+    export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+  fi
+fi
+
 
 ms() { python3 -c "import time; print(int(time.time()*1000))"; }
 
@@ -90,7 +96,7 @@ run_preloop_server() {
   local host_ip
   host_ip=$(ipconfig getifaddr en0 2>/dev/null || echo "127.0.0.1")
   export PRELOOP_PUBLIC_URL="http://${host_ip}:9191"
-  RUST_LOG=info "$HOST_SERVER" serve --listen "0.0.0.0:9191" --state-dir "/tmp/preloop-e2e-state-$$" > /tmp/preloop-e2e-server.log 2>&1 &
+  RUST_LOG=info PRELOOP_SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN" "$HOST_SERVER" serve --listen "0.0.0.0:9191" --state-dir "/tmp/preloop-e2e-state-$$" > /tmp/preloop-e2e-server.log 2>&1 &
   local server_pid=$!
   sleep 1
   curl -sf "http://127.0.0.1:9191/healthz" >/dev/null || { log "Server failed"; cat /tmp/preloop-e2e-server.log; exit 1; }

--- a/benchmarks/real-world/local-server-mitm-capture.sh
+++ b/benchmarks/real-world/local-server-mitm-capture.sh
@@ -18,7 +18,10 @@ PRELOOP_RUNNER="${PRELOOP_RUNNER:-/workspace/target/aarch64-unknown-linux-musl/r
 MITM_PORT="${MITM_PORT:-18081}"
 OUT_ROOT="${RESULTS_ROOT:-$ROOT/benchmarks/compatibility/runner/protocol-local}"
 WORKFLOW="$ROOT/benchmarks/real-world/overnight-workflows/$SCENARIO"
-SYSTEM_TOKEN="${PRELOOP_SYSTEM_TOKEN:-local-mitm-token}"
+if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
+  export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+fi
+SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN"
 
 log() { echo "[$(date -u +%H:%M:%S)] $*"; }
 ensure_vms() {
@@ -81,7 +84,7 @@ run_one() {
   for p in "${pids[@]}"; do wait "$p" 2>/dev/null || true; done
   for i in $(seq 1 "$JOB_COUNT"); do smolvm machine exec --name "$VM_PREFIX-$i" -- pkill -x mitmdump >/dev/null 2>&1 || true; done
   python3 - "$out" "$kind" "$SCENARIO" "$run_id" <<'PY'
-import json,sys
+import json,os,sys
 from pathlib import Path
 r=Path(sys.argv[1]); flows=[]
 for p in r.glob('vm-*/vm-mitm/flows.jsonl'):
@@ -89,7 +92,7 @@ for p in r.glob('vm-*/vm-mitm/flows.jsonl'):
   if l.strip(): flows.append(json.loads(l))
 flows.sort(key=lambda x:(x.get('ts_request') or 0,x.get('flow_index') or 0)); (r/'flows.jsonl').write_text('\n'.join(json.dumps(x) for x in flows)+'\n')
 status='unknown'
-try: status=json.loads(__import__('subprocess').check_output(['curl','-sf','-H','Authorization: Bearer preloop-system-token',f'http://127.0.0.1:{sys.argv[1]}']))
+try: status=json.loads(__import__('subprocess').check_output(['curl','-sf','-H',f"Authorization: Bearer {os.environ['PRELOOP_SYSTEM_TOKEN']}",f'http://127.0.0.1:{sys.argv[1]}']))
 except: pass
 (r/'summary.json').write_text(json.dumps({'runner':sys.argv[2],'scenario':sys.argv[3],'run_id':sys.argv[4],'flows_count':len(flows)},indent=2))
 PY

--- a/benchmarks/real-world/run-all-benchmarks.sh
+++ b/benchmarks/real-world/run-all-benchmarks.sh
@@ -13,6 +13,10 @@ esac
 export PATH="$HOME/.rustup/toolchains/$TC/bin:$HOME/.cargo/bin:$PATH"
 export CARGO_HOME="$HOME/.cargo"
 export RUSTUP_HOME="$HOME/.rustup"
+if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
+  export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+fi
+
 
 # Copy workflow
 mkdir -p /tmp/bench-repos/$REPO/.github/workflows
@@ -34,7 +38,7 @@ echo "--- BASELINE ---"
 echo ""
 echo "--- AKSH-RUNNER ---"
 sudo kill $(pgrep -f preloop-runner-server) 2>/dev/null || true; sleep 0.3
-sudo PRELOOP_PUBLIC_URL=http://127.0.0.1 RUST_LOG=info \
+sudo PRELOOP_PUBLIC_URL=http://127.0.0.1 PRELOOP_SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN" RUST_LOG=info \
   $HOME/preloop-runner/preloop-runner-server serve --listen 127.0.0.1:80 --state-dir /tmp/bs-$REPO \
   > /tmp/bs-$REPO.log 2>&1 &
 SPID=$!; sleep 1
@@ -61,7 +65,7 @@ grep -E "Running step|completed:" /tmp/${REPO}-preloop.log
 echo ""
 echo "--- OFFICIAL RUNNER ---"
 sudo kill $SPID 2>/dev/null; sleep 0.3
-sudo PRELOOP_PUBLIC_URL=http://127.0.0.1 RUST_LOG=info \
+sudo PRELOOP_PUBLIC_URL=http://127.0.0.1 PRELOOP_SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN" RUST_LOG=info \
   $HOME/preloop-runner/preloop-runner-server serve --listen 127.0.0.1:80 --state-dir /tmp/bs-${REPO}-off \
   > /tmp/bs-${REPO}-off.log 2>&1 &
 SPID=$!; sleep 1

--- a/benchmarks/real-world/run-concurrency-preloop-capture.sh
+++ b/benchmarks/real-world/run-concurrency-preloop-capture.sh
@@ -15,6 +15,10 @@ RUNNER_DIR="$OUT/runner"
 LOG_DIR="$OUT/_process-logs"
 mkdir -p "$OUT" "$STATE_DIR" "$RUNNER_DIR" "$LOG_DIR"
 
+if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
+  export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+fi
+
 cleanup() {
   if [[ -n "${RPID:-}" ]]; then kill "$RPID" 2>/dev/null || true; fi
   if [[ -n "${SPID:-}" ]]; then kill "$SPID" 2>/dev/null || true; fi
@@ -26,7 +30,7 @@ echo "OUT=$OUT"
 pkill -f "preloop-server.*${PORT}" 2>/dev/null || true
 sleep 1
 
-RUST_LOG=info PRELOOP_PUBLIC_URL="$SERVER_URL" \
+RUST_LOG=info PRELOOP_PUBLIC_URL="$SERVER_URL" PRELOOP_SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN" \
   "$SERVER_BIN" serve --listen "127.0.0.1:${PORT}" --state-dir "$STATE_DIR" \
   >"$LOG_DIR/server.log" 2>&1 &
 SPID=$!
@@ -34,7 +38,7 @@ for i in $(seq 1 50); do curl -sf "$SERVER_URL/healthz" >/dev/null && break; sle
 curl -sf "$SERVER_URL/healthz" >/dev/null
 
 (cd "$RUNNER_DIR" && "$RUNNER_BIN" configure \
-  --url "$SERVER_URL" --token preloop-system-token \
+  --url "$SERVER_URL" --token "$PRELOOP_SYSTEM_TOKEN" \
   --name conc-cmp --labels self-hosted,ubuntu-latest,macOS,ARM64 \
   --work _work) >"$LOG_DIR/configure.log" 2>&1
 
@@ -42,7 +46,7 @@ curl -sf "$SERVER_URL/healthz" >/dev/null
 RPID=$!
 sleep 2
 
-export SERVER_URL OUT STATE_DIR LOG_DIR
+export SERVER_URL OUT STATE_DIR LOG_DIR PRELOOP_SYSTEM_TOKEN
 python3 - <<'PY'
 import json, os, time, urllib.request, pathlib, re, subprocess, urllib.error
 from pathlib import Path
@@ -50,7 +54,7 @@ from pathlib import Path
 SERVER = os.environ["SERVER_URL"]
 OUT = Path(os.environ["OUT"])
 STATE = Path(os.environ["STATE_DIR"])
-AUTH = {"Authorization": "Bearer preloop-system-token", "Content-Type": "application/json"}
+AUTH = {"Authorization": f"Bearer {os.environ['PRELOOP_SYSTEM_TOKEN']}", "Content-Type": "application/json"}
 
 def api(method, path, body=None):
     data = None if body is None else json.dumps(body).encode()

--- a/benchmarks/real-world/run-matrix-comparison.py
+++ b/benchmarks/real-world/run-matrix-comparison.py
@@ -19,6 +19,7 @@ import subprocess
 import urllib.request
 import urllib.error
 from pathlib import Path
+import secrets
 from collections import defaultdict
 from dataclasses import dataclass, field
 
@@ -99,7 +100,7 @@ def wait_for_new_github_run(workflow_file: str, repo: str, known_ids: set[str], 
 def api_request(method: str, url: str, body: dict = None) -> dict:
     data = None if body is None else json.dumps(body).encode("utf-8")
     headers = {
-        "Authorization": "Bearer preloop-system-token",
+        "Authorization": f"Bearer {os.environ['PRELOOP_SYSTEM_TOKEN']}",
         "Content-Type": "application/json"
     }
     req = urllib.request.Request(url, data=data, headers=headers, method=method)
@@ -328,7 +329,7 @@ def start_runner(runner_type: str, server_url: str, runner_dir: Path, state_dir:
         subprocess.run([
             str(runner_bin), "configure",
             "--url", server_url,
-            "--token", "preloop-system-token",
+            "--token", os.environ["PRELOOP_SYSTEM_TOKEN"],
             "--name", f"preloop-{int(time.time())}",
             "--labels", "self-hosted,fidelity-test",
             "--work", "_work",
@@ -428,7 +429,7 @@ def execute_local_scenario(scenario: str, server_url: str, state_dir: Path, out_
         log_text = ""
         try:
             req = urllib.request.Request(f"{server_url}/api/v1/runs/{run_id}/logs")
-            req.add_header("Authorization", "Bearer preloop-system-token")
+            req.add_header("Authorization", f"Bearer {os.environ['PRELOOP_SYSTEM_TOKEN']}")
             with urllib.request.urlopen(req) as response:
                 log_text = response.read().decode("utf-8", "replace")
         except Exception as e:
@@ -610,6 +611,9 @@ def main() -> int:
     env_name = f"{args.runner}-{args.server}"
     out_path = args.out_dir / env_name
     out_path.mkdir(parents=True, exist_ok=True)
+
+    if args.server == "preloop" and not os.environ.get("PRELOOP_SYSTEM_TOKEN"):
+        os.environ["PRELOOP_SYSTEM_TOKEN"] = secrets.token_hex(32)
 
     server_proc = None
     runner_proc = None

--- a/benchmarks/v2336-all.sh
+++ b/benchmarks/v2336-all.sh
@@ -32,6 +32,10 @@ fi
 OUTDIR=/workspace/benchmarks/v2336-official-vs-preloop
 FLOWS=$OUTDIR/combined-flows.jsonl
 
+if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
+  export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+fi
+
 pkill -f "preloop-server.*:80" 2>/dev/null || true
 sleep 1
 
@@ -39,13 +43,13 @@ mkdir -p "$OUTDIR"
 chmod 777 "$OUTDIR"
 
 # Official runner strips non-default ports. Must listen on 80.
-PRELOOP_PUBLIC_URL=http://127.0.0.1 $SERVER serve --listen 127.0.0.1:80 --record-flows "$FLOWS" > /tmp/server.log 2>&1 &
+PRELOOP_PUBLIC_URL=http://127.0.0.1 PRELOOP_SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN" $SERVER serve --listen 127.0.0.1:80 --record-flows "$FLOWS" > /tmp/server.log 2>&1 &
 SERVER_PID=$!
 sleep 2
 
 curl -s http://127.0.0.1/ -o /dev/null -w "server: %{http_code}\n"
 
-su - ubuntu -c "
+su -m ubuntu -c "
 set -euo pipefail
 RUNNER_DIR=\$(mktemp -d)
 cp -r $RUNNER_SRC/* \"\$RUNNER_DIR/\"
@@ -65,8 +69,8 @@ run_wf() {
   ./run.sh --once > $OUTDIR/runner-\$num.log 2>&1
   
   mkdir -p $OUTDIR/preloop/\$num
-  curl -s -H 'Authorization: Bearer preloop-system-token' http://127.0.0.1/api/v1/runs/\$run_id > $OUTDIR/preloop/\$num/run-result.json
-  curl -s -H 'Authorization: Bearer preloop-system-token' http://127.0.0.1/api/v1/runs/\$run_id/logs > $OUTDIR/preloop/\$num/run-logs.txt
+  curl -s -H 'Authorization: Bearer '\${PRELOOP_SYSTEM_TOKEN} http://127.0.0.1/api/v1/runs/\$run_id > $OUTDIR/preloop/\$num/run-result.json
+  curl -s -H 'Authorization: Bearer '\${PRELOOP_SYSTEM_TOKEN} http://127.0.0.1/api/v1/runs/\$run_id/logs > $OUTDIR/preloop/\$num/run-logs.txt
 }
 
 run_wf 200 v2336-combined.yml

--- a/benchmarks/v2336-all.sh
+++ b/benchmarks/v2336-all.sh
@@ -32,9 +32,8 @@ fi
 OUTDIR=/workspace/benchmarks/v2336-official-vs-preloop
 FLOWS=$OUTDIR/combined-flows.jsonl
 
-if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
-  export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
-fi
+SYSTEM_TOKEN="${PRELOOP_SYSTEM_TOKEN:-$(python3 -c 'import secrets; print(secrets.token_hex(32))')}"
+TOKEN_QUOTED=$(printf '%q' "$SYSTEM_TOKEN")
 
 pkill -f "preloop-server.*:80" 2>/dev/null || true
 sleep 1
@@ -43,18 +42,18 @@ mkdir -p "$OUTDIR"
 chmod 777 "$OUTDIR"
 
 # Official runner strips non-default ports. Must listen on 80.
-PRELOOP_PUBLIC_URL=http://127.0.0.1 PRELOOP_SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN" $SERVER serve --listen 127.0.0.1:80 --record-flows "$FLOWS" > /tmp/server.log 2>&1 &
+PRELOOP_PUBLIC_URL=http://127.0.0.1 PRELOOP_SYSTEM_TOKEN="$SYSTEM_TOKEN" $SERVER serve --listen 127.0.0.1:80 --record-flows "$FLOWS" > /tmp/server.log 2>&1 &
 SERVER_PID=$!
 sleep 2
 
 curl -s http://127.0.0.1/ -o /dev/null -w "server: %{http_code}\n"
 
-su -m ubuntu -c "
+su - ubuntu -c "
 set -euo pipefail
 RUNNER_DIR=\$(mktemp -d)
 cp -r $RUNNER_SRC/* \"\$RUNNER_DIR/\"
 cd \"\$RUNNER_DIR\"
-./config.sh --url http://127.0.0.1 --token dummy-token --name v2336-test --work _work --unattended --replace 2>&1 | tail -3
+env -u PRELOOP_SYSTEM_TOKEN ./config.sh --url http://127.0.0.1 --token dummy-token --name v2336-test --work _work --unattended --replace 2>&1 | tail -3
 
 # Helper to run a workflow and save results
 run_wf() {
@@ -62,15 +61,15 @@ run_wf() {
   local yaml=\$2
   
   echo \"=== Running Workflow \$num: \$yaml ===\"
-  $CLIENT --server http://127.0.0.1 submit -W /workspace/crates/preloop-conformance/fixtures/\$yaml > /tmp/submit.json
+  PRELOOP_SYSTEM_TOKEN=$TOKEN_QUOTED $CLIENT --server http://127.0.0.1 submit -W /workspace/crates/preloop-conformance/fixtures/\$yaml > /tmp/submit.json
   local run_id=\$(python3 -c \"import json; print(json.load(open('/tmp/submit.json'))['run_id'])\")
   echo \"RUN_ID=\$run_id\"
   
-  ./run.sh --once > $OUTDIR/runner-\$num.log 2>&1
+  env -u PRELOOP_SYSTEM_TOKEN ./run.sh --once > $OUTDIR/runner-\$num.log 2>&1
   
   mkdir -p $OUTDIR/preloop/\$num
-  curl -s -H 'Authorization: Bearer '\${PRELOOP_SYSTEM_TOKEN} http://127.0.0.1/api/v1/runs/\$run_id > $OUTDIR/preloop/\$num/run-result.json
-  curl -s -H 'Authorization: Bearer '\${PRELOOP_SYSTEM_TOKEN} http://127.0.0.1/api/v1/runs/\$run_id/logs > $OUTDIR/preloop/\$num/run-logs.txt
+  curl -s -H 'Authorization: Bearer '$TOKEN_QUOTED http://127.0.0.1/api/v1/runs/\$run_id > $OUTDIR/preloop/\$num/run-result.json
+  curl -s -H 'Authorization: Bearer '$TOKEN_QUOTED http://127.0.0.1/api/v1/runs/\$run_id/logs > $OUTDIR/preloop/\$num/run-logs.txt
 }
 
 run_wf 200 v2336-combined.yml

--- a/benchmarks/v2336-runner.sh
+++ b/benchmarks/v2336-runner.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 CLIENT=/workspace/target/aarch64-unknown-linux-musl/release/preloop-runner-client
 RUNNER_SRC=/opt/runners/actions-runner
 OUTDIR=/workspace/benchmarks/v2336-official-vs-preloop
+SYSTEM_TOKEN="${PRELOOP_SYSTEM_TOKEN:?set PRELOOP_SYSTEM_TOKEN to the engine administrator token}"
+export PRELOOP_SYSTEM_TOKEN="$SYSTEM_TOKEN"
+
 
 RUNNER_DIR=$(mktemp -d)
 cp -r $RUNNER_SRC/* "$RUNNER_DIR/"
@@ -19,14 +22,14 @@ RPID=$!
 
 for i in $(seq 1 60); do
   sleep 2
-  STATUS=$(curl -s "http://127.0.0.1/api/v1/runs/$RUN_ID" | python3 -c "import json,sys; print(json.load(sys.stdin).get('status','unknown'))" 2>/dev/null || echo error)
+  STATUS=$(curl -s -H "Authorization: Bearer $SYSTEM_TOKEN" "http://127.0.0.1/api/v1/runs/$RUN_ID" | python3 -c "import json,sys; print(json.load(sys.stdin).get('status','unknown'))" 2>/dev/null || echo error)
   if [ "$STATUS" = completed ] || [ "$STATUS" = success ] || [ "$STATUS" = failed ]; then
     echo "Run: $STATUS"
     break
   fi
 done
 
-curl -s "http://127.0.0.1/api/v1/runs/$RUN_ID" > $OUTDIR/run-result.json
-curl -s "http://127.0.0.1/api/v1/runs/$RUN_ID/logs" > $OUTDIR/run-logs.txt
+curl -s -H "Authorization: Bearer $SYSTEM_TOKEN" "http://127.0.0.1/api/v1/runs/$RUN_ID" > $OUTDIR/run-result.json
+curl -s -H "Authorization: Bearer $SYSTEM_TOKEN" "http://127.0.0.1/api/v1/runs/$RUN_ID/logs" > $OUTDIR/run-logs.txt
 wait $RPID 2>/dev/null || true
 echo "DONE"

--- a/benchmarks/v2336-server.sh
+++ b/benchmarks/v2336-server.sh
@@ -6,5 +6,8 @@ FLOWS=$OUTDIR/combined-flows.jsonl
 pkill -f "preloop-server.*:80" 2>/dev/null || true
 sleep 1
 mkdir -p "$OUTDIR"
+SYSTEM_TOKEN="${PRELOOP_SYSTEM_TOKEN:?set PRELOOP_SYSTEM_TOKEN to the engine administrator token}"
+export PRELOOP_SYSTEM_TOKEN="$SYSTEM_TOKEN"
+
 chmod 777 "$OUTDIR"
-PRELOOP_PUBLIC_URL=http://127.0.0.1 exec $SERVER serve --listen 127.0.0.1:80 --record-flows "$FLOWS"
+PRELOOP_PUBLIC_URL=http://127.0.0.1 PRELOOP_SYSTEM_TOKEN="$SYSTEM_TOKEN" exec $SERVER serve --listen 127.0.0.1:80 --record-flows "$FLOWS"

--- a/benchmarks/v2336-test.sh
+++ b/benchmarks/v2336-test.sh
@@ -7,6 +7,10 @@ RUNNER_SRC=/opt/runners/actions-runner
 OUTDIR=/workspace/benchmarks/v2336-official-vs-preloop
 FLOWS=$OUTDIR/combined-flows.jsonl
 
+if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
+  export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+fi
+
 pkill -f "preloop-server.*:80" 2>/dev/null || true
 sleep 1
 
@@ -14,13 +18,13 @@ mkdir -p "$OUTDIR"
 chmod 777 "$OUTDIR"
 
 # Official runner strips non-default ports. Must listen on 80.
-PRELOOP_PUBLIC_URL=http://127.0.0.1 $SERVER serve --listen 127.0.0.1:80 --record-flows "$FLOWS" > /tmp/server.log 2>&1 &
+PRELOOP_PUBLIC_URL=http://127.0.0.1 PRELOOP_SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN" $SERVER serve --listen 127.0.0.1:80 --record-flows "$FLOWS" > /tmp/server.log 2>&1 &
 SERVER_PID=$!
 sleep 2
 
 curl -s http://127.0.0.1/ -o /dev/null -w "server: %{http_code}\n"
 
-su - ubuntu -c "
+su -m ubuntu -c "
 set -euo pipefail
 RUNNER_DIR=\$(mktemp -d)
 cp -r $RUNNER_SRC/* \"\$RUNNER_DIR/\"
@@ -37,15 +41,15 @@ RPID=\$!
 
 for i in \$(seq 1 60); do
   sleep 2
-  STATUS=\$(curl -s -H 'Authorization: Bearer preloop-system-token' http://127.0.0.1/api/v1/runs/\$RUN_ID | python3 -c \"import json,sys; print(json.load(sys.stdin).get('status','unknown'))\" 2>/dev/null || echo error)
+  STATUS=\$(curl -s -H 'Authorization: Bearer '\${PRELOOP_SYSTEM_TOKEN} http://127.0.0.1/api/v1/runs/\$RUN_ID | python3 -c \"import json,sys; print(json.load(sys.stdin).get('status','unknown'))\" 2>/dev/null || echo error)
   if [ \"\$STATUS\" = completed ] || [ \"\$STATUS\" = success ] || [ \"\$STATUS\" = failed ]; then
     echo \"Run: \$STATUS\"
     break
   fi
 done
 
-curl -s -H 'Authorization: Bearer preloop-system-token' http://127.0.0.1/api/v1/runs/\$RUN_ID > $OUTDIR/run-result.json
-curl -s -H 'Authorization: Bearer preloop-system-token' http://127.0.0.1/api/v1/runs/\$RUN_ID/logs > $OUTDIR/run-logs.txt
+curl -s -H 'Authorization: Bearer '\${PRELOOP_SYSTEM_TOKEN} http://127.0.0.1/api/v1/runs/\$RUN_ID > $OUTDIR/run-result.json
+curl -s -H 'Authorization: Bearer '\${PRELOOP_SYSTEM_TOKEN} http://127.0.0.1/api/v1/runs/\$RUN_ID/logs > $OUTDIR/run-logs.txt
 wait \$RPID 2>/dev/null || true
 echo 'Runner done'
 "

--- a/benchmarks/v2336-test.sh
+++ b/benchmarks/v2336-test.sh
@@ -7,9 +7,9 @@ RUNNER_SRC=/opt/runners/actions-runner
 OUTDIR=/workspace/benchmarks/v2336-official-vs-preloop
 FLOWS=$OUTDIR/combined-flows.jsonl
 
-if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
-  export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
-fi
+SYSTEM_TOKEN="${PRELOOP_SYSTEM_TOKEN:-$(python3 -c 'import secrets; print(secrets.token_hex(32))')}"
+TOKEN_QUOTED=$(printf '%q' "$SYSTEM_TOKEN")
+
 
 pkill -f "preloop-server.*:80" 2>/dev/null || true
 sleep 1
@@ -18,38 +18,38 @@ mkdir -p "$OUTDIR"
 chmod 777 "$OUTDIR"
 
 # Official runner strips non-default ports. Must listen on 80.
-PRELOOP_PUBLIC_URL=http://127.0.0.1 PRELOOP_SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN" $SERVER serve --listen 127.0.0.1:80 --record-flows "$FLOWS" > /tmp/server.log 2>&1 &
+PRELOOP_PUBLIC_URL=http://127.0.0.1 PRELOOP_SYSTEM_TOKEN="$SYSTEM_TOKEN" $SERVER serve --listen 127.0.0.1:80 --record-flows "$FLOWS" > /tmp/server.log 2>&1 &
 SERVER_PID=$!
 sleep 2
 
 curl -s http://127.0.0.1/ -o /dev/null -w "server: %{http_code}\n"
 
-su -m ubuntu -c "
+su - ubuntu -c "
 set -euo pipefail
 RUNNER_DIR=\$(mktemp -d)
 cp -r $RUNNER_SRC/* \"\$RUNNER_DIR/\"
 cd \"\$RUNNER_DIR\"
-./config.sh --url http://127.0.0.1 --token dummy-token --name v2336-test --work _work --unattended --replace 2>&1 | tail -3
+env -u PRELOOP_SYSTEM_TOKEN ./config.sh --url http://127.0.0.1 --token dummy-token --name v2336-test --work _work --unattended --replace 2>&1 | tail -3
 
-$CLIENT --server http://127.0.0.1 submit -W /workspace/crates/preloop-conformance/fixtures/v2336-combined.yml > /tmp/submit.json 2>&1
+PRELOOP_SYSTEM_TOKEN=$TOKEN_QUOTED $CLIENT --server http://127.0.0.1 submit -W /workspace/crates/preloop-conformance/fixtures/v2336-combined.yml > /tmp/submit.json 2>&1
 cat /tmp/submit.json
 RUN_ID=\$(python3 -c \"import json; print(json.load(open('/tmp/submit.json'))['run_id'])\")
 echo \"RUN_ID=\$RUN_ID\"
 
-./run.sh --once > $OUTDIR/official-runner.log 2>&1 &
+env -u PRELOOP_SYSTEM_TOKEN ./run.sh --once > $OUTDIR/official-runner.log 2>&1 &
 RPID=\$!
 
 for i in \$(seq 1 60); do
   sleep 2
-  STATUS=\$(curl -s -H 'Authorization: Bearer '\${PRELOOP_SYSTEM_TOKEN} http://127.0.0.1/api/v1/runs/\$RUN_ID | python3 -c \"import json,sys; print(json.load(sys.stdin).get('status','unknown'))\" 2>/dev/null || echo error)
+  STATUS=\$(curl -s -H 'Authorization: Bearer '$TOKEN_QUOTED http://127.0.0.1/api/v1/runs/\$RUN_ID | python3 -c \"import json,sys; print(json.load(sys.stdin).get('status','unknown'))\" 2>/dev/null || echo error)
   if [ \"\$STATUS\" = completed ] || [ \"\$STATUS\" = success ] || [ \"\$STATUS\" = failed ]; then
     echo \"Run: \$STATUS\"
     break
   fi
 done
 
-curl -s -H 'Authorization: Bearer '\${PRELOOP_SYSTEM_TOKEN} http://127.0.0.1/api/v1/runs/\$RUN_ID > $OUTDIR/run-result.json
-curl -s -H 'Authorization: Bearer '\${PRELOOP_SYSTEM_TOKEN} http://127.0.0.1/api/v1/runs/\$RUN_ID/logs > $OUTDIR/run-logs.txt
+curl -s -H 'Authorization: Bearer '$TOKEN_QUOTED http://127.0.0.1/api/v1/runs/\$RUN_ID > $OUTDIR/run-result.json
+curl -s -H 'Authorization: Bearer '$TOKEN_QUOTED http://127.0.0.1/api/v1/runs/\$RUN_ID/logs > $OUTDIR/run-logs.txt
 wait \$RPID 2>/dev/null || true
 echo 'Runner done'
 "

--- a/crates/preloop-cli/src/dap_client.rs
+++ b/crates/preloop-cli/src/dap_client.rs
@@ -16,7 +16,8 @@ pub struct DapArgs {
     #[arg(long)]
     pub url: Option<String>,
 
-    /// Native API token. Defaults to PRELOOP_TOKEN/PRELOOP_SYSTEM_TOKEN.
+    /// Native API token. Defaults to PRELOOP_TOKEN/PRELOOP_SYSTEM_TOKEN
+    /// or the managed engine credential.
     #[arg(long)]
     pub token: Option<String>,
 }

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -7,8 +7,8 @@ use futures_util::StreamExt;
 use preloop_gha_protocol::{ExecutionStatus, NdjsonEvent, RunAccepted, RunId, WorkflowSubmission};
 use preloop_orchestrator::environment::{is_stock_base_image, DEFAULT_BASE_IMAGE};
 use preloop_orchestrator::{artifact_payload, RunnerPool, RunnerPoolConfig};
+use preloop_runner_server::credential_store::{CredentialStore, OsCredentialStore};
 use preloop_vm::SmolVmProvider;
-use rand::RngCore;
 use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::io::Read;
@@ -357,10 +357,9 @@ pub(crate) fn api_token() -> Option<String> {
         .or_else(|_| std::env::var("PRELOOP_SYSTEM_TOKEN"))
         .ok()
         .or_else(|| {
-            std::fs::read_to_string(preloop_home().join("engine.token"))
+            preloop_runner_server::credential_store::load_engine_token(&preloop_home())
                 .ok()
-                .map(|token| token.trim().to_owned())
-                .filter(|token| !token.is_empty())
+                .flatten()
         })
 }
 
@@ -1099,26 +1098,18 @@ async fn ensure_engine_running() -> anyhow::Result<()> {
     eprintln!("[preloop] Starting local background engine...");
 
     let preloop_dir = preloop_home();
-
     let state_dir = preloop_dir.join("state");
     let pid_path = preloop_dir.join("preloop.pid");
-    let token_path = preloop_dir.join("engine.token");
 
     std::fs::create_dir_all(&state_dir)?;
     set_private_directory_permissions(&preloop_dir)?;
 
-    let token = if let Ok(existing) = std::fs::read_to_string(&token_path) {
-        existing.trim().to_owned()
-    } else {
-        let mut bytes = [0_u8; 32];
-        rand::thread_rng().fill_bytes(&mut bytes);
-        let token = bytes
-            .iter()
-            .map(|byte| format!("{byte:02x}"))
-            .collect::<String>();
-        write_private_file(&token_path, token.as_bytes())?;
-        token
-    };
+    let store = OsCredentialStore;
+    let token = prepare_engine_token(
+        &preloop_dir,
+        std::env::var("PRELOOP_SYSTEM_TOKEN").ok(),
+        &store,
+    )?;
 
     let engine_bin = std::env::current_exe().context("resolve preloop executable")?;
 
@@ -1212,32 +1203,11 @@ pub(crate) fn write_private_file(path: &std::path::Path, contents: &[u8]) -> any
 fn prepare_engine_token(
     home: &std::path::Path,
     configured: Option<String>,
+    store: &dyn CredentialStore,
 ) -> anyhow::Result<String> {
-    std::fs::create_dir_all(home)
-        .with_context(|| format!("create PRELOOP_HOME {}", home.display()))?;
-    set_private_directory_permissions(home)?;
-
-    let token_path = home.join("engine.token");
-    if let Some(token) = configured {
-        anyhow::ensure!(!token.trim().is_empty(), "PRELOOP_SYSTEM_TOKEN is empty");
-        write_private_file(&token_path, token.as_bytes())?;
-        return Ok(token);
-    }
-    if let Ok(existing) = std::fs::read_to_string(&token_path) {
-        let token = existing.trim().to_owned();
-        anyhow::ensure!(!token.is_empty(), "{} is empty", token_path.display());
-        set_private_file_permissions(&token_path)?;
-        return Ok(token);
-    }
-
-    let mut bytes = [0_u8; 32];
-    rand::thread_rng().fill_bytes(&mut bytes);
-    let token = bytes
-        .iter()
-        .map(|byte| format!("{byte:02x}"))
-        .collect::<String>();
-    write_private_file(&token_path, token.as_bytes())?;
-    Ok(token)
+    preloop_runner_server::credential_store::resolve_engine_token_with_store(
+        home, configured, store,
+    )
 }
 
 /// Move any inline GitHub credential in `config` into the OS credential
@@ -1469,8 +1439,10 @@ async fn cmd_engine(
     let state_dir = home.join("state");
     let socket = home.join("preloop.sock");
 
-    // Ensure PRELOOP_SYSTEM_TOKEN and engine.token stay synchronized.
-    let token = prepare_engine_token(&home, std::env::var("PRELOOP_SYSTEM_TOKEN").ok())?;
+    // Keep AppState's resolver on the same engine home as this CLI.
+    std::env::set_var("PRELOOP_HOME", &home);
+    let store = OsCredentialStore;
+    let token = prepare_engine_token(&home, std::env::var("PRELOOP_SYSTEM_TOKEN").ok(), &store)?;
     std::env::set_var("PRELOOP_SYSTEM_TOKEN", &token);
     let listen: std::net::SocketAddr = args
         .listen
@@ -4522,32 +4494,32 @@ mod tests {
     }
 
     #[test]
-    fn first_serve_token_creates_private_home_and_file() {
+    fn first_serve_token_creates_private_home_and_store_entry() {
         let root = tempfile::tempdir().unwrap();
         let home = root.path().join("missing").join(".preloop");
         assert!(!home.exists());
+        let store = preloop_runner_server::credential_store::MemoryCredentialStore::default();
 
-        let token = prepare_engine_token(&home, None).unwrap();
+        let token = prepare_engine_token(&home, None, &store).unwrap();
 
         assert_eq!(token.len(), 64);
+        let reference =
+            preloop_runner_server::credential_store::engine_token_reference(&home).unwrap();
         assert_eq!(
-            std::fs::read_to_string(home.join("engine.token")).unwrap(),
-            token
+            store
+                .get(&reference)
+                .unwrap()
+                .as_ref()
+                .map(|value| value.expose()),
+            Some(token.as_str())
         );
+        assert!(!home.join("engine.token").exists());
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt as _;
             assert_eq!(
                 std::fs::metadata(&home).unwrap().permissions().mode() & 0o777,
                 0o700
-            );
-            assert_eq!(
-                std::fs::metadata(home.join("engine.token"))
-                    .unwrap()
-                    .permissions()
-                    .mode()
-                    & 0o777,
-                0o600
             );
         }
     }

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -361,6 +361,20 @@ pub(crate) fn api_token() -> Option<String> {
                 .ok()
                 .flatten()
         })
+        .or_else(|| {
+            // Standalone `serve` without PRELOOP_HOME stores under its
+            // state dir (default `./.preloop` in the server's cwd), while
+            // preloop_home() prefers `$HOME/.preloop`. Try the cwd default
+            // so a CLI run from the same directory finds it.
+            let home = preloop_home();
+            let cwd_default = std::path::PathBuf::from(".preloop");
+            if home == cwd_default {
+                return None;
+            }
+            preloop_runner_server::credential_store::load_engine_token(&cwd_default)
+                .ok()
+                .flatten()
+        })
 }
 
 pub(crate) fn build_client() -> reqwest::Client {

--- a/crates/preloop-conformance/Cargo.toml
+++ b/crates/preloop-conformance/Cargo.toml
@@ -22,6 +22,7 @@ flate2.workspace = true
 tar.workspace = true
 serde_yaml.workspace = true
 
+uuid.workspace = true
 
 runner-watch = { path = "../runner-watch" }
 tempfile.workspace = true

--- a/crates/preloop-conformance/src/main.rs
+++ b/crates/preloop-conformance/src/main.rs
@@ -561,6 +561,7 @@ async fn run_runner_e2e(
     std::fs::create_dir_all(&state_dir)?;
     std::fs::create_dir_all(&runner_root)?;
 
+    let system_token = format!("preloop-conformance-{}", uuid::Uuid::new_v4());
     // Pre-seed any private action references locally before starting the server
     preseed_private_actions(&workflow, &state_dir)?;
 
@@ -568,6 +569,7 @@ async fn run_runner_e2e(
     let mut server_cmd = Command::new(server_bin);
     server_cmd
         .env("PRELOOP_PUBLIC_URL", &server_url)
+        .env("PRELOOP_SYSTEM_TOKEN", &system_token)
         // The goldens carry real GitHub-issued registration tokens this
         // control plane cannot verify; the harness is the one sanctioned
         // consumer of the permissive policy.
@@ -645,6 +647,7 @@ async fn run_runner_e2e(
 
     // Submit workflow
     let submit_output = Command::new(client_bin)
+        .env("PRELOOP_SYSTEM_TOKEN", &system_token)
         .args(["--server", &server_url, "submit", "-W"])
         .arg(&submit_workflow_path)
         .output()
@@ -665,8 +668,7 @@ async fn run_runner_e2e(
     // Loop runner until the run reaches a terminal status (handles multi-job workflows).
     let terminal = ["completed", "success", "failed", "cancelled"];
     let run_status_url = format!("{server_url}/api/v1/runs/{run_id}");
-    let native_api_token =
-        std::env::var("PRELOOP_SYSTEM_TOKEN").unwrap_or_else(|_| "preloop-system-token".to_owned());
+    let native_api_token = &system_token;
     let mut run_status = "unknown".to_string();
     let mut last_runner_status = None::<bool>;
     for _ in 0..50 {
@@ -681,7 +683,7 @@ async fn run_runner_e2e(
         // Poll run status
         if let Ok(resp) = client
             .get(&run_status_url)
-            .bearer_auth(&native_api_token)
+            .bearer_auth(native_api_token)
             .send()
             .await
         {

--- a/crates/preloop-runner-client/Cargo.toml
+++ b/crates/preloop-runner-client/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+preloop-runner-server = { path = "../preloop-runner-server" }
 preloop-gha-protocol = { path = "../preloop-gha-protocol" }
 preloop-gha-parser = { path = "../preloop-gha-parser" }
 reqwest.workspace = true

--- a/crates/preloop-runner-client/src/main.rs
+++ b/crates/preloop-runner-client/src/main.rs
@@ -13,6 +13,29 @@ use serde_json::Value;
 
 const MAX_REUSABLE_WORKFLOW_DEPTH: usize = 4;
 
+fn resolve_native_api_token(server: &Url) -> anyhow::Result<String> {
+    if let Ok(token) = env::var("PRELOOP_SYSTEM_TOKEN") {
+        return Ok(token);
+    }
+
+    let is_local_server = matches!(server.host_str(), Some("127.0.0.1" | "localhost" | "::1"));
+    if is_local_server {
+        let storage_dir = env::var_os("PRELOOP_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(".preloop"));
+        if let Some(token) =
+            preloop_runner_server::credential_store::load_engine_token(&storage_dir)
+                .context("load local engine token")?
+        {
+            return Ok(token);
+        }
+    }
+
+    anyhow::bail!(
+        "PRELOOP_SYSTEM_TOKEN must be set for runner-client (automatic discovery is limited to local servers)"
+    );
+}
+
 #[derive(Debug, Parser)]
 #[command(name = "preloop")]
 #[command(about = "Submit and manage local Preloop GitHub Actions runs")]
@@ -88,7 +111,6 @@ enum Command {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
-    let native_api_token = env::var("PRELOOP_SYSTEM_TOKEN").ok();
     let cli = Cli::parse();
     let timeout_seconds = env::var("PRELOOP_CLIENT_TIMEOUT_SECONDS")
         .ok()
@@ -114,9 +136,7 @@ async fn main() -> anyhow::Result<()> {
             debug,
             debugger_welcome_message,
         } => {
-            let native_api_token = native_api_token
-                .as_deref()
-                .context("PRELOOP_SYSTEM_TOKEN must be set for runner-client")?;
+            let native_api_token = resolve_native_api_token(&cli.server)?;
             let workflow_yaml = tokio::fs::read_to_string(&workflow)
                 .await
                 .with_context(|| format!("read workflow {}", workflow.display()))?;
@@ -183,9 +203,7 @@ async fn main() -> anyhow::Result<()> {
             println!("{response}");
         }
         Command::Run { run_id } => {
-            let native_api_token = native_api_token
-                .as_deref()
-                .context("PRELOOP_SYSTEM_TOKEN must be set for runner-client")?;
+            let native_api_token = resolve_native_api_token(&cli.server)?;
             print_response(
                 http.get(cli.server.join(&format!("/api/v1/runs/{run_id}"))?)
                     .bearer_auth(native_api_token)
@@ -195,9 +213,7 @@ async fn main() -> anyhow::Result<()> {
             .await?;
         }
         Command::Cancel { run_id } => {
-            let native_api_token = native_api_token
-                .as_deref()
-                .context("PRELOOP_SYSTEM_TOKEN must be set for runner-client")?;
+            let native_api_token = resolve_native_api_token(&cli.server)?;
             print_response(
                 http.post(cli.server.join(&format!("/api/v1/runs/{run_id}/cancel"))?)
                     .bearer_auth(native_api_token)
@@ -207,9 +223,7 @@ async fn main() -> anyhow::Result<()> {
             .await?;
         }
         Command::Rerun { run_id } => {
-            let native_api_token = native_api_token
-                .as_deref()
-                .context("PRELOOP_SYSTEM_TOKEN must be set for runner-client")?;
+            let native_api_token = resolve_native_api_token(&cli.server)?;
             print_response(
                 http.post(cli.server.join(&format!("/api/v1/runs/{run_id}/rerun"))?)
                     .bearer_auth(native_api_token)
@@ -219,9 +233,7 @@ async fn main() -> anyhow::Result<()> {
             .await?;
         }
         Command::Events { run_id } => {
-            let native_api_token = native_api_token
-                .as_deref()
-                .context("PRELOOP_SYSTEM_TOKEN must be set for runner-client")?;
+            let native_api_token = resolve_native_api_token(&cli.server)?;
             print_response(
                 http.get(
                     cli.server

--- a/crates/preloop-runner-client/src/main.rs
+++ b/crates/preloop-runner-client/src/main.rs
@@ -88,8 +88,7 @@ enum Command {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
-    let native_api_token =
-        env::var("PRELOOP_SYSTEM_TOKEN").unwrap_or_else(|_| "preloop-system-token".to_owned());
+    let native_api_token = env::var("PRELOOP_SYSTEM_TOKEN").ok();
     let cli = Cli::parse();
     let timeout_seconds = env::var("PRELOOP_CLIENT_TIMEOUT_SECONDS")
         .ok()
@@ -115,6 +114,9 @@ async fn main() -> anyhow::Result<()> {
             debug,
             debugger_welcome_message,
         } => {
+            let native_api_token = native_api_token
+                .as_deref()
+                .context("PRELOOP_SYSTEM_TOKEN must be set for runner-client")?;
             let workflow_yaml = tokio::fs::read_to_string(&workflow)
                 .await
                 .with_context(|| format!("read workflow {}", workflow.display()))?;
@@ -158,7 +160,7 @@ async fn main() -> anyhow::Result<()> {
             };
             let mut request = http
                 .post(cli.server.join("/api/v1/runs")?)
-                .bearer_auth(&native_api_token);
+                .bearer_auth(native_api_token);
             // Hand the workspace to the server so it can snapshot the local
             // tree and redirect default-source checkout steps to the snapshot
             // (mirrors `preloop run`). Without this, `actions/checkout` with no
@@ -181,39 +183,51 @@ async fn main() -> anyhow::Result<()> {
             println!("{response}");
         }
         Command::Run { run_id } => {
+            let native_api_token = native_api_token
+                .as_deref()
+                .context("PRELOOP_SYSTEM_TOKEN must be set for runner-client")?;
             print_response(
                 http.get(cli.server.join(&format!("/api/v1/runs/{run_id}"))?)
-                    .bearer_auth(&native_api_token)
+                    .bearer_auth(native_api_token)
                     .send()
                     .await?,
             )
             .await?;
         }
         Command::Cancel { run_id } => {
+            let native_api_token = native_api_token
+                .as_deref()
+                .context("PRELOOP_SYSTEM_TOKEN must be set for runner-client")?;
             print_response(
                 http.post(cli.server.join(&format!("/api/v1/runs/{run_id}/cancel"))?)
-                    .bearer_auth(&native_api_token)
+                    .bearer_auth(native_api_token)
                     .send()
                     .await?,
             )
             .await?;
         }
         Command::Rerun { run_id } => {
+            let native_api_token = native_api_token
+                .as_deref()
+                .context("PRELOOP_SYSTEM_TOKEN must be set for runner-client")?;
             print_response(
                 http.post(cli.server.join(&format!("/api/v1/runs/{run_id}/rerun"))?)
-                    .bearer_auth(&native_api_token)
+                    .bearer_auth(native_api_token)
                     .send()
                     .await?,
             )
             .await?;
         }
         Command::Events { run_id } => {
+            let native_api_token = native_api_token
+                .as_deref()
+                .context("PRELOOP_SYSTEM_TOKEN must be set for runner-client")?;
             print_response(
                 http.get(
                     cli.server
                         .join(&format!("/api/v1/runs/{run_id}/events.ndjson"))?,
                 )
-                .bearer_auth(&native_api_token)
+                .bearer_auth(native_api_token)
                 .send()
                 .await?,
             )

--- a/crates/preloop-runner-server/src/bootstrap.rs
+++ b/crates/preloop-runner-server/src/bootstrap.rs
@@ -1065,11 +1065,6 @@ pub async fn serve(config: ServerConfig) -> anyhow::Result<()> {
         );
         *state.status_snapshot.write() = init;
     }
-    if !config.listen.ip().is_loopback() && state.system_token == DEFAULT_PRELOOP_SYSTEM_TOKEN {
-        anyhow::bail!(
-            "PRELOOP_SYSTEM_TOKEN must be explicitly configured when listening beyond loopback"
-        );
-    }
     let oidc_issuer = normalize_oidc_issuer(
         config
             .oidc_issuer

--- a/crates/preloop-runner-server/src/credential_store.rs
+++ b/crates/preloop-runner-server/src/credential_store.rs
@@ -1,8 +1,16 @@
 use anyhow::{Context, Result};
 pub use preloop_gha_protocol::SecretString;
+use rand::RngCore;
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::fmt;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+
+/// The private-file fallback for the per-engine administrator token.
+pub const ENGINE_TOKEN_FILE: &str = "engine.token";
+
+const ENGINE_TOKEN_REFERENCE_PREFIX: &str = "engine-token-";
 
 /// A validated, non-secret identifier for one stored credential.
 ///
@@ -178,6 +186,329 @@ impl CredentialStore for OsCredentialStore {
         }
     }
 }
+/// Resolve the storage directory used for the engine administrator token.
+///
+/// Managed engines set `PRELOOP_HOME` and use that engine home as the token
+/// storage scope; standalone servers use their state directory directly.
+pub fn engine_token_dir(state_dir: &Path) -> PathBuf {
+    std::env::var_os("PRELOOP_HOME")
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| state_dir.to_path_buf())
+}
+
+/// Build the OS-store reference for one engine instance.
+///
+/// The reference is scoped by the resolved storage path so two engine homes
+/// owned by one OS user do not share an administrator credential.
+pub fn engine_token_reference(storage_dir: &Path) -> Result<CredentialRef> {
+    let path = if storage_dir.is_absolute() {
+        storage_dir.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .context("resolve relative engine-token storage directory")?
+            .join(storage_dir)
+    };
+    let path = std::fs::canonicalize(&path).unwrap_or(path);
+    let digest = Sha256::digest(path.to_string_lossy().as_bytes());
+    CredentialRef::new(format!("{ENGINE_TOKEN_REFERENCE_PREFIX}{digest:x}"))
+}
+
+/// Load an existing engine token without creating or changing credentials.
+///
+/// The OS credential store is authoritative when available. A private
+/// `engine.token` file remains the fallback for headless/service environments.
+pub fn load_engine_token(storage_dir: &Path) -> Result<Option<String>> {
+    load_engine_token_with_store(storage_dir, &OsCredentialStore)
+}
+
+/// Resolve the engine token, generating and persisting one when absent.
+///
+/// An explicitly supplied token is validated and returned without copying it
+/// into another backend; externally managed secrets should not be duplicated.
+/// Generated or migrated tokens use the OS credential store when available and
+/// fall back to a private `engine.token` file when it is not.
+pub fn resolve_engine_token(storage_dir: &Path, configured: Option<String>) -> Result<String> {
+    resolve_engine_token_with_store(storage_dir, configured, &OsCredentialStore)
+}
+
+/// Resolve an engine token against a supplied backend.
+///
+/// This is public so embedders can provide a backend appropriate to their
+/// lifecycle, while tests can use [`MemoryCredentialStore`] without touching a
+/// user's keychain.
+pub fn resolve_engine_token_with_store(
+    storage_dir: &Path,
+    configured: Option<String>,
+    store: &dyn CredentialStore,
+) -> Result<String> {
+    std::fs::create_dir_all(storage_dir)
+        .with_context(|| format!("create engine-token directory {}", storage_dir.display()))?;
+    set_private_directory_permissions(storage_dir)?;
+
+    if let Some(configured) = configured {
+        return validate_engine_token(&configured, "PRELOOP_SYSTEM_TOKEN");
+    }
+
+    let reference = engine_token_reference(storage_dir)?;
+    let mut store_available = match store.available() {
+        Ok(()) => true,
+        Err(error) => {
+            tracing::warn!(
+                store = store.name(),
+                %error,
+                "engine token OS credential store unavailable; using private file fallback"
+            );
+            false
+        }
+    };
+
+    let token_path = storage_dir.join(ENGINE_TOKEN_FILE);
+    if store_available {
+        match store.get(&reference) {
+            Ok(Some(secret)) => {
+                let token = validate_engine_token(secret.expose(), store.name())?;
+                remove_engine_token_file(&token_path)?;
+                return Ok(token);
+            }
+            Ok(None) => {}
+            Err(error) => {
+                tracing::warn!(
+                    store = store.name(),
+                    %error,
+                    "failed to read engine token from OS credential store; \
+                     using private file fallback"
+                );
+                store_available = false;
+            }
+        }
+    }
+
+    if let Some(token) = read_engine_token_file(&token_path)? {
+        if store_available {
+            match store.set(&reference, &SecretString::new(&token)) {
+                Ok(()) => match store.get(&reference) {
+                    Ok(Some(stored)) => {
+                        match validate_engine_token(stored.expose(), store.name()) {
+                            Ok(stored) if stored == token => {
+                                remove_engine_token_file(&token_path)?;
+                            }
+                            Ok(stored) => {
+                                tracing::warn!(
+                                    store = store.name(),
+                                    "OS credential store changed the migrated engine token; \
+                                 using the stored value"
+                                );
+                                remove_engine_token_file(&token_path)?;
+                                return Ok(stored);
+                            }
+                            Err(error) => tracing::warn!(
+                                store = store.name(),
+                                %error,
+                                "OS credential store returned an invalid migrated engine token; \
+                                 retaining private file fallback"
+                            ),
+                        }
+                    }
+                    Ok(None) => tracing::warn!(
+                        store = store.name(),
+                        "OS credential store did not return the migrated engine token; \
+                         retaining private file fallback"
+                    ),
+                    Err(error) => tracing::warn!(
+                        store = store.name(),
+                        %error,
+                        "OS credential store could not read back the migrated engine token; \
+                         retaining private file fallback"
+                    ),
+                },
+                Err(error) => tracing::warn!(
+                    store = store.name(),
+                    %error,
+                    "failed to migrate engine token into OS credential store; \
+                     retaining private file fallback"
+                ),
+            }
+        }
+        return Ok(token);
+    }
+
+    let mut bytes = [0_u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    let token = bytes
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    if store_available {
+        match store.set(&reference, &SecretString::new(&token)) {
+            Ok(()) => match store.get(&reference) {
+                Ok(Some(stored)) => match validate_engine_token(stored.expose(), store.name()) {
+                    Ok(stored) if stored == token => return Ok(token),
+                    Ok(stored) => {
+                        tracing::warn!(
+                            store = store.name(),
+                            "OS credential store changed the generated engine token; \
+                             using the stored value"
+                        );
+                        return Ok(stored);
+                    }
+                    Err(error) => tracing::warn!(
+                        store = store.name(),
+                        %error,
+                        "OS credential store returned an invalid generated engine token; \
+                         using private file fallback"
+                    ),
+                },
+                Ok(None) => tracing::warn!(
+                    store = store.name(),
+                    "OS credential store did not return the generated engine token; \
+                     using private file fallback"
+                ),
+                Err(error) => tracing::warn!(
+                    store = store.name(),
+                    %error,
+                    "OS credential store could not read back the generated engine token; \
+                     using private file fallback"
+                ),
+            },
+            Err(error) => {
+                tracing::warn!(
+                    store = store.name(),
+                    %error,
+                    "failed to persist generated engine token in OS credential store; \
+                     using private file fallback"
+                );
+            }
+        }
+    }
+    write_engine_token_file(&token_path, &token)?;
+    Ok(token)
+}
+
+fn load_engine_token_with_store(
+    storage_dir: &Path,
+    store: &dyn CredentialStore,
+) -> Result<Option<String>> {
+    let reference = engine_token_reference(storage_dir)?;
+    let store_available = match store.available() {
+        Ok(()) => true,
+        Err(error) => {
+            tracing::debug!(
+                store = store.name(),
+                %error,
+                "engine token OS credential store unavailable while loading"
+            );
+            false
+        }
+    };
+    let token_path = storage_dir.join(ENGINE_TOKEN_FILE);
+
+    if store_available {
+        match store.get(&reference) {
+            Ok(Some(secret)) => {
+                return validate_engine_token(secret.expose(), store.name()).map(Some);
+            }
+            Ok(None) => {}
+            Err(error) => {
+                tracing::debug!(
+                    store = store.name(),
+                    %error,
+                    "failed to read engine token from OS credential store; trying private file fallback"
+                );
+            }
+        }
+    }
+    read_engine_token_file(&token_path)
+}
+
+fn validate_engine_token(value: &str, source: &str) -> Result<String> {
+    let token = value.trim();
+    anyhow::ensure!(!token.is_empty(), "{source} is empty");
+    Ok(token.to_owned())
+}
+
+fn read_engine_token_file(path: &Path) -> Result<Option<String>> {
+    match std::fs::read_to_string(path) {
+        Ok(value) => {
+            set_private_file_permissions(path)?;
+            validate_engine_token(&value, &path.display().to_string()).map(Some)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error).with_context(|| format!("read {}", path.display())),
+    }
+}
+
+fn write_engine_token_file(path: &Path, token: &str) -> Result<()> {
+    use std::io::Write as _;
+
+    let parent = path
+        .parent()
+        .context("engine token file has no parent directory")?;
+    let temporary = parent.join(format!(
+        ".{ENGINE_TOKEN_FILE}.{:016x}.tmp",
+        rand::random::<u64>()
+    ));
+    let write_result = (|| -> Result<()> {
+        let mut options = std::fs::OpenOptions::new();
+        options.create_new(true).write(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            options.mode(0o600);
+        }
+        let mut file = options
+            .open(&temporary)
+            .with_context(|| format!("create {}", temporary.display()))?;
+        set_private_file_permissions(&temporary)?;
+        file.write_all(token.as_bytes())
+            .with_context(|| format!("write {}", temporary.display()))?;
+        file.sync_all()
+            .with_context(|| format!("sync {}", temporary.display()))?;
+        #[cfg(windows)]
+        if path.exists() {
+            std::fs::remove_file(path).with_context(|| format!("replace {}", path.display()))?;
+        }
+        std::fs::rename(&temporary, path).with_context(|| format!("replace {}", path.display()))?;
+        set_private_file_permissions(path)?;
+        Ok(())
+    })();
+    if write_result.is_err() {
+        let _ = std::fs::remove_file(&temporary);
+    }
+    write_result
+}
+
+fn remove_engine_token_file(path: &Path) -> Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error).with_context(|| format!("remove {}", path.display())),
+    }
+}
+
+#[cfg(unix)]
+fn set_private_directory_permissions(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+        .with_context(|| format!("protect {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_private_directory_permissions(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_private_file_permissions(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("protect {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_private_file_permissions(_path: &Path) -> Result<()> {
+    Ok(())
+}
 
 /// In-memory backend for deterministic tests and embedders.
 #[derive(Clone, Default)]
@@ -244,6 +575,54 @@ impl CredentialStore for UnavailableCredentialStore {
 
     fn available(&self) -> Result<()> {
         anyhow::bail!("credential store unavailable")
+    }
+}
+
+/// A backend that reports successful writes without persisting them.
+#[cfg(test)]
+#[derive(Clone, Copy, Default)]
+struct NonPersistingCredentialStore;
+
+#[cfg(test)]
+impl CredentialStore for NonPersistingCredentialStore {
+    fn get(&self, _reference: &CredentialRef) -> Result<Option<SecretString>> {
+        Ok(None)
+    }
+
+    fn set(&self, _reference: &CredentialRef, _value: &SecretString) -> Result<()> {
+        Ok(())
+    }
+
+    fn delete(&self, _reference: &CredentialRef) -> Result<()> {
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "non-persisting credential store"
+    }
+}
+
+/// A backend that accepts writes but cannot read them back.
+#[cfg(test)]
+#[derive(Clone, Copy, Default)]
+struct WriteOnlyCredentialStore;
+
+#[cfg(test)]
+impl CredentialStore for WriteOnlyCredentialStore {
+    fn get(&self, _reference: &CredentialRef) -> Result<Option<SecretString>> {
+        anyhow::bail!("credential store readback unavailable")
+    }
+
+    fn set(&self, _reference: &CredentialRef, _value: &SecretString) -> Result<()> {
+        Ok(())
+    }
+
+    fn delete(&self, _reference: &CredentialRef) -> Result<()> {
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "write-only credential store"
     }
 }
 
@@ -316,5 +695,135 @@ mod tests {
                 .as_str(),
             "github-ghe.example.com-app-pem-12345"
         );
+    }
+    #[test]
+    fn engine_token_references_are_stable_and_scoped() {
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        let first_ref = engine_token_reference(first.path()).unwrap();
+        let first_again = engine_token_reference(first.path()).unwrap();
+        let second_ref = engine_token_reference(second.path()).unwrap();
+
+        assert_eq!(first_ref, first_again);
+        assert_ne!(first_ref, second_ref);
+        assert!(first_ref.as_str().starts_with("engine-token-"));
+    }
+
+    #[test]
+    fn engine_token_uses_store_and_reuses_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = MemoryCredentialStore::default();
+        let first = resolve_engine_token_with_store(dir.path(), None, &store).unwrap();
+        let second = resolve_engine_token_with_store(dir.path(), None, &store).unwrap();
+        let reference = engine_token_reference(dir.path()).unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 64);
+        assert!(first.bytes().all(|byte| byte.is_ascii_hexdigit()));
+        assert_eq!(
+            store
+                .get(&reference)
+                .unwrap()
+                .as_ref()
+                .map(|value| value.expose()),
+            Some(first.as_str())
+        );
+        assert!(!dir.path().join(ENGINE_TOKEN_FILE).exists());
+    }
+    #[test]
+    fn engine_token_falls_back_when_store_readback_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = WriteOnlyCredentialStore;
+        let token = resolve_engine_token_with_store(dir.path(), None, &store).unwrap();
+        let token_path = dir.path().join(ENGINE_TOKEN_FILE);
+
+        assert_eq!(std::fs::read_to_string(&token_path).unwrap(), token);
+        assert_eq!(
+            load_engine_token_with_store(dir.path(), &store).unwrap(),
+            Some(token)
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            assert_eq!(
+                std::fs::metadata(token_path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[test]
+    fn engine_token_migration_keeps_file_without_verified_store_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let token_path = dir.path().join(ENGINE_TOKEN_FILE);
+        write_engine_token_file(&token_path, "existing-token").unwrap();
+        let store = NonPersistingCredentialStore;
+
+        let token = resolve_engine_token_with_store(dir.path(), None, &store).unwrap();
+
+        assert_eq!(token, "existing-token");
+        assert_eq!(
+            std::fs::read_to_string(&token_path).unwrap(),
+            "existing-token"
+        );
+    }
+
+    #[test]
+    fn engine_token_falls_back_to_private_file_and_migrates() {
+        let dir = tempfile::tempdir().unwrap();
+        let unavailable = UnavailableCredentialStore;
+        let first = resolve_engine_token_with_store(dir.path(), None, &unavailable).unwrap();
+        let token_path = dir.path().join(ENGINE_TOKEN_FILE);
+        assert_eq!(std::fs::read_to_string(&token_path).unwrap(), first);
+        assert_eq!(
+            load_engine_token_with_store(dir.path(), &unavailable).unwrap(),
+            Some(first.clone())
+        );
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            assert_eq!(
+                std::fs::metadata(&token_path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+
+        let store = MemoryCredentialStore::default();
+        let migrated = resolve_engine_token_with_store(dir.path(), None, &store).unwrap();
+        let reference = engine_token_reference(dir.path()).unwrap();
+        assert_eq!(migrated, first);
+        assert!(!token_path.exists());
+        assert_eq!(
+            store
+                .get(&reference)
+                .unwrap()
+                .as_ref()
+                .map(|value| value.expose()),
+            Some(first.as_str())
+        );
+        assert_eq!(
+            load_engine_token_with_store(dir.path(), &store).unwrap(),
+            Some(first)
+        );
+    }
+
+    #[test]
+    fn explicit_engine_token_is_validated_without_copying() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = MemoryCredentialStore::default();
+        let token = resolve_engine_token_with_store(
+            dir.path(),
+            Some("  configured-token  ".into()),
+            &store,
+        )
+        .unwrap();
+
+        assert_eq!(token, "configured-token");
+        assert!(store
+            .get(&engine_token_reference(dir.path()).unwrap())
+            .unwrap()
+            .is_none());
+        assert!(!dir.path().join(ENGINE_TOKEN_FILE).exists());
     }
 }

--- a/crates/preloop-runner-server/src/credential_store.rs
+++ b/crates/preloop-runner-server/src/credential_store.rs
@@ -242,13 +242,16 @@ pub fn resolve_engine_token_with_store(
     configured: Option<String>,
     store: &dyn CredentialStore,
 ) -> Result<String> {
-    std::fs::create_dir_all(storage_dir)
-        .with_context(|| format!("create engine-token directory {}", storage_dir.display()))?;
-    set_private_directory_permissions(storage_dir)?;
-
+    // An explicitly configured token needs no storage: return it before
+    // touching the filesystem so a directory error cannot abort startup
+    // when there is nothing to persist.
     if let Some(configured) = configured {
         return validate_engine_token(&configured, "PRELOOP_SYSTEM_TOKEN");
     }
+
+    std::fs::create_dir_all(storage_dir)
+        .with_context(|| format!("create engine-token directory {}", storage_dir.display()))?;
+    set_private_directory_permissions(storage_dir)?;
 
     let reference = engine_token_reference(storage_dir)?;
     let mut store_available = match store.available() {
@@ -707,6 +710,23 @@ mod tests {
         assert_eq!(first_ref, first_again);
         assert_ne!(first_ref, second_ref);
         assert!(first_ref.as_str().starts_with("engine-token-"));
+    }
+
+    #[test]
+    fn configured_token_returns_without_touching_storage() {
+        let store = MemoryCredentialStore::default();
+        // Point at a directory that does not exist: an explicitly configured
+        // token must be validated and returned without creating anything.
+        let missing = tempfile::tempdir().unwrap().path().join("does-not-exist");
+        assert!(!missing.exists());
+        let token = resolve_engine_token_with_store(
+            &missing,
+            Some("  explicit-token  ".to_owned()),
+            &store,
+        )
+        .unwrap();
+        assert_eq!(token, "explicit-token");
+        assert!(!missing.exists());
     }
 
     #[test]

--- a/crates/preloop-runner-server/src/lib.rs
+++ b/crates/preloop-runner-server/src/lib.rs
@@ -137,7 +137,8 @@ use tokio::sync::{broadcast, Mutex, Notify};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
-/// Default local token used when `PRELOOP_SYSTEM_TOKEN` is not configured.
+#[cfg(test)]
+/// Deterministic administrator token used only by in-process tests.
 const DEFAULT_PRELOOP_SYSTEM_TOKEN: &str = "preloop-system-token";
 #[cfg(test)]
 const TEST_LOCAL_JWT_KEY: &[u8] = b"preloop-test-local-jwt-signing-key";

--- a/crates/preloop-runner-server/src/openapi.rs
+++ b/crates/preloop-runner-server/src/openapi.rs
@@ -208,7 +208,8 @@ impl Modify for SecuritySchemes {
                 Http::builder()
                     .scheme(HttpAuthScheme::Bearer)
                     .description(Some(
-                        "System token (`PRELOOP_SYSTEM_TOKEN` or default `preloop-system-token`). \
+                        "System token (`PRELOOP_SYSTEM_TOKEN`, or a per-engine token generated \
+                         and stored in the OS credential store or private engine.token file). \
                          Used by CLI clients, agents, and operators.",
                     ))
                     .build(),

--- a/crates/preloop-runner-server/src/state.rs
+++ b/crates/preloop-runner-server/src/state.rs
@@ -732,8 +732,22 @@ impl AppState {
         let (keypair_result, oidc_result) = tokio::join!(keypair_handle, oidc_handle);
         let keypair = keypair_result??;
         let oidc_keypair = oidc_result??;
-        let system_token = env::var("PRELOOP_SYSTEM_TOKEN")
-            .unwrap_or_else(|_| DEFAULT_PRELOOP_SYSTEM_TOKEN.to_owned());
+        let token_dir = crate::credential_store::engine_token_dir(&state_dir);
+        let configured_token = env::var("PRELOOP_SYSTEM_TOKEN").ok();
+        #[cfg(test)]
+        let system_token = {
+            let configured_token =
+                configured_token.or_else(|| Some(DEFAULT_PRELOOP_SYSTEM_TOKEN.to_owned()));
+            let store = crate::credential_store::MemoryCredentialStore::default();
+            crate::credential_store::resolve_engine_token_with_store(
+                &token_dir,
+                configured_token,
+                &store,
+            )?
+        };
+        #[cfg(not(test))]
+        let system_token =
+            crate::credential_store::resolve_engine_token(&token_dir, configured_token)?;
         #[cfg(test)]
         let local_jwt_key = TEST_LOCAL_JWT_KEY.to_vec();
         #[cfg(not(test))]

--- a/crates/runner-watch/src/main.rs
+++ b/crates/runner-watch/src/main.rs
@@ -2025,8 +2025,8 @@ async fn replay_flows_to_preloop(
         .parent()
         .unwrap_or(out_dir)
         .join("official-filtered");
-    let native_token =
-        std::env::var("PRELOOP_SYSTEM_TOKEN").unwrap_or_else(|_| "preloop-system-token".to_owned());
+    let native_token = std::env::var("PRELOOP_SYSTEM_TOKEN")
+        .context("PRELOOP_SYSTEM_TOKEN must be set for runner-watch replay")?;
     // Runs are submitted by materialize before the replay starts; they must
     // be cancelled on EVERY exit from here on — including a materialization
     // or replay error — or the next scenario's acquire picks up this
@@ -2759,8 +2759,8 @@ async fn materialize_replay_state(
         return Ok(());
     }
 
-    let native_api_token =
-        std::env::var("PRELOOP_SYSTEM_TOKEN").unwrap_or_else(|_| "preloop-system-token".to_owned());
+    let native_api_token = std::env::var("PRELOOP_SYSTEM_TOKEN")
+        .context("PRELOOP_SYSTEM_TOKEN must be set for runner-watch replay")?;
     let submissions = replay_workflow_submissions(golden_dir, scenario_root)?;
     // Idle scenarios have no submit_workflow steps — skip job creation.
     // The replay will use the golden capture's message responses directly.
@@ -4180,6 +4180,7 @@ mod tests {
     /// swallowed (`let _ =`), so queued runs cannot silently survive.
     #[tokio::test]
     async fn replay_surfaces_failed_cancellation_instead_of_silently_succeeding() {
+        std::env::set_var("PRELOOP_SYSTEM_TOKEN", "runner-watch-test-token");
         let temp = TestTemp::new("cancel-failure");
         let (golden, out, scenario_root) = replay_scenario_fixture(&temp, false);
         let cancels = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
@@ -4212,6 +4213,7 @@ mod tests {
     /// submissions: leftover queued runs contaminate the next scenario.
     #[tokio::test]
     async fn replay_cancels_runs_even_when_the_replay_errors() {
+        std::env::set_var("PRELOOP_SYSTEM_TOKEN", "runner-watch-test-token");
         let temp = TestTemp::new("cancel-on-error");
         let (golden, out, scenario_root) = replay_scenario_fixture(&temp, true);
         let cancels = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));

--- a/docs/cli_reference.md
+++ b/docs/cli_reference.md
@@ -339,6 +339,16 @@ steps.
 | `PRELOOP_GITHUB_API_URL` | Override the GitHub API base (tests, GHES) |
 | `PRELOOP_WEBHOOK_SECRET` | Webhook signature secret (the server's only source of truth for repo hooks) |
 
+### Engine token storage
+
+The native API administrator token is generated on first engine startup when
+`PRELOOP_SYSTEM_TOKEN` is not set. Preloop stores it in the operating system's
+credential store, scoped to the engine home. On hosts without an available or
+readable OS credential service, it uses `$PRELOOP_HOME/engine.token` with private
+permissions instead. Managed CLI commands read this token automatically; do
+not commit or print the file. Set `PRELOOP_SYSTEM_TOKEN` explicitly for a
+separate client or service.
+
 ## Quick examples
 
 ```sh

--- a/docs/demo/dap/README.md
+++ b/docs/demo/dap/README.md
@@ -47,12 +47,16 @@ the debugger), built binaries, `asciinema`, and `omp`.
 cargo build --release -p preloop-runner-server -p preloop-runner
 
 # 1. engine (permissive registration for the demo runner)
+# Set this same variable in every client terminal; do not print it.
+export PRELOOP_SYSTEM_TOKEN="${PRELOOP_SYSTEM_TOKEN:-$(python3 -c 'import secrets; print(secrets.token_hex(32))')}"
 PRELOOP_REGISTRATION_POLICY=permissive \
 PRELOOP_PUBLIC_URL=http://127.0.0.1:9191 \
 PRELOOP_CONFIG=/tmp/dapdemo/server-config.toml \
 target/release/preloop-server serve --listen 127.0.0.1:9191 \
   --state-dir /tmp/dapdemo/server-state --enable-test-api --test-api-token dev-token
+```
 
+```sh
 # 2. runner (30 min window to attach the debugger)
 mkdir -p /tmp/dapdemo/runner && cd /tmp/dapdemo/runner
 ACTIONS_RUNNER_DAP_CONNECTION_TIMEOUT=30 \
@@ -67,9 +71,10 @@ asciinema rec demo-again.cast --command \
   "omp --auto-approve --cwd . @agent-prompt.md"
 ```
 
-`agent-prompt.md` assumes the engine URL and token from the commands above;
-edit it if your port or token differ. The native API token defaults to
-`preloop-system-token` (env `PRELOOP_SYSTEM_TOKEN`).
+Run the client commands above in the shell that exported
+`PRELOOP_SYSTEM_TOKEN`, or export the same value in each client terminal.
+`agent-prompt.md` consumes the variable directly; it does not contain a
+credential.
 
 ## Files
 

--- a/docs/demo/dap/agent-prompt.md
+++ b/docs/demo/dap/agent-prompt.md
@@ -4,7 +4,7 @@ fix it, and re-run until the workflow is green.
 
 ## Environment
 
-- Preloop engine: http://127.0.0.1:9191  (native API token: preloop-system-token)
+- Preloop engine: http://127.0.0.1:9191  (native API token: `$PRELOOP_SYSTEM_TOKEN`)
 - Working directory: /tmp/dapdemo (all demo files are here)
 - The workflow under test: /tmp/dapdemo/demo.yml
 - Payload files: /tmp/dapdemo/payload-release.json, /tmp/dapdemo/payload-prod.json
@@ -17,13 +17,13 @@ fix it, and re-run until the workflow is green.
   within a reasonable time after submitting.
 - `dapctl` — DAP debug client for preloop:
   - Start the session daemon (background it, one per run):
-    `nohup dapctl daemon --url ws://127.0.0.1:9191/api/v1/runs/<RUN_ID>/debug --token preloop-system-token >/tmp/dapd.log 2>&1 &`
+    `nohup dapctl daemon --url ws://127.0.0.1:9191/api/v1/runs/<RUN_ID>/debug --token "$PRELOOP_SYSTEM_TOKEN" >/tmp/dapd.log 2>&1 &`
   - Then drive it: `dapctl init` (handshake), `dapctl ready`
     (configurationDone; the job starts), `dapctl wait 20` (next DAP event:
     `stopped` at job entry), `dapctl source`, `dapctl scopes`,
     `dapctl vars <ref>`, `dapctl eval <expr>`, `dapctl continue`
     (resume the job), `dapctl quit`.
-- REST API: `curl -H "Authorization: Bearer preloop-system-token" ...`
+- REST API: `curl -H "Authorization: Bearer $PRELOOP_SYSTEM_TOKEN" ...`
   - Run status/conclusion: GET http://127.0.0.1:9191/api/v1/runs/<RUN_ID>
   - Full log: GET http://127.0.0.1:9191/api/v1/runs/<RUN_ID>/logs
 

--- a/docs/demo/dap/submit.sh
+++ b/docs/demo/dap/submit.sh
@@ -3,7 +3,7 @@
 # Usage: submit.sh [workflow.yml] [event] [payload.json]
 set -euo pipefail
 URL="${PRELOOP_URL:-http://127.0.0.1:9191}"
-TOKEN="${PRELOOP_TOKEN:-preloop-system-token}"
+TOKEN="${PRELOOP_TOKEN:-${PRELOOP_SYSTEM_TOKEN:?set PRELOOP_TOKEN or PRELOOP_SYSTEM_TOKEN}}"
 WF="${1:-/tmp/dapdemo/demo.yml}"
 EVENT="${2:-workflow_dispatch}"
 PAYLOAD="${3:-}"

--- a/docs/github-app-api-compat.md
+++ b/docs/github-app-api-compat.md
@@ -79,7 +79,7 @@ protected router. Auth is **mandatory** (github.com returns 401 without a token)
 accidentally denied — see M2.
 
 ### D2. Token validation chain (in order)
-1. **System bearer** (`preloop-system-token` style, existing native auth) — trusted operator; tier AdminManual.
+1. **System bearer** (the per-engine token from `PRELOOP_SYSTEM_TOKEN` or its secure store) — trusted operator; tier AdminManual.
 2. **PAT** (`PRELOOP_GITHUB_TOKEN`) — constant-time compare; tier AdminManual.
 3. **Own-App JWT** (RS256, `iss` = one of the registered App ids) — verify with that App's PEM; offline-safe; tier AdminManual.
 4. **Installation tokens** (any App, including third-party):

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -107,15 +107,17 @@ All configuration is environment variables; CLI flags override them.
 | `PRELOOP_HOME` | `$HOME/.preloop` | State directory (database, blobs, cache, credentials) |
 | `PRELOOP_STORE_URL` | SQLite in the state dir | `sqlite://<path>`, a bare path, or `postgres://…?sslmode=require\|verify-full` |
 | `PRELOOP_UNIX_SOCKET` | — | Control socket path; mounted into runner VMs, serves the runner surface only |
-| `PRELOOP_SYSTEM_TOKEN` | generated | Admin credential for `/api/v1/*`. Treat it as root for the control plane |
+| `PRELOOP_SYSTEM_TOKEN` | generated and stored in the OS credential store; private `$PRELOOP_HOME/engine.token` fallback | Admin credential for `/api/v1/*`. Treat it as root for the control plane |
 | `PRELOOP_TOKEN_TTL_SECS` | `2999` | Issued runner token lifetime |
 | `PRELOOP_CONFIG` | `$PRELOOP_HOME/config.toml` | Config file path |
 | `PRELOOP_SECRETS_STORE` | config file | Secrets backend selector |
 | `PRELOOP_RUNNER_URL` | loopback listen address | Origin handed to runners. Set automatically; override only for remote runners |
 | `PRELOOP_CONTROL_UPSTREAM` | — | LAN address remote runners use when loopback is not reachable |
 
-Client-side (`preloop` CLI): `PRELOOP_URL` (default `http://127.0.0.1:9090`) and
-`PRELOOP_TOKEN`.
+Managed engines read their generated token from the OS credential store (or
+`$PRELOOP_HOME/engine.token` when that store is unavailable or unreadable). For
+a separate client or service, set `PRELOOP_SYSTEM_TOKEN` explicitly; never print
+or commit the fallback file.
 
 ### GitHub
 
@@ -281,11 +283,12 @@ path exposes job logs.
 
 ## 6. Security: what must not be public
 
-**`PRELOOP_LISTEN` defaults to `127.0.0.1:9090`**, so a bare `preloop serve` is
-only reachable from the host. To expose the control plane (tunnels reach it via
-`127.0.0.1` anyway), bind a private address or `0.0.0.0` — and put a proxy in
-front. Publishing `0.0.0.0` on a host with a public IP exposes the API to the
-internet with no authentication on the queue path.
+`PRELOOP_LISTEN` defaults to `127.0.0.1:9090`, so a bare `preloop serve` is
+only reachable from the host. A generated native API token protects
+`/api/v1/*` even when you bind a private non-loopback address, but it does not
+protect the runner registration surface. Bind a private address or `0.0.0.0`
+behind a proxy or tunnel, and do not publish the registration endpoint to the
+internet.
 
 **Never publish the whole API surface.** Restrict your proxy or tunnel to
 `/api/v1/github/webhooks`, as every example above does.
@@ -304,8 +307,8 @@ endpoint can:
 
 Requests arriving on the mounted control socket are held to a stricter rule (the
 system credential is required), because untrusted workflow code can reach that
-socket. The TCP surface has no equivalent gate, so **network reachability is the
-control**.
+socket. The TCP runner-registration surface has no equivalent gate, so
+**network reachability is the control**.
 
 Also worth knowing:
 
@@ -333,6 +336,7 @@ Also worth knowing:
 | `state/blobs/`, `state/replay/` | Step logs and job artifacts |
 | `state/cache/` | Actions cache entries |
 | `vms/` | Golden images and per-machine state |
+| `engine.token` | Private fallback for the generated native API token when no OS credential service is available |
 
 Back up at least the database and `github-app.json`. Losing the database strands
 any check run GitHub is still waiting on; losing the key means re-keying the App.

--- a/justfile
+++ b/justfile
@@ -93,21 +93,22 @@ bench-preloop-quick:
 
 # e2e redirect (one-time setup) 
 
-#serve
+# Local runner-client commands discover the persisted token in this same
+# engine home. Set PRELOOP_SYSTEM_TOKEN explicitly for a different server.
 
 serve:
-    PRELOOP_LOCAL_WORKSPACE="${PRELOOP_LOCAL_WORKSPACE:-$PWD}" cargo run --release -p preloop-runner-server -- serve --listen 127.0.0.1:9090
+    PRELOOP_HOME="${PRELOOP_HOME:-$PWD/.preloop}" PRELOOP_LOCAL_WORKSPACE="${PRELOOP_LOCAL_WORKSPACE:-$PWD}" cargo run --release -p preloop-runner-server -- serve --listen 127.0.0.1:9090
 
 serve-dev:
-    PRELOOP_LOCAL_WORKSPACE="${PRELOOP_LOCAL_WORKSPACE:-$PWD}" cargo run --release -p preloop-runner-server -- serve --listen 127.0.0.1:9090 --enable-test-api --test-api-token dev-token
+    PRELOOP_HOME="${PRELOOP_HOME:-$PWD/.preloop}" PRELOOP_LOCAL_WORKSPACE="${PRELOOP_LOCAL_WORKSPACE:-$PWD}" cargo run --release -p preloop-runner-server -- serve --listen 127.0.0.1:9090 --enable-test-api --test-api-token dev-token
 
-#submit 
+#submit
 
 submit-ci:
-    cargo run -p preloop-runner-client -- --server {{server}} submit -W .github/workflows/ci.yml --repository {{repo}}
+    PRELOOP_HOME="${PRELOOP_HOME:-$PWD/.preloop}" cargo run -p preloop-runner-client -- --server {{server}} submit -W .github/workflows/ci.yml --repository {{repo}}
 
 submit-dogfood:
-    cargo run -p preloop-runner-client -- --server {{server}} submit -W fixtures/workflows/dogfood.yml
+    PRELOOP_HOME="${PRELOOP_HOME:-$PWD/.preloop}" cargo run -p preloop-runner-client -- --server {{server}} submit -W fixtures/workflows/dogfood.yml
 
 #runner 
 

--- a/scripts/batch-compare.sh
+++ b/scripts/batch-compare.sh
@@ -16,7 +16,6 @@ RESULTS_DIR="$REPO_ROOT/benchmarks/compatibility/server/behavior"
 if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
     export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
 fi
-SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN"
 
 
 red()   { printf '\033[1;31m%s\033[0m\n' "$*"; }
@@ -52,10 +51,10 @@ run_scenario() {
     smolvm machine cp "$PRELOOP_SERVER_BIN" "$vm:/usr/local/bin/preloop-server" >/dev/null 2>&1
 
     local output
-    output=$(smolvm machine exec --name "$vm" -- bash -lc "
+    output=$(smolvm machine exec --name "$vm" --secret-env PRELOOP_SYSTEM_TOKEN=PRELOOP_SYSTEM_TOKEN -- bash -lc "
         set -u
         chmod +x /usr/local/bin/preloop-server
-        RUST_LOG=info PRELOOP_SYSTEM_TOKEN=$SYSTEM_TOKEN PRELOOP_PUBLIC_URL=http://127.0.0.1 preloop-server serve --listen 0.0.0.0:80 > /tmp/server.log 2>&1 &
+        RUST_LOG=info PRELOOP_PUBLIC_URL=http://127.0.0.1 preloop-server serve --listen 0.0.0.0:80 > /tmp/server.log 2>&1 &
         server_pid=\$!
         sleep 2
         if ! wget -qO- http://127.0.0.1/healthz >/dev/null; then
@@ -66,7 +65,7 @@ run_scenario() {
 
         RESULT=\$(wget -qO- --post-file=/workspace/benchmarks/compatibility/server/behavior/payload-${scenario}.json \\
             --header='Content-Type: application/json' \
-            --header='Authorization: Bearer $SYSTEM_TOKEN' \
+            --header="Authorization: Bearer \$PRELOOP_SYSTEM_TOKEN" \
             http://127.0.0.1/api/v1/runs 2>/dev/null)
         echo "SUBMISSION: \$RESULT"
         RUN_ID=\$(echo "\$RESULT" | python3 -c 'import sys,json; print(json.load(sys.stdin)["run_id"])')
@@ -76,16 +75,16 @@ run_scenario() {
         rm -f /tmp/runner/.runner /tmp/runner/.credentials /tmp/runner/.credentials_rsaparams
         rm -rf /tmp/runner/_work; mkdir -p /tmp/runner/_work
         cd /tmp/runner
-        ./config.sh --unattended --url 'http://127.0.0.1' --token '$SYSTEM_TOKEN' \
+        ./config.sh --unattended --url 'http://127.0.0.1' --token "\$PRELOOP_SYSTEM_TOKEN" \
             --name 'batch-test' --labels 'self-hosted,linux,x64' --work _work --replace --ephemeral > /tmp/config.log 2>&1
         rm -rf _work; mkdir -p _work
-        timeout 180 ./run.sh > /tmp/runner.log 2>&1
+        env -u PRELOOP_SYSTEM_TOKEN timeout 180 ./run.sh > /tmp/runner.log 2>&1
         runner_rc=\$?
         echo "RUNNER_EXIT: \$runner_rc"
         cat /tmp/runner.log
 
         echo '---RESULT---'
-        wget -qO /tmp/status.json --header='Authorization: Bearer $SYSTEM_TOKEN' \
+        wget -qO /tmp/status.json --header="Authorization: Bearer \$PRELOOP_SYSTEM_TOKEN" \
             "http://127.0.0.1/api/v1/runs/\$RUN_ID" 2>/dev/null
         cat /tmp/status.json | python3 -c '
 import sys, json

--- a/scripts/batch-compare.sh
+++ b/scripts/batch-compare.sh
@@ -13,6 +13,11 @@ OFFICIAL_RUNNER_HOST="${OFFICIAL_RUNNER_HOST:-$HOME/cachingv4}"
 PRELOOP_SERVER_BIN="$REPO_ROOT/target/aarch64-unknown-linux-musl/release/preloop-server"
 GH_REPO="${GH_REPO:-preloopdev/preloop-conformance-sample}"
 RESULTS_DIR="$REPO_ROOT/benchmarks/compatibility/server/behavior"
+if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
+    export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+fi
+SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN"
+
 
 red()   { printf '\033[1;31m%s\033[0m\n' "$*"; }
 green() { printf '\033[1;32m%s\033[0m\n' "$*"; }
@@ -50,7 +55,7 @@ run_scenario() {
     output=$(smolvm machine exec --name "$vm" -- bash -lc "
         set -u
         chmod +x /usr/local/bin/preloop-server
-        RUST_LOG=info PRELOOP_PUBLIC_URL=http://127.0.0.1 preloop-server serve --listen 0.0.0.0:80 > /tmp/server.log 2>&1 &
+        RUST_LOG=info PRELOOP_SYSTEM_TOKEN=$SYSTEM_TOKEN PRELOOP_PUBLIC_URL=http://127.0.0.1 preloop-server serve --listen 0.0.0.0:80 > /tmp/server.log 2>&1 &
         server_pid=\$!
         sleep 2
         if ! wget -qO- http://127.0.0.1/healthz >/dev/null; then
@@ -61,7 +66,7 @@ run_scenario() {
 
         RESULT=\$(wget -qO- --post-file=/workspace/benchmarks/compatibility/server/behavior/payload-${scenario}.json \\
             --header='Content-Type: application/json' \
-            --header='Authorization: Bearer preloop-system-token' \
+            --header='Authorization: Bearer $SYSTEM_TOKEN' \
             http://127.0.0.1/api/v1/runs 2>/dev/null)
         echo "SUBMISSION: \$RESULT"
         RUN_ID=\$(echo "\$RESULT" | python3 -c 'import sys,json; print(json.load(sys.stdin)["run_id"])')
@@ -71,7 +76,7 @@ run_scenario() {
         rm -f /tmp/runner/.runner /tmp/runner/.credentials /tmp/runner/.credentials_rsaparams
         rm -rf /tmp/runner/_work; mkdir -p /tmp/runner/_work
         cd /tmp/runner
-        ./config.sh --unattended --url 'http://127.0.0.1' --token 'preloop-system-token' \
+        ./config.sh --unattended --url 'http://127.0.0.1' --token '$SYSTEM_TOKEN' \
             --name 'batch-test' --labels 'self-hosted,linux,x64' --work _work --replace --ephemeral > /tmp/config.log 2>&1
         rm -rf _work; mkdir -p _work
         timeout 180 ./run.sh > /tmp/runner.log 2>&1
@@ -80,7 +85,7 @@ run_scenario() {
         cat /tmp/runner.log
 
         echo '---RESULT---'
-        wget -qO /tmp/status.json --header='Authorization: Bearer preloop-system-token' \
+        wget -qO /tmp/status.json --header='Authorization: Bearer $SYSTEM_TOKEN' \
             "http://127.0.0.1/api/v1/runs/\$RUN_ID" 2>/dev/null
         cat /tmp/status.json | python3 -c '
 import sys, json

--- a/scripts/batch-preloop-compare.sh
+++ b/scripts/batch-preloop-compare.sh
@@ -13,7 +13,6 @@ RESULTS_BASE="$REPO_ROOT/benchmarks/compatibility/server/behavior"
 if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
     export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
 fi
-SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN"
 
 
 red()   { printf '\033[1;31m%s\033[0m\n' "$*"; }
@@ -67,12 +66,12 @@ print(json.dumps({
     RESULT_BASE_VM="/workspace/benchmarks/compatibility/server/behavior/$scenario/preloop-server"
 
     # Run scenario in the persistent VM (each run: start server, run runners, stop server)
-    smolvm machine exec --name "$VM" -- bash -lc "
+    smolvm machine exec --name "$VM" --secret-env PRELOOP_SYSTEM_TOKEN=PRELOOP_SYSTEM_TOKEN -- bash -lc "
         set -u
         chmod +x /usr/local/bin/preloop-server
         
         # Start server
-        RUST_LOG=info PRELOOP_SYSTEM_TOKEN=$SYSTEM_TOKEN PRELOOP_PUBLIC_URL=http://127.0.0.1 preloop-server serve --listen 0.0.0.0:80 > /tmp/server.log 2>&1 &
+        RUST_LOG=info PRELOOP_PUBLIC_URL=http://127.0.0.1 preloop-server serve --listen 0.0.0.0:80 > /tmp/server.log 2>&1 &
         server_pid=\$!
         sleep 2
         wget -qO- http://127.0.0.1/healthz >/dev/null || { echo 'healthz failed'; kill \$server_pid 2>/dev/null; exit 1; }
@@ -80,7 +79,7 @@ print(json.dumps({
         # Submit workflow
         RESULT=\$(wget -qO- --post-file=/workspace/benchmarks/compatibility/server/behavior/payload-${scenario}.json \\
             --header='Content-Type: application/json' \
-            --header='Authorization: Bearer $SYSTEM_TOKEN' \
+            --header="Authorization: Bearer \$PRELOOP_SYSTEM_TOKEN" \
             http://127.0.0.1/api/v1/runs 2>/dev/null)
         RUN_ID=\$(echo \"\$RESULT\" | python3 -c 'import sys,json; print(next(iter(json.load(sys.stdin).values())))' 2>/dev/null)
         echo \"RUN_ID=\$RUN_ID\"
@@ -95,7 +94,7 @@ print(json.dumps({
             rm -f \$RUNNER_DIR/.runner \$RUNNER_DIR/.credentials \$RUNNER_DIR/.credentials_rsaparams
             rm -rf \$RUNNER_DIR/_work \$RUNNER_DIR/_diag; mkdir -p \$RUNNER_DIR/_work
             cd \$RUNNER_DIR
-            ./config.sh --unattended --url 'http://127.0.0.1' --token '$SYSTEM_TOKEN' \
+            ./config.sh --unattended --url 'http://127.0.0.1' --token "\$PRELOOP_SYSTEM_TOKEN" \
                 --name \"cmp-\$i\" --labels 'self-hosted,linux,x64' --work _work --replace --ephemeral > /tmp/config-\$i.log 2>&1
             rm -rf _work; mkdir -p _work
         done
@@ -104,14 +103,14 @@ print(json.dumps({
         RUNNER_PIDS=""
         for i in \$(seq 1 \$JOB_COUNT); do
             RUNNER_DIR=/tmp/runner-\$i
-            (cd \$RUNNER_DIR && timeout 120 ./run.sh > /tmp/runner-\$i.log 2>&1; echo \$? > /tmp/runner-\$i.rc) &
+            (cd \$RUNNER_DIR && env -u PRELOOP_SYSTEM_TOKEN timeout 120 ./run.sh > /tmp/runner-\$i.log 2>&1; echo \$? > /tmp/runner-\$i.rc) &
             RUNNER_PIDS=\"\$RUNNER_PIDS \$!\"
         done
         for pid in \$RUNNER_PIDS; do wait \$pid 2>/dev/null || true; done
 
         # Collect results
         sleep 1
-        wget -qO /tmp/status.json --header='Authorization: Bearer $SYSTEM_TOKEN' \
+        wget -qO /tmp/status.json --header="Authorization: Bearer \$PRELOOP_SYSTEM_TOKEN" \
             \"http://127.0.0.1/api/v1/runs/\$RUN_ID\" 2>/dev/null || true
 
         # Copy artifacts

--- a/scripts/batch-preloop-compare.sh
+++ b/scripts/batch-preloop-compare.sh
@@ -10,6 +10,11 @@ TEMPLATE="${TEMPLATE:-/private/tmp/bench-runner.smolmachine}"
 OFFICIAL_RUNNER_HOST="${OFFICIAL_RUNNER_HOST:-$HOME/cachingv4}"
 PRELOOP_SERVER_BIN="$REPO_ROOT/target/aarch64-unknown-linux-musl/release/preloop-server"
 RESULTS_BASE="$REPO_ROOT/benchmarks/compatibility/server/behavior"
+if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
+    export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+fi
+SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN"
+
 
 red()   { printf '\033[1;31m%s\033[0m\n' "$*"; }
 green() { printf '\033[1;32m%s\033[0m\n' "$*"; }
@@ -67,7 +72,7 @@ print(json.dumps({
         chmod +x /usr/local/bin/preloop-server
         
         # Start server
-        RUST_LOG=info PRELOOP_PUBLIC_URL=http://127.0.0.1 preloop-server serve --listen 0.0.0.0:80 > /tmp/server.log 2>&1 &
+        RUST_LOG=info PRELOOP_SYSTEM_TOKEN=$SYSTEM_TOKEN PRELOOP_PUBLIC_URL=http://127.0.0.1 preloop-server serve --listen 0.0.0.0:80 > /tmp/server.log 2>&1 &
         server_pid=\$!
         sleep 2
         wget -qO- http://127.0.0.1/healthz >/dev/null || { echo 'healthz failed'; kill \$server_pid 2>/dev/null; exit 1; }
@@ -75,7 +80,7 @@ print(json.dumps({
         # Submit workflow
         RESULT=\$(wget -qO- --post-file=/workspace/benchmarks/compatibility/server/behavior/payload-${scenario}.json \\
             --header='Content-Type: application/json' \
-            --header='Authorization: Bearer preloop-system-token' \
+            --header='Authorization: Bearer $SYSTEM_TOKEN' \
             http://127.0.0.1/api/v1/runs 2>/dev/null)
         RUN_ID=\$(echo \"\$RESULT\" | python3 -c 'import sys,json; print(next(iter(json.load(sys.stdin).values())))' 2>/dev/null)
         echo \"RUN_ID=\$RUN_ID\"
@@ -90,7 +95,7 @@ print(json.dumps({
             rm -f \$RUNNER_DIR/.runner \$RUNNER_DIR/.credentials \$RUNNER_DIR/.credentials_rsaparams
             rm -rf \$RUNNER_DIR/_work \$RUNNER_DIR/_diag; mkdir -p \$RUNNER_DIR/_work
             cd \$RUNNER_DIR
-            ./config.sh --unattended --url 'http://127.0.0.1' --token 'preloop-system-token' \
+            ./config.sh --unattended --url 'http://127.0.0.1' --token '$SYSTEM_TOKEN' \
                 --name \"cmp-\$i\" --labels 'self-hosted,linux,x64' --work _work --replace --ephemeral > /tmp/config-\$i.log 2>&1
             rm -rf _work; mkdir -p _work
         done
@@ -106,7 +111,7 @@ print(json.dumps({
 
         # Collect results
         sleep 1
-        wget -qO /tmp/status.json --header='Authorization: Bearer preloop-system-token' \
+        wget -qO /tmp/status.json --header='Authorization: Bearer $SYSTEM_TOKEN' \
             \"http://127.0.0.1/api/v1/runs/\$RUN_ID\" 2>/dev/null || true
 
         # Copy artifacts

--- a/scripts/collect-preloop-conformance.py
+++ b/scripts/collect-preloop-conformance.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Run each scenario through preloop infrastructure and collect results as JSONL."""
 
-import json, os, subprocess, time, tempfile
+import json, os, secrets, subprocess, time, tempfile
 from pathlib import Path
 
 SERVER_PORT = 9191
@@ -23,6 +23,9 @@ scenarios = [
     ("114-step-timeout-graceful-kill", "workflow_dispatch"),
     ("115-cache-v2-restore-fallback", "workflow_dispatch"),
 ]
+
+SYSTEM_TOKEN = os.environ.get("PRELOOP_SYSTEM_TOKEN") or secrets.token_hex(32)
+os.environ["PRELOOP_SYSTEM_TOKEN"] = SYSTEM_TOKEN
 
 records = []
 
@@ -56,7 +59,7 @@ for name, event in scenarios:
              "--state-dir", str(state_dir)],
             env={**os.environ,
                  "PRELOOP_PUBLIC_URL": f"http://127.0.0.1:{SERVER_PORT}",
-                 "PRELOOP_SYSTEM_TOKEN": "preloop-system-token"},
+                 "PRELOOP_SYSTEM_TOKEN": SYSTEM_TOKEN},
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
         )
         time.sleep(3)
@@ -121,7 +124,7 @@ for name, event in scenarios:
             time.sleep(1)
             try:
                 g = subprocess.run(
-                    ["curl", "-s", "-H", "Authorization: Bearer preloop-system-token",
+                    ["curl", "-s", "-H", f"Authorization: Bearer {SYSTEM_TOKEN}",
                      f"http://127.0.0.1:{SERVER_PORT}/api/v1/runs/{run_id}"],
                     capture_output=True, text=True, timeout=5
                 )

--- a/scripts/compare-multi-vm.sh
+++ b/scripts/compare-multi-vm.sh
@@ -13,7 +13,6 @@ PAYLOAD="$ROOT/benchmarks/compatibility/server/behavior/payload-$SCENARIO.json"
 if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
   export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
 fi
-SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN"
 
 mkdir -p "$RESULT/diag"
 SERVER="multi-server-${SCENARIO}-$$"
@@ -33,13 +32,13 @@ smolvm machine start --name "$SERVER" >/dev/null
 smolvm machine exec --name "$SERVER" -- bash -lc 'mount -t binfmt_misc binfmt_misc /proc/sys/fs/binfmt_misc 2>/dev/null || true; if [ -x /usr/bin/rosetta-wrapper ] && [ -x /mnt/rosetta/rosetta ]; then echo ":rosetta:M::\\x7fELF\\x02\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x3e\\x00:\\xff\\xff\\xff\\xff\\xff\\xfe\\xfe\\x00\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xfe\\xff\\xff\\xff:/usr/bin/rosetta-wrapper:F" > /proc/sys/fs/binfmt_misc/register 2>/dev/null || true; fi' >/dev/null 2>&1 || true
 smolvm machine cp "$BIN" "$SERVER:/usr/local/bin/preloop-server" >/dev/null
 SERVER_IP=$(smolvm machine exec --name "$SERVER" -- bash -lc "hostname -I | cut -d' ' -f1")
-smolvm machine exec --name "$SERVER" -- bash -lc "
+smolvm machine exec --name "$SERVER" --secret-env PRELOOP_SYSTEM_TOKEN=PRELOOP_SYSTEM_TOKEN -- bash -lc "
   chmod +x /usr/local/bin/preloop-server
-  RUST_LOG=info PRELOOP_SYSTEM_TOKEN=$SYSTEM_TOKEN PRELOOP_PUBLIC_URL=http://$SERVER_IP preloop-server serve --listen 0.0.0.0:80 > /tmp/server.log 2>&1 &
+  RUST_LOG=info PRELOOP_PUBLIC_URL=http://$SERVER_IP preloop-server serve --listen 0.0.0.0:80 > /tmp/server.log 2>&1 &
   sleep 2
   wget -qO- http://127.0.0.1/healthz >/dev/null
   RESULT=\$(wget -qO- --post-file=/workspace/benchmarks/compatibility/server/behavior/payload-$SCENARIO.json \\
-    --header='Content-Type: application/json' --header='Authorization: Bearer $SYSTEM_TOKEN' \\
+    --header="Authorization: Bearer \$PRELOOP_SYSTEM_TOKEN" \\
     http://127.0.0.1/api/v1/runs)
   echo \"\$RESULT\" > /workspace/benchmarks/compatibility/server/behavior/$SCENARIO/preloop-multi/submission.json
   echo \$RESULT | python3 -c 'import sys,json; print(next(iter(json.load(sys.stdin).values())))' > /workspace/benchmarks/compatibility/server/behavior/$SCENARIO/preloop-multi/run-id
@@ -58,16 +57,16 @@ done
 
 for i in $(seq 1 "$RUNNERS"); do
   vm="${VMS[$((i-1))]}"
-  smolvm machine exec --name "$vm" -- bash -lc "
+  smolvm machine exec --name "$vm" --secret-env PRELOOP_SYSTEM_TOKEN=PRELOOP_SYSTEM_TOKEN -- bash -lc "
     set +e
     export RUNNER_ALLOW_RUNASROOT=1 ACTIONS_RUNNER_DEBUG=true RUNNER_DEBUG=1
     cp -a /opt/runners/actions-runner /tmp/runner
     rm -f /tmp/runner/.runner /tmp/runner/.credentials /tmp/runner/.credentials_rsaparams
     mkdir -p /tmp/runner/_work
     cd /tmp/runner
-    ./config.sh --unattended --url 'http://$SERVER_IP' --token '$SYSTEM_TOKEN' \\
+    ./config.sh --unattended --url 'http://$SERVER_IP' --token "\$PRELOOP_SYSTEM_TOKEN" \\
       --name 'multi-$SCENARIO-$i' --labels 'self-hosted,linux,x64' --work _work --replace --ephemeral > /tmp/config.log 2>&1
-    timeout 240 ./run.sh > /tmp/runner.log 2>&1
+    env -u PRELOOP_SYSTEM_TOKEN timeout 240 ./run.sh > /tmp/runner.log 2>&1
     rc=\$?
     mkdir -p /workspace/benchmarks/compatibility/server/behavior/$SCENARIO/preloop-multi/runner-$i
     cp /tmp/runner.log /workspace/benchmarks/compatibility/server/behavior/$SCENARIO/preloop-multi/runner-$i/official-runner.log
@@ -79,9 +78,9 @@ done
 wait || true
 
 RUN_ID=$(cat "$RESULT/run-id")
-smolvm machine exec --name "$SERVER" -- bash -lc "
+smolvm machine exec --name "$SERVER" --secret-env PRELOOP_SYSTEM_TOKEN=PRELOOP_SYSTEM_TOKEN -- bash -lc "
   sleep 2
-  wget -qO /tmp/status.json --header='Authorization: Bearer $SYSTEM_TOKEN' http://127.0.0.1/api/v1/runs/$RUN_ID || true
+  wget -qO /tmp/status.json --header="Authorization: Bearer \$PRELOOP_SYSTEM_TOKEN" http://127.0.0.1/api/v1/runs/$RUN_ID || true
   cp /tmp/status.json /workspace/benchmarks/compatibility/server/behavior/$SCENARIO/preloop-multi/status.json 2>/dev/null || true
   cp /tmp/server.log /workspace/benchmarks/compatibility/server/behavior/$SCENARIO/preloop-multi/server.log 2>/dev/null || true
 " >/dev/null 2>&1 || true

--- a/scripts/compare-multi-vm.sh
+++ b/scripts/compare-multi-vm.sh
@@ -10,6 +10,11 @@ RUNNER_HOST="${OFFICIAL_RUNNER_HOST:-$HOME/cachingv4}"
 BIN="$ROOT/target/aarch64-unknown-linux-musl/release/preloop-server"
 RESULT="$ROOT/benchmarks/compatibility/server/behavior/$SCENARIO/preloop-multi"
 PAYLOAD="$ROOT/benchmarks/compatibility/server/behavior/payload-$SCENARIO.json"
+if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
+  export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+fi
+SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN"
+
 mkdir -p "$RESULT/diag"
 SERVER="multi-server-${SCENARIO}-$$"
 VMS=()
@@ -30,11 +35,11 @@ smolvm machine cp "$BIN" "$SERVER:/usr/local/bin/preloop-server" >/dev/null
 SERVER_IP=$(smolvm machine exec --name "$SERVER" -- bash -lc "hostname -I | cut -d' ' -f1")
 smolvm machine exec --name "$SERVER" -- bash -lc "
   chmod +x /usr/local/bin/preloop-server
-  RUST_LOG=info PRELOOP_PUBLIC_URL=http://$SERVER_IP preloop-server serve --listen 0.0.0.0:80 > /tmp/server.log 2>&1 &
+  RUST_LOG=info PRELOOP_SYSTEM_TOKEN=$SYSTEM_TOKEN PRELOOP_PUBLIC_URL=http://$SERVER_IP preloop-server serve --listen 0.0.0.0:80 > /tmp/server.log 2>&1 &
   sleep 2
   wget -qO- http://127.0.0.1/healthz >/dev/null
   RESULT=\$(wget -qO- --post-file=/workspace/benchmarks/compatibility/server/behavior/payload-$SCENARIO.json \\
-    --header='Content-Type: application/json' --header='Authorization: Bearer preloop-system-token' \\
+    --header='Content-Type: application/json' --header='Authorization: Bearer $SYSTEM_TOKEN' \\
     http://127.0.0.1/api/v1/runs)
   echo \"\$RESULT\" > /workspace/benchmarks/compatibility/server/behavior/$SCENARIO/preloop-multi/submission.json
   echo \$RESULT | python3 -c 'import sys,json; print(next(iter(json.load(sys.stdin).values())))' > /workspace/benchmarks/compatibility/server/behavior/$SCENARIO/preloop-multi/run-id
@@ -60,7 +65,7 @@ for i in $(seq 1 "$RUNNERS"); do
     rm -f /tmp/runner/.runner /tmp/runner/.credentials /tmp/runner/.credentials_rsaparams
     mkdir -p /tmp/runner/_work
     cd /tmp/runner
-    ./config.sh --unattended --url 'http://$SERVER_IP' --token 'preloop-system-token' \\
+    ./config.sh --unattended --url 'http://$SERVER_IP' --token '$SYSTEM_TOKEN' \\
       --name 'multi-$SCENARIO-$i' --labels 'self-hosted,linux,x64' --work _work --replace --ephemeral > /tmp/config.log 2>&1
     timeout 240 ./run.sh > /tmp/runner.log 2>&1
     rc=\$?
@@ -76,7 +81,7 @@ wait || true
 RUN_ID=$(cat "$RESULT/run-id")
 smolvm machine exec --name "$SERVER" -- bash -lc "
   sleep 2
-  wget -qO /tmp/status.json --header='Authorization: Bearer preloop-system-token' http://127.0.0.1/api/v1/runs/$RUN_ID || true
+  wget -qO /tmp/status.json --header='Authorization: Bearer $SYSTEM_TOKEN' http://127.0.0.1/api/v1/runs/$RUN_ID || true
   cp /tmp/status.json /workspace/benchmarks/compatibility/server/behavior/$SCENARIO/preloop-multi/status.json 2>/dev/null || true
   cp /tmp/server.log /workspace/benchmarks/compatibility/server/behavior/$SCENARIO/preloop-multi/server.log 2>/dev/null || true
 " >/dev/null 2>&1 || true

--- a/scripts/compare-servers.sh
+++ b/scripts/compare-servers.sh
@@ -15,6 +15,11 @@ RESULTS_DIR="$REPO_ROOT/benchmarks/compatibility/server/behavior/${SCENARIO%.yml
 PROTOCOL_DIR="$REPO_ROOT/benchmarks/compatibility/server/protocol/captures/${SCENARIO%.yml}"
 MITM_PORT=18081
 GITHUB_ACTIONS_TOKEN="${PRELOOP_GITHUB_TOKEN:-}"
+if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
+    export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+fi
+SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN"
+
 
 red()   { printf '\033[1;31m%s\033[0m\n' "$*"; }
 green() { printf '\033[1;32m%s\033[0m\n' "$*"; }
@@ -248,7 +253,7 @@ print(json.dumps({
             bash -c '</dev/tcp/127.0.0.1/$MITM_PORT' 2>/dev/null && break; sleep .25
         done
         chmod +x /usr/local/bin/preloop-server
-        RUST_LOG=info PRELOOP_PUBLIC_URL=http://127.0.0.1 PRELOOP_GITHUB_TOKEN='$GITHUB_ACTIONS_TOKEN' preloop-server serve --listen 127.0.0.1:80 --state-dir /tmp/preloop-state > /tmp/server.log 2>&1 &
+        RUST_LOG=info PRELOOP_PUBLIC_URL=http://127.0.0.1 PRELOOP_GITHUB_TOKEN='$GITHUB_ACTIONS_TOKEN' PRELOOP_SYSTEM_TOKEN='$SYSTEM_TOKEN' preloop-server serve --listen 127.0.0.1:80 --state-dir /tmp/preloop-state > /tmp/server.log 2>&1 &
         server_pid=\$!
         sleep 2
         wget -qO- http://127.0.0.1/healthz >/dev/null || { echo 'healthz failed'; cat /tmp/server.log; cp /tmp/server.log $result_base/server.log || true; exit 1; }
@@ -265,7 +270,7 @@ print(json.dumps({
         esac
         RESULT=\$(wget -qO- --post-file=/workspace/benchmarks/compatibility/server/behavior/payload-${SCENARIO%.yml}.json \\
             --header='Content-Type: application/json' \\
-            --header='Authorization: Bearer preloop-system-token' \\
+            --header='Authorization: Bearer $SYSTEM_TOKEN' \\
             http://127.0.0.1/api/v1/runs 2>/dev/null)
         echo \"SUBMISSION: \$RESULT\"
         RUN_ID=\$(echo \"\$RESULT\" | python3 -c 'import sys,json; print(next(iter(json.load(sys.stdin).values())))')
@@ -286,7 +291,7 @@ print(json.dumps({
             rm -f \$RUNNER_DIR/.runner \$RUNNER_DIR/.credentials \$RUNNER_DIR/.credentials_rsaparams
             rm -rf \$RUNNER_DIR/_work \$RUNNER_DIR/_diag; mkdir -p \$RUNNER_DIR/_work
             cd \$RUNNER_DIR
-            ./config.sh --unattended --url 'http://127.0.0.1' --token 'preloop-system-token' \\
+            ./config.sh --unattended --url 'http://127.0.0.1' --token '$SYSTEM_TOKEN' \\
                 --name \"cmp-preloop-\$i-$$\" --labels 'self-hosted,linux,x64' --work _work --replace --ephemeral > /tmp/config-\$i.log 2>&1
             rm -rf _work; mkdir -p _work
         done
@@ -305,7 +310,7 @@ print(json.dumps({
             (
                 sleep 5
                 wget -qO /dev/null --post-data='' \
-                    --header='Authorization: Bearer preloop-system-token' \
+                    --header='Authorization: Bearer $SYSTEM_TOKEN' \
                     "http://127.0.0.1/api/v1/runs/\$RUN_ID/cancel"
             ) &
         fi
@@ -319,7 +324,7 @@ print(json.dumps({
 
         echo \"RUN_ID=\$RUN_ID\"
         sleep 2
-        wget -qO /tmp/status.json --header='Authorization: Bearer preloop-system-token' \\
+        wget -qO /tmp/status.json --header='Authorization: Bearer $SYSTEM_TOKEN' \\
             \"http://127.0.0.1/api/v1/runs/\$RUN_ID\" 2>/dev/null || true
 
         # Collect artifacts from all runners

--- a/scripts/compare-servers.sh
+++ b/scripts/compare-servers.sh
@@ -18,7 +18,6 @@ GITHUB_ACTIONS_TOKEN="${PRELOOP_GITHUB_TOKEN:-}"
 if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
     export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
 fi
-SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN"
 
 
 red()   { printf '\033[1;31m%s\033[0m\n' "$*"; }
@@ -232,7 +231,7 @@ print(json.dumps({
 
     local result_base="/workspace/benchmarks/compatibility/server/behavior/${SCENARIO%.yml}/preloop-server"
 
-    smolvm machine exec --name "$vm" -- bash -lc "
+    smolvm machine exec --name "$vm" --secret-env PRELOOP_SYSTEM_TOKEN=PRELOOP_SYSTEM_TOKEN -- bash -lc "
         set -u
 
        echo 'Waiting for internet access...'
@@ -253,7 +252,7 @@ print(json.dumps({
             bash -c '</dev/tcp/127.0.0.1/$MITM_PORT' 2>/dev/null && break; sleep .25
         done
         chmod +x /usr/local/bin/preloop-server
-        RUST_LOG=info PRELOOP_PUBLIC_URL=http://127.0.0.1 PRELOOP_GITHUB_TOKEN='$GITHUB_ACTIONS_TOKEN' PRELOOP_SYSTEM_TOKEN='$SYSTEM_TOKEN' preloop-server serve --listen 127.0.0.1:80 --state-dir /tmp/preloop-state > /tmp/server.log 2>&1 &
+        RUST_LOG=info PRELOOP_PUBLIC_URL=http://127.0.0.1 PRELOOP_GITHUB_TOKEN='$GITHUB_ACTIONS_TOKEN' preloop-server serve --listen 127.0.0.1:80 --state-dir /tmp/preloop-state > /tmp/server.log 2>&1 &
         server_pid=\$!
         sleep 2
         wget -qO- http://127.0.0.1/healthz >/dev/null || { echo 'healthz failed'; cat /tmp/server.log; cp /tmp/server.log $result_base/server.log || true; exit 1; }
@@ -270,7 +269,7 @@ print(json.dumps({
         esac
         RESULT=\$(wget -qO- --post-file=/workspace/benchmarks/compatibility/server/behavior/payload-${SCENARIO%.yml}.json \\
             --header='Content-Type: application/json' \\
-            --header='Authorization: Bearer $SYSTEM_TOKEN' \\
+            --header="Authorization: Bearer \$PRELOOP_SYSTEM_TOKEN" \\
             http://127.0.0.1/api/v1/runs 2>/dev/null)
         echo \"SUBMISSION: \$RESULT\"
         RUN_ID=\$(echo \"\$RESULT\" | python3 -c 'import sys,json; print(next(iter(json.load(sys.stdin).values())))')
@@ -291,7 +290,7 @@ print(json.dumps({
             rm -f \$RUNNER_DIR/.runner \$RUNNER_DIR/.credentials \$RUNNER_DIR/.credentials_rsaparams
             rm -rf \$RUNNER_DIR/_work \$RUNNER_DIR/_diag; mkdir -p \$RUNNER_DIR/_work
             cd \$RUNNER_DIR
-            ./config.sh --unattended --url 'http://127.0.0.1' --token '$SYSTEM_TOKEN' \\
+            ./config.sh --unattended --url 'http://127.0.0.1' --token "\$PRELOOP_SYSTEM_TOKEN" \\
                 --name \"cmp-preloop-\$i-$$\" --labels 'self-hosted,linux,x64' --work _work --replace --ephemeral > /tmp/config-\$i.log 2>&1
             rm -rf _work; mkdir -p _work
         done
@@ -300,7 +299,7 @@ print(json.dumps({
         RUNNER_PIDS=""
         for i in \$(seq 1 \$JOB_COUNT); do
             RUNNER_DIR=/tmp/runner-\$i
-            (cd \$RUNNER_DIR && timeout 240 ./run.sh > /tmp/runner-\$i.log 2>&1; echo \$? > /tmp/runner-\$i.rc) &
+            (cd \$RUNNER_DIR && env -u PRELOOP_SYSTEM_TOKEN timeout 240 ./run.sh > /tmp/runner-\$i.log 2>&1; echo \$? > /tmp/runner-\$i.rc) &
             RUNNER_PIDS=\"\$RUNNER_PIDS \$!\"
         done
 
@@ -310,7 +309,7 @@ print(json.dumps({
             (
                 sleep 5
                 wget -qO /dev/null --post-data='' \
-                    --header='Authorization: Bearer $SYSTEM_TOKEN' \
+                    --header="Authorization: Bearer \$PRELOOP_SYSTEM_TOKEN" \\
                     "http://127.0.0.1/api/v1/runs/\$RUN_ID/cancel"
             ) &
         fi
@@ -324,7 +323,7 @@ print(json.dumps({
 
         echo \"RUN_ID=\$RUN_ID\"
         sleep 2
-        wget -qO /tmp/status.json --header='Authorization: Bearer $SYSTEM_TOKEN' \\
+        wget -qO /tmp/status.json --header="Authorization: Bearer \$PRELOOP_SYSTEM_TOKEN" \\
             \"http://127.0.0.1/api/v1/runs/\$RUN_ID\" 2>/dev/null || true
 
         # Collect artifacts from all runners

--- a/scripts/conformance-test.sh
+++ b/scripts/conformance-test.sh
@@ -27,7 +27,10 @@ echo ""
 echo "Starting preloop server..."
 WEBHOOK_SECRET="conformance-test-secret"
 TEST_API_TOKEN="conformance-test-api-token"
+SYSTEM_TOKEN="${PRELOOP_SYSTEM_TOKEN:-$(python3 -c 'import secrets; print(secrets.token_hex(32))')}"
+
 PRELOOP_LOCAL_WORKSPACE="$TEMP_DIR/workspace" \
+PRELOOP_SYSTEM_TOKEN="$SYSTEM_TOKEN" \
 PRELOOP_WEBHOOK_SECRET="$WEBHOOK_SECRET" \
 "$PROJECT_ROOT/target/debug/preloop-server" serve \
   --listen 127.0.0.1:9199 \

--- a/scripts/e2e-smolvm.sh
+++ b/scripts/e2e-smolvm.sh
@@ -15,6 +15,11 @@ SERVER_URL="http://127.0.0.1:${SERVER_PORT}"
 SERVER_BIN="$REPO_ROOT/target/release/preloop-server"
 RUNNER_BIN="$REPO_ROOT/target/aarch64-unknown-linux-musl/release/preloop-runner"
 MAX_JOBS="${MAX_JOBS:-3}"
+if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
+    export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+fi
+SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN"
+
 
 red()   { printf '\033[1;31m%s\033[0m\n' "$*"; }
 green() { printf '\033[1;32m%s\033[0m\n' "$*"; }
@@ -44,7 +49,7 @@ trap cleanup EXIT
 info "Starting preloop server on port $SERVER_PORT..."
 pkill -f "preloop-server.*${SERVER_PORT}" 2>/dev/null || true
 sleep 1
-RUST_LOG=info PRELOOP_PUBLIC_URL="$SERVER_URL" "$SERVER_BIN" serve --listen "0.0.0.0:${SERVER_PORT}" > /tmp/preloop-e2e-server.log 2>&1 &
+RUST_LOG=info PRELOOP_PUBLIC_URL="$SERVER_URL" PRELOOP_SYSTEM_TOKEN="$SYSTEM_TOKEN" "$SERVER_BIN" serve --listen "0.0.0.0:${SERVER_PORT}" > /tmp/preloop-e2e-server.log 2>&1 &
 sleep 2
 curl -sf "$SERVER_URL/healthz" > /dev/null || { red "Server failed to start"; exit 1; }
 info "Server running"
@@ -66,7 +71,7 @@ run_job_in_vm() {
     # Configure runner
     smolvm machine exec --name "$vm_name" -- /workspace/preloop-runner configure \
         --url "$SERVER_URL" \
-        --token preloop-system-token \
+        --token "$SYSTEM_TOKEN" \
         --name "$runner_name" \
         --labels self-hosted,Linux,ARM64 \
         --work /workspace/_work \
@@ -121,7 +126,7 @@ print(json.dumps({
 ")
 RESULT=$(curl -s -X POST "$SERVER_URL/api/v1/runs" \
     -H 'Content-Type: application/json' \
-    -H 'Authorization: Bearer preloop-system-token' \
+    -H "Authorization: Bearer $SYSTEM_TOKEN" \
     -d "$PAYLOAD")
 RUN_ID=$(echo "$RESULT" | python3 -c 'import sys,json; print(json.load(sys.stdin)["run_id"])')
 QUEUED=$(echo "$RESULT" | python3 -c 'import sys,json; print(json.load(sys.stdin)["queued_jobs"])')
@@ -134,7 +139,7 @@ done
 
 # Check final status
 FINAL=$(curl -s "$SERVER_URL/api/v1/runs/$RUN_ID" \
-    -H 'Authorization: Bearer preloop-system-token')
+    -H "Authorization: Bearer $SYSTEM_TOKEN")
 STATUS=$(echo "$FINAL" | python3 -c 'import sys,json; print(json.load(sys.stdin)["status"])')
 
 echo ""

--- a/scripts/e2e-start.sh
+++ b/scripts/e2e-start.sh
@@ -25,7 +25,10 @@ CLIENT="${CLIENT:-http://127.0.0.1:$PRELOOP_PORT}"
 LOG_DIR="$REPO_ROOT/logs/e2e"
 TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
 LOG_FILE="$LOG_DIR/e2e-$TIMESTAMP.log"
-SYSTEM_TOKEN="${PRELOOP_SYSTEM_TOKEN:-preloop-system-token}"
+if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
+    export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+fi
+SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN"
 
 mkdir -p "$LOG_DIR"
 

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -11,6 +11,11 @@ RUNNER_DIR="/tmp/preloop-e2e-runner"
 RUNNER_BIN="$REPO_ROOT/target/release/preloop-runner"
 SERVER_BIN="$REPO_ROOT/target/release/preloop-server"
 VERBOSE="${2:-}"
+if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
+  export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+fi
+SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN"
+
 
 red()   { printf '\033[1;31m%s\033[0m\n' "$*"; }
 green() { printf '\033[1;32m%s\033[0m\n' "$*"; }
@@ -33,7 +38,7 @@ WORKFLOW_YAML=$(cat "$WORKFLOW_FILE")
 info "Starting server on port $SERVER_PORT..."
 pkill -f "preloop-server.*${SERVER_PORT}" 2>/dev/null || true
 sleep 1
-RUST_LOG=info PRELOOP_PUBLIC_URL="$SERVER_URL" "$SERVER_BIN" serve --listen "0.0.0.0:${SERVER_PORT}" > /tmp/preloop-e2e-server.log 2>&1 &
+RUST_LOG=info PRELOOP_PUBLIC_URL="$SERVER_URL" PRELOOP_SYSTEM_TOKEN="$SYSTEM_TOKEN" "$SERVER_BIN" serve --listen "0.0.0.0:${SERVER_PORT}" > /tmp/preloop-e2e-server.log 2>&1 &
 SERVER_PID=$!
 sleep 2
 
@@ -51,7 +56,7 @@ cd "$RUNNER_DIR"
 info "Configuring runner..."
 "$RUNNER_BIN" configure \
   --url "$SERVER_URL" \
-  --token preloop-system-token \
+  --token "$SYSTEM_TOKEN" \
   --name e2e-runner \
   --labels self-hosted,macOS,ARM64 \
   --work _work \
@@ -73,7 +78,7 @@ print(json.dumps({
 
 RESULT=$(curl -s -X POST "$SERVER_URL/api/v1/runs" \
   -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer preloop-system-token' \
+  -H "Authorization: Bearer $SYSTEM_TOKEN" \
   -d "$PAYLOAD")
 RUN_ID=$(echo "$RESULT" | python3 -c 'import sys,json; print(json.load(sys.stdin)["run_id"])')
 info "Run submitted: $RUN_ID"
@@ -88,7 +93,7 @@ RUST_LOG=$LOG_LEVEL perl -e 'alarm 120; exec @ARGV' -- "$RUNNER_BIN" run --once 
 
 # Check result
 FINAL=$(curl -s "$SERVER_URL/api/v1/runs/$RUN_ID" \
-  -H 'Authorization: Bearer preloop-system-token')
+  -H "Authorization: Bearer $SYSTEM_TOKEN")
 STATUS=$(echo "$FINAL" | python3 -c 'import sys,json; print(json.load(sys.stdin)["status"])')
 
 echo ""

--- a/scripts/oidc-conformance-run.sh
+++ b/scripts/oidc-conformance-run.sh
@@ -9,7 +9,10 @@ SERVER="$REPO/target/release/preloop-server"
 RUNNER="$REPO/target/release/preloop-runner"
 PORT=9192
 BASE="http://127.0.0.1:$PORT"
-SYSTEM_TOKEN="${PRELOOP_SYSTEM_TOKEN:-preloop-system-token}"
+if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
+    export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+fi
+SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN"
 NOW=$(date -u +%Y-%m-%dT%H-%M-%SZ)
 STATE=$(mktemp -d /tmp/preloop-oidc.XXXXXX)
 RESULTS="$REPO/benchmarks/real-world/results/runner-flow"
@@ -93,7 +96,7 @@ PYEOF
 
 # ── Start server ────────────────────────────────────────────────────
 echo -e "${BLUE}▸${NC} Starting server on $PORT..."
-PRELOOP_PUBLIC_URL="$BASE" "$SERVER" serve --listen "127.0.0.1:$PORT" --state-dir "$STATE" \
+PRELOOP_PUBLIC_URL="$BASE" PRELOOP_SYSTEM_TOKEN="$SYSTEM_TOKEN" "$SERVER" serve --listen "127.0.0.1:$PORT" --state-dir "$STATE" \
     > "$STATE/server.log" 2>&1 &
 SPID=$!
 for i in $(seq 1 30); do curl -sf --max-time 1 "$BASE/healthz" >/dev/null 2>&1 && break; sleep 0.5; done

--- a/scripts/overnight-conformance.sh
+++ b/scripts/overnight-conformance.sh
@@ -18,6 +18,10 @@ LOG="$RESULTS_DIR/run-$TIMESTAMP.log"
 SERVER_PID=""
 
 mkdir -p "$RESULTS_DIR"
+if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
+    export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+fi
+
 
 log() {
     echo "[$(date '+%H:%M:%S')] $*" | tee -a "$LOG"

--- a/scripts/preloop-e2e-bench.sh
+++ b/scripts/preloop-e2e-bench.sh
@@ -24,7 +24,10 @@ PRELOOP_BIN="$REPO_ROOT/target/release/preloop-server"
 RUNNER_DIR="${RUNNER_DIR:-$HOME/.cache/actions-runner/current}"
 PRELOOP_PORT="${PRELOOP_PORT:-9090}"
 CLIENT_URL="${CLIENT_URL:-http://127.0.0.1:$PRELOOP_PORT}"
-SYSTEM_TOKEN="${PRELOOP_SYSTEM_TOKEN:-preloop-system-token}"
+if [[ -z "${PRELOOP_SYSTEM_TOKEN:-}" ]]; then
+    export PRELOOP_SYSTEM_TOKEN="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+fi
+SYSTEM_TOKEN="$PRELOOP_SYSTEM_TOKEN"
 STATE_DIR="$(mktemp -d /tmp/preloop-bench-XXXXXX)"
 LOG="$STATE_DIR/preloop.log"
 PRELOOP_PID=""
@@ -66,6 +69,7 @@ lsof -i :"$PRELOOP_PORT" -sTCP:LISTEN >/dev/null 2>&1 \
 # ── start preloop ───────────────────────────────────────────────────────────────
 
 PRELOOP_PUBLIC_URL="$CLIENT_URL" PRELOOP_RUNNER_URL="$CLIENT_URL" \
+    PRELOOP_SYSTEM_TOKEN="$SYSTEM_TOKEN" \
     RUST_LOG=info "$PRELOOP_BIN" serve \
     --listen "127.0.0.1:${PRELOOP_PORT}" \
     --state-dir "$STATE_DIR/state" \

--- a/scripts/record_dap_conformance.js
+++ b/scripts/record_dap_conformance.js
@@ -2,14 +2,14 @@
 const { spawn, spawnSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
-
+const crypto = require("crypto");
 const REPO_ROOT = path.resolve(__dirname, "..");
 const MITM_DIR = path.resolve(REPO_ROOT, "../mitm-proxy/experiments/mitm");
 const MITMDUMP_BIN = path.resolve(MITM_DIR, ".venv/bin/mitmdump");
 const CAPTURES_DIR = path.resolve(REPO_ROOT, ".runner-watch/dap-captures");
 const OFFICIAL_RUNNER_DIR = path.resolve(MITM_DIR, ".cache/runner-official");
 const PRELOOP_RUNNER_DIR = path.resolve(REPO_ROOT, "target/release");
-const SYSTEM_TOKEN = process.env.PRELOOP_SYSTEM_TOKEN || "preloop-system-token";
+const SYSTEM_TOKEN = process.env.PRELOOP_SYSTEM_TOKEN || crypto.randomBytes(32).toString("hex");
 
 // Ensure capture directories exist
 fs.mkdirSync(CAPTURES_DIR, { recursive: true });

--- a/scripts/run-timing.sh
+++ b/scripts/run-timing.sh
@@ -15,7 +15,7 @@
 #
 # Environment:
 #   PRELOOP_URL          server base URL (default http://127.0.0.1:9090)
-#   PRELOOP_SYSTEM_TOKEN native bearer token (default preloop-system-token)
+#   PRELOOP_SYSTEM_TOKEN native bearer token (required unless the private fallback file exists)
 #
 # Emits the same JSON keys the poller captured, plus `snapshot_timing` and
 # per-step `started_at`/`finished_at`, so jq consumers can reuse it.
@@ -25,10 +25,13 @@ set -euo pipefail
 PRELOOP_URL="${PRELOOP_URL:-http://127.0.0.1:9090}"
 if [ -n "${PRELOOP_SYSTEM_TOKEN:-}" ]; then
     TOKEN="$PRELOOP_SYSTEM_TOKEN"
+elif [ -n "${PRELOOP_TOKEN:-}" ]; then
+    TOKEN="$PRELOOP_TOKEN"
 elif [ -f "${PRELOOP_HOME:-$HOME/.preloop}/engine.token" ]; then
     TOKEN="$(tr -d '[:space:]' < "${PRELOOP_HOME:-$HOME/.preloop}/engine.token")"
 else
-    TOKEN="preloop-system-token"
+    echo "ERROR: set PRELOOP_SYSTEM_TOKEN (or PRELOOP_TOKEN) for this client" >&2
+    exit 1
 fi
 RUN_ID="${1:-}"
 


### PR DESCRIPTION
## Summary
- remove the global `preloop-system-token` production fallback
- generate a random per-engine token and persist it in the OS credential store, with a private `0600` `engine.token` fallback
- make managed CLI startup and clients use the shared credential flow; update conformance, benchmark, DAP, and documentation paths

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `PROPTEST_CASES=8 GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgsign GIT_CONFIG_VALUE_0=false cargo test --locked --workspace --quiet`
- macOS managed-engine smoke: keychain-backed token reused by a separate `preloop status --json` process; unauthenticated API returned `401`; no fallback file was created
- shell, Node, and Python syntax checks

## Environment notes
- `just test-ci` reaches the pre-existing `zizmor` failures for the pinned `dtolnay/rust-toolchain` commit in `.github/workflows/ci.yml`
- `just conform` reports six existing protocol/body divergences
- `just dogfood` built the release server but could not run because `~/.cache/actions-runner/current` is absent

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the hardcoded `preloop-system-token` default and replaces it with a random per-engine admin token persisted in the OS credential store, with a private `engine.token` fallback. Managed CLI commands now load the token through the same credential flow.

**Behavior**
- The token is generated on first engine startup and scoped to the engine home, so separate engines get different secrets.
- Existing `engine.token` files are migrated to the OS credential store when available, then removed.
- Explicit `PRELOOP_SYSTEM_TOKEN` values are validated before any filesystem access and never copied into the credential store.
- CLI clients also search `./.preloop` in the working directory, so a client next to a standalone server finds that token without setting `PRELOOP_HOME`.

**Migration**
- `preloop-runner-client` auto-discovers the engine token only for local servers and otherwise fails with a clear error; `runner-watch` requires `PRELOOP_SYSTEM_TOKEN`.
- Benchmark, conformance, and demo scripts generate a random token when the variable is unset.

<sup>Written for commit 7e562bbe9c454614b9548720681dfcb3917dc8ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Native API administrator tokens are now generated per engine and securely stored in the OS credential store, with a protected file fallback.
  - Fixed default credentials have been replaced with generated or explicitly configured tokens.
  - Authentication is now consistently applied across server, runner, and API operations.

- **Bug Fixes**
  - Tools now report missing token configuration instead of silently using insecure defaults.

- **Documentation**
  - Added guidance for token storage, configuration, migration, and demo setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->