### PR TITLE
fix(parser): canonicalize $/ prefix in reusable workflow refs

### DIFF
--- a/crates/preloop-gha-parser/src/expand.rs
+++ b/crates/preloop-gha-parser/src/expand.rs
@@ -1162,7 +1162,10 @@ fn merge_job_conditions(outer: Option<&str>, inner: Option<&str>) -> Option<Stri
 }
 fn normalize_reusable_path(uses: &str) -> String {
     let without_ref = uses.split('@').next().unwrap_or(uses);
-    let path = without_ref.strip_prefix("./").unwrap_or(without_ref);
+    let path = without_ref
+        .strip_prefix("./")
+        .or_else(|| without_ref.strip_prefix("$/"))
+        .unwrap_or(without_ref);
     Path::new(path)
         .components()
         .collect::<PathBuf>()

--- a/crates/preloop-gha-parser/src/lib_tests.rs
+++ b/crates/preloop-gha-parser/src/lib_tests.rs
@@ -1647,6 +1647,31 @@ jobs:
 }
 
 #[test]
+fn reusable_workflow_dollar_slash_alias_canonicalized() {
+    // Caller calls 50 workflows, mixing `./` and `$/` prefixes for the same 50 workflow files.
+    // E.g., 25 called with `./` and 25 with `$/` across 100 jobs, referring to 50 distinct files.
+    let mut caller_yaml = "on: push\njobs:\n".to_owned();
+    let mut reusable = BTreeMap::new();
+    for i in 1..=50 {
+        caller_yaml.push_str(&format!(
+            "  job_dot_{i}:\n    uses: ./.github/workflows/sub{i}.yml\n  job_dollar_{i}:\n    uses: $/.github/workflows/sub{i}.yml\n"
+        ));
+        reusable.insert(
+            format!(".github/workflows/sub{i}.yml"),
+            "on: { workflow_call: {} }\njobs:\n  leaf:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok".to_owned(),
+        );
+    }
+
+    let caller = parse_workflow(&caller_yaml).unwrap();
+    let root = expand_jobs_with_reusables(&caller, &reusable);
+    assert!(
+        root.is_ok(),
+        "Mixing ./ and $/ for the same 50 files must canonicalize to 50 unique workflows, not 100"
+    );
+    assert_eq!(root.unwrap().jobs.len(), 100);
+}
+
+#[test]
 fn reusable_workflow_outer_needs_propagated() {
     let caller = parse_workflow(
         r#"

--- a/crates/preloop-runner-server/src/broker.rs
+++ b/crates/preloop-runner-server/src/broker.rs
@@ -114,7 +114,10 @@ pub(crate) fn format_reusable_workflow_ref(
     workflow_ref: &str,
     caller_ref: &str,
 ) -> String {
-    if let Some(path) = workflow_ref.strip_prefix("./") {
+    let local_path = workflow_ref
+        .strip_prefix("./")
+        .or_else(|| workflow_ref.strip_prefix("$/"));
+    if let Some(path) = local_path {
         let (path, git_ref) = path.split_once('@').unwrap_or((path, caller_ref));
         return format!("{repository}/{path}@{git_ref}");
     }


### PR DESCRIPTION
### Summary
- Canonicalizes both `./` and `$/` local-workflow reference prefixes in `normalize_reusable_path`.
- Prevents workflows referencing the same reusable workflow via `./` and `$/` from creating duplicate entries in the call tree / `unique_workflows` set and prematurely exceeding the 50-workflow limit.
- Also canonicalizes `$/` in `format_reusable_workflow_ref` in `preloop-runner-server` for consistent OIDC claims.
- Added unit test `reusable_workflow_dollar_slash_alias_canonicalized`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Canonicalizes `$/` in reusable workflow references so `./` and `$/` pointing to the same file resolve to one workflow. This stops duplicate call-tree entries that could prematurely exceed the 50-workflow limit.

**Bug Fixes**
- Treats `./` and `$/` as the same local path in `normalize_reusable_path`.
- Formats `$/` refs consistently in `format_reusable_workflow_ref` for OIDC claims.
- Adds a test mixing both prefixes across 50 unique workflows.

<sup>Written for commit f8f3f2563c420a0b1920ff04f9cc0b97b912b7bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

