### PR TITLE
perf(ci): avoid redundant LFS downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
-          lfs: true
       - name: Materialize conformance goldens
         run: |
           git lfs pull --include=".runner-watch/golden/**"
@@ -40,8 +39,6 @@ jobs:
             echo "LFS fixture was not materialized: $fixture" >&2
             exit 1
           fi
-
-
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - run: cargo fmt --all --check
@@ -60,7 +57,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
-          lfs: true
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Verify concurrency_properties filter matches at least one test
@@ -157,7 +153,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
-          lfs: true
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Verify concurrency_properties filter matches at least one test


### PR DESCRIPTION
Only the full workspace job needs conformance goldens. Fetches that fixture set once and skips LFS entirely for the property-test jobs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables Git LFS checkout for the property-test jobs so only the full workspace job fetches conformance goldens. The property-test jobs never used the LFS fixtures, so they now skip the download entirely and CI runs faster.

<sup>Written for commit c6e7012b93d3e740998d15b1d7cf5cae44e12bee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

