### PR TITLE
fix: canonicalize Results job UUID storage identifiers

### DIFF
--- a/crates/preloop-runner-server/src/auth.rs
+++ b/crates/preloop-runner-server/src/auth.rs
@@ -442,6 +442,24 @@ pub(crate) fn require_results_job(
     }
 }
 
+/// Authorize a Results plan/job target and return its storage representation.
+///
+/// Runtime job identities only pass UUID-parsable job ids, so alternate
+/// spellings collapse to the lower-case hyphenated form used by the runner's
+/// lookup path. The system identity keeps accepting opaque backend ids for
+/// compatibility, while still canonicalizing valid UUIDs.
+pub(crate) fn require_canonical_results_job_id(
+    identity: &ResultsIdentity,
+    plan_id: &str,
+    job_id: &str,
+) -> Result<String, ApiError> {
+    require_results_job(identity, plan_id, job_id)?;
+    Ok(job_id
+        .parse::<uuid::Uuid>()
+        .map(|job| job.to_string())
+        .unwrap_or_else(|_| job_id.to_owned()))
+}
+
 /// Runner identity proven by a listen token on this request.
 ///
 /// `runner_id` is `Some` only when the bearer verifies as a runner-listen JWT

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -20748,6 +20748,422 @@ async fn replay_blob_urls_are_minted_only_for_the_callers_own_job() {
 }
 
 #[tokio::test]
