### PR TITLE
chore(supply-chain): vet toml datetime 1.1

### DIFF
--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1395,6 +1395,10 @@ criteria = "safe-to-deploy"
 version = "0.6.11"
 criteria = "safe-to-deploy"
 
+[[exemptions.toml_datetime]]
+version = "1.1.1+spec-1.1.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.toml_edit]]
 version = "0.22.27"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## What
Add the missing cargo-vet exemption for `toml_datetime 1.1.1+spec-1.1.0`.

## Why
The credential-store dependency update introduced this lockfile package, causing every supply-chain job to fail at `cargo vet --locked`.

## Verification
- `cargo vet --locked` passes locally
- `git diff --check` passes

Policy-only PR, as required by the supply-chain workflow guard.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing `cargo vet` exemption for `toml_datetime 1.1.1+spec-1.1.0` so supply-chain jobs stop failing at `cargo vet --locked`.

The package was introduced by a credential-store dependency update. This is a policy-only change; `cargo vet --locked` and `git diff --check` both pass locally.

<sup>Written for commit 4282508b1ca44ade713100fb337ffd0ac2f32a69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

