### PR TITLE
perf(ci): prebake pinned Rust toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,15 +41,9 @@ jobs:
             exit 1
           fi
 
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-        with:
-          toolchain: "1.97"
-          components: rustfmt,clippy
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
-      - name: Install lld linker
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends lld
       - run: cargo fmt --all --check
       - run: |
           cargo clippy --locked -p preloop-gha-protocol -p preloop-gha-parser -p preloop-gha-expressions -p preloop-cache -p preloop-artifacts -p runner-watch -p preloop-conformance --all-targets -- -D warnings
@@ -67,9 +61,7 @@ jobs:
         with:
           persist-credentials: false
           lfs: true
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-        with:
-          toolchain: "1.97"
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Verify concurrency_properties filter matches at least one test
         run: |
@@ -166,9 +158,7 @@ jobs:
         with:
           persist-credentials: false
           lfs: true
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-        with:
-          toolchain: "1.97"
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Verify concurrency_properties filter matches at least one test
         run: |

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           persist-credentials: false
           lfs: true
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Replay official runner flows
         run: bash ./benchmarks/conformance/run.sh

--- a/.github/workflows/release-golden.yml
+++ b/.github/workflows/release-golden.yml
@@ -70,7 +70,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
         with:
           toolchain: "1.97"
           targets: ${{ matrix.target }}
@@ -146,7 +146,7 @@ jobs:
           echo "BASE_IMAGE=$BASE_IMAGE" >> "$GITHUB_ENV"
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
 
       - name: Build Preloop binaries
         run: |
@@ -368,7 +368,7 @@ jobs:
           echo "BASE_IMAGE=$BASE_IMAGE" >> "$GITHUB_ENV"
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
         with:
           toolchain: "1.97"
           targets: aarch64-unknown-linux-gnu

--- a/.github/workflows/release-linux-runner.yml
+++ b/.github/workflows/release-linux-runner.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
         with:
           toolchain: "1.97"
           targets: ${{ matrix.triple }}

--- a/.github/workflows/runner-sync.yml
+++ b/.github/workflows/runner-sync.yml
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
           lfs: true
           fetch-depth: 2
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
       - name: Resolve versions
         id: versions
         env:
@@ -124,7 +124,7 @@ jobs:
           persist-credentials: false
           lfs: true
           fetch-depth: 2
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
       - name: Detect runner_version movement
         id: moved
         env:

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -51,7 +51,7 @@ jobs:
             echo "Policy file guard: OK (no policy files modified)"
           fi
 
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
         with:
           toolchain: "1.97"
 

--- a/.github/workflows/tier2-property-live.yml
+++ b/.github/workflows/tier2-property-live.yml
@@ -39,7 +39,7 @@ jobs:
           persist-credentials: false
 
       - name: Install pinned Rust toolchain
-        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
 
       - name: Run targeted Tier 2 Rust property filters
         shell: bash

--- a/crates/preloop-orchestrator/src/environment.rs
+++ b/crates/preloop-orchestrator/src/environment.rs
@@ -239,25 +239,29 @@ impl ToolchainLayer {
             Self::Go(_) => "go",
         }
     }
+
+    /// Shell predicate proving this exact layer is usable.
+    pub fn verify_command(&self) -> String {
+        match self {
+            Self::Rust(channel) => {
+                let channel = safe_component(channel);
+                format!(
+                    "command -v cargo >/dev/null && \
+                     rustup run {channel} rustc --version >/dev/null && \
+                     rustup run {channel} cargo-fmt --version >/dev/null && \
+                     rustup run {channel} cargo-clippy --version >/dev/null"
+                )
+            }
+            _ => format!("command -v {} >/dev/null", self.verify_binary()),
+        }
+    }
 }
 
