### PR TITLE
fix(orchestrator): symlink cargo-fmt and cargo-clippy to /usr/local/bin

### DIFF
--- a/crates/preloop-orchestrator/src/environment.rs
+++ b/crates/preloop-orchestrator/src/environment.rs
@@ -173,12 +173,8 @@ impl ToolchainLayer {
                     // Run steps execute with `bash --noprofile --norc`, so
                     // profile.d PATH exports are never sourced. Symlink the
                     // cargo binaries into /usr/local/bin so they are on the
-                    // default system PATH for every step shell. `rustdoc` is
-                    // included because `cargo test` spawns it by bare name for
-                    // doctests: without it on PATH the whole workspace test
-                    // step dies with `could not execute process rustdoc`
-                    // after every real test has already passed.
-                    "ln -sf $HOME/.cargo/bin/cargo /usr/local/bin/cargo; ln -sf $HOME/.cargo/bin/rustc /usr/local/bin/rustc; ln -sf $HOME/.cargo/bin/rustdoc /usr/local/bin/rustdoc; ln -sf $HOME/.cargo/bin/rustup /usr/local/bin/rustup".into(),
+                    // default system PATH for every step shell.
+                    "ln -sf $HOME/.cargo/bin/cargo /usr/local/bin/cargo; ln -sf $HOME/.cargo/bin/cargo-fmt /usr/local/bin/cargo-fmt; ln -sf $HOME/.cargo/bin/cargo-clippy /usr/local/bin/cargo-clippy; ln -sf $HOME/.cargo/bin/rustc /usr/local/bin/rustc; ln -sf $HOME/.cargo/bin/rustdoc /usr/local/bin/rustdoc; ln -sf $HOME/.cargo/bin/rustup /usr/local/bin/rustup".into(),
                 ],
             ],
             Self::Python(version) => {
@@ -550,7 +546,14 @@ mod tests {
     fn rust_layer_puts_rustdoc_on_default_path() {
         let commands = ToolchainLayer::Rust("stable".into()).install_commands();
         let script = commands[1].join(" ");
-        for binary in ["cargo", "rustc", "rustdoc", "rustup"] {
+        for binary in [
+            "cargo",
+            "cargo-fmt",
+            "cargo-clippy",
+            "rustc",
+            "rustdoc",
+            "rustup",
+        ] {
             assert!(
                 script.contains(&format!("/usr/local/bin/{binary}")),
                 "{binary} must be linked onto the default PATH: {script}"


### PR DESCRIPTION
## What & why

Step shells run `bash --noprofile --norc`, so subcommands like `cargo fmt` fail with `error: no such command: fmt` when only `cargo` is symlinked. Adding `cargo-fmt` and `cargo-clippy` to `/usr/local/bin`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Symlinks `cargo-fmt` and `cargo-clippy` into `/usr/local/bin` so `cargo fmt` and `cargo clippy` work in step shells. Step shells run with `bash --noprofile --norc`, so PATH exports are never sourced; previously only `cargo` was linked and subcommands failed with `error: no such command: fmt`.

<sup>Written for commit ce5e00a9843e9754599788b6852a2120aa239481. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