+async fn results_uuid_spellings_use_canonical_paths_and_metadata_keys() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let plan = uuid::Uuid::parse_str("fedcba98-7654-4321-89ab-cdef01234567")
+        .unwrap()
+        .to_string();
+    let job = uuid::Uuid::parse_str("01234567-89ab-4cde-8fab-cdef01234567").unwrap();
+    let canonical = job.to_string();
+    let forms = [
+        canonical.clone(),
+        canonical.to_ascii_uppercase(),
+        format!("{{{canonical}}}"),
+        canonical.replace('-', ""),
+        format!("urn:uuid:{canonical}"),
+    ];
+    let token = state.mint_runtime_token(&plan, &job);
+
+    for form in &forms {
+        let requests = [
+            (
+                "/twirp/results.services.receiver.Receiver/GetJobLogsSignedBlobURL",
+                "logs_url",
+                format!("/replay/results/{plan}/{canonical}/job-logs.txt"),
+            ),
+            (
+                "/twirp/results.services.receiver.Receiver/GetStepLogsSignedBlobURL",
+                "logs_url",
+                format!("/replay/results/{plan}/{canonical}/step-step-1.txt"),
+            ),
+            (
+                "/twirp/results.services.receiver.Receiver/GetStepSummarySignedBlobURL",
+                "summary_url",
+                format!("/replay/results/{plan}/{canonical}/step-step-1-summary.md"),
+            ),
+        ];
+        for (uri, field, expected_path) in requests {
+            let payload = request_json_with_bearer(
+                &app,
+                Method::POST,
+                uri,
+                json!({
+                    "workflow_run_backend_id": plan,
+                    "workflow_job_run_backend_id": form,
+                    "step_backend_id": "step-1",
+                }),
+                &token,
+            )
+            .await;
+            let url = payload[field].as_str().unwrap();
+            assert!(
+                url.contains(&expected_path),
+                "equivalent job spelling must use the canonical path: {url}"
+            );
+        }
+
+        let diag = request_json_with_bearer(
+            &app,
+            Method::POST,
+            "/twirp/results.services.receiver.Receiver/GetJobDiagLogsSignedBlobURL",
+            json!({
+                "workflow_run_backend_id": plan,
+                "workflow_job_run_backend_id": form,
+            }),
+            &token,
+        )
+        .await;
+        assert!(
+            diag["diag_logs_url"]
+                .as_str()
+                .is_some_and(|url| url.contains("/twirp-blob/diag/")),
+            "diagnostic URL must remain a token-only path"
+        );
+
+        let update = request_json_with_bearer(
+            &app,
+            Method::POST,
+            "/twirp/github.actions.results.api.v1.WorkflowStepUpdateService/WorkflowStepsUpdate",
+            json!({
+                "workflow_run_backend_id": plan,
+                "workflow_job_run_backend_id": form,
+                "steps": [],
+            }),
+            &token,
+        )
+        .await;
+        assert_eq!(update["ok"], true);
+
+        request_json_with_bearer(
+            &app,
+            Method::POST,
+            "/twirp/results.services.receiver.Receiver/CreateStepSummaryMetadata",
+            json!({
+                "workflow_run_backend_id": plan,
+                "workflow_job_run_backend_id": form,
+                "step_backend_id": "step-1",
+                "size": 17,
+            }),
+            &token,
+        )
+        .await;
+        request_json_with_bearer(
+            &app,
+            Method::POST,
+            "/twirp/results.services.receiver.Receiver/CreateStepLogsMetadata",
+            json!({
+                "workflow_run_backend_id": plan,
+                "workflow_job_run_backend_id": form,
+                "step_backend_id": "step-1",
+                "line_count": 3,
+            }),
+            &token,
+        )
+        .await;
+        request_json_with_bearer(
+            &app,
+            Method::POST,
+            "/twirp/results.services.receiver.Receiver/CreateJobLogsMetadata",
+            json!({
+                "workflow_run_backend_id": plan,
+                "workflow_job_run_backend_id": form,
+                "line_count": 5,
+            }),
+            &token,
+        )
+        .await;
+    }
+
+    let step_payload = request_json_with_bearer(
+        &app,
+        Method::POST,
+        "/twirp/results.services.receiver.Receiver/GetStepLogsSignedBlobURL",
+        json!({
+            "workflow_run_backend_id": plan,
+            "workflow_job_run_backend_id": format!("{{{canonical}}}"),
+            "step_backend_id": "step-1",
+        }),
+        &token,
+    )
+    .await;
+    let uploaded = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::PUT)
+                .uri(step_payload["logs_url"].as_str().unwrap())
+                .body(Body::from("canonical path"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(uploaded.status(), StatusCode::CREATED);
+    assert_eq!(
+        tokio::fs::read_to_string(
+            temp.path()
+                .join("replay")
+                .join("results")
+                .join(&plan)
+                .join(&canonical)
+                .join("step-step-1.txt"),
+        )
+        .await
+        .unwrap(),
+        "canonical path"
+    );
+
+    let inner = state.inner.lock().await;
+    let expected_keys = [
+        format!("results:{plan}:{canonical}:summary:step-1"),
+        format!("results:{plan}:{canonical}:step:step-1"),
+        format!("results:{plan}:{canonical}:job:{canonical}"),
+    ]
+    .into_iter()
+    .collect::<BTreeSet<_>>();
+    let actual_keys = inner.log_metadata.keys().cloned().collect::<BTreeSet<_>>();
+    assert_eq!(
+        actual_keys, expected_keys,
+        "all accepted UUID spellings must share one metadata namespace"
+    );
+    assert_eq!(
+        inner
+            .log_metadata
+            .get(&format!("results:{plan}:{canonical}:summary:step-1"))
+            .map(|meta| (meta.byte_count, meta.line_count)),
+        Some((17, 0))
+    );
+    assert_eq!(
+        inner
+            .log_metadata
+            .get(&format!("results:{plan}:{canonical}:step:step-1"))
+            .map(|meta| (meta.byte_count, meta.line_count)),
+        Some((240, 3))
+    );
+    assert_eq!(
+        inner
+            .log_metadata
+            .get(&format!("results:{plan}:{canonical}:job:{canonical}"))
+            .map(|meta| (meta.byte_count, meta.line_count)),
+        Some((400, 5))
+    );
+}
+
+#[tokio::test]
+async fn alternate_results_job_spelling_preserves_canonical_log_lookup() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let (run_id, jobs) = two_job_run_for_log_filters(&app, &state).await;
+    let (_, plan, canonical) = jobs
+        .iter()
+        .find(|(job, _, _)| job == "build")
+        .cloned()
+        .expect("build job must be present");
+    let job = canonical.parse::<uuid::Uuid>().unwrap();
+    let token = state.mint_runtime_token(&plan, &job);
+    let alternate = format!("{{{canonical}}}");
+
+    let payload = request_json_with_bearer(
+        &app,
+        Method::POST,
+        "/twirp/results.services.receiver.Receiver/GetJobLogsSignedBlobURL",
+        json!({
+            "workflow_run_backend_id": plan,
+            "workflow_job_run_backend_id": alternate,
+        }),
+        &token,
+    )
+    .await;
+    let uploaded = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::PUT)
+                .uri(payload["logs_url"].as_str().unwrap())
+                .body(Body::from("lookup survives"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(uploaded.status(), StatusCode::CREATED);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri(format!("/api/v1/runs/{run_id}/logs?job={canonical}"))
+                .header(header::AUTHORIZATION, "Bearer preloop-system-token")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap()
+            .as_ref(),
+        b"lookup survives"
+    );
+    assert!(
+        !temp
+            .path()
+            .join("replay")
+            .join("results")
+            .join(&plan)
+            .join(&alternate)
+            .exists(),
+        "alternate spelling must not create a second lookup directory"
+    );
+}
+
+#[tokio::test]
+async fn results_reject_cross_job_and_malformed_uuid_targets() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let plan = "plan-1";
+    let own_job = uuid::Uuid::parse_str("01234567-89ab-4cde-8fab-cdef01234567").unwrap();
+    let other_job = uuid::Uuid::parse_str("fedcba98-7654-4321-89ab-cdef01234567").unwrap();
+    let token = state.mint_runtime_token(plan, &own_job);
+    let targets = [
+        format!("{{{other_job}}}"),
+        other_job.to_string().to_ascii_uppercase(),
+        "not-a-uuid".to_owned(),
+    ];
+
+    for target in &targets {
+        for uri in [
+            "/twirp/results.services.receiver.Receiver/GetJobLogsSignedBlobURL",
+            "/twirp/results.services.receiver.Receiver/GetStepLogsSignedBlobURL",
+            "/twirp/results.services.receiver.Receiver/GetStepSummarySignedBlobURL",
+            "/twirp/results.services.receiver.Receiver/GetJobDiagLogsSignedBlobURL",
+        ] {
+            assert_eq!(
+                status_with_bearer(
+                    &app,
+                    &token,
+                    Method::POST,
+                    uri,
+                    json!({
+                        "workflow_run_backend_id": plan,
+                        "workflow_job_run_backend_id": target,
+                        "step_backend_id": "step-1",
+                    }),
+                )
+                .await,
+                StatusCode::FORBIDDEN,
+                "Results target must stay bound to the token's job: {target}"
+            );
+        }
+
+        for (uri, body) in [
+            (
+                "/twirp/results.services.receiver.Receiver/CreateStepSummaryMetadata",
+                json!({
+                    "workflow_run_backend_id": plan,
+                    "workflow_job_run_backend_id": target,
+                    "step_backend_id": "step-1",
+                    "size": 99,
+                }),
+            ),
+            (
+                "/twirp/results.services.receiver.Receiver/CreateStepLogsMetadata",
+                json!({
+                    "workflow_run_backend_id": plan,
+                    "workflow_job_run_backend_id": target,
+                    "step_backend_id": "step-1",
+                    "line_count": 99,
+                }),
+            ),
+            (
+                "/twirp/results.services.receiver.Receiver/CreateJobLogsMetadata",
+                json!({
+                    "workflow_run_backend_id": plan,
+                    "workflow_job_run_backend_id": target,
+                    "line_count": 99,
+                }),
+            ),
+        ] {
+            assert_eq!(
+                status_with_bearer(&app, &token, Method::POST, uri, body).await,
+                StatusCode::FORBIDDEN,
+                "metadata target must stay bound to the token's job: {target}"
+            );
+        }
+    }
+
+    assert_eq!(
+        status_with_bearer(
+            &app,
+            &token,
+            Method::POST,
+            "/twirp/results.services.receiver.Receiver/GetJobLogsSignedBlobURL",
+            json!({
+                "workflow_run_backend_id": "different-plan",
+                "workflow_job_run_backend_id": own_job.to_string(),
+            }),
+        )
+        .await,
+        StatusCode::FORBIDDEN,
+        "a matching UUID under another plan is still a different Results target"
+    );
+
+    let inner = state.inner.lock().await;
+    assert!(
+        inner.log_metadata.is_empty(),
+        "rejected Results targets must not create metadata"
+    );
+}
+
+#[tokio::test]
+async fn system_results_token_preserves_opaque_identifier_compatibility() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let payload = request_json_with_bearer(
+        &app,
+        Method::POST,
+        "/twirp/results.services.receiver.Receiver/GetJobLogsSignedBlobURL",
+        json!({
+            "workflow_run_backend_id": "plan-opaque",
+            "workflow_job_run_backend_id": "job-opaque",
+        }),
+        DEFAULT_PRELOOP_SYSTEM_TOKEN,
+    )
+    .await;
+    assert!(
+        payload["logs_url"]
+            .as_str()
+            .is_some_and(|url| url.contains("/replay/results/plan-opaque/job-opaque/job-logs.txt")),
+        "system callers may continue to address opaque backend ids"
+    );
+
+    request_json_with_bearer(
+        &app,
+        Method::POST,
+        "/twirp/results.services.receiver.Receiver/CreateJobLogsMetadata",
+        json!({
+            "workflow_run_backend_id": "plan-opaque",
+            "workflow_job_run_backend_id": "job-opaque",
+            "line_count": 2,
+        }),
+        DEFAULT_PRELOOP_SYSTEM_TOKEN,
+    )
+    .await;
+    let inner = state.inner.lock().await;
+    assert!(
+        inner
+            .log_metadata
+            .contains_key("results:plan-opaque:job-opaque:job:job-opaque"),
+        "opaque system-token metadata ids must retain their existing spelling"
+    );
+}
+
+#[tokio::test]
 async fn results_workflow_steps_require_the_calling_job() {
     let temp = tempfile::tempdir().unwrap();
     let state = AppState::new(temp.path().to_path_buf()).await.unwrap();

--- a/crates/preloop-runner-server/src/results_twirp.rs
+++ b/crates/preloop-runner-server/src/results_twirp.rs
@@ -156,18 +156,14 @@ pub(crate) async fn twirp_get_job_logs_signed_blob_url(
     // bearerless route reachable from inside every runner VM. Only mint for
     // the plan/job the caller's token actually names, or workflow code could
     // ask for another job's URL and overwrite its logs.
-    if !crate::auth::results_identity_binds_job(
+    let job_id = crate::auth::require_canonical_results_job_id(
         &identity,
         &request.workflow_run_backend_id,
         &request.workflow_job_run_backend_id,
-    ) {
-        return Err(ApiError::forbidden(
-            "replay blob URL minting requires a token for that job",
-        ));
-    }
+    )?;
     let path = format!(
         "/replay/results/{}/{}/job-logs.txt",
-        request.workflow_run_backend_id, request.workflow_job_run_backend_id
+        request.workflow_run_backend_id, job_id
     );
     let expires_at = crate::auth::replay_ticket_expiry();
     let sig = crate::auth::sign_replay_upload_ticket(&shared.state, &path, expires_at);
@@ -201,20 +197,14 @@ pub(crate) async fn twirp_get_step_logs_signed_blob_url(
     axum::extract::Extension(identity): axum::extract::Extension<crate::auth::ResultsIdentity>,
     Json(request): Json<StepLogsSignedBlobUrlRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    if !crate::auth::results_identity_binds_job(
+    let job_id = crate::auth::require_canonical_results_job_id(
         &identity,
         &request.workflow_run_backend_id,
         &request.workflow_job_run_backend_id,
-    ) {
-        return Err(ApiError::forbidden(
-            "replay blob URL minting requires a token for that job",
-        ));
-    }
+    )?;
     let path = format!(
         "/replay/results/{}/{}/step-{}.txt",
-        request.workflow_run_backend_id,
-        request.workflow_job_run_backend_id,
-        request.step_backend_id
+        request.workflow_run_backend_id, job_id, request.step_backend_id
     );
     let expires_at = crate::auth::replay_ticket_expiry();
     let sig = crate::auth::sign_replay_upload_ticket(&shared.state, &path, expires_at);
@@ -240,20 +230,14 @@ pub(crate) async fn twirp_get_step_summary_signed_blob_url(
     axum::extract::Extension(identity): axum::extract::Extension<crate::auth::ResultsIdentity>,
     Json(request): Json<StepSummarySignedBlobUrlRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    if !crate::auth::results_identity_binds_job(
+    let job_id = crate::auth::require_canonical_results_job_id(
         &identity,
         &request.workflow_run_backend_id,
         &request.workflow_job_run_backend_id,
-    ) {
-        return Err(ApiError::forbidden(
-            "replay blob URL minting requires a token for that job",
-        ));
-    }
+    )?;
     let path = format!(
         "/replay/results/{}/{}/step-{}-summary.md",
-        request.workflow_run_backend_id,
-        request.workflow_job_run_backend_id,
-        request.step_backend_id
+        request.workflow_run_backend_id, job_id, request.step_backend_id
     );
     let expires_at = crate::auth::replay_ticket_expiry();
     let sig = crate::auth::sign_replay_upload_ticket(&shared.state, &path, expires_at);
@@ -307,7 +291,7 @@ pub(crate) async fn twirp_create_step_summary_metadata(
     axum::extract::Extension(identity): axum::extract::Extension<crate::auth::ResultsIdentity>,
     Json(request): Json<StepSummaryMetadataRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    crate::auth::require_results_job(
+    let job_id = crate::auth::require_canonical_results_job_id(
         &identity,
         &request.workflow_run_backend_id,
         &request.workflow_job_run_backend_id,
@@ -318,7 +302,7 @@ pub(crate) async fn twirp_create_step_summary_metadata(
         results_metadata_key(
             "summary",
             Some(&request.workflow_run_backend_id),
-            Some(&request.workflow_job_run_backend_id),
+            Some(job_id.as_str()),
             Some(&request.step_backend_id),
         ),
         LogMetadata {
@@ -356,21 +340,24 @@ pub(crate) async fn twirp_create_step_logs_metadata(
     let Some(step_backend_id) = request.step_backend_id else {
         return Ok(Json(json!({"ok": true})));
     };
-    // Absent identifiers mean there is nothing to key or authorize against;
-    // stay compatible by succeeding without writing, as with a missing step id.
-    let (Some(plan_id), Some(job_id)) = (
+    let (Some(plan_id), Some(raw_job_id)) = (
         request.workflow_run_backend_id.as_deref(),
         request.workflow_job_run_backend_id.as_deref(),
     ) else {
         return Ok(Json(json!({"ok": true})));
     };
-    crate::auth::require_results_job(&identity, plan_id, job_id)?;
+    let job_id = crate::auth::require_canonical_results_job_id(&identity, plan_id, raw_job_id)?;
     let line_count = request.line_count.unwrap_or_default();
     let line_count_usize = line_count.min(usize::MAX as u64) as usize;
     let byte_count = line_count.saturating_mul(80).min(usize::MAX as u64) as usize;
     let mut inner = shared.state.inner.lock().await;
     inner.log_metadata.insert(
-        results_metadata_key("step", Some(plan_id), Some(job_id), Some(&step_backend_id)),
+        results_metadata_key(
+            "step",
+            Some(plan_id),
+            Some(job_id.as_str()),
+            Some(&step_backend_id),
+        ),
         LogMetadata {
             byte_count,
             line_count: line_count_usize,
@@ -401,15 +388,13 @@ pub(crate) async fn twirp_create_job_logs_metadata(
     axum::extract::Extension(identity): axum::extract::Extension<crate::auth::ResultsIdentity>,
     Json(request): Json<JobLogsMetadataRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let Some(workflow_job_run_backend_id) = request.workflow_job_run_backend_id else {
+    let Some(raw_job_id) = request.workflow_job_run_backend_id else {
         return Ok(Json(json!({"ok": true})));
     };
-    // Absent plan means there is nothing to key or authorize against; stay
-    // compatible by succeeding without writing.
     let Some(plan_id) = request.workflow_run_backend_id.as_deref() else {
         return Ok(Json(json!({"ok": true})));
     };
-    crate::auth::require_results_job(&identity, plan_id, &workflow_job_run_backend_id)?;
+    let job_id = crate::auth::require_canonical_results_job_id(&identity, plan_id, &raw_job_id)?;
     let line_count = request.line_count.unwrap_or_default();
     let line_count_usize = line_count.min(usize::MAX as u64) as usize;
     let byte_count = line_count.saturating_mul(80).min(usize::MAX as u64) as usize;
@@ -418,8 +403,8 @@ pub(crate) async fn twirp_create_job_logs_metadata(
         results_metadata_key(
             "job",
             Some(plan_id),
-            Some(&workflow_job_run_backend_id),
-            Some(&workflow_job_run_backend_id),
+            Some(job_id.as_str()),
+            Some(job_id.as_str()),
         ),
         LogMetadata {
             byte_count,


### PR DESCRIPTION
## Summary
- canonicalize UUID-equivalent Results job identifiers only after Results authorization
- use the canonical lower-case hyphenated UUID for replay signed URL paths and scoped metadata keys
- preserve system-token opaque backend IDs and canonical run-log lookup

This is stacked on #216 (`fix: bind Results mutations to job tokens`), which supplies typed Results job authorization.

## Reproduction
On the authorization baseline, a braced job UUID was accepted by the Results token check but minted `/replay/results/plan-1/{UUID}/step-step-1.txt`, while log lookup reads the canonical UUID directory. The committed regression test reproduced that namespace fork before the fix and passes after it.

## Coverage
- canonical, uppercase, braced, simple, and lowercase `urn:uuid:` forms
- malformed and explicit cross-job/plan targets rejected
- all three replay signed URL endpoints and metadata namespaces
- system-token opaque IDs and canonical lookup after an alternate-form upload

## Checks
- `cargo test -p preloop-runner-server results_ --lib -- --nocapture` (16 passed)
- `cargo fmt --all -- --check`
- `cargo clippy -p preloop-runner-server --all-targets -- -D warnings`

`just test-ci` reached workspace clippy but stopped at existing zizmor `impostor-commit` findings for pinned `dtolnay/rust-toolchain` refs. Full workspace tests were stopped after 11 minutes with no failure result because an existing server test remained active. `just sg-scan-strict` could not run because `sg` is not installed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Canonicalizes Results job UUIDs so braced, uppercase, simple, and `urn:uuid:` spellings all resolve to one storage namespace, fixing a fork where alternate forms minted replay paths and metadata keys the log lookup never read.

- Signed URL paths and scoped metadata keys use the lower-case hyphenated UUID form.
- Runtime tokens authorize against the canonical UUID; the system token keeps accepting opaque backend IDs unchanged.
- Metadata keys are scoped to `results:{plan}:{job}:{kind}:{resource}` when plan/job identifiers are present.
- Results mutations (workflow step updates and metadata writes) now reject targets outside the token's job.

<sup>Written for commit 4f9bfe999f3f73716e7af2b3d82864c98e9e8c65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

