### PR TITLE
chore(deps): update smolvm to v1.14.2

### DIFF
--- a/versions.toml
+++ b/versions.toml
@@ -18,7 +18,7 @@ smolvm_min_version = "1.8.1"
 # .github/workflows/smolvm-release-verify.yml gates the merge with the real-VM
 # E2E on the smolvm-host. Deliberately separate from smolvm_min_version:
 # goldens track the last *verified* release, the runtime floor rarely moves.
-smolvm_golden_version = "1.13.1"
+smolvm_golden_version = "1.14.2"
 
 # Image inputs for the runner golden. The OCI bases are immutable filesystem
 # inputs. `github_runner_image_version` is the actions/runner-images snapshot


### PR DESCRIPTION
Bumps `smolvm_golden_version` in `versions.toml` to `1.14.2`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `smolvm_golden_version` in `versions.toml` from `1.13.1` to `1.14.2` so goldens track the latest verified release.

<sup>Written for commit 7e452f702bc03867f907f2ae5b12fa54192528e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the SmolVM version used for golden-image builds from 1.13.1 to 1.14.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->