### PR TITLE
ci: run KVM workflows on GitHub-hosted runners

### DIFF
--- a/.github/workflows/release-golden.yml
+++ b/.github/workflows/release-golden.yml
@@ -121,7 +121,7 @@ jobs:
   build-and-publish-golden:
     name: Build & Publish Golden MicroVM Artifact
     if: (github.event_name == 'workflow_dispatch' && !inputs.reuse_previous_goldens) || github.event_name == 'release'
-    runs-on: [self-hosted, Linux, X64, smolvm-host]
+    runs-on: ubuntu-latest
     timeout-minutes: 180
     env:
       CARGO_BUILD_JOBS: "1"

--- a/.github/workflows/runner-conformance.yml
+++ b/.github/workflows/runner-conformance.yml
@@ -34,9 +34,9 @@ jobs:
           if-no-files-found: error
 
   runner-deep:
-    name: Runner deep conformance
+    name: Runner deep conformance on GitHub-hosted KVM
     if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && vars.PRELOOP_CONFORMANCE_DEEP == '1'
-    runs-on: [self-hosted, Linux, X64, smolvm-host]
+    runs-on: ubuntu-latest
     timeout-minutes: 180
     env:
       GH_REPO: ${{ vars.RUNNER_CONFORMANCE_REPO || 'preloopdev/preloop-conformance' }}

--- a/.github/workflows/smolvm-release-verify.yml
+++ b/.github/workflows/smolvm-release-verify.yml
@@ -15,14 +15,14 @@ permissions:
   contents: read
 
 concurrency:
-  group: smolvm-host
+  group: github-hosted-kvm
   cancel-in-progress: false
 
 jobs:
   verify:
-    name: Verify smolvm release on smolvm-host
-    if: (github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'renovate/')) && vars.SMOLVM_VERIFY_HOST_WORKSPACE != ''
-    runs-on: [self-hosted, smolvm-host]
+    name: Verify smolvm release on GitHub-hosted KVM
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'renovate/')
+    runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/docs/vm-images.md
+++ b/docs/vm-images.md
@@ -383,19 +383,18 @@ tooling: Renovate (`renovate.json`) watches the `actions/runner` and
 opens bump PRs against `versions.toml`. Runner bumps enter the
 watch → diff → triage → conform pipeline (`docs/conformance.md`). SmolVM
 golden bumps are gated by `.github/workflows/smolvm-release-verify.yml`,
-which installs the candidate on the `smolvm-host` and boots a real microVM
-with it (create → start → exec → delete, including a `--mount-socket`
+which installs the candidate on a GitHub-hosted Ubuntu runner and boots a real
+microVM with it (create → start → exec → delete, including a `--mount-socket`
 mount) before merge — a green run also blesses the updater's automatic
 latest-stable adoption of that release. `smolvm_min_version` is deliberately
 not auto-bumped: it is a capability floor, not a tracked release.
 
 The job runs on Renovate's `smolvm_golden_version` bump PRs (head branches
-`renovate/**`) and manual dispatches, and targets the dedicated
-`smolvm-host,preloop-cpane-host` runner. That Linux host needs KVM, registry
-access for the pinned Ubuntu base, and `SMOLVM_VERIFY_HOST_WORKSPACE` set on
-the repo. Renovate auto-merges smolvm golden bumps
-once the verify check and `ci.yml` pass — the merge gate is Renovate's
-auto-merge, not branch protection.
+`renovate/**`) and manual dispatches, and targets `ubuntu-latest`. The runner
+must expose usable `/dev/kvm` access for the nested microVM smoke test and
+provide registry access for the pinned Ubuntu base. Renovate auto-merges smolvm
+golden bumps once the verify check and `ci.yml` pass — the merge gate is
+Renovate's auto-merge, not branch protection.
 
 `versions.toml` defines Preloop's compiled distribution defaults. It is not a
 per-install user configuration file. Operators select custom OCI bases and


### PR DESCRIPTION
## Summary
- target golden release and SmolVM verification jobs at `ubuntu-latest`
- target deep runner conformance at `ubuntu-latest`
- remove the self-hosted `smolvm-host` gate from SmolVM verification
- document the GitHub-hosted KVM requirement

## Verification
- parsed all changed workflow files with PyYAML
- `git diff --check`