### PR TITLE
fix(ci): use sudo for apt-get install lld in rust job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,7 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Install lld linker
-        run: apt-get update && apt-get install -y --no-install-recommends lld
-
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends lld
       - run: cargo fmt --all --check
       - run: |
           cargo clippy --locked -p preloop-gha-protocol -p preloop-gha-parser -p preloop-gha-expressions -p preloop-cache -p preloop-artifacts -p runner-watch -p preloop-conformance --all-targets -- -D warnings

--- a/crates/preloop-orchestrator/src/environment.rs
+++ b/crates/preloop-orchestrator/src/environment.rs
@@ -173,8 +173,12 @@ impl ToolchainLayer {
                     // Run steps execute with `bash --noprofile --norc`, so
                     // profile.d PATH exports are never sourced. Symlink the
                     // cargo binaries into /usr/local/bin so they are on the
-                    // default system PATH for every step shell.
-                    "ln -sf $HOME/.cargo/bin/cargo /usr/local/bin/cargo; ln -sf $HOME/.cargo/bin/rustc /usr/local/bin/rustc; ln -sf $HOME/.cargo/bin/rustup /usr/local/bin/rustup".into(),
+                    // default system PATH for every step shell. `rustdoc` is
+                    // included because `cargo test` spawns it by bare name for
+                    // doctests: without it on PATH the whole workspace test
+                    // step dies with `could not execute process rustdoc`
+                    // after every real test has already passed.
+                    "ln -sf $HOME/.cargo/bin/cargo /usr/local/bin/cargo; ln -sf $HOME/.cargo/bin/rustc /usr/local/bin/rustc; ln -sf $HOME/.cargo/bin/rustdoc /usr/local/bin/rustdoc; ln -sf $HOME/.cargo/bin/rustup /usr/local/bin/rustup".into(),
                 ],
             ],
             Self::Python(version) => {
@@ -536,6 +540,22 @@ mod tests {
         assert!(script.contains("--profile minimal"));
         assert!(script.contains("--default-toolchain stable"));
         assert!(!script.contains("sh.rustup.rs"));
+    }
+
+    /// `cargo test --workspace` spawns `rustdoc` by bare name for doctests, so
+    /// the interpreter must be on the default PATH of a `bash --noprofile
+    /// --norc` step shell. Without the symlink the workspace test step fails
+    /// with `could not execute process rustdoc` after every real test passed.
+    #[test]
+    fn rust_layer_puts_rustdoc_on_default_path() {
+        let commands = ToolchainLayer::Rust("stable".into()).install_commands();
+        let script = commands[1].join(" ");
+        for binary in ["cargo", "rustc", "rustdoc", "rustup"] {
+            assert!(
+                script.contains(&format!("/usr/local/bin/{binary}")),
+                "{binary} must be linked onto the default PATH: {script}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What & why

The self-hosted runner executes job steps as the  user (uid 1001), not root.  without  failed with . Using  grants root privileges for installing system packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Rust workspace test step failing on `could not execute process rustdoc` after all real tests pass, and fixes the CI rust job failing to install `lld` on self-hosted runners.

- Symlinks `rustdoc` into `/usr/local/bin` alongside cargo, rustc, and rustup so `cargo test --workspace` doctests can find it.
- Adds a test asserting the Rust toolchain layer links all four binaries onto the default PATH.
- Runs `apt-get update` and `apt-get install` with `sudo` in the CI rust job because the self-hosted runner user is not root.

<sup>Written for commit 0c7b9bd003fbd2c64777a76927ff47e5f7e3c16b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CI setup so the required linker installs reliably.
  * Rust toolchain setup now makes `rustdoc` available on the system path, allowing documentation tests to run successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->