### PR TITLE
fix(ci): initialize local git lfs filter before pull

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           persist-credentials: false
       - name: Materialize conformance goldens
         run: |
+          git lfs install --local
           git lfs pull --include=".runner-watch/golden/**"
           fixture=".runner-watch/golden/v2.335.1/06-multi-step/flows.jsonl"
           test -s "$fixture"


### PR DESCRIPTION
Runs `git lfs install --local` before `git lfs pull` in the full workspace job.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs `git lfs install --local` before `git lfs pull` in the full workspace job so the local LFS filter is initialized before materializing golden files, preventing the job from failing.

<sup>Written for commit 59894b28877bcdc1cc026cb7a05cb9950ff53fdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