-/// The fixed set of toolchains baked into every golden.
-///
-/// Deliberately not workspace-derived. The base install script already bakes
-/// the GitHub-hosted parity toolset (node/python/go toolcaches, git, git-lfs,
-/// docker, nvm, yarn — see `base_install_script`), so per-project version
-/// files add nothing there. Rust is the one toolchain the base bake lacks,
-/// so it is baked for everyone — pinned for CI-Bench reproducibility — and Go
-/// rides along at the corpus-pinned version so per-job VMs stay identical.
-/// `setup-*` actions download any other version a job asks for at job time —
-/// the same model GitHub-hosted runners use.
+/// Toolchains missing from the stock Ubuntu base and therefore baked once
+/// into the reusable golden instead of installed in every ephemeral job VM.
 pub fn curated_toolchains() -> Vec<ToolchainLayer> {
-    // CI-Bench pins its corpus toolchains: Rust 1.88.0 (the version every
-    // task was authored and validated against) and Go 1.26.x. Baking them
-    // into every golden keeps the per-job VMs identical instead of
-    // re-installing per job.
     vec![
-        ToolchainLayer::Rust("1.88.0".into()),
+        ToolchainLayer::Rust(crate::RUST_TOOLCHAIN_VERSION.into()),
         ToolchainLayer::Go("1.26".into()),
     ]
 }
