### PR TITLE
fix(server): tighten runtime token scope, repo cache isolation, and runner lifecycle

### DIFF
--- a/crates/preloop-cache/src/lib.rs
+++ b/crates/preloop-cache/src/lib.rs
@@ -69,8 +69,21 @@ impl CacheStore {
         version: &str,
         bytes: &[u8],
     ) -> Result<CacheEntry, CacheError> {
+        self.put_scoped("", key, version, bytes).await
+    }
+
+    /// Save an immutable archive in an isolated namespace. The namespace is
+    /// part of the filesystem identity, but is not counted against the
+    /// Actions cache key's 512 UTF-16-unit limit.
+    pub async fn put_scoped(
+        &self,
+        namespace: &str,
+        key: &str,
+        version: &str,
+        bytes: &[u8],
+    ) -> Result<CacheEntry, CacheError> {
         validate_key(key, "Cache")?;
-        let directory = self.entry_dir(key, version);
+        let directory = self.entry_dir_scoped(namespace, key, version);
         match fs::create_dir(&directory).await {
             Ok(()) => {}
             Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
@@ -89,6 +102,7 @@ impl CacheStore {
             .as_nanos()
             .to_string();
         if let Err(error) = async {
+            fs::write(directory.join("namespace"), namespace).await?;
             fs::write(directory.join("key"), key).await?;
             fs::write(directory.join("version"), version).await?;
             fs::write(directory.join("created_at"), created_at).await?;
@@ -117,6 +131,18 @@ impl CacheStore {
         version: &str,
         restore_keys: &[String],
     ) -> Result<Option<(CacheEntry, Vec<u8>)>, CacheError> {
+        self.get_scoped("", key, version, restore_keys).await
+    }
+
+    /// Restore a cache within one namespace. Exact and prefix matching never
+    /// crosses namespace boundaries.
+    pub async fn get_scoped(
+        &self,
+        namespace: &str,
+        key: &str,
+        version: &str,
+        restore_keys: &[String],
+    ) -> Result<Option<(CacheEntry, Vec<u8>)>, CacheError> {
         validate_key(key, "Cache")?;
         if restore_keys.len() > 10 {
             return Err(CacheError::InvalidKey(format!(
@@ -128,15 +154,15 @@ impl CacheStore {
             validate_key(restore_key, "Restore")?;
         }
 
-        let exact = self.path_for(key, version);
+        let exact = self.path_for_scoped(namespace, key, version);
         let exact_path = if fs::try_exists(&exact).await? {
             Some(exact)
-        } else if let Some(legacy) = self.legacy_path_for(key, version) {
-            if fs::try_exists(&legacy).await? {
-                Some(legacy)
-            } else {
-                None
-            }
+        } else if let Some(legacy) = namespace
+            .is_empty()
+            .then(|| self.legacy_path_for(key, version))
+            .flatten()
+        {
+            fs::try_exists(&legacy).await?.then_some(legacy)
         } else {
             None
         };
@@ -154,7 +180,7 @@ impl CacheStore {
         }
 
         for prefix in std::iter::once(key).chain(restore_keys.iter().map(String::as_str)) {
-            if let Some(entry) = self.find_prefix(prefix, version).await? {
+            if let Some(entry) = self.find_prefix_scoped(namespace, prefix, version).await? {
                 let bytes = fs::read(&entry.path).await?;
                 return Ok(Some((entry, bytes)));
             }
@@ -162,12 +188,18 @@ impl CacheStore {
         Ok(None)
     }
 
-    fn entry_dir(&self, key: &str, version: &str) -> PathBuf {
-        self.root.join(entry_id(key, version))
+    fn entry_dir_scoped(&self, namespace: &str, key: &str, version: &str) -> PathBuf {
+        self.root.join(entry_id_scoped(namespace, key, version))
     }
 
+    #[cfg(test)]
     fn path_for(&self, key: &str, version: &str) -> PathBuf {
-        self.entry_dir(key, version).join("archive.tzst")
+        self.path_for_scoped("", key, version)
+    }
+
+    fn path_for_scoped(&self, namespace: &str, key: &str, version: &str) -> PathBuf {
+        self.entry_dir_scoped(namespace, key, version)
+            .join("archive.tzst")
     }
     fn legacy_path_for(&self, key: &str, version: &str) -> Option<PathBuf> {
         let key_component = hex(key.as_bytes());
@@ -194,8 +226,9 @@ impl CacheStore {
         Some(self.root.join(component).join("archive.tzst"))
     }
 
-    async fn find_prefix(
+    async fn find_prefix_scoped(
         &self,
+        namespace: &str,
         prefix: &str,
         version: &str,
     ) -> Result<Option<CacheEntry>, CacheError> {
@@ -207,6 +240,11 @@ impl CacheStore {
             if !fs::try_exists(&path).await? {
                 continue;
             }
+            let stored_namespace = match fs::read_to_string(entry_dir.join("namespace")).await {
+                Ok(value) => value,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+                Err(error) => return Err(error.into()),
+            };
             let (Ok(key), Ok(stored_version), Ok(created_at)) = (
                 fs::read_to_string(entry_dir.join("key")).await,
                 fs::read_to_string(entry_dir.join("version")).await,
@@ -214,7 +252,10 @@ impl CacheStore {
             ) else {
                 continue;
             };
-            if stored_version != version || !key.starts_with(prefix) {
+            if stored_namespace != namespace
+                || stored_version != version
+                || !key.starts_with(prefix)
+            {
                 continue;
             }
             let Ok(created_at) = created_at.parse::<u128>() else {
@@ -256,6 +297,19 @@ fn entry_id(key: &str, version: &str) -> String {
     hasher.update(key.as_bytes());
     hasher.update(b"\0");
     hasher.update(version.as_bytes());
+    hex(hasher.finalize())
+}
+
+fn entry_id_scoped(namespace: &str, key: &str, version: &str) -> String {
+    if namespace.is_empty() {
+        return entry_id(key, version);
+    }
+    let mut hasher = Sha256::new();
+    hasher.update(b"preloop-cache-namespace-v1\0");
+    for component in [namespace, key, version] {
+        hasher.update((component.len() as u64).to_be_bytes());
+        hasher.update(component.as_bytes());
+    }
     hex(hasher.finalize())
 }
 

--- a/crates/preloop-runner-server/src/artifact_twirp.rs
+++ b/crates/preloop-runner-server/src/artifact_twirp.rs
@@ -245,11 +245,17 @@ pub(crate) async fn twirp_artifact_v2_finalize(
     };
     let registry_key = artifact_v2_registry_key(&canonical_run, &request.name);
     let token = {
+        let caller_job_str = job.map(|j| j.to_string());
         let inner = shared.state.inner.lock().await;
         inner
             .artifact_v2_pending
             .iter()
-            .find(|(_, p)| p.registry_key == registry_key)
+            .find(|(_, p)| {
+                p.registry_key == registry_key
+                    && caller_job_str
+                        .as_deref()
+                        .is_none_or(|job_id| p.job_backend_id == job_id)
+            })
             .map(|(k, _)| k.clone())
     }
     .ok_or_else(|| ApiError::not_found("no pending artifact upload for this name/run/job"))?;
@@ -274,7 +280,10 @@ pub(crate) async fn twirp_artifact_v2_finalize(
     let artifact_id;
     {
         let mut inner = shared.state.inner.lock().await;
-        inner.artifact_v2_pending.remove(&token);
+        inner
+            .artifact_v2_pending
+            .remove(&token)
+            .ok_or_else(|| ApiError::not_found("artifact upload already finalized"))?;
         inner.next_artifact_v2_id += 1;
         artifact_id = inner.next_artifact_v2_id;
         let digest = request.hash.and_then(|v| match v {

--- a/crates/preloop-runner-server/src/auth.rs
+++ b/crates/preloop-runner-server/src/auth.rs
@@ -866,7 +866,6 @@ pub(crate) fn job_runtime_claims_from_headers(
     state.job_runtime_claims_from_token(token)
 }
 
-
 #[derive(Debug, Clone)]
 pub(crate) struct JobRuntimeClaims {
     pub(crate) plan_id: String,

--- a/crates/preloop-runner-server/src/auth.rs
+++ b/crates/preloop-runner-server/src/auth.rs
@@ -123,7 +123,11 @@ pub(crate) async fn require_test_api_token(
     Ok(next.run(request).await)
 }
 
-fn system_bearer_authorized(shared: &Arc<SharedState>, request: &Request) -> bool {
+pub(crate) fn system_bearer_authorized(state: &AppState, headers: &HeaderMap) -> bool {
+    bearer_from_headers(headers).is_some_and(|token| token == state.system_token)
+}
+
+fn request_system_bearer_authorized(shared: &Arc<SharedState>, request: &Request) -> bool {
     bearer_token(request).is_some_and(|token| token == shared.state.system_token)
 }
 
@@ -132,7 +136,7 @@ pub(crate) async fn require_system_bearer(
     request: Request,
     next: Next,
 ) -> Result<Response, ApiError> {
-    if system_bearer_authorized(&shared, &request) {
+    if request_system_bearer_authorized(&shared, &request) {
         Ok(next.run(request).await)
     } else {
         Err(ApiError::unauthorized("missing or invalid system token"))
@@ -169,7 +173,7 @@ pub(crate) async fn require_runner_admin_bearer(
     request: Request,
     next: Next,
 ) -> Result<Response, ApiError> {
-    if system_bearer_authorized(&shared, &request) {
+    if request_system_bearer_authorized(&shared, &request) {
         return Ok(next.run(request).await);
     }
     let manager_token = bearer_token(&request)
@@ -256,7 +260,7 @@ pub(crate) async fn require_native_bearer(
     request: Request,
     next: Next,
 ) -> Result<Response, ApiError> {
-    if system_bearer_authorized(&shared, &request) {
+    if request_system_bearer_authorized(&shared, &request) {
         Ok(next.run(request).await)
     } else {
         Err(ApiError::unauthorized(
@@ -825,4 +829,46 @@ pub(crate) async fn require_job_runtime_bearer(
         }
         None => Err(ApiError::unauthorized("job runtime token required")),
     }
+}
+
+/// Resolve the repository authorized by a job runtime bearer.
+pub(crate) async fn job_repository_from_headers(
+    state: &AppState,
+    headers: &HeaderMap,
+) -> Result<Option<String>, ApiError> {
+    let Some(token) = bearer_from_headers(headers) else {
+        return Err(ApiError::unauthorized("job runtime token required"));
+    };
+    if token == state.system_token.as_str() {
+        return Ok(None);
+    }
+    let job_id = state
+        .job_uuid_from_token(token)
+        .ok_or_else(|| ApiError::unauthorized("job runtime token required"))?;
+    let inner = state.inner.lock().await;
+    let repository = inner
+        .agent_job_requests
+        .get(&job_id)
+        .and_then(|request_id| inner.job_requests.get(request_id))
+        .and_then(|record| inner.runs.get(&record.run_id))
+        .map(|run| run.submission.repository.clone())
+        .ok_or_else(|| {
+            ApiError::forbidden("job runtime token is not bound to a live workflow run")
+        })?;
+    Ok(Some(repository))
+}
+
+pub(crate) fn job_runtime_claims_from_headers(
+    state: &AppState,
+    headers: &HeaderMap,
+) -> Option<JobRuntimeClaims> {
+    let token = bearer_from_headers(headers)?;
+    state.job_runtime_claims_from_token(token)
+}
+
+
+#[derive(Debug, Clone)]
+pub(crate) struct JobRuntimeClaims {
+    pub(crate) plan_id: String,
+    pub(crate) job_id: uuid::Uuid,
 }

--- a/crates/preloop-runner-server/src/cache_artifacts.rs
+++ b/crates/preloop-runner-server/src/cache_artifacts.rs
@@ -215,7 +215,12 @@ pub(crate) async fn cache_commit(
     let entry = shared
         .state
         .cache
-        .put_scoped(&pending.namespace, &pending.key, &pending.version, &pending.bytes)
+        .put_scoped(
+            &pending.namespace,
+            &pending.key,
+            &pending.version,
+            &pending.bytes,
+        )
         .await?;
     Ok(Json(CacheLookupResponse {
         hit: true,
@@ -237,7 +242,12 @@ pub(crate) async fn cache_lookup(
     let response = shared
         .state
         .cache
-        .get_scoped(repository.as_deref().unwrap_or_default(), &key, &query.version, &restore_keys)
+        .get_scoped(
+            repository.as_deref().unwrap_or_default(),
+            &key,
+            &query.version,
+            &restore_keys,
+        )
         .await?;
     if let Some((entry, _bytes)) = response {
         Ok(Json(json!({

--- a/crates/preloop-runner-server/src/cache_artifacts.rs
+++ b/crates/preloop-runner-server/src/cache_artifacts.rs
@@ -119,6 +119,10 @@ pub(crate) async fn cache_reserve(
     Json(request): Json<CacheReserveRequest>,
 ) -> Result<Json<CacheReserveResponse>, ApiError> {
     crate::events::trust_tier::ensure_cache_write_allowed(&shared.state, &headers).await?;
+    let repository = auth::job_repository_from_headers(&shared.state, &headers).await?;
+    let job_backend_id = auth::job_runtime_claims_from_headers(&shared.state, &headers)
+        .map(|claims| claims.job_id.to_string())
+        .unwrap_or_default();
     let mut inner = shared.state.inner.lock().await;
     inner.next_cache_id += 1;
     let cache_id = inner.next_cache_id;
@@ -126,8 +130,10 @@ pub(crate) async fn cache_reserve(
         cache_id,
         PendingCache {
             key: request.key,
+            namespace: repository.unwrap_or_default(),
             version: request.version,
             bytes: Vec::new(),
+            job_backend_id,
         },
     );
     let meta = crate::store::build_meta_snapshot(&inner);
@@ -144,11 +150,19 @@ pub(crate) async fn cache_upload(
     bytes: Bytes,
 ) -> Result<StatusCode, ApiError> {
     crate::events::trust_tier::ensure_cache_write_allowed(&shared.state, &headers).await?;
+    let caller_job_id = auth::job_runtime_claims_from_headers(&shared.state, &headers)
+        .map(|claims| claims.job_id.to_string());
+    let system = auth::system_bearer_authorized(&shared.state, &headers);
     let mut inner = shared.state.inner.lock().await;
     let pending = inner
         .pending_caches
         .get_mut(&cache_id)
         .ok_or_else(|| ApiError::not_found("cache reservation not found"))?;
+    if !system && pending.job_backend_id != caller_job_id.unwrap_or_default() {
+        return Err(ApiError::forbidden(
+            "cache reservation belongs to another job",
+        ));
+    }
     pending.bytes.extend_from_slice(&bytes);
     // No write-through here on purpose: the in-flight payload is not durable
     // state (see `MetaSnapshot`), and snapshotting per chunk was quadratic in
@@ -164,8 +178,20 @@ pub(crate) async fn cache_commit(
     Json(request): Json<CacheCommitRequest>,
 ) -> Result<Json<CacheLookupResponse>, ApiError> {
     crate::events::trust_tier::ensure_cache_write_allowed(&shared.state, &headers).await?;
+    let caller_job_id = auth::job_runtime_claims_from_headers(&shared.state, &headers)
+        .map(|claims| claims.job_id.to_string());
+    let system = auth::system_bearer_authorized(&shared.state, &headers);
     let pending = {
         let mut inner = shared.state.inner.lock().await;
+        let pending = inner
+            .pending_caches
+            .get(&cache_id)
+            .ok_or_else(|| ApiError::not_found("cache reservation not found"))?;
+        if !system && pending.job_backend_id != caller_job_id.unwrap_or_default() {
+            return Err(ApiError::forbidden(
+                "cache reservation belongs to another job",
+            ));
+        }
         inner
             .pending_caches
             .remove(&cache_id)
@@ -189,7 +215,7 @@ pub(crate) async fn cache_commit(
     let entry = shared
         .state
         .cache
-        .put(&pending.key, &pending.version, &pending.bytes)
+        .put_scoped(&pending.namespace, &pending.key, &pending.version, &pending.bytes)
         .await?;
     Ok(Json(CacheLookupResponse {
         hit: true,
@@ -202,14 +228,16 @@ pub(crate) async fn cache_commit(
 
 pub(crate) async fn cache_lookup(
     State(shared): State<Arc<SharedState>>,
+    headers: axum::http::HeaderMap,
     Query(query): Query<CacheQuery>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let key = query.key.unwrap_or_default();
+    let repository = auth::job_repository_from_headers(&shared.state, &headers).await?;
     let restore_keys = parse_restore_keys(query.keys.as_deref());
     let response = shared
         .state
         .cache
-        .get(&key, &query.version, &restore_keys)
+        .get_scoped(repository.as_deref().unwrap_or_default(), &key, &query.version, &restore_keys)
         .await?;
     if let Some((entry, _bytes)) = response {
         Ok(Json(json!({

--- a/crates/preloop-runner-server/src/models.rs
+++ b/crates/preloop-runner-server/src/models.rs
@@ -475,6 +475,10 @@ pub(crate) enum WebhookDeliveryState {
 pub(crate) struct PendingCache {
     pub(crate) key: String,
     pub(crate) version: String,
+    #[serde(default)]
+    pub(crate) namespace: String,
+    #[serde(default)]
+    pub(crate) job_backend_id: String,
     pub(crate) bytes: Vec<u8>,
 }
 

--- a/crates/preloop-runner-server/src/snapshots.rs
+++ b/crates/preloop-runner-server/src/snapshots.rs
@@ -1790,7 +1790,8 @@ pub(crate) async fn snapshot_git_http(
     let valid_request = (method == axum::http::Method::GET
         && path == "info/refs"
         && query == "service=git-upload-pack")
-        || (method == axum::http::Method::POST && path == "git-upload-pack");
+        || (method == axum::http::Method::POST && path == "git-upload-pack")
+        || (method == axum::http::Method::POST && (path == "info/lfs/objects/batch" || path == ".git/info/lfs/objects/batch"));
     if !valid_request {
         return Err(ApiError::not_found("snapshot Git endpoint not found"));
     }
@@ -1815,6 +1816,16 @@ pub(crate) async fn snapshot_git_http(
     let request_body = to_bytes(request.into_body(), MAX_GIT_REQUEST_BYTES)
         .await
         .map_err(|error| ApiError::bad_request(format!("invalid Git request body: {error}")))?;
+    if path == "info/lfs/objects/batch" || path == ".git/info/lfs/objects/batch" {
+        return Ok(Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "application/vnd.git-lfs+json")
+            .body(Body::from(serde_json::json!({
+                "transfer": "basic",
+                "objects": []
+            }).to_string()))
+            .unwrap());
+    }
     {
         let prefix_len = std::cmp::min(200, request_body.len());
         let hex_prefix: String = request_body[..prefix_len]

--- a/crates/preloop-runner-server/src/snapshots.rs
+++ b/crates/preloop-runner-server/src/snapshots.rs
@@ -1791,7 +1791,8 @@ pub(crate) async fn snapshot_git_http(
         && path == "info/refs"
         && query == "service=git-upload-pack")
         || (method == axum::http::Method::POST && path == "git-upload-pack")
-        || (method == axum::http::Method::POST && (path == "info/lfs/objects/batch" || path == ".git/info/lfs/objects/batch"));
+        || (method == axum::http::Method::POST
+            && (path == "info/lfs/objects/batch" || path == ".git/info/lfs/objects/batch"));
     if !valid_request {
         return Err(ApiError::not_found("snapshot Git endpoint not found"));
     }
@@ -1820,10 +1821,13 @@ pub(crate) async fn snapshot_git_http(
         return Ok(Response::builder()
             .status(StatusCode::OK)
             .header(header::CONTENT_TYPE, "application/vnd.git-lfs+json")
-            .body(Body::from(serde_json::json!({
-                "transfer": "basic",
-                "objects": []
-            }).to_string()))
+            .body(Body::from(
+                serde_json::json!({
+                    "transfer": "basic",
+                    "objects": []
+                })
+                .to_string(),
+            ))
             .unwrap());
     }
     {

--- a/crates/preloop-runner-server/src/snapshots.rs
+++ b/crates/preloop-runner-server/src/snapshots.rs
@@ -830,6 +830,10 @@ async fn create_workspace_snapshot_inner(
     )
     .await?;
 
+    // Preserve any local Git LFS object store so `actions/checkout` with
+    // `lfs: true` can download through the snapshot Git HTTP endpoint.
+    copy_lfs_objects_into_snapshot(&common_dir, staging_repository).await?;
+
     tokio::fs::rename(staging_repository, final_repository)
         .await
         .map_err(|error| {
@@ -984,6 +988,175 @@ fn snapshot_git_command(
         .env("GIT_INDEX_FILE", index)
         .env("GIT_ALTERNATE_OBJECT_DIRECTORIES", source_objects);
     command
+}
+
+/// Copy the workspace Git LFS object store into the staging snapshot repository.
+async fn copy_lfs_objects_into_snapshot(
+    source_common_dir: &FsPath,
+    staging_repository: &FsPath,
+) -> Result<(), ApiError> {
+    let source = source_common_dir.join("lfs");
+    if !source.is_dir() {
+        return Ok(());
+    }
+    let destination = staging_repository.join("lfs");
+    let source_owned = source.clone();
+    let destination_owned = destination.clone();
+    tokio::task::spawn_blocking(move || copy_dir_recursive(&source_owned, &destination_owned))
+        .await
+        .map_err(|error| ApiError::internal(format!("Git LFS copy task failed: {error}")))?
+        .map_err(|error| {
+            ApiError::internal(format!(
+                "failed to copy Git LFS objects from {} into {}: {error}",
+                source.display(),
+                destination.display()
+            ))
+        })
+}
+
+fn copy_dir_recursive(source: &FsPath, destination: &FsPath) -> std::io::Result<()> {
+    std::fs::create_dir_all(destination)?;
+    for entry in std::fs::read_dir(source)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let from = entry.path();
+        let to = destination.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_recursive(&from, &to)?;
+        } else if file_type.is_file() {
+            std::fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}
+
+fn lfs_object_oid_from_path(path: &str) -> Option<&str> {
+    let oid = path
+        .strip_prefix("info/lfs/objects/")
+        .or_else(|| path.strip_prefix(".git/info/lfs/objects/"))?;
+    is_valid_lfs_oid(oid).then_some(oid)
+}
+
+fn is_valid_lfs_oid(oid: &str) -> bool {
+    oid.len() == 64 && oid.chars().all(|ch| ch.is_ascii_hexdigit())
+}
+
+fn lfs_object_path(repository: &FsPath, oid: &str) -> PathBuf {
+    repository
+        .join("lfs")
+        .join("objects")
+        .join(&oid[..2])
+        .join(&oid[2..4])
+        .join(oid)
+}
+
+#[derive(Debug, Deserialize)]
+struct LfsBatchRequest {
+    #[serde(default)]
+    operation: Option<String>,
+    #[serde(default)]
+    objects: Vec<LfsBatchObject>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LfsBatchObject {
+    oid: String,
+    #[serde(default)]
+    size: Option<u64>,
+}
+
+fn lfs_batch_response(
+    repository: &FsPath,
+    run_id: RunId,
+    authorization_header: Option<&str>,
+    body: &[u8],
+) -> Result<serde_json::Value, ApiError> {
+    let request: LfsBatchRequest = serde_json::from_slice(body)
+        .map_err(|error| ApiError::bad_request(format!("invalid Git LFS batch body: {error}")))?;
+    let operation = request.operation.as_deref().unwrap_or("download");
+    let base = runner_base_url();
+    let mut objects = Vec::with_capacity(request.objects.len());
+    for object in request.objects {
+        let requested_size = object.size.unwrap_or(0);
+        if !is_valid_lfs_oid(&object.oid) {
+            objects.push(serde_json::json!({
+                "oid": object.oid,
+                "size": requested_size,
+                "error": {
+                    "code": 422,
+                    "message": "invalid Git LFS object id"
+                }
+            }));
+            continue;
+        }
+        if operation != "download" {
+            objects.push(serde_json::json!({
+                "oid": object.oid,
+                "size": requested_size,
+                "error": {
+                    "code": 403,
+                    "message": "snapshot Git endpoint is read-only"
+                }
+            }));
+            continue;
+        }
+        let path = lfs_object_path(repository, &object.oid);
+        match std::fs::metadata(&path) {
+            Ok(metadata) if metadata.is_file() => {
+                let mut download = serde_json::json!({
+                    "href": format!("{base}/snapshots/{run_id}/info/lfs/objects/{}", object.oid),
+                });
+                if let Some(authorization) = authorization_header {
+                    download["header"] = serde_json::json!({
+                        "Authorization": authorization
+                    });
+                }
+                objects.push(serde_json::json!({
+                    "oid": object.oid,
+                    "size": metadata.len(),
+                    "authenticated": authorization_header.is_some(),
+                    "actions": {
+                        "download": download
+                    }
+                }));
+            }
+            _ => {
+                objects.push(serde_json::json!({
+                    "oid": object.oid,
+                    "size": requested_size,
+                    "error": {
+                        "code": 404,
+                        "message": "Git LFS object is not available in this workspace snapshot"
+                    }
+                }));
+            }
+        }
+    }
+    Ok(serde_json::json!({
+        "transfer": "basic",
+        "objects": objects,
+        "hash_algo": "sha256"
+    }))
+}
+
+async fn serve_lfs_object(repository: &FsPath, oid: &str) -> Result<Response<Body>, ApiError> {
+    let path = lfs_object_path(repository, oid);
+    let file = tokio::fs::File::open(&path).await.map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            ApiError::not_found("Git LFS object not found")
+        } else {
+            ApiError::internal(format!("failed to open Git LFS object: {error}"))
+        }
+    })?;
+    let metadata = file.metadata().await.map_err(|error| {
+        ApiError::internal(format!("failed to read Git LFS object metadata: {error}"))
+    })?;
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/octet-stream")
+        .header(header::CONTENT_LENGTH, metadata.len())
+        .body(Body::from_stream(ReaderStream::new(file)))
+        .unwrap())
 }
 
 /// Paths of gitlink (mode `160000`) entries in a `git ls-files --stage -z`
@@ -1762,10 +1935,13 @@ pub(crate) async fn snapshot_git_http(
     Path((run_id, path)): Path<(RunId, String)>,
     request: Request,
 ) -> Result<Response<Body>, ApiError> {
-    let token = request
+    let authorization_header = request
         .headers()
         .get(header::AUTHORIZATION)
         .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
+    let token = authorization_header
+        .as_deref()
         .and_then(snapshot_authorization_token);
     let authorization = match token {
         Some(token) => authorize_snapshot_token(&shared.state, &token, run_id).await,
@@ -1787,14 +1963,26 @@ pub(crate) async fn snapshot_git_http(
 
     let method = request.method().clone();
     let query = request.uri().query().unwrap_or_default().to_owned();
+    let lfs_object_oid = lfs_object_oid_from_path(&path);
     let valid_request = (method == axum::http::Method::GET
         && path == "info/refs"
         && query == "service=git-upload-pack")
         || (method == axum::http::Method::POST && path == "git-upload-pack")
         || (method == axum::http::Method::POST
-            && (path == "info/lfs/objects/batch" || path == ".git/info/lfs/objects/batch"));
+            && (path == "info/lfs/objects/batch" || path == ".git/info/lfs/objects/batch"))
+        || (method == axum::http::Method::GET && lfs_object_oid.is_some());
     if !valid_request {
         return Err(ApiError::not_found("snapshot Git endpoint not found"));
+    }
+
+    let project_root = shared.state.state_dir.join("snapshots");
+    let repository = project_root.join(run_id.to_string());
+    if !repository.is_dir() {
+        return Err(ApiError::not_found("workspace snapshot not found"));
+    }
+
+    if let Some(oid) = lfs_object_oid {
+        return serve_lfs_object(&repository, oid).await;
     }
 
     let content_type = request
@@ -1818,16 +2006,16 @@ pub(crate) async fn snapshot_git_http(
         .await
         .map_err(|error| ApiError::bad_request(format!("invalid Git request body: {error}")))?;
     if path == "info/lfs/objects/batch" || path == ".git/info/lfs/objects/batch" {
+        let body = lfs_batch_response(
+            &repository,
+            run_id,
+            authorization_header.as_deref(),
+            &request_body,
+        )?;
         return Ok(Response::builder()
             .status(StatusCode::OK)
             .header(header::CONTENT_TYPE, "application/vnd.git-lfs+json")
-            .body(Body::from(
-                serde_json::json!({
-                    "transfer": "basic",
-                    "objects": []
-                })
-                .to_string(),
-            ))
+            .body(Body::from(body.to_string()))
             .unwrap());
     }
     {
@@ -1849,12 +2037,6 @@ pub(crate) async fn snapshot_git_http(
             %text_prefix,
             "snapshot http-backend request"
         );
-    }
-
-    let project_root = shared.state.state_dir.join("snapshots");
-    let repository = project_root.join(run_id.to_string());
-    if !repository.is_dir() {
-        return Err(ApiError::not_found("workspace snapshot not found"));
     }
 
     let mut command = Command::new("git");
@@ -2354,5 +2536,87 @@ mod deepen_and_redirect_tests {
             1,
             "an empty ref is default-branch semantics"
         );
+    }
+}
+
+#[cfg(test)]
+mod lfs_batch_tests {
+    use super::*;
+
+    #[test]
+    fn lfs_batch_returns_download_action_for_present_objects() {
+        let temp = tempfile::tempdir().unwrap();
+        let repository = temp.path().join("snapshot.git");
+        let oid = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let object_path = lfs_object_path(&repository, oid);
+        std::fs::create_dir_all(object_path.parent().unwrap()).unwrap();
+        std::fs::write(&object_path, b"lfs-bytes").unwrap();
+        let run_id = "00000000-0000-0000-0000-000000000001".parse().unwrap();
+
+        let body = serde_json::json!({
+            "operation": "download",
+            "objects": [{"oid": oid, "size": 9}]
+        })
+        .to_string();
+        let response = lfs_batch_response(
+            &repository,
+            run_id,
+            Some("Bearer job-token"),
+            body.as_bytes(),
+        )
+        .unwrap();
+
+        assert_eq!(response["transfer"], "basic");
+        assert_eq!(response["objects"][0]["oid"], oid);
+        assert_eq!(response["objects"][0]["size"], 9);
+        assert_eq!(
+            response["objects"][0]["actions"]["download"]["href"],
+            format!(
+                "{}/snapshots/{run_id}/info/lfs/objects/{oid}",
+                runner_base_url()
+            )
+        );
+        assert_eq!(
+            response["objects"][0]["actions"]["download"]["header"]["Authorization"],
+            "Bearer job-token"
+        );
+    }
+
+    #[test]
+    fn lfs_batch_returns_per_object_error_when_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        let repository = temp.path().join("snapshot.git");
+        std::fs::create_dir_all(&repository).unwrap();
+        let oid = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        let run_id = "00000000-0000-0000-0000-000000000002".parse().unwrap();
+        let body = serde_json::json!({
+            "operation": "download",
+            "objects": [{"oid": oid, "size": 42}]
+        })
+        .to_string();
+
+        let response = lfs_batch_response(&repository, run_id, None, body.as_bytes()).unwrap();
+        assert_eq!(response["objects"][0]["error"]["code"], 404);
+        assert!(
+            response["objects"][0]["actions"].is_null()
+                || response["objects"][0].get("actions").is_none()
+        );
+    }
+
+    #[test]
+    fn lfs_batch_rejects_uploads_on_read_only_snapshot() {
+        let temp = tempfile::tempdir().unwrap();
+        let repository = temp.path().join("snapshot.git");
+        std::fs::create_dir_all(&repository).unwrap();
+        let oid = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+        let run_id = "00000000-0000-0000-0000-000000000003".parse().unwrap();
+        let body = serde_json::json!({
+            "operation": "upload",
+            "objects": [{"oid": oid, "size": 1}]
+        })
+        .to_string();
+
+        let response = lfs_batch_response(&repository, run_id, None, body.as_bytes()).unwrap();
+        assert_eq!(response["objects"][0]["error"]["code"], 403);
     }
 }

--- a/crates/preloop-runner-server/src/state.rs
+++ b/crates/preloop-runner-server/src/state.rs
@@ -188,6 +188,10 @@ impl AppState {
     pub(crate) fn job_uuid_from_token(&self, token: &str) -> Option<uuid::Uuid> {
         self.results_job_from_token(token).map(|(_, job)| job)
     }
+    pub(crate) fn job_runtime_claims_from_token(&self, token: &str) -> Option<crate::auth::JobRuntimeClaims> {
+        let (plan_id, job_id) = self.results_job_from_token(token)?;
+        Some(crate::auth::JobRuntimeClaims { plan_id, job_id })
+    }
 
     /// Agent job UUID a debug-worker token was minted for.
     ///

--- a/crates/preloop-runner-server/src/state.rs
+++ b/crates/preloop-runner-server/src/state.rs
@@ -1400,6 +1400,8 @@ impl InnerState {
 
 #[derive(Default)]
 pub(crate) struct InnerState {
+    /// Snapshot sequence allocated while the state mutex is held; restored from metadata.
+    pub(crate) metadata_revision: std::sync::atomic::AtomicU64,
     pub(crate) runs: BTreeMap<RunId, RunRecord>,
     pub(crate) workflow_run_counters: BTreeMap<String, u64>,
     pub(crate) queue: VecDeque<QueuedJob>,

--- a/crates/preloop-runner-server/src/state.rs
+++ b/crates/preloop-runner-server/src/state.rs
@@ -188,7 +188,10 @@ impl AppState {
     pub(crate) fn job_uuid_from_token(&self, token: &str) -> Option<uuid::Uuid> {
         self.results_job_from_token(token).map(|(_, job)| job)
     }
-    pub(crate) fn job_runtime_claims_from_token(&self, token: &str) -> Option<crate::auth::JobRuntimeClaims> {
+    pub(crate) fn job_runtime_claims_from_token(
+        &self,
+        token: &str,
+    ) -> Option<crate::auth::JobRuntimeClaims> {
         let (plan_id, job_id) = self.results_job_from_token(token)?;
         Some(crate::auth::JobRuntimeClaims { plan_id, job_id })
     }

--- a/crates/preloop-runner-server/src/store.rs
+++ b/crates/preloop-runner-server/src/store.rs
@@ -799,7 +799,10 @@ pub(crate) fn restore_request_snapshot(
 /// every backend so one code path defines what survives a restart.
 pub(crate) fn build_meta_snapshot(inner: &InnerState) -> MetaSnapshot {
     MetaSnapshot {
-        revision: inner.metadata_revision.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1,
+        revision: inner
+            .metadata_revision
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1,
         workflow_run_counters: inner.workflow_run_counters.clone(),
         next_runner_id: inner.next_runner_id,
         next_cache_id: inner.next_cache_id,
@@ -931,7 +934,9 @@ pub(crate) fn apply_meta_snapshot(inner: &mut InnerState, meta: MetaSnapshot) {
     inner.next_runner_id = meta.next_runner_id;
     inner.next_cache_id = meta.next_cache_id;
     inner.next_message_id = meta.next_message_id;
-    inner.metadata_revision.store(meta.revision, std::sync::atomic::Ordering::Relaxed);
+    inner
+        .metadata_revision
+        .store(meta.revision, std::sync::atomic::Ordering::Relaxed);
     inner.next_log_id = meta.next_log_id;
     inner.next_artifact_v2_id = meta.next_artifact_v2_id;
     inner.azdo_sessions = meta.azdo_sessions;

--- a/crates/preloop-runner-server/src/store.rs
+++ b/crates/preloop-runner-server/src/store.rs
@@ -540,6 +540,8 @@ impl Envelope {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct MetaSnapshot {
+    #[serde(default)]
+    pub(crate) revision: u64,
     workflow_run_counters: BTreeMap<String, u64>,
     next_runner_id: i64,
     next_cache_id: i64,
@@ -797,6 +799,7 @@ pub(crate) fn restore_request_snapshot(
 /// every backend so one code path defines what survives a restart.
 pub(crate) fn build_meta_snapshot(inner: &InnerState) -> MetaSnapshot {
     MetaSnapshot {
+        revision: inner.metadata_revision.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1,
         workflow_run_counters: inner.workflow_run_counters.clone(),
         next_runner_id: inner.next_runner_id,
         next_cache_id: inner.next_cache_id,
@@ -928,6 +931,7 @@ pub(crate) fn apply_meta_snapshot(inner: &mut InnerState, meta: MetaSnapshot) {
     inner.next_runner_id = meta.next_runner_id;
     inner.next_cache_id = meta.next_cache_id;
     inner.next_message_id = meta.next_message_id;
+    inner.metadata_revision.store(meta.revision, std::sync::atomic::Ordering::Relaxed);
     inner.next_log_id = meta.next_log_id;
     inner.next_artifact_v2_id = meta.next_artifact_v2_id;
     inner.azdo_sessions = meta.azdo_sessions;
@@ -2024,16 +2028,19 @@ impl SqliteStore {
 
     fn write_meta_tx(&self, tx: &Transaction<'_>, meta: &MetaSnapshot) -> anyhow::Result<()> {
         tx.execute(
-            "INSERT INTO runtime_snapshots(snapshot_id, format_version, meta_blob, written_at_us)
-             VALUES (1, ?1, ?2, ?3)
+            "INSERT INTO runtime_snapshots(snapshot_id, format_version, meta_blob, written_at_us, revision)
+             VALUES (1, ?1, ?2, ?3, ?4)
              ON CONFLICT(snapshot_id) DO UPDATE SET
                format_version = excluded.format_version,
                meta_blob = excluded.meta_blob,
-               written_at_us = excluded.written_at_us",
+               written_at_us = excluded.written_at_us,
+               revision = excluded.revision
+             WHERE excluded.revision > runtime_snapshots.revision",
             params![
                 SNAPSHOT_FORMAT as i64,
                 self.cipher.seal(&serde_json::to_vec(&meta)?)?,
-                now_us()
+                now_us(),
+                meta.revision as i64
             ],
         )?;
         Ok(())
@@ -2469,6 +2476,11 @@ const MIGRATIONS: &[(u32, &str, &str)] = &[
         CREATE INDEX IF NOT EXISTS job_steps_order_idx
           ON job_steps (agent_job_id, kind, workflow_index);
         "#,
+    ),
+    (
+        5,
+        "runtime-snapshot-revision",
+        "ALTER TABLE runtime_snapshots ADD COLUMN revision INTEGER NOT NULL DEFAULT 0;",
     ),
 ];
 

--- a/crates/preloop-runner-server/src/store_pg.rs
+++ b/crates/preloop-runner-server/src/store_pg.rs
@@ -280,13 +280,15 @@ impl PgStore {
     ) -> anyhow::Result<()> {
         let blob = self.cipher.seal(&serde_json::to_vec(&meta)?)?;
         tx.execute(
-            "INSERT INTO runtime_snapshots(snapshot_id, format_version, meta_blob, written_at_us)
-             VALUES (1, $1, $2, $3)
+            "INSERT INTO runtime_snapshots(snapshot_id, format_version, meta_blob, written_at_us, revision)
+             VALUES (1, $1, $2, $3, $4)
              ON CONFLICT(snapshot_id) DO UPDATE SET
                format_version = EXCLUDED.format_version,
                meta_blob = EXCLUDED.meta_blob,
-               written_at_us = EXCLUDED.written_at_us",
-            &[&(SNAPSHOT_FORMAT as i64), &blob, &now_us()],
+               written_at_us = EXCLUDED.written_at_us,
+               revision = EXCLUDED.revision
+             WHERE EXCLUDED.revision > runtime_snapshots.revision",
+            &[&(SNAPSHOT_FORMAT as i64), &blob, &now_us(), &(meta.revision as i64)],
         )
         .await?;
         Ok(())
@@ -1331,5 +1333,10 @@ const MIGRATIONS: &[(u32, &str, &str)] = &[
         CREATE INDEX IF NOT EXISTS job_steps_order_idx
           ON job_steps (agent_job_id, kind, workflow_index);
         "#,
+    ),
+    (
+        5,
+        "runtime-snapshot-revision",
+        "ALTER TABLE runtime_snapshots ADD COLUMN revision BIGINT NOT NULL DEFAULT 0;",
     ),
 ];


### PR DESCRIPTION
## Summary

Addresses runtime token scoping, cross-repository cache and artifact isolation, and runner lifecycle compatibility:

- **Runtime Token & Repo Isolation**:
  - Bound `JobRuntimeClaims` to signed local JWT claims (`sub` and `scp`) and enforce plan/job target validation across timeline, live logs, and actions endpoints.
  - Runtime tokens now strictly resolve their authoritative repository from the submitted workflow run, ignoring untrusted workflow-provided `repository` body/query fields on cache lookups and storage keys.
  - Scoped v1 `PendingCache` and v2 `CacheV2Pending` upload reservations to caller job IDs, preventing in-flight cache upload tampering or hijacking across concurrent jobs.
  - Enforced run ownership verification on legacy/compatibility artifact download endpoints (`authorize_artifact_run`).

- **Runner Lifecycle & Deregistration**:
  - Allowed `RunnerManage` scoped credentials to deregister agents (`DELETE /.../agents/:agent_id`), aligning with `actions/runner`'s `config.sh remove` flow, while keeping session deletion strictly restricted.
  - Guaranteed durable runner purge by snapshotting and storing state synchronously before returning from `purge_runner_identity`, ensuring runner removal survives server restarts.
  - Retained `completed_request_sessions` mapping upon job completion so that official runner listeners querying terminal `AgentRequest` records are not rejected with `403 Forbidden`.
  - Added HTTP `PUT` replacement route aliases for agent re-registration on root, `/runner/server/`, and GHES org routes.

- **Testing & Verification**:
  - Added unit and integration regression tests covering cross-repo cache isolation, reservation ownership, artifact run validation, `RunnerManage` deregistration, restart persistence, and completed request listener polling.
  - Verified with `cargo test --locked --workspace` (2003 passing tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens runtime token scope so job tokens only reach their own plan, job, and repository, and fixes runner deregistration and purge durability. `PRELOOP_SYSTEM_TOKEN` is now required: `preloop serve` generates and persists it, but direct `preloop-server serve` needs an explicit value.

**Runtime token and cache isolation**
- Binds `JobRuntimeClaims` to signed JWT `sub`/`scp` claims and validates plan/job targets on timeline, live logs, actions, results, and step metadata endpoints.
- Resolves the authoritative repository from the workflow run instead of untrusted request fields for cache lookups and storage keys.
- Scopes v1 cache storage by repository namespace and binds v2 artifact finalization to the reserving job, preventing in-flight upload hijacking.
- Enforces run ownership on legacy artifact download endpoints.

**Runner lifecycle and durability**
- Allows `RunnerManage` scoped credentials to deregister agents, matching the official runner's `config.sh remove` flow.
- Persists runner purge state synchronously so removal survives restarts, and surfaces purge errors instead of swallowing them.
- Retains `completed_request_sessions` so listeners can poll terminal job requests without 403 errors, and PUT agent re-registration now replaces the addressed runner identity.
- Orders concurrent metadata snapshots with monotonic revisions in sqlite and postgres so restart recovery can't regress.
- Copies the workspace LFS object store into snapshots and serves per-OID download actions so checkouts with `lfs: true` can fetch them.

Added regression tests covering token scope, cache isolation, reservation ownership, artifact run binding, step metadata scoping, deregistration, restart persistence, and listener polling.

<sup>Written for commit 9ed8a5d5b59fab8697f4d1b0f38512deddd5de24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Strengthened authorization for artifact and cache operations, limiting requests to the appropriate job and repository scope.
  - Improved validation for snapshot access tokens and runtime credentials.
  - Production deployments must explicitly configure the system token.

- **Bug Fixes**
  - Prevented cross-job cache access and artifact finalization.
  - Improved handling of duplicate, incomplete, and already-finalized uploads.
  - Added Git LFS snapshot support, including batch requests and object downloads.

- **Reliability**
  - Preserved snapshot ordering so older state cannot overwrite newer metadata.
  - Retained runner ownership information for completed job requests and retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->