### PR TITLE
fix(server): centralize Results identity parsing

### DIFF
--- a/crates/preloop-runner-server/src/auth.rs
+++ b/crates/preloop-runner-server/src/auth.rs
@@ -45,7 +45,7 @@ pub(crate) async fn require_results_bearer(
         return Ok(next.run(request).await);
     }
     let Some(identity) =
-        bearer_token(&request).and_then(|token| results_identity(&shared.state, token))
+        bearer_token(&request).and_then(|token| results_identity(&shared.state, token).ok())
     else {
         return Err(ApiError::unauthorized("results-service job token required"));
     };
@@ -354,19 +354,61 @@ pub(crate) enum ResultsIdentity {
     Job(ResultsJobIdentity),
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ResultsIdentityError {
+    /// The bearer is signed locally but does not identify a Results job.
+    NotJob,
+    /// A job-shaped bearer has a valid job subject but malformed Results claims.
+    MalformedJob,
+    /// A job-shaped bearer has an invalid job subject.
+    MalformedJobSubject,
+    /// A valid job subject is paired with a non-Results scope.
+    MalformedScope,
+    /// The bearer is not a valid local JWT.
+    Invalid,
+}
+
 /// Parse the Results bearer into the identity handlers must authorize against.
 ///
 /// Requiring both the `sub` and the full Results scope to agree prevents a
 /// valid local JWT minted for one protocol surface from being repurposed as a
-/// different job's Results credential.
-pub(crate) fn results_identity(state: &AppState, bearer: &str) -> Option<ResultsIdentity> {
+/// different job's Results credential. The error distinguishes a malformed
+/// job-shaped token so cache writes can retain their fail-closed behavior.
+pub(crate) fn results_identity(
+    state: &AppState,
+    bearer: &str,
+) -> Result<ResultsIdentity, ResultsIdentityError> {
     if bearer == state.system_token {
-        return Some(ResultsIdentity::System);
+        return Ok(ResultsIdentity::System);
     }
 
-    let claims = state.verify_local_jwt_claims(bearer)?;
-    let (plan_id, job_id) = AppState::results_job_from_payload(&claims)?;
-    Some(ResultsIdentity::Job(ResultsJobIdentity { plan_id, job_id }))
+    let claims = state
+        .verify_local_jwt_claims(bearer)
+        .ok_or(ResultsIdentityError::Invalid)?;
+    let job_shaped = claims
+        .get("sub")
+        .and_then(|value| value.as_str())
+        .is_some_and(|subject| subject.starts_with("preloop-job-"))
+        && claims
+            .get("scp")
+            .and_then(|value| value.as_str())
+            .is_some_and(|scope| scope.starts_with("Actions.Results:"));
+    let parsed = AppState::results_job_from_payload(&claims);
+    let Some((plan_id, job_id)) = parsed else {
+        let subject_is_job = claims
+            .get("sub")
+            .and_then(|value| value.as_str())
+            .and_then(|subject| subject.strip_prefix("preloop-job-"))
+            .and_then(|job| job.parse::<uuid::Uuid>().ok())
+            .is_some();
+        return Err(match (job_shaped, subject_is_job) {
+            (true, true) => ResultsIdentityError::MalformedJob,
+            (true, false) => ResultsIdentityError::MalformedJobSubject,
+            (false, true) => ResultsIdentityError::MalformedScope,
+            (false, false) => ResultsIdentityError::NotJob,
+        });
+    };
+    Ok(ResultsIdentity::Job(ResultsJobIdentity { plan_id, job_id }))
 }
 
 pub(crate) fn results_identity_binds_job(

--- a/crates/preloop-runner-server/src/events/trust_tier.rs
+++ b/crates/preloop-runner-server/src/events/trust_tier.rs
@@ -145,24 +145,16 @@ pub(crate) async fn fork_restricted_from_token(
     state: &crate::state::AppState,
     token: &str,
 ) -> Option<bool> {
-    let payload = state.verify_local_jwt_claims(token)?;
-    let subject = payload.get("sub").and_then(|value| value.as_str());
-    let scope = payload.get("scp").and_then(|value| value.as_str());
-    // Only job runtime tokens carry the fork restriction. Anything not shaped
-    // like one (system token, runner-listen, debug-worker surfaces) belongs
-    // to the control plane and keeps its existing access.
-    let job_shaped = subject.is_some_and(|sub| sub.starts_with("preloop-job-"))
-        && scope.is_some_and(|scope| scope.starts_with("Actions.Results:"));
-    // Same agreement rule as `AppState::results_job_from_payload` — `sub` is
-    // the job, `scp` is exactly `Actions.Results:{plan_id}:{job_id}`, both
-    // must name the same job — derived from the payload we already verified,
-    // so the HMAC/expiry checks run once per cache write instead of twice.
-    let job = crate::state::AppState::results_job_from_payload(&payload).map(|(_, job)| job);
-    let Some(job) = job else {
-        // Signed like a job token but its subject/scope no longer parse to a
-        // job: nothing left to prove it trusted, so refuse.
-        return job_shaped.then_some(true);
+    let identity = match crate::auth::results_identity(state, token) {
+        Ok(crate::auth::ResultsIdentity::Job(identity)) => identity,
+        Ok(crate::auth::ResultsIdentity::System)
+        | Err(crate::auth::ResultsIdentityError::NotJob)
+        | Err(crate::auth::ResultsIdentityError::MalformedScope)
+        | Err(crate::auth::ResultsIdentityError::Invalid) => return None,
+        Err(crate::auth::ResultsIdentityError::MalformedJob)
+        | Err(crate::auth::ResultsIdentityError::MalformedJobSubject) => return Some(true),
     };
+    let job = identity.job_id;
     let inner = state.inner.lock().await;
     // Every hop of the correlation must survive. When the job is retired or
     // purged mid-flight the worker still holds a valid JWT, and the missing

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -7460,6 +7460,96 @@ async fn oidc_endpoint_mints_rs256_jwt_with_requested_audience() {
 }
 
 #[tokio::test]
+async fn results_surfaces_agree_on_alternate_uuid_scope_spelling() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+
+    request_json(
+        &app,
+        Method::POST,
+        "/api/v1/runs",
+        json!({
+            "workflow_yaml": "on: push\npermissions:\n  id-token: write\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps: [{ run: \"echo hi\" }]\n",
+            "event": "push",
+            "repository": "owner/repo"
+        }),
+    )
+    .await;
+
+    let (plan_id, agent_job_id) = {
+        let inner = state.inner.lock().await;
+        inner
+            .queue
+            .front()
+            .map(|job| (job.message.plan.plan_id.clone(), job.message.job_id))
+            .unwrap()
+    };
+    let alternate_scope_token = state
+        .local_jwt(json!({
+            "sub": format!("preloop-job-{agent_job_id}"),
+            "scp": format!(
+                "Actions.Results:{plan_id}:{}",
+                agent_job_id.to_string().to_uppercase()
+            ),
+        }))
+        .unwrap();
+
+    // The trust-tier surface already accepts UUID spelling variants through
+    // the canonical Results payload parser.
+    assert_eq!(
+        crate::events::trust_tier::fork_restricted_from_token(&state, &alternate_scope_token).await,
+        Some(false)
+    );
+
+    let malformed_job_token = state
+        .local_jwt(json!({
+            "sub": "preloop-job-not-a-uuid",
+            "scp": format!("Actions.Results:{plan_id}:{agent_job_id}"),
+        }))
+        .unwrap();
+    assert_eq!(
+        crate::events::trust_tier::fork_restricted_from_token(&state, &malformed_job_token).await,
+        Some(true),
+        "job-shaped malformed claims must keep cache writes fail-closed"
+    );
+    // Before centralization, the OIDC surface compared the raw scope string,
+    // so this valid Results identity was rejected.
+    let oidc_status = status_with_bearer(
+        &app,
+        &alternate_scope_token,
+        Method::GET,
+        &format!(
+            "/runner/server/_apis/distributedtask/hubs/actions/plans/{plan_id}/jobs/{}/oidctoken",
+            agent_job_id.to_string().to_uppercase()
+        ),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(
+        oidc_status,
+        StatusCode::OK,
+        "OIDC must accept the same typed identity as trust-tier checks"
+    );
+
+    let invalid_path_status = status_with_bearer(
+        &app,
+        &alternate_scope_token,
+        Method::GET,
+        &format!(
+            "/runner/server/_apis/distributedtask/hubs/actions/plans/{plan_id}/jobs/not-a-uuid/oidctoken"
+        ),
+        Value::Null,
+    )
+    .await;
+    assert_eq!(
+        invalid_path_status,
+        StatusCode::FORBIDDEN,
+        "an invalid job path remains an authorization failure for a job token"
+    );
+}
+
+#[tokio::test]
 async fn oidc_default_audience_is_owner_url() {
     let temp = tempfile::tempdir().unwrap();
     let state = AppState::new(temp.path().to_path_buf()).await.unwrap();

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -7514,14 +7514,16 @@ async fn results_surfaces_agree_on_alternate_uuid_scope_spelling() {
         "job-shaped malformed claims must keep cache writes fail-closed"
     );
     // Before centralization, the OIDC surface compared the raw scope string,
-    // so this valid Results identity was rejected.
+    // so this valid Results identity was rejected: the scope spells the job
+    // UUID uppercase while the path uses the canonical lowercase spelling.
+    // (Using the same spelling in both would compare equal pre-centralization
+    // and prove nothing.)
     let oidc_status = status_with_bearer(
         &app,
         &alternate_scope_token,
         Method::GET,
         &format!(
-            "/runner/server/_apis/distributedtask/hubs/actions/plans/{plan_id}/jobs/{}/oidctoken",
-            agent_job_id.to_string().to_uppercase()
+            "/runner/server/_apis/distributedtask/hubs/actions/plans/{plan_id}/jobs/{agent_job_id}/oidctoken"
         ),
         Value::Null,
     )

--- a/crates/preloop-runner-server/src/memory_caps.rs
+++ b/crates/preloop-runner-server/src/memory_caps.rs
@@ -121,12 +121,10 @@ pub(crate) fn now_unix() -> i64 {
 /// recovered from only the scope suffix.
 pub(crate) fn job_backend_id_from_bearer(state: &AppState, headers: &HeaderMap) -> Option<String> {
     let token = bearer_from_headers(headers)?;
-    if token == state.system_token {
-        return None;
+    match results_identity(state, token).ok()? {
+        ResultsIdentity::System => None,
+        ResultsIdentity::Job(identity) => Some(identity.job_id.to_string()),
     }
-    state
-        .results_job_from_token(token)
-        .map(|(_, job_id)| job_id.to_string())
 }
 // ─── Retention helpers ───────────────────────────────────────────────────────
 //

--- a/crates/preloop-runner-server/src/oidc_handlers.rs
+++ b/crates/preloop-runner-server/src/oidc_handlers.rs
@@ -42,13 +42,16 @@ pub(crate) async fn oidc_token(
         .and_then(|value| value.to_str().ok())
         .and_then(|value| value.strip_prefix("Bearer "))
         .ok_or_else(|| ApiError::unauthorized("OIDC bearer token required"))?;
-    let expected_scope = format!("Actions.Results:{plan_id}:{job_id}");
-    let is_system_token = bearer == shared.state.system_token;
-    if !is_system_token && !shared.state.verify_local_jwt_scope(bearer, &expected_scope) {
+    let identity = crate::auth::results_identity(&shared.state, bearer)
+        .map_err(|_| ApiError::forbidden("OIDC runtime token is not bound to this job"))?;
+    if !crate::auth::results_identity_binds_job(&identity, &plan_id, &job_id) {
         return Err(ApiError::forbidden(
             "OIDC runtime token is not bound to this job",
         ));
     }
+    let requested_job_id = job_id
+        .parse::<uuid::Uuid>()
+        .map_err(|_| ApiError::not_found("OIDC: plan and job do not match"))?;
     let inner = shared.state.inner.lock().await;
     let request_id = inner
         .plan_requests
@@ -59,7 +62,7 @@ pub(crate) async fn oidc_token(
         .job_requests
         .get(&request_id)
         .ok_or_else(|| ApiError::not_found("OIDC: job request not found"))?;
-    if request.agent_job_id.to_string() != job_id {
+    if request.agent_job_id != requested_job_id {
         return Err(ApiError::not_found("OIDC: plan and job do not match"));
     }
     let run_id = request.run_id;

--- a/crates/preloop-runner-server/src/snapshots.rs
+++ b/crates/preloop-runner-server/src/snapshots.rs
@@ -1977,33 +1977,38 @@ async fn authorize_snapshot_token(
     token: &str,
     run_id: RunId,
 ) -> Result<(), ApiError> {
-    let claims = state
-        .verify_local_jwt_claims(token)
-        .ok_or_else(|| ApiError::unauthorized("invalid snapshot Git token"))?;
-    let job_id = claims
-        .get("sub")
-        .and_then(serde_json::Value::as_str)
-        .and_then(|subject| subject.strip_prefix("preloop-job-"))
-        .and_then(|value| uuid::Uuid::parse_str(value).ok())
-        .ok_or_else(|| ApiError::unauthorized("snapshot Git token is not a job token"))?;
-    let valid_scope = claims
-        .get("scp")
-        .and_then(serde_json::Value::as_str)
-        .is_some_and(|scope| {
-            scope.starts_with("Actions.Results:") && scope.ends_with(&format!(":{job_id}"))
-        });
-    if !valid_scope {
-        return Err(ApiError::unauthorized(
-            "snapshot Git token lacks job result scope",
-        ));
-    }
+    let identity = match crate::auth::results_identity(state, token) {
+        Ok(crate::auth::ResultsIdentity::Job(identity)) => identity,
+        Ok(crate::auth::ResultsIdentity::System) => {
+            return Err(ApiError::unauthorized("invalid snapshot Git token"));
+        }
+        Err(crate::auth::ResultsIdentityError::NotJob)
+        | Err(crate::auth::ResultsIdentityError::MalformedJobSubject) => {
+            return Err(ApiError::unauthorized(
+                "snapshot Git token is not a job token",
+            ));
+        }
+        Err(crate::auth::ResultsIdentityError::MalformedJob)
+        | Err(crate::auth::ResultsIdentityError::MalformedScope) => {
+            return Err(ApiError::unauthorized(
+                "snapshot Git token lacks job result scope",
+            ));
+        }
+        Err(crate::auth::ResultsIdentityError::Invalid) => {
+            return Err(ApiError::unauthorized("invalid snapshot Git token"));
+        }
+    };
 
     let inner = state.inner.lock().await;
     let belongs_to_run = inner
         .agent_job_requests
-        .get(&job_id)
+        .get(&identity.job_id)
         .and_then(|request_id| inner.job_requests.get(request_id))
-        .is_some_and(|request| request.run_id == run_id);
+        .is_some_and(|request| {
+            request.run_id == run_id
+                && request.plan_id == identity.plan_id
+                && request.agent_job_id == identity.job_id
+        });
     if !belongs_to_run {
         return Err(ApiError::forbidden(
             "snapshot Git token does not belong to this run",
@@ -2030,7 +2035,7 @@ fn snapshot_authorization_token(value: &str) -> Option<String> {
 
 #[cfg(test)]
 mod auth_scoping_tests {
-    use super::github_auth_header_for_remote;
+    use super::*;
 
     #[test]
     fn github_remote_gets_scoped_basic_header() {
@@ -2045,6 +2050,45 @@ mod auth_scoping_tests {
             value,
             "AUTHORIZATION: basic eC1hY2Nlc3MtdG9rZW46Z2hvX3NlY3JldA=="
         );
+    }
+
+    #[tokio::test]
+    async fn results_snapshot_auth_preserves_malformed_claim_errors() {
+        let temp = tempfile::tempdir().unwrap();
+        let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+        let job_id = uuid::Uuid::new_v4();
+        let cases = [
+            (
+                "preloop-job-not-a-uuid".to_owned(),
+                format!("Actions.Results:plan:{job_id}"),
+                "snapshot Git token is not a job token",
+            ),
+            (
+                format!("preloop-job-{job_id}"),
+                "not-results".to_owned(),
+                "snapshot Git token lacks job result scope",
+            ),
+            (
+                format!("preloop-job-{job_id}"),
+                format!("Actions.Results:plan:extra:{job_id}"),
+                "snapshot Git token lacks job result scope",
+            ),
+        ];
+        let run_id = "00000000-0000-0000-0000-000000000001".parse().unwrap();
+
+        for (subject, scope, expected_message) in cases {
+            let token = state
+                .local_jwt(json!({
+                    "sub": subject,
+                    "scp": scope,
+                }))
+                .unwrap();
+            let error = authorize_snapshot_token(&state, &token, run_id)
+                .await
+                .expect_err("malformed Results claims must be rejected");
+            assert_eq!(error.status(), StatusCode::UNAUTHORIZED);
+            assert_eq!(error.message(), expected_message);
+        }
     }
 
     #[test]

--- a/crates/preloop-runner-server/src/state.rs
+++ b/crates/preloop-runner-server/src/state.rs
@@ -124,18 +124,6 @@ impl AppState {
         mac.verify_slice(&provided).is_ok()
     }
 
-    pub(crate) fn verify_local_jwt_scope(&self, token: &str, expected_scope: &str) -> bool {
-        self.verify_local_jwt_claims(token)
-            .and_then(|payload| {
-                payload
-                    .get("scp")
-                    .and_then(|value| value.as_str())
-                    .map(str::to_owned)
-            })
-            .as_deref()
-            == Some(expected_scope)
-    }
-
     pub(crate) fn runner_id_from_token(&self, token: &str) -> Option<i64> {
         let payload = self.verify_local_jwt_claims(token)?;
         let scope = payload.get("scp")?.as_str()?;


### PR DESCRIPTION
## Summary

- Route quota backend identity, cache trust-tier checks, OIDC minting, and snapshot Git authorization through the canonical typed `ResultsIdentity` parser.
- Remove the redundant raw-scope helper and preserve the Results system credential bypass plus job-only snapshot behavior.
- Add same-token cross-surface regression coverage and malformed-claim/error-parity coverage.

## Why

Before this change, one valid Results token could produce different authorization decisions. The failing-first regression minted one token whose UUID scope used an alternate but equivalent spelling:

- trust-tier classification: `Some(false)`
- OIDC endpoint: `403`

The pre-centralization test was `results_surfaces_disagree_on_alternate_uuid_scope_spelling`; it failed with `left: 403`, `right: 200`. The renamed regression, `results_surfaces_agree_on_alternate_uuid_scope_spelling`, now passes and also verifies malformed job-shaped trust tokens fail closed and an invalid job path remains `403` for a Job identity.

## Drift removed

| Surface | Previous parser | Current behavior |
| --- | --- | --- |
| Quota (`memory_caps.rs`) | Separate Results job extraction | Uses the typed Job identity; System remains unscoped. |
| Cache trust tier (`events/trust_tier.rs`) | Direct JWT subject/scope shape checks and payload parsing | Uses the canonical identity; malformed job-shaped credentials retain the existing fail-closed `Some(true)` result. |
| OIDC (`oidc_handlers.rs`) | Raw exact `Actions.Results:{plan}:{job}` scope comparison | Uses typed plan/job binding. Equivalent UUID spellings are consistent across scope and path; System bypass remains available. Authorization runs before path UUID resolution, preserving the Job-token `403` for an invalid path. |
| Snapshots (`snapshots.rs`) | Job subject plus scope prefix/suffix checks | Uses typed plan/job identity plus run binding. Extra scope components and mismatched plan/job claims are rejected; existing malformed-claim messages and job-only/System rejection are preserved. |

No golden files changed.

## Verification

- `cargo fmt --all --check` — passed.
- `cargo clippy --locked -p preloop-runner-server --all-targets -- -D warnings` — passed.
- `cargo test --locked -p preloop-runner-server results_surfaces_agree_on_alternate_uuid_scope_spelling -- --nocapture` — passed.
- `cargo test --locked -p preloop-runner-server results_snapshot_auth_preserves_malformed_claim_errors -- --nocapture` — passed.
- `cargo test --locked -p preloop-runner-server job_backend_id_from_bearer -- --nocapture` — 3 passed.
- `cargo test --locked -p preloop-runner-server oidc_ -- --nocapture` — 8 passed.
- The full server suite independently had 682 passed, 1 failed, and 3 ignored; the lone failure was the existing timing-sensitive `fork_job_never_receives_the_configured_pat_override` assertion, differing only in JWT `iat`/`exp` by one second. A separate Opus run of the same suite had 683 passed, 0 failed, and 3 ignored.
- `just test-ci` passed formatting and workspace clippy, then stopped at the existing `zizmor` `impostor-commit` workflow findings (exit 14), before tests/conformance.
- `just sg-scan-strict` could not run because `sg` is not installed.

## Runner/golden evidence

The v2.335.1 official golden captures redact Authorization values, and `runner-watch` replays use the system credential, so those captures cannot prove Job-token parsing. Replays for `10-uses-checkout`, `11-cache-roundtrip`, and `15-oidc-id-token` reached the relevant endpoints with matching statuses/schemas where exercised; reports still show the pre-existing broker `acquirejob` response-schema drift (and the cache scenario's existing finalize-upload `404`). No official runner binary was available at `~/.cache/actions-runner/current`, so live official-runner dogfood was unavailable. The local tests use real server-generated JWTs and cover subject/scope agreement, UUID spellings, System/Job boundaries, malformed claims, cross-target binding, and fail-closed cache writes.

## Review

A separate read-only Opus 5 adversarial review was run in the active worktree using the requested command. Initial review findings were resolved: OIDC authorization ordering now preserves the original invalid-path status, and snapshot malformed-subject/scope classification is covered and parity-correct. Final verdict: **PASS**, with no bypasses or blockers; the remaining UUID normalization behavior is intentional and regression-tested.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes Results bearer-token identity parsing so the same token yields consistent authorization decisions across quota, cache trust-tier, OIDC, and snapshot Git surfaces.

- Routes quota, trust-tier, OIDC, and snapshot authorization through the shared `ResultsIdentity` parser in `auth.rs`.
- Fixes a regression where a token with an alternate UUID scope spelling passed trust-tier checks but got `403` from the OIDC endpoint.
- Keeps the System credential bypass, the job-only snapshot restriction, and the fail-closed `Some(true)` cache result for malformed job-shaped tokens.
- Removes the now-redundant `verify_local_jwt_scope` helper.
- Adds regression tests covering alternate UUID spellings (uppercase in scope vs canonical in path) and malformed-claim error parity.

<sup>Written for commit 388a24ae0b82557fce111b8f08824336b8834ec4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened credential validation across results, snapshots, OIDC, trust-tier, and quota flows.
  * Ensured credentials are matched to the requested plan, job, and run.
  * Added clearer unauthorized responses for invalid, malformed, or incorrectly scoped credentials.
  * Preserved fail-closed behavior for malformed job credentials.

* **Tests**
  * Added coverage for alternate job ID scope formats and malformed credential claims across related endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->