### PR TITLE
fix(orchestrator): put rustdoc on the guest PATH

### DIFF
--- a/crates/preloop-orchestrator/src/environment.rs
+++ b/crates/preloop-orchestrator/src/environment.rs
@@ -173,8 +173,12 @@ impl ToolchainLayer {
                     // Run steps execute with `bash --noprofile --norc`, so
                     // profile.d PATH exports are never sourced. Symlink the
                     // cargo binaries into /usr/local/bin so they are on the
-                    // default system PATH for every step shell.
-                    "ln -sf $HOME/.cargo/bin/cargo /usr/local/bin/cargo; ln -sf $HOME/.cargo/bin/rustc /usr/local/bin/rustc; ln -sf $HOME/.cargo/bin/rustup /usr/local/bin/rustup".into(),
+                    // default system PATH for every step shell. `rustdoc` is
+                    // included because `cargo test` spawns it by bare name for
+                    // doctests: without it on PATH the whole workspace test
+                    // step dies with `could not execute process rustdoc`
+                    // after every real test has already passed.
+                    "ln -sf $HOME/.cargo/bin/cargo /usr/local/bin/cargo; ln -sf $HOME/.cargo/bin/rustc /usr/local/bin/rustc; ln -sf $HOME/.cargo/bin/rustdoc /usr/local/bin/rustdoc; ln -sf $HOME/.cargo/bin/rustup /usr/local/bin/rustup".into(),
                 ],
             ],
             Self::Python(version) => {
@@ -536,6 +540,22 @@ mod tests {
         assert!(script.contains("--profile minimal"));
         assert!(script.contains("--default-toolchain stable"));
         assert!(!script.contains("sh.rustup.rs"));
+    }
+
+    /// `cargo test --workspace` spawns `rustdoc` by bare name for doctests, so
+    /// the interpreter must be on the default PATH of a `bash --noprofile
+    /// --norc` step shell. Without the symlink the workspace test step fails
+    /// with `could not execute process rustdoc` after every real test passed.
+    #[test]
+    fn rust_layer_puts_rustdoc_on_default_path() {
+        let commands = ToolchainLayer::Rust("stable".into()).install_commands();
+        let script = commands[1].join(" ");
+        for binary in ["cargo", "rustc", "rustdoc", "rustup"] {
+            assert!(
+                script.contains(&format!("/usr/local/bin/{binary}")),
+                "{binary} must be linked onto the default PATH: {script}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What & why

With node externals resolvable again, the dogfood engine's `property-tests-fast` job ran the real suite — 42 expression tests, 14/9/11 concurrency filters, all green — and then died on:

```
error: doctest failed, to rerun pass `-p preloop-gha-expressions --doc`
Caused by:
  could not execute process `rustdoc --edition=2021 …`
```

Step shells run `bash --noprofile --norc`, so profile.d PATH exports never load and only binaries symlinked into `/usr/local/bin` resolve. The Rust toolchain layer linked `cargo`, `rustc`, and `rustup` — but not `rustdoc`, which `cargo test --workspace` spawns by bare name for doctests. Same class of bug the Go layer's symlinks already fix.

## Protocol surface

Not affected.

## Verification performed

- `cargo test --locked -p preloop-orchestrator --lib environment` — 21 passed
- `cargo clippy --locked -p preloop-orchestrator --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- New test `rust_layer_puts_rustdoc_on_default_path` asserts all four binaries land on PATH

Note: this changes the bake script, so the environment fingerprint changes and goldens rebake on next engine start — intended.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Rust toolchain layer so `rustdoc` is symlinked into `/usr/local/bin`, allowing `cargo test --workspace` to run doctests in step shells that don't source profile files. Previously the entire test suite passed and then failed with `could not execute process rustdoc`. This changes the bake script, so the environment fingerprint changes and goldens rebake on next engine start.

<sup>Written for commit 820b8ad6ed6fd7c4efa61be595a600da6365e724. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

