### PR TITLE
fix: require Results step metadata ids

### DIFF
--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -6827,6 +6827,45 @@ async fn job_results_token_cannot_update_another_jobs_steps() {
 }
 
 #[tokio::test]
+async fn twirp_step_metadata_rejects_missing_step_backend_id() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let requests = [
+        (
+            "/twirp/results.services.receiver.Receiver/CreateStepSummaryMetadata",
+            json!({
+                "workflow_job_run_backend_id": "job-1",
+                "workflow_run_backend_id": "run-1",
+                "size": 321,
+            }),
+        ),
+        (
+            "/twirp/results.services.receiver.Receiver/CreateStepLogsMetadata",
+            json!({
+                "workflow_job_run_backend_id": "job-1",
+                "workflow_run_backend_id": "run-1",
+                "line_count": 7,
+            }),
+        ),
+    ];
+
+    for (uri, body) in requests {
+        let (status, payload) = request_json_status(&app, Method::POST, uri, body).await;
+        assert!(status.is_client_error(), "{uri} returned {status}");
+        assert!(
+            !matches!(payload.get("ok"), Some(Value::Bool(true))),
+            "{uri} must not report success"
+        );
+    }
+
+    assert!(
+        state.inner.lock().await.log_metadata.is_empty(),
+        "missing step ids must not create metadata"
+    );
+}
+
+#[tokio::test]
 async fn twirp_diag_route_rejects_runner_listen_scope() {
     let temp = tempfile::tempdir().unwrap();
     let state = AppState::new(temp.path().to_path_buf()).await.unwrap();

--- a/crates/preloop-runner-server/src/results_twirp.rs
+++ b/crates/preloop-runner-server/src/results_twirp.rs
@@ -321,7 +321,7 @@ pub(crate) async fn twirp_create_step_summary_metadata(
 #[derive(Debug, Deserialize)]
 pub(crate) struct StepLogsMetadataRequest {
     // The backend identifiers identify the target job for Results authorization.
-    pub(crate) step_backend_id: Option<String>,
+    pub(crate) step_backend_id: String,
     pub(crate) workflow_job_run_backend_id: Option<String>,
     pub(crate) workflow_run_backend_id: Option<String>,
     // serde: metadata is accepted for protocol compatibility; field is not inspected.
@@ -337,9 +337,6 @@ pub(crate) async fn twirp_create_step_logs_metadata(
     axum::extract::Extension(identity): axum::extract::Extension<crate::auth::ResultsIdentity>,
     Json(request): Json<StepLogsMetadataRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    let Some(step_backend_id) = request.step_backend_id else {
-        return Ok(Json(json!({"ok": true})));
-    };
     let (Some(plan_id), Some(raw_job_id)) = (
         request.workflow_run_backend_id.as_deref(),
         request.workflow_job_run_backend_id.as_deref(),
@@ -356,7 +353,7 @@ pub(crate) async fn twirp_create_step_logs_metadata(
             "step",
             Some(plan_id),
             Some(job_id.as_str()),
-            Some(&step_backend_id),
+            Some(&request.step_backend_id),
         ),
         LogMetadata {
             byte_count,
@@ -373,7 +370,7 @@ pub(crate) async fn twirp_create_step_logs_metadata(
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct JobLogsMetadataRequest {
-    // The backend identifiers identify the target job for Results authorization.
+    // Job-log metadata is job-scoped and intentionally has no step_backend_id.
     pub(crate) workflow_job_run_backend_id: Option<String>,
     pub(crate) workflow_run_backend_id: Option<String>,
     // serde: metadata is accepted for protocol compatibility; field is not inspected.


### PR DESCRIPTION
## Summary
- Require `step_backend_id` in `StepLogsMetadataRequest`; missing step metadata now fails with a 4xx instead of returning success without writing state.
- Keep `StepSummaryMetadataRequest` step identity required and keep job-log metadata intentionally step-free, matching the official runner contract.
- Preserve the parent branch's Results job-token binding and add a regression test covering missing step ids and no metadata mutation.

## Protocol evidence
- Official runner v2.336.0 contracts and `ResultsHttpClient` send `step_backend_id` for step summaries and step logs; job logs have no step id.
- Checked-in official goldens: v2.336.0 had 130 step-scoped metadata calls with 0 missing step ids; v2.337.0 `gh-official` had 198 step-scoped calls with 0 missing step ids.

## Validation
- Focused server tests: missing-step rejection, metadata persistence, and calling-job authorization all pass.
- `cargo fmt --all` passes.
- `cargo clippy -p preloop-runner-server --all-targets -- -D warnings` passes.
- `just test-ci` reaches workspace fmt/clippy successfully, then fails on existing `zizmor` `impostor-commit` findings for the pinned `dtolnay/rust-toolchain` workflow references; no changed files are workflow files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Requires Results step metadata to be authenticated by the owning job token, with step-log requests also requiring `step_backend_id`; missing identity now returns a 4xx instead of silently reporting success. Hardens legacy runner authentication so registration needs real credentials, message polling and job lifecycle bind to the verified runner identity, and the mounted socket stays strict even in permissive TCP mode. The per-engine admin token is now generated on first startup and stored securely instead of using a hardcoded default.

**Security**

- Results mutations, OIDC, snapshot, and quota checks share one canonical Results token parser requiring an exact job UUID match.
- Broker polling rejects foreign sessions; duplicate completes are idempotent and renews on completed jobs conflict.
- Permissive registration is loopback-only and sensitive headers are redacted from recorded flows.

**Fixes**

- Orchestrator fails closed when node externals are unresolvable and links rustdoc, cargo-fmt, and cargo-clippy on the guest PATH.
- CI prebakes the pinned Rust toolchain and fetches LFS fixtures only where needed.

<sup>Written for commit de7659f62dc470a2b858f86e14a70fa17dd55927. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