@@ -269,10 +273,10 @@ pub fn curated_toolchains() -> Vec<ToolchainLayer> {
 /// reason anyone recorded. These pins are the provenance: bumping one is a
 /// deliberate, reviewable change. Digests are the registry manifest-list
 /// digests, valid for both x86_64 and arm64 guests.
-/// Digest-pinned base images, declared in `versions.toml` (build.rs compiles
-/// the pins into constants — see `UBUNTU_24_04_BASE`/`UBUNTU_22_04_BASE`).
 pub const UBUNTU_24_04_PIN: &str = crate::UBUNTU_24_04_BASE;
 pub const UBUNTU_22_04_PIN: &str = crate::UBUNTU_22_04_BASE;
+pub const OFFICIAL_RUNNER_IMAGE_AMD64_PIN: &str = crate::OFFICIAL_RUNNER_IMAGE_BASE_AMD64;
+pub const OFFICIAL_RUNNER_IMAGE_ARM64_PIN: &str = crate::OFFICIAL_RUNNER_IMAGE_BASE_ARM64;
 
 /// The default base image for GitHub-runner-labelled jobs.
 pub const DEFAULT_BASE_IMAGE: &str = UBUNTU_24_04_PIN;
@@ -283,10 +287,6 @@ pub fn base_name(image_ref: &str) -> &str {
 }
 
 /// Whether an image reference is one of Preloop's stock Ubuntu bases.
-///
-/// Stock bases can still switch between the digest-pinned 22.04 and 24.04
-/// images when a queued job's `runs-on` labels require it. A custom OCI image
-/// or packed artifact is deliberately used for every job instead.
 pub fn is_stock_base_image(image_ref: &str) -> bool {
     matches!(
         base_name(image_ref),
@@ -297,6 +297,15 @@ pub fn is_stock_base_image(image_ref: &str) -> bool {
     )
 }
 
+/// Whether an image is one of Preloop's official GitHub runner snapshots.
+pub fn is_official_runner_image(image_ref: &str) -> bool {
+    matches!(
+        base_name(image_ref),
+        "ghcr.io/preloopdev/runner-images:ubuntu24-runner-large-latest"
+            | "ghcr.io/preloopdev/runner-images:ubuntu24-arm64-runner-large-latest"
+    )
+}
+
 /// Resolved base image and toolchains for one job.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EnvironmentSpec {
@@ -304,11 +313,7 @@ pub struct EnvironmentSpec {
     pub base: String,
     /// Sorted, deduplicated toolchain layers.
     pub toolchains: Vec<ToolchainLayer>,
-    /// Whether Preloop's curated toolchain bake applies to this base.
-    ///
-    /// True only for the stock digest-pinned Ubuntu bases: those get the
-    /// GitHub-hosted parity toolset layered on top. A custom base image is
-    /// the operator's contract — it is used as-is, without the bake.
+    /// Whether Preloop's complete package bake applies to this base.
     pub curated: bool,
     /// SHA-256 hex digest of the normalized base and toolchain list.
     pub fingerprint: String,
@@ -316,21 +321,18 @@ pub struct EnvironmentSpec {
 
 impl EnvironmentSpec {
     /// Build a normalized environment specification and compute its fingerprint.
-    ///
-    /// Explicit constructions are curated: callers that want the bare
-    /// treatment for a custom base use [`Self::for_base`].
     pub fn new(base: String, toolchains: Vec<ToolchainLayer>) -> Self {
         Self::from_parts(base, toolchains, true)
     }
 
     /// Resolve the environment for a base image.
     ///
-    /// Stock digest-pinned Ubuntu bases get Preloop's curated toolchain
-    /// bake; a custom base image is used exactly as given — the operator
-    /// chose it, so layering our toolset on top would break the contract.
+    /// Stock Ubuntu bases receive the complete Preloop package bake. Official
+    /// runner snapshots already contain that package set, so they receive only
+    /// the repository-pinned toolchains. Other custom images are used as-is.
     pub fn for_base(base: String) -> Self {
         let curated = is_stock_base_image(&base);
-        let toolchains = if curated {
+        let toolchains = if curated || is_official_runner_image(&base) {
             curated_toolchains()
         } else {
             Vec::new()
@@ -624,13 +626,20 @@ mod tests {
         );
     }
 
-    /// Stock bases get Preloop's curated toolchain bake; a custom base is
-    /// the operator's contract and must be used as-is.
+    /// Stock bases get Preloop's complete bake, official runner snapshots get
+    /// only pinned toolchains, and arbitrary custom images stay untouched.
     #[test]
-    fn for_base_curates_stock_but_never_custom_bases() {
+    fn for_base_selects_only_required_layers() {
         let stock = EnvironmentSpec::for_base(UBUNTU_24_04_PIN.to_owned());
         assert!(stock.curated, "stock bases must carry the curated bake");
         assert!(!stock.toolchains.is_empty());
+
+        let official = EnvironmentSpec::for_base(OFFICIAL_RUNNER_IMAGE_AMD64_PIN.to_owned());
+        assert!(
+            !official.curated,
+            "official images already contain packages"
+        );
+        assert_eq!(official.toolchains, curated_toolchains());
 
         let custom = EnvironmentSpec::for_base("ghcr.io/acme/runner:latest".to_owned());
         assert!(!custom.curated, "custom bases must not be curated");
@@ -643,7 +652,6 @@ mod tests {
             "the bake decision must invalidate the golden fingerprint"
         );
 
-        // The stock 22.04 pin curates too.
         assert!(EnvironmentSpec::for_base(UBUNTU_22_04_PIN.to_owned()).curated);
     }
 
@@ -657,10 +665,10 @@ mod tests {
             first.len(),
             "no duplicate toolchains"
         );
-        // Rust is the one toolchain the base bake does not cover, so it is
-        // the deliberate member of the curated set (pinned for CI-Bench
-        // reproducibility; Go rides along).
-        assert!(first.contains(&ToolchainLayer::Rust("1.88.0".into())));
+        // The repository CI pin is compiled from versions.toml and baked into
+        // stock goldens; changing it therefore changes the environment
+        // fingerprint and forces a rebuild.
+        assert!(first.contains(&ToolchainLayer::Rust(crate::RUST_TOOLCHAIN_VERSION.into())));
         assert!(first.contains(&ToolchainLayer::Go("1.26".into())));
     }
 

--- a/crates/preloop-orchestrator/src/lib.rs
+++ b/crates/preloop-orchestrator/src/lib.rs
@@ -7,7 +7,8 @@ mod keys;
 pub mod node_externals;
 
 use crate::environment::{
-    curated_toolchains, is_stock_base_image, EnvironmentSpec, ToolchainLayer,
+    curated_toolchains, is_official_runner_image, is_stock_base_image, EnvironmentSpec,
+    ToolchainLayer,
 };
 use crate::keys::{KeyPool, StagedKey};
 use preloop_gha_protocol::RUNNER_BUSY_SENTINEL;
@@ -2940,18 +2941,19 @@ impl<P: VmProvider + 'static> RunnerPool<P> {
         };
         self.provider.create(&spec).await?;
         self.provider.start(&name).await?;
-        // A custom base image is the operator's contract: use it as-is. Only
-        // the stock digest-pinned Ubuntu bases get the curated bake (the
-        // GitHub-hosted parity toolset — node/python/go toolcaches, git,
-        // docker, nvm, yarn — plus the Rust layer; `setup-*` actions download
-        // any other version a job asks for at job time).
-        if is_stock_base_image(&self.config.base_image) {
+        // Plain Ubuntu needs the hosted-runner package baseline. Official
+        // runner snapshots already contain it. Both receive the small,
+        // repository-pinned toolchain layer once while the artifact is built.
+        let stock_base = is_stock_base_image(&self.config.base_image);
+        let official_base = is_official_runner_image(&self.config.base_image);
+        if stock_base {
             if let Err(error) = install_base_dependencies(self.provider.as_ref(), &name).await {
                 let _ = self.provider.delete(&name).await;
                 return Err(error);
             }
-            let toolchains = curated_toolchains();
-            for layer in &toolchains {
+        }
+        if stock_base || official_base {
+            for layer in curated_toolchains() {
                 for command in layer.install_commands() {
                     if let Err(error) = self.provider.exec(&name, &command).await {
                         let _ = self.provider.delete(&name).await;
@@ -4823,9 +4825,7 @@ async fn verify_toolchain_installed<P: VmProvider>(
     name: &MachineName,
     layer: &ToolchainLayer,
 ) -> Result<(), OrchestratorError> {
-    let binary = layer.verify_binary();
-    let mut command = vec!["sh".to_owned(), "-c".to_owned()];
-    command.push(format!("command -v {binary}"));
+    let command = vec!["sh".to_owned(), "-c".to_owned(), layer.verify_command()];
     if let Err(error) = provider.exec(name, &command).await {
         return Err(OrchestratorError::Vm(error));
     }
@@ -6099,7 +6099,7 @@ chmod +x "$dest/bin/node"
             let mut absent = self.absent_binary.lock().await;
             if let Some(binary) = *absent {
                 let probe = format!("command -v {binary}");
-                if argv.contains(&probe) {
+                if argv.iter().any(|arg| arg.contains(&probe)) {
                     return Err(test_error("binary-not-found"));
                 }
                 // An install command that names the binary lands it on PATH.

--- a/versions.toml
+++ b/versions.toml
@@ -45,6 +45,7 @@ official_runner_image_base_arm64 = "ghcr.io/preloopdev/runner-images:ubuntu24-ar
 # Provisioning version pins baked into the runner golden.
 node_version = "22.23.1"
 rustup_version = "1.29.0"
+rust_toolchain_version = "1.97"
 cargo_shear_version = "1.12.4"
 node20_externals_version = "20.20.2"
 node24_externals_version = "24.19.0"


### PR DESCRIPTION
Bakes the repository-pinned Rust 1.97 toolchain into stock and official runner goldens, verifies the exact toolchain plus rustfmt/clippy, removes redundant CI rustup and apt installs, and enables Cargo caching for property jobs. Also refreshes the stale dtolnay action pin required by zizmor.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prebakes the repository-pinned Rust 1.97 toolchain into stock Ubuntu and official runner goldens so CI jobs no longer install it on every run.

- Removes per-job rustup and apt installs in CI workflows and enables Cargo caching on additional jobs.
- Official runner snapshots now receive the pinned toolchain layers while their existing packages are left untouched.
- Toolchain verification now checks `rustc`, `rustfmt`, and `clippy` via `rustup` instead of only the `cargo` binary.
- The curated Rust version moves from a hardcoded 1.88.0 to `rust_toolchain_version` in `versions.toml`, so bumping it invalidates the golden fingerprint.
- Refreshes the stale `dtolnay/rust-toolchain` action pin required by zizmor.

<sup>Written for commit 341cd6546a3d49f6fb9f992450d183843093669c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

