### PR TITLE
fix(protocol): acquirejob token fidelity — actionsEnvironment, timeout-minutes, defaults

### DIFF
--- a/crates/preloop-conformance/src/main.rs
+++ b/crates/preloop-conformance/src/main.rs
@@ -616,17 +616,27 @@ async fn run_runner_e2e(
     // this harness flaky for reasons unrelated to what it is testing. Match
     // the minute-scale allowance `benchmarks/conformance/run.sh` uses, and
     // fail loudly with the server's exit status when it actually died.
-    let mut ready = false;
-    for _ in 0..600 {
-        if let Some(status) = server.try_wait()? {
-            anyhow::bail!("preloop-runner-server exited during startup ({status})");
+    let ready = match tokio::time::timeout(Duration::from_secs(60), async {
+        for _ in 0..600 {
+            if let Some(status) = server.try_wait()? {
+                anyhow::bail!("preloop-runner-server exited during startup ({status})");
+            }
+            if client.get(&server_url).send().await.is_ok() {
+                return Ok::<bool, anyhow::Error>(true);
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
         }
-        if client.get(&server_url).send().await.is_ok() {
-            ready = true;
-            break;
+        Ok::<bool, anyhow::Error>(false)
+    })
+    .await
+    {
+        Ok(Ok(ready)) => ready,
+        Ok(Err(error)) => {
+            let _ = server.kill().await;
+            return Err(error);
         }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
+        Err(_) => false,
+    };
     if !ready {
         let _ = server.kill().await;
         anyhow::bail!("preloop-runner-server did not become ready on port {port} within 60s");

--- a/crates/preloop-conformance/src/main.rs
+++ b/crates/preloop-conformance/src/main.rs
@@ -516,6 +516,41 @@ fn preseed_private_actions(
     Ok(())
 }
 
+/// Pick the `target/{release,debug}` build of `name` that was built most
+/// recently, and say which one was chosen.
+///
+/// Preferring `release` merely because the file *exists* silently pins the
+/// harness to a stale artifact: a months-old release binary outranks a debug
+/// build from seconds ago, so an e2e run reports on code that is not in the
+/// working tree. Comparing mtimes keeps the speed win when release is current
+/// without the staleness trap, and the log line makes the choice auditable.
+fn select_built_binary(name: &str) -> anyhow::Result<String> {
+    let release = format!("target/release/{name}");
+    let debug = format!("target/debug/{name}");
+    let mtime = |path: &str| {
+        std::fs::metadata(path)
+            .and_then(|meta| meta.modified())
+            .ok()
+    };
+    let chosen = match (mtime(&release), mtime(&debug)) {
+        (Some(r), Some(d)) => {
+            if r >= d {
+                release
+            } else {
+                debug
+            }
+        }
+        (Some(_), None) => release,
+        (None, Some(_)) => debug,
+        (None, None) => anyhow::bail!(
+            "{name} not built: run `cargo build -p preloop-runner-server -p preloop-runner-client` \
+             (looked in target/release and target/debug)"
+        ),
+    };
+    println!("conformance: using {chosen}");
+    Ok(chosen)
+}
+
 async fn run_runner_e2e(
     runner_bin: PathBuf,
     workflow: PathBuf,
@@ -534,25 +569,8 @@ async fn run_runner_e2e(
         anyhow::bail!("workflow file not found: {}", workflow.display());
     }
 
-    let server_bin = if std::path::Path::new("target/release/preloop-server").exists() {
-        "target/release/preloop-server"
-    } else {
-        "target/debug/preloop-server"
-    };
-    if !std::path::Path::new(server_bin).exists() {
-        anyhow::bail!(
-            "server binary not found at {server_bin}: build it with `cargo build -p preloop-runner-server`"
-        );
-    }
-
-    let client_bin = if std::path::Path::new("target/release/preloop-runner-client").exists() {
-        "target/release/preloop-runner-client"
-    } else {
-        "target/debug/preloop-runner-client"
-    };
-    if !std::path::Path::new(client_bin).exists() {
-        anyhow::bail!("client binary not found: please build preloop-runner-client");
-    }
+    let server_bin = select_built_binary("preloop-server")?;
+    let client_bin = select_built_binary("preloop-runner-client")?;
 
     // Temporary directories
     let temp_dir = tempfile::TempDir::new()?;
@@ -592,8 +610,17 @@ async fn run_runner_e2e(
         .user_agent("preloop-conformance")
         .build()
         .expect("HTTP client");
+    // Fresh state generates the runner-session and OIDC RSA keypairs before
+    // the listener binds. Prime generation is nondeterministic and routinely
+    // exceeds a second or two even on an idle host, so a short window makes
+    // this harness flaky for reasons unrelated to what it is testing. Match
+    // the minute-scale allowance `benchmarks/conformance/run.sh` uses, and
+    // fail loudly with the server's exit status when it actually died.
     let mut ready = false;
-    for _ in 0..30 {
+    for _ in 0..600 {
+        if let Some(status) = server.try_wait()? {
+            anyhow::bail!("preloop-runner-server exited during startup ({status})");
+        }
         if client.get(&server_url).send().await.is_ok() {
             ready = true;
             break;
@@ -602,7 +629,7 @@ async fn run_runner_e2e(
     }
     if !ready {
         let _ = server.kill().await;
-        anyhow::bail!("preloop-runner-server failed to start on port {port}");
+        anyhow::bail!("preloop-runner-server did not become ready on port {port} within 60s");
     }
 
     // Configure the runner

--- a/crates/preloop-gha-parser/src/dag.rs
+++ b/crates/preloop-gha-parser/src/dag.rs
@@ -323,6 +323,8 @@ mod tests {
             permissions: None,
             oidc_environment: None,
             oidc_job_workflow_ref: None,
+            environment: None,
+            defaults: vec![],
             concurrency_group: None,
             concurrency_cancel_in_progress: None,
             concurrency_queue: None,

--- a/crates/preloop-gha-parser/src/eval.rs
+++ b/crates/preloop-gha-parser/src/eval.rs
@@ -279,13 +279,7 @@ const CTX_STEP_IF: &[&str] = &[
     "hashfiles",
 ];
 const CTX_STEP_TIMEOUT: &[&str] = &[
-    "github",
-    "inputs",
-    "vars",
-    "needs",
-    "strategy",
-    "matrix",
-    "env",
+    "github", "inputs", "vars", "needs", "strategy", "matrix", "env",
 ];
 const CTX_STEP_ENV: &[&str] = &[
     "github",
@@ -338,9 +332,7 @@ fn validate_run_defaults(
     ] {
         if let Some(value) = value {
             validate_expressions_in_string(value, false, Some(CTX_JOB_DEFAULTS_RUN)).map_err(
-                |error| {
-                    ParserError::InvalidExpression(format!("{label}.run.{field}: {error}"))
-                },
+                |error| ParserError::InvalidExpression(format!("{label}.run.{field}: {error}")),
             )?;
         }
     }

--- a/crates/preloop-gha-parser/src/eval.rs
+++ b/crates/preloop-gha-parser/src/eval.rs
@@ -560,6 +560,11 @@ pub fn build_context(
     ctx.insert("matrix", Value::Object(matrix_value));
 
     ctx.insert("strategy", strategy.clone());
+    // `needs` is empty here by construction: the upstream jobs have not run
+    // when a job message is built. Because the resolver coalesces a missing
+    // property to "" instead of erroring, anything resolved against this
+    // context that reads `needs.*` silently becomes "". Callers must gate on
+    // [`resolves_after_job_build`] rather than resolving blindly.
     ctx.insert("needs", Value::Object(Map::new()));
 
     let secrets_value: Map<String, Value> = secrets
@@ -572,6 +577,25 @@ pub fn build_context(
         inputs.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
     ctx.insert("inputs", Value::Object(inputs_value));
     ctx
+}
+
+/// Whether a `${{ }}` value reads a context that is not yet populated when the
+/// job message is built, and must therefore be left as a template for a later
+/// evaluation.
+///
+/// Two such contexts exist:
+///
+/// * `needs.*` — the upstream jobs have not run, so [`build_context`] supplies
+///   an empty map (the server fills the real one in once they complete).
+/// * `github.workspace` — the server has no runner work directory; only the
+///   runner knows the path.
+///
+/// Neither produces an evaluation *error*: the resolver coalesces a missing
+/// property to "". Resolving early therefore replaces a real value with an
+/// empty string, with nothing to catch it — which is exactly why this
+/// predicate exists instead of a `let _ = resolve(...)` at each call site.
+pub fn resolves_after_job_build(value: &str) -> bool {
+    value.contains("github.workspace") || value.contains("needs.") || value.contains("needs[")
 }
 
 #[cfg(test)]

--- a/crates/preloop-gha-parser/src/eval.rs
+++ b/crates/preloop-gha-parser/src/eval.rs
@@ -278,6 +278,15 @@ const CTX_STEP_IF: &[&str] = &[
     "success",
     "hashfiles",
 ];
+const CTX_STEP_TIMEOUT: &[&str] = &[
+    "github",
+    "inputs",
+    "vars",
+    "needs",
+    "strategy",
+    "matrix",
+    "env",
+];
 const CTX_STEP_ENV: &[&str] = &[
     "github",
     "inputs",
@@ -316,6 +325,28 @@ fn validate_container_expressions(value: &Value) -> Result<(), String> {
     Ok(())
 }
 
+fn validate_run_defaults(
+    defaults: &crate::models::JobDefaults,
+    label: &str,
+) -> Result<(), ParserError> {
+    let Some(run) = &defaults.run else {
+        return Ok(());
+    };
+    for (field, value) in [
+        ("shell", run.shell.as_ref()),
+        ("working-directory", run.working_directory.as_ref()),
+    ] {
+        if let Some(value) = value {
+            validate_expressions_in_string(value, false, Some(CTX_JOB_DEFAULTS_RUN)).map_err(
+                |error| {
+                    ParserError::InvalidExpression(format!("{label}.run.{field}: {error}"))
+                },
+            )?;
+        }
+    }
+    Ok(())
+}
+
 /// Validate all `${{ }}` expressions in a workflow.
 pub fn validate_workflow_expressions(workflow: &Workflow) -> Result<(), ParserError> {
     if let Some(run_name) = &workflow.run_name {
@@ -324,6 +355,9 @@ pub fn validate_workflow_expressions(workflow: &Workflow) -> Result<(), ParserEr
     }
     validate_env_expressions(&workflow.env, Some(CTX_WORKFLOW_ENV))
         .map_err(ParserError::InvalidExpression)?;
+    if let Some(defaults) = &workflow.defaults {
+        validate_run_defaults(defaults, "workflow defaults")?;
+    }
 
     if let Some(concurrency) = &workflow.concurrency {
         validate_expressions_in_string(&concurrency.group, false, Some(CTX_WORKFLOW_CONCURRENCY))
@@ -425,28 +459,7 @@ pub fn validate_workflow_expressions(workflow: &Workflow) -> Result<(), ParserEr
             }
         }
         if let Some(defaults) = &job.defaults {
-            if let Some(run) = &defaults.run {
-                if let Some(shell) = &run.shell {
-                    validate_expressions_in_string(shell, false, Some(CTX_JOB_DEFAULTS_RUN))
-                        .map_err(|e| {
-                            ParserError::InvalidExpression(format!(
-                                "job `{job_id}` defaults.run.shell: {e}"
-                            ))
-                        })?;
-                }
-                if let Some(working_directory) = &run.working_directory {
-                    validate_expressions_in_string(
-                        working_directory,
-                        false,
-                        Some(CTX_JOB_DEFAULTS_RUN),
-                    )
-                    .map_err(|e| {
-                        ParserError::InvalidExpression(format!(
-                            "job `{job_id}` defaults.run.working-directory: {e}"
-                        ))
-                    })?;
-                }
-            }
+            validate_run_defaults(defaults, &format!("job `{job_id}` defaults"))?;
         }
         for (output_name, output) in &job.outputs {
             validate_value_expressions(output, Some(CTX_RUNNER)).map_err(|e| {
@@ -481,6 +494,17 @@ pub fn validate_workflow_expressions(workflow: &Workflow) -> Result<(), ParserEr
                     |e| {
                         ParserError::InvalidExpression(format!(
                             "job `{job_id}` {step_ref} continue-on-error: {e}"
+                        ))
+                    },
+                )?;
+            }
+            if let Some(crate::models::DeferredNumber::Expression(expression)) =
+                &step.timeout_minutes
+            {
+                validate_expressions_in_string(expression, false, Some(CTX_STEP_TIMEOUT)).map_err(
+                    |e| {
+                        ParserError::InvalidExpression(format!(
+                            "job `{job_id}` {step_ref} timeout-minutes: {e}"
                         ))
                     },
                 )?;

--- a/crates/preloop-gha-parser/src/expand.rs
+++ b/crates/preloop-gha-parser/src/expand.rs
@@ -70,13 +70,13 @@ fn defaults_run_token(run: &crate::DefaultsRun) -> Value {
     if let Some(shell) = &run.shell {
         map.push(serde_json::json!({
             "Key": { "type": 0, "file": 1, "line": 1, "col": 1, "lit": "shell" },
-            "Value": { "type": 0, "file": 1, "line": 1, "col": 1, "lit": shell }
+            "Value": crate::job_builder::template_token(&Value::String(shell.clone()))
         }));
     }
     if let Some(wd) = &run.working_directory {
         map.push(serde_json::json!({
             "Key": { "type": 0, "file": 1, "line": 1, "col": 1, "lit": "working-directory" },
-            "Value": { "type": 0, "file": 1, "line": 1, "col": 1, "lit": wd }
+            "Value": crate::job_builder::template_token(&Value::String(wd.clone()))
         }));
     }
     serde_json::json!({
@@ -294,6 +294,36 @@ fn resolve_deferred_number(
         }
     }
 }
+fn resolve_step_timeout(
+    job_id: &str,
+    step_label: &str,
+    value: Option<&DeferredNumber>,
+    matrix: &IndexMap<String, Value>,
+    inputs: Option<&BTreeMap<String, Value>>,
+    matrix_deferred: bool,
+) -> Result<Option<u32>, ParserError> {
+    let resolved = if matrix_deferred {
+        match value {
+            Some(DeferredNumber::Literal(value)) => Some(*value),
+            Some(DeferredNumber::Expression(_)) => None,
+            None => None,
+        }
+    } else {
+        resolve_deferred_number(value, matrix, inputs)?
+    };
+    let Some(value) = resolved else {
+        return Ok(None);
+    };
+    if !(1..=360).contains(&value) {
+        return Err(ParserError::InvalidStepTimeout {
+            job_id: job_id.to_owned(),
+            step: step_label.to_owned(),
+            message: format!("expected a value from 1 through 360, got {value}"),
+        });
+    }
+    Ok(Some(value as u32))
+}
+
 
 /// Omit empty `services: {}` to match `EmitDefaultValue=false` behavior.
 fn non_empty_services(services: Option<serde_json::Value>) -> Option<serde_json::Value> {
@@ -546,7 +576,18 @@ fn job_plan_from_job(
         .steps
         .iter()
         .cloned()
-        .map(|step| step_plan(step, &job.defaults, &matrix, inputs, matrix_deferred))
+        .enumerate()
+        .map(|(step_index, step)| {
+            step_plan(
+                job_id,
+                step_index,
+                step,
+                &job.defaults,
+                &matrix,
+                inputs,
+                matrix_deferred,
+            )
+        })
         .collect::<Result<Vec<_>, _>>()?;
     let mut defaults = Vec::new();
     if let Some(wf_defaults) = workflow_defaults {
@@ -1224,12 +1265,26 @@ fn normalize_reusable_path(uses: &str) -> String {
 }
 
 fn step_plan(
+    job_id: &str,
+    step_index: usize,
     step: Step,
     defaults: &Option<JobDefaults>,
     matrix: &IndexMap<String, Value>,
     inputs: Option<&BTreeMap<String, Value>>,
     matrix_deferred: bool,
 ) -> Result<StepPlan, ParserError> {
+    let step_label = step
+        .name
+        .clone()
+        .unwrap_or_else(|| format!("step #{step_index}"));
+    let timeout_in_minutes = resolve_step_timeout(
+        job_id,
+        &step_label,
+        step.timeout_minutes.as_ref(),
+        matrix,
+        inputs,
+        matrix_deferred,
+    )?;
     // Merge job-level defaults into step — step values take precedence.
     let working_directory = step.working_directory.or_else(|| {
         defaults
@@ -1265,7 +1320,7 @@ fn step_plan(
                 resolve_deferred_bool(Some(value), matrix, inputs, false).map(Some)
             }
         })?,
-        timeout_in_minutes: step.timeout_minutes,
+        timeout_in_minutes,
     })
 }
 

--- a/crates/preloop-gha-parser/src/expand.rs
+++ b/crates/preloop-gha-parser/src/expand.rs
@@ -282,7 +282,17 @@ fn resolve_deferred_number(
 ) -> Result<Option<u64>, ParserError> {
     let Some(value) = value else { return Ok(None) };
     match value {
-        DeferredNumber::Literal(value) => Ok(Some(*value)),
+        DeferredNumber::Literal(_) | DeferredNumber::Float(_) => {
+            value.literal().map(Some).ok_or_else(|| {
+                ParserError::InvalidExpression(format!(
+                    "expected a whole number, got {}",
+                    match value {
+                        DeferredNumber::Float(value) => value.to_string(),
+                        _ => unreachable!("literal variants only"),
+                    }
+                ))
+            })
+        }
         DeferredNumber::Expression(expression) => {
             let result = eval_expression(expression, &expression_context(matrix, inputs, None))
                 .map_err(|error| ParserError::InvalidExpression(error.to_string()))?;
@@ -304,9 +314,10 @@ fn resolve_step_timeout(
 ) -> Result<Option<u32>, ParserError> {
     let resolved = if matrix_deferred {
         match value {
-            Some(DeferredNumber::Literal(value)) => Some(*value),
-            Some(DeferredNumber::Expression(_)) => None,
-            None => None,
+            Some(value @ (DeferredNumber::Literal(_) | DeferredNumber::Float(_))) => {
+                value.literal()
+            }
+            Some(DeferredNumber::Expression(_)) | None => None,
         }
     } else {
         resolve_deferred_number(value, matrix, inputs)?
@@ -564,10 +575,10 @@ fn job_plan_from_job(
         resolve_deferred_bool(job.strategy.fail_fast.as_ref(), &matrix, inputs, true)?
     };
     let max_parallel = if matrix_deferred {
-        match job.strategy.max_parallel {
-            Some(DeferredNumber::Literal(value)) => Some(value),
-            _ => None,
-        }
+        job.strategy
+            .max_parallel
+            .as_ref()
+            .and_then(DeferredNumber::literal)
     } else {
         resolve_deferred_number(job.strategy.max_parallel.as_ref(), &matrix, inputs)?
     };

--- a/crates/preloop-gha-parser/src/expand.rs
+++ b/crates/preloop-gha-parser/src/expand.rs
@@ -65,6 +65,38 @@ fn validate_reusable_workflow_tree(
     Ok(())
 }
 
+fn defaults_run_token(run: &crate::DefaultsRun) -> Value {
+    let mut map = Vec::new();
+    if let Some(shell) = &run.shell {
+        map.push(serde_json::json!({
+            "Key": { "type": 0, "file": 1, "line": 1, "col": 1, "lit": "shell" },
+            "Value": { "type": 0, "file": 1, "line": 1, "col": 1, "lit": shell }
+        }));
+    }
+    if let Some(wd) = &run.working_directory {
+        map.push(serde_json::json!({
+            "Key": { "type": 0, "file": 1, "line": 1, "col": 1, "lit": "working-directory" },
+            "Value": { "type": 0, "file": 1, "line": 1, "col": 1, "lit": wd }
+        }));
+    }
+    serde_json::json!({
+        "type": 2,
+        "file": 1,
+        "line": 1,
+        "col": 1,
+        "map": [{
+            "Key": { "type": 0, "file": 1, "line": 1, "col": 1, "lit": "run" },
+            "Value": {
+                "type": 2,
+                "file": 1,
+                "line": 1,
+                "col": 1,
+                "map": map
+            }
+        }]
+    })
+}
+
 /// GitHub display name for one expanded job.
 ///
 /// When the job declares `name:`, expressions are resolved against the
@@ -451,6 +483,7 @@ pub fn expand_jobs(workflow: &Workflow) -> Result<Vec<JobPlan>, ParserError> {
                 env,
                 oidc_environment,
                 workflow.permissions.as_ref(),
+                workflow.defaults.as_ref(),
                 None,
                 matrix_deferred,
             )?;
@@ -473,6 +506,7 @@ fn job_plan_from_job(
     env: BTreeMap<String, String>,
     oidc_environment: Option<String>,
     workflow_permissions: Option<&Value>,
+    workflow_defaults: Option<&JobDefaults>,
     inputs: Option<&BTreeMap<String, Value>>,
     matrix_deferred: bool,
 ) -> Result<JobPlan, ParserError> {
@@ -514,6 +548,17 @@ fn job_plan_from_job(
         .cloned()
         .map(|step| step_plan(step, &job.defaults, &matrix, inputs, matrix_deferred))
         .collect::<Result<Vec<_>, _>>()?;
+    let mut defaults = Vec::new();
+    if let Some(wf_defaults) = workflow_defaults {
+        if let Some(run) = &wf_defaults.run {
+            defaults.push(defaults_run_token(run));
+        }
+    }
+    if let Some(job_defaults) = &job.defaults {
+        if let Some(run) = &job_defaults.run {
+            defaults.push(defaults_run_token(run));
+        }
+    }
     let name = resolved_job_name(job.name.as_deref(), &expanded_id, &matrix, inputs);
     Ok(JobPlan {
         id: JobId(expanded_id),
@@ -552,6 +597,8 @@ fn job_plan_from_job(
         permissions: resolve_permissions(job.permissions.as_ref(), workflow_permissions),
         oidc_environment,
         oidc_job_workflow_ref: None,
+        environment: job.environment.clone(),
+        defaults,
         concurrency_group,
         concurrency_cancel_in_progress,
         concurrency_queue,
@@ -861,6 +908,8 @@ fn expand_jobs_with_reusables_internal(
                     ),
                     oidc_environment: None,
                     oidc_job_workflow_ref: None,
+                    environment: job.environment.clone(),
+                    defaults: Vec::new(),
                     // Caller/embedded concurrency is gated as a JobSet from
                     // ReusableCallMetadata at runtime; the placeholder node
                     // itself must not take a job-level gate.
@@ -905,6 +954,7 @@ fn expand_jobs_with_reusables_internal(
                 env,
                 oidc_environment,
                 workflow.permissions.as_ref(),
+                workflow.defaults.as_ref(),
                 inputs,
                 matrix_deferred,
             )?;
@@ -1215,6 +1265,7 @@ fn step_plan(
                 resolve_deferred_bool(Some(value), matrix, inputs, false).map(Some)
             }
         })?,
+        timeout_in_minutes: step.timeout_minutes,
     })
 }
 
@@ -1359,6 +1410,7 @@ pub fn expand_deferred_matrix_job(
             env,
             oidc_environment,
             workflow.permissions.as_ref(),
+            workflow.defaults.as_ref(),
             inputs,
             false,
         )?;

--- a/crates/preloop-gha-parser/src/expand.rs
+++ b/crates/preloop-gha-parser/src/expand.rs
@@ -324,7 +324,6 @@ fn resolve_step_timeout(
     Ok(Some(value as u32))
 }
 
-
 /// Omit empty `services: {}` to match `EmitDefaultValue=false` behavior.
 fn non_empty_services(services: Option<serde_json::Value>) -> Option<serde_json::Value> {
     match &services {

--- a/crates/preloop-gha-parser/src/job_builder.rs
+++ b/crates/preloop-gha-parser/src/job_builder.rs
@@ -404,14 +404,13 @@ pub fn build_agent_job_message_with_normalized_context(
     // a boolean literal) fail on first use.
     let mut resolved_env: BTreeMap<String, String> = BTreeMap::new();
     for (k, v) in &plan.env {
-        // Runtime-only context keys must survive job-build resolution:
-        // `github.workspace` is filled in by the runner at execution
-        // time (the server has no runner work directory), and the
-        // expression resolver turns a missing property into "" — so
-        // neovim's `BIN_DIR: ${{ github.workspace }}/bin` would silently
-        // collapse to `/bin` here. Leave those values untouched for the
-        // runner's step-time evaluation.
-        if v.contains("github.workspace") {
+        // Some contexts do not exist yet when the job message is built, and
+        // the resolver turns a missing property into "" rather than an error
+        // — so resolving them here silently destroys the value. Ship those
+        // untouched; `environment_variables` carries them as template tokens
+        // and the runner evaluates them at step time against the completed
+        // context. See [`resolves_after_job_build`].
+        if crate::eval::resolves_after_job_build(v) {
             resolved_env.insert(k.clone(), v.clone());
             continue;
         }
@@ -686,13 +685,21 @@ pub fn build_agent_job_message_with_normalized_context(
     })
 }
 
-/// Resolve a deployment-environment name, failing the job when its expression
-/// cannot be evaluated rather than shipping the raw `${{ … }}` template.
+/// Resolve a deployment-environment name.
+///
+/// A name reading a not-yet-populated context is left as a template: unlike
+/// `env:`, the runner never evaluates this field, so the server re-resolves it
+/// once `needs` completes (`hydrate_needs_context`). Everything else is
+/// resolved here, and a failure fails the job exactly as an unevaluable
+/// `env:` value does — the raw template must never become the deployment name.
 fn resolve_environment_name(
     name: &str,
     context: &Context,
     job_name: &str,
 ) -> Result<String, String> {
+    if crate::eval::resolves_after_job_build(name) {
+        return Ok(name.to_owned());
+    }
     resolve_string(name, context)
         .map_err(|error| format!("job `{job_name}` environment failed to evaluate: {error}"))
 }
@@ -1099,6 +1106,67 @@ jobs:
             error.contains("environment failed to evaluate"),
             "error must name the environment: {error}"
         );
+    }
+
+    /// `needs` is empty when the job message is built, and the resolver
+    /// coalesces a missing property to "" — so resolving a `needs`-reading
+    /// `env:` value here would replace the upstream output with an empty
+    /// string, and nothing downstream re-resolves it. The value must survive
+    /// as a template for the runner to evaluate against the hydrated context.
+    #[test]
+    fn needs_dependent_env_survives_as_a_template() {
+        let workflow = parse_workflow(
+            r#"
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      target: ${{ steps.x.outputs.target }}
+    steps:
+      - id: x
+        run: echo target=prod >> $GITHUB_OUTPUT
+  deploy:
+    needs: [build]
+    runs-on: ubuntu-latest
+    env:
+      TARGET: ${{ needs.build.outputs.target }}
+    steps:
+      - run: echo $TARGET
+"#,
+        )
+        .unwrap();
+        let plans = crate::expand_jobs(&workflow).unwrap();
+        let deploy = plans.iter().find(|plan| plan.base_id == "deploy").unwrap();
+        let message = build_agent_job_message(
+            deploy,
+            &serde_json::json!({"event_name": "push"}),
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            message
+                .variables
+                .get("TARGET")
+                .and_then(|variable| variable.value.clone()),
+            Some("${{ needs.build.outputs.target }}".to_owned()),
+            "a needs-dependent env value must not be resolved against the empty needs context"
+        );
+        // A deferred value must reach the wire as an *expression* token, which
+        // is what makes the runner evaluate it against the hydrated context.
+        let target = message
+            .environment_variables
+            .iter()
+            .find_map(|entry| {
+                let pair = entry.get("map")?.as_array()?.first()?;
+                (pair.get("Key")?.get("lit")?.as_str()? == "TARGET").then(|| pair["Value"].clone())
+            })
+            .expect("TARGET must be present on the wire");
+        assert_eq!(target["type"], 3, "expected an expression token: {target}");
+        assert_eq!(target["expr"], "needs.build.outputs.target");
     }
 
     /// Job/workflow-level `env:` must reach the wire as

--- a/crates/preloop-gha-parser/src/job_builder.rs
+++ b/crates/preloop-gha-parser/src/job_builder.rs
@@ -66,7 +66,7 @@ fn job_outputs_token(outputs: &BTreeMap<String, String>) -> Option<Value> {
     }))
 }
 
-fn template_string_token(raw: &str) -> Value {
+pub(crate) fn template_string_token(raw: &str) -> Value {
     let location = || json!({"file": 1, "line": 1, "col": 1});
     let trimmed = raw.trim();
     if let Some(expression_source) = trimmed.strip_prefix("${{") {
@@ -124,7 +124,7 @@ fn template_string_token(raw: &str) -> Value {
     })
 }
 
-fn template_token(value: &Value) -> Value {
+pub(crate) fn template_token(value: &Value) -> Value {
     let location = || json!({"file": 1, "line": 1, "col": 1});
     match value {
         Value::Object(object) => {

--- a/crates/preloop-gha-parser/src/job_builder.rs
+++ b/crates/preloop-gha-parser/src/job_builder.rs
@@ -615,27 +615,26 @@ pub fn build_agent_job_message_with_normalized_context(
 
     let request_id: i64 = 1;
 
-    let actions_environment = plan.environment.as_ref().and_then(|env| match env {
-        Value::String(name) => {
-            let resolved_name =
-                resolve_string(name, &job_expr_context).unwrap_or_else(|_| name.clone());
-            Some(preloop_gha_protocol::azdo::ActionsEnvironment {
-                name: resolved_name,
-                url: None,
-            })
-        }
-        Value::Object(map) => {
-            let name = map.get("name")?.as_str()?;
-            let resolved_name =
-                resolve_string(name, &job_expr_context).unwrap_or_else(|_| name.to_string());
-            let url = map.get("url").map(template_token);
-            Some(preloop_gha_protocol::azdo::ActionsEnvironment {
-                name: resolved_name,
-                url,
-            })
-        }
+    // Same rule as the job `env` path above: GitHub fails the workflow when a
+    // deployment-environment expression cannot be evaluated. Shipping the raw
+    // template would name the deployment `${{ … }}` in the runner and in every
+    // downstream environment record.
+    let actions_environment = match plan.environment.as_ref() {
+        Some(Value::String(name)) => Some(preloop_gha_protocol::azdo::ActionsEnvironment {
+            name: resolve_environment_name(name, &job_expr_context, &plan.name)?,
+            url: None,
+        }),
+        Some(Value::Object(map)) => match map.get("name").and_then(Value::as_str) {
+            Some(name) => Some(preloop_gha_protocol::azdo::ActionsEnvironment {
+                name: resolve_environment_name(name, &job_expr_context, &plan.name)?,
+                // The URL is evaluated by the runner after the job's steps
+                // produce it, so it ships as an unevaluated template token.
+                url: map.get("url").map(template_token),
+            }),
+            None => None,
+        },
         _ => None,
-    });
+    };
 
     Ok(AgentJobRequestMessage {
         message_type: None,
@@ -685,6 +684,17 @@ pub fn build_agent_job_message_with_normalized_context(
         preloop_snapshot_token_steps: None,
         preloop_snapshot_origin_rewrite: None,
     })
+}
+
+/// Resolve a deployment-environment name, failing the job when its expression
+/// cannot be evaluated rather than shipping the raw `${{ … }}` template.
+fn resolve_environment_name(
+    name: &str,
+    context: &Context,
+    job_name: &str,
+) -> Result<String, String> {
+    resolve_string(name, context)
+        .map_err(|error| format!("job `{job_name}` environment failed to evaluate: {error}"))
 }
 
 /// Omit empty `services: {}` to match `EmitDefaultValue=false` behavior.
@@ -1056,6 +1066,38 @@ jobs:
         assert_eq!(
             step["reference"],
             serde_json::json!({"type": "containerRegistry", "image": "alpine:3.20"})
+        );
+    }
+
+    /// A deployment environment whose expression cannot be evaluated must fail
+    /// the job, exactly as an unevaluable job `env:` value does. Shipping the
+    /// raw template would name the deployment `${{ … }}` on the wire.
+    #[test]
+    fn unevaluable_environment_expression_fails_the_job() {
+        let workflow = parse_workflow(
+            r#"
+on: push
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ nosuchfunction('prod') }}
+    steps:
+      - run: echo deploy
+"#,
+        )
+        .unwrap();
+        let plan = &crate::expand_jobs(&workflow).unwrap()[0];
+        let error = build_agent_job_message(
+            plan,
+            &serde_json::json!({"event_name": "push"}),
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+        )
+        .expect_err("an unevaluable environment expression must fail the job");
+        assert!(
+            error.contains("environment failed to evaluate"),
+            "error must name the environment: {error}"
         );
     }
 

--- a/crates/preloop-gha-parser/src/job_builder.rs
+++ b/crates/preloop-gha-parser/src/job_builder.rs
@@ -474,8 +474,11 @@ pub fn build_agent_job_message_with_normalized_context(
         .map(|(k, v)| {
             serde_json::json!({
                 "type": 2,
+                "file": 1,
+                "line": 1,
+                "col": 1,
                 "map": [{
-                    "Key": { "type": 0, "lit": k },
+                    "Key": { "type": 0, "file": 1, "line": 1, "col": 1, "lit": k },
                     "Value": template_string_token(v)
                 }]
             })
@@ -612,6 +615,28 @@ pub fn build_agent_job_message_with_normalized_context(
 
     let request_id: i64 = 1;
 
+    let actions_environment = plan.environment.as_ref().and_then(|env| match env {
+        Value::String(name) => {
+            let resolved_name =
+                resolve_string(name, &job_expr_context).unwrap_or_else(|_| name.clone());
+            Some(preloop_gha_protocol::azdo::ActionsEnvironment {
+                name: resolved_name,
+                url: None,
+            })
+        }
+        Value::Object(map) => {
+            let name = map.get("name")?.as_str()?;
+            let resolved_name =
+                resolve_string(name, &job_expr_context).unwrap_or_else(|_| name.to_string());
+            let url = map.get("url").map(template_token);
+            Some(preloop_gha_protocol::azdo::ActionsEnvironment {
+                name: resolved_name,
+                url,
+            })
+        }
+        _ => None,
+    });
+
     Ok(AgentJobRequestMessage {
         message_type: None,
         job_id,
@@ -634,7 +659,7 @@ pub fn build_agent_job_message_with_normalized_context(
         locked_until: "0001-01-01T00:00:00".to_owned(),
         billing_owner_id: None,
         file_table: Vec::new(),
-        defaults: Vec::new(),
+        defaults: plan.defaults.clone(),
         environment_variables,
         snapshot: None,
         condition: plan.if_condition.as_deref().map(runner_condition),
@@ -649,6 +674,7 @@ pub fn build_agent_job_message_with_normalized_context(
         job_container: plan.container.as_ref().map(template_token),
         job_service_containers: non_empty_services(plan.services.as_ref()),
         job_outputs: job_outputs_token(&plan.job_outputs),
+        actions_environment,
         enable_debugger: false,
         debugger_tunnel: None,
         debugger_welcome_message: None,
@@ -941,7 +967,7 @@ fn build_task_step(step: &crate::StepPlan, context: &Context) -> TaskStep {
             .working_directory
             .as_ref()
             .map(|wd| resolve_string(wd, context).unwrap_or_else(|_| wd.clone())),
-        timeout_in_minutes: None,
+        timeout_in_minutes: step.timeout_in_minutes,
     }
 }
 

--- a/crates/preloop-gha-parser/src/lib_tests.rs
+++ b/crates/preloop-gha-parser/src/lib_tests.rs
@@ -2065,6 +2065,64 @@ jobs:
 }
 
 #[test]
+fn workflow_defaults_run_working_directory_rejects_secrets() {
+    let result = parse_workflow(
+        r#"on: push
+defaults:
+  run:
+    working-directory: ${{ secrets.WORKING_DIR }}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+"#,
+    );
+
+    match result {
+        Err(ParserError::InvalidExpression(message)) => {
+            assert!(message.contains("workflow defaults.run.working-directory"));
+            assert!(message.contains("secrets"));
+        }
+        other => panic!("expected invalid workflow defaults expression, got {other:?}"),
+    }
+}
+
+#[test]
+fn step_timeout_expression_resolves_and_range_is_checked() {
+    let workflow = parse_workflow(
+        r#"on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        timeout: [5]
+    steps:
+      - name: bounded
+        timeout-minutes: ${{ matrix.timeout }}
+        run: echo ok
+"#,
+    )
+    .unwrap();
+    let jobs = expand_jobs(&workflow).unwrap();
+    assert_eq!(jobs[0].steps[0].timeout_in_minutes, Some(5));
+
+    for (value, expected) in [(0, "1 through 360"), (361, "1 through 360")] {
+        let workflow = parse_workflow(&format!(
+            "on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - name: bounded\n        timeout-minutes: {value}\n        run: echo ok\n"
+        ))
+        .unwrap();
+        match expand_jobs(&workflow) {
+            Err(ParserError::InvalidStepTimeout { message, .. }) => {
+                assert!(message.contains(expected));
+            }
+            other => panic!("expected invalid timeout for {value}, got {other:?}"),
+        }
+    }
+}
+
+#[test]
 fn concurrency_bare_string_shorthand() {
     let wf = parse_workflow(
         r#"

--- a/crates/preloop-gha-parser/src/lib_tests.rs
+++ b/crates/preloop-gha-parser/src/lib_tests.rs
@@ -2112,6 +2112,37 @@ jobs:
     assert_eq!(value["expr"], "matrix.shell");
 }
 
+/// The official schema types `timeout-minutes` as `number`
+/// (`workflow-v1.0.json`: `step-timeout-minutes` → `"number": {}`), and a
+/// template number is a double — so generated YAML rendering `5` as `5.0` is
+/// valid input. Rejecting it at deserialization failed the *entire* workflow,
+/// not just the field.
+#[test]
+fn decimal_step_timeout_is_accepted_and_fractions_are_rejected() {
+    let workflow_with = |timeout: &str| {
+        format!(
+            "on: push\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo ok\n        timeout-minutes: {timeout}\n"
+        )
+    };
+
+    let workflow = parse_workflow(&workflow_with("5.0")).expect("`5.0` is a valid number");
+    let jobs = expand_jobs(&workflow).unwrap();
+    assert_eq!(jobs[0].steps[0].timeout_in_minutes, Some(5));
+
+    // A fraction is not a whole number of minutes; reject it rather than
+    // truncating a `2.5` into a two-minute timeout.
+    let workflow = parse_workflow(&workflow_with("2.5")).expect("`2.5` still parses as a number");
+    match expand_jobs(&workflow) {
+        Err(ParserError::InvalidExpression(message)) => {
+            assert!(
+                message.contains("2.5"),
+                "error must name the value: {message}"
+            );
+        }
+        other => panic!("expected a whole-number rejection, got {other:?}"),
+    }
+}
+
 #[test]
 fn step_timeout_expression_resolves_and_range_is_checked() {
     let workflow = parse_workflow(

--- a/crates/preloop-gha-parser/src/lib_tests.rs
+++ b/crates/preloop-gha-parser/src/lib_tests.rs
@@ -2089,6 +2089,29 @@ jobs:
 }
 
 #[test]
+fn defaults_run_expression_is_encoded_as_template_token() {
+    let workflow = parse_workflow(
+        r#"on: push
+defaults:
+  run:
+    shell: ${{ matrix.shell }}
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shell: [bash]
+    steps:
+      - run: echo ok
+"#,
+    )
+    .unwrap();
+    let plan = &expand_jobs(&workflow).unwrap()[0];
+    assert_eq!(plan.defaults[0]["Value"]["type"], 3);
+    assert_eq!(plan.defaults[0]["Value"]["expr"], "matrix.shell");
+}
+
+#[test]
 fn step_timeout_expression_resolves_and_range_is_checked() {
     let workflow = parse_workflow(
         r#"on: push

--- a/crates/preloop-gha-parser/src/lib_tests.rs
+++ b/crates/preloop-gha-parser/src/lib_tests.rs
@@ -2107,8 +2107,9 @@ jobs:
     )
     .unwrap();
     let plan = &expand_jobs(&workflow).unwrap()[0];
-    assert_eq!(plan.defaults[0]["Value"]["type"], 3);
-    assert_eq!(plan.defaults[0]["Value"]["expr"], "matrix.shell");
+    let value = &plan.defaults[0]["map"][0]["Value"]["map"][0]["Value"];
+    assert_eq!(value["type"], 3);
+    assert_eq!(value["expr"], "matrix.shell");
 }
 
 #[test]

--- a/crates/preloop-gha-parser/src/models.rs
+++ b/crates/preloop-gha-parser/src/models.rs
@@ -813,13 +813,40 @@ pub enum DeferredBool {
 }
 
 /// A workflow number that may be deferred as a GitHub Actions expression.
+///
+/// The official schema types every numeric workflow field as `number`
+/// (`workflow-v1.0.json`: `step-timeout-minutes` → `"number": {}`), and a
+/// template number is a double — so `timeout-minutes: 5.0` is as valid as
+/// `5`. Generated YAML routinely renders integers that way, and rejecting it
+/// here would fail the whole workflow at parse time over a value GitHub
+/// accepts.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum DeferredNumber {
     /// Literal unsigned integer value.
     Literal(u64),
+    /// Literal number written in decimal form (`5.0`), as the schema allows.
+    Float(f64),
     /// Expression evaluated when the job is expanded.
     Expression(String),
+}
+
+impl DeferredNumber {
+    /// The literal value, when this is not a deferred expression.
+    ///
+    /// A decimal with a fractional part is not a whole number of minutes (or
+    /// of parallel jobs) and is rejected by the caller rather than silently
+    /// truncated.
+    pub fn literal(&self) -> Option<u64> {
+        match self {
+            DeferredNumber::Literal(value) => Some(*value),
+            DeferredNumber::Float(value) => {
+                (value.is_finite() && value.fract() == 0.0 && *value >= 0.0)
+                    .then_some(*value as u64)
+            }
+            DeferredNumber::Expression(_) => None,
+        }
+    }
 }
 
 /// A static matrix or an expression producing a matrix object.

--- a/crates/preloop-gha-parser/src/models.rs
+++ b/crates/preloop-gha-parser/src/models.rs
@@ -27,6 +27,7 @@ pub enum ParserError {
         /// Validation detail.
         message: String,
     },
+    /// Workflow has no jobs to expand.
     #[error("workflow does not define any jobs")]
     EmptyJobs,
     /// A job references a dependency that does not exist after expansion.

--- a/crates/preloop-gha-parser/src/models.rs
+++ b/crates/preloop-gha-parser/src/models.rs
@@ -177,6 +177,9 @@ pub struct Workflow {
     pub concurrency: Option<Concurrency>,
     /// Job definitions.
     pub jobs: IndexMap<String, Job>,
+    /// Workflow-level defaults (`defaults.run`).
+    #[serde(default)]
+    pub defaults: Option<JobDefaults>,
 }
 
 impl Workflow {
@@ -991,6 +994,9 @@ pub struct Step {
     /// Whether to continue on error.
     #[serde(default, rename = "continue-on-error")]
     pub continue_on_error: Option<DeferredBool>,
+    /// Step timeout in minutes.
+    #[serde(default, rename = "timeout-minutes")]
+    pub timeout_minutes: Option<u32>,
 }
 
 /// Action metadata from `action.yml` or `action.yaml`.

--- a/crates/preloop-gha-parser/src/models.rs
+++ b/crates/preloop-gha-parser/src/models.rs
@@ -17,7 +17,16 @@ pub enum ParserError {
     /// Expression syntax or function error.
     #[error("invalid expression in workflow: {0}")]
     InvalidExpression(String),
-    /// Workflow did not define jobs.
+    /// A resolved step timeout is missing or outside GitHub's accepted range.
+    #[error("invalid timeout-minutes for job `{job_id}` step `{step}`: {message}")]
+    InvalidStepTimeout {
+        /// Expanded or source job id.
+        job_id: String,
+        /// Step display name or ordinal.
+        step: String,
+        /// Validation detail.
+        message: String,
+    },
     #[error("workflow does not define any jobs")]
     EmptyJobs,
     /// A job references a dependency that does not exist after expansion.
@@ -994,9 +1003,9 @@ pub struct Step {
     /// Whether to continue on error.
     #[serde(default, rename = "continue-on-error")]
     pub continue_on_error: Option<DeferredBool>,
-    /// Step timeout in minutes.
+    /// Step timeout in minutes; expressions resolve during expansion.
     #[serde(default, rename = "timeout-minutes")]
-    pub timeout_minutes: Option<u32>,
+    pub timeout_minutes: Option<DeferredNumber>,
 }
 
 /// Action metadata from `action.yml` or `action.yaml`.

--- a/crates/preloop-gha-protocol/src/azdo/azdo_tests.rs
+++ b/crates/preloop-gha-protocol/src/azdo/azdo_tests.rs
@@ -222,7 +222,9 @@ fn expected_step_wire(step: &TaskStep) -> Value {
     }
     object.insert(
         "timeoutInMinutes".to_owned(),
-        json!(step.timeout_in_minutes),
+        step.timeout_in_minutes
+            .map(|value| json!({"type": 6, "file": 1, "line": 0, "col": 0, "num": value}))
+            .unwrap_or(Value::Null),
     );
     Value::Object(object)
 }
@@ -337,6 +339,9 @@ fn expected_job_wire(job: &AgentJobRequestMessage) -> Value {
         json!(job.job_service_containers),
     );
     object.insert("jobOutputs".to_owned(), json!(job.job_outputs));
+    if let Some(value) = &job.actions_environment {
+        object.insert("actionsEnvironment".to_owned(), json!(value));
+    }
     if job.enable_debugger {
         object.insert("enableDebugger".to_owned(), json!(true));
     }
@@ -497,6 +502,7 @@ fn arb_job() -> impl Strategy<Value = AgentJobRequestMessage> {
                 job_container,
                 job_service_containers,
                 job_outputs,
+                actions_environment: None,
                 enable_debugger,
                 debugger_tunnel: has_tunnel.then_some(DebuggerTunnelInfo {
                     tunnel_id: "tunnel".to_owned(),

--- a/crates/preloop-gha-protocol/src/azdo/azdo_tests.rs
+++ b/crates/preloop-gha-protocol/src/azdo/azdo_tests.rs
@@ -432,6 +432,7 @@ fn arb_job() -> impl Strategy<Value = AgentJobRequestMessage> {
             prop::option::of(arb_text().prop_map(|value| json!({"type": 0, "lit": value}))),
             prop::option::of(arb_text().prop_map(|value| json!({"type": 2, "lit": value}))),
             prop::option::of(arb_text().prop_map(|value| json!({"type": 2, "lit": value}))),
+            prop::option::of(arb_text().prop_map(|name| ActionsEnvironment { name, url: None })),
         ),
         (
             any::<bool>(),
@@ -463,6 +464,7 @@ fn arb_job() -> impl Strategy<Value = AgentJobRequestMessage> {
                     job_container,
                     job_service_containers,
                     job_outputs,
+                    actions_environment,
                 ),
                 (enable_debugger, debugger_welcome_message, has_tunnel, key_bytes),
             )| AgentJobRequestMessage {
@@ -502,7 +504,7 @@ fn arb_job() -> impl Strategy<Value = AgentJobRequestMessage> {
                 job_container,
                 job_service_containers,
                 job_outputs,
-                actions_environment: None,
+                actions_environment,
                 enable_debugger,
                 debugger_tunnel: has_tunnel.then_some(DebuggerTunnelInfo {
                     tunnel_id: "tunnel".to_owned(),

--- a/crates/preloop-gha-protocol/src/azdo/job.rs
+++ b/crates/preloop-gha-protocol/src/azdo/job.rs
@@ -294,10 +294,31 @@ pub struct DebuggerTunnelInfo {
     pub tunnel_id: String,
     #[serde(rename = "clusterId", default)]
     pub cluster_id: String,
+
     #[serde(rename = "hostToken", default)]
     pub host_token: String,
     #[serde(rename = "port", default)]
     pub port: u16,
+}
+/// Read an unsigned integer from the TemplateToken shapes used by GitHub.
+///
+/// Live runner payloads use `num`; older captures and compatibility payloads
+/// also use `number`, `lit`, a JSON number, or a numeric string.
+pub fn number_from_template_token(value: &serde_json::Value) -> Option<u64> {
+    match value {
+        serde_json::Value::Number(_) => value.as_u64(),
+        serde_json::Value::String(value) => value.trim().parse().ok(),
+        serde_json::Value::Object(map) => map
+            .get("num")
+            .or_else(|| map.get("number"))
+            .and_then(serde_json::Value::as_u64)
+            .or_else(|| {
+                map.get("lit")
+                    .and_then(serde_json::Value::as_str)
+                    .and_then(|value| value.trim().parse().ok())
+            }),
+        _ => None,
+    }
 }
 
 /// Deployment environment metadata (`actionsEnvironment`).
@@ -398,6 +419,9 @@ impl Serialize for TaskStep {
         if let Some(working_directory) = &self.working_directory {
             map.serialize_entry("workingDirectory", working_directory)?;
         }
+        // The parser model does not retain YAML source spans, so generated
+        // tokens use synthetic coordinates. The runner consumes only `num`;
+        // preserving real line/column data requires source-span plumbing.
         let timeout_in_minutes = self.timeout_in_minutes.map(|value| {
             serde_json::json!({
                 "type": 6,
@@ -469,11 +493,10 @@ impl<'de> Deserialize<'de> for TaskStep {
                 .get("workingDirectory")
                 .and_then(|v| v.as_str())
                 .map(str::to_owned),
-            timeout_in_minutes: obj.get("timeoutInMinutes").and_then(|v| {
-                v.as_u64()
-                    .or_else(|| v.get("num").and_then(serde_json::Value::as_u64))
-                    .map(|n| n as u32)
-            }),
+            timeout_in_minutes: obj
+                .get("timeoutInMinutes")
+                .and_then(number_from_template_token)
+                .and_then(|value| u32::try_from(value).ok()),
         })
     }
 }
@@ -846,6 +869,19 @@ mod tests {
             step.inputs.get("script"),
             Some(&"${{ format('echo {0}', github.repository) }}".to_owned())
         );
+    }
+
+    #[test]
+    fn timeout_token_reader_accepts_all_numeric_shapes() {
+        for token in [
+            serde_json::json!(5),
+            serde_json::json!("5"),
+            serde_json::json!({"num": 5}),
+            serde_json::json!({"number": 5}),
+            serde_json::json!({"lit": "5"}),
+        ] {
+            assert_eq!(number_from_template_token(&token), Some(5));
+        }
     }
 
     /// The snapshot credential must never appear in Debug output of the job

--- a/crates/preloop-gha-protocol/src/azdo/job.rs
+++ b/crates/preloop-gha-protocol/src/azdo/job.rs
@@ -119,6 +119,14 @@ pub struct AgentJobRequestMessage {
     #[serde(rename = "jobOutputs", default)]
     pub job_outputs: Option<serde_json::Value>,
 
+    /// Deployment environment metadata (`actionsEnvironment`).
+    #[serde(
+        rename = "actionsEnvironment",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub actions_environment: Option<ActionsEnvironment>,
+
     /// Whether the debugger is enabled for this job.
     /// Mirrors `AgentJobRequestMessage.EnableDebugger` in `actions/runner` v2.335.0+.
     #[serde(rename = "enableDebugger", default, skip_serializing_if = "is_false")]
@@ -292,6 +300,14 @@ pub struct DebuggerTunnelInfo {
     pub port: u16,
 }
 
+/// Deployment environment metadata (`actionsEnvironment`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct ActionsEnvironment {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<serde_json::Value>,
+}
+
 /// Task step — a single unit of work within a job.
 #[derive(Debug, Clone)]
 pub struct TaskStep {
@@ -382,7 +398,16 @@ impl Serialize for TaskStep {
         if let Some(working_directory) = &self.working_directory {
             map.serialize_entry("workingDirectory", working_directory)?;
         }
-        map.serialize_entry("timeoutInMinutes", &self.timeout_in_minutes)?;
+        let timeout_in_minutes = self.timeout_in_minutes.map(|value| {
+            serde_json::json!({
+                "type": 6,
+                "file": 1,
+                "line": 0,
+                "col": 0,
+                "num": value
+            })
+        });
+        map.serialize_entry("timeoutInMinutes", &timeout_in_minutes)?;
         map.end()
     }
 }
@@ -444,10 +469,11 @@ impl<'de> Deserialize<'de> for TaskStep {
                 .get("workingDirectory")
                 .and_then(|v| v.as_str())
                 .map(str::to_owned),
-            timeout_in_minutes: obj
-                .get("timeoutInMinutes")
-                .and_then(|v| v.as_u64())
-                .map(|n| n as u32),
+            timeout_in_minutes: obj.get("timeoutInMinutes").and_then(|v| {
+                v.as_u64()
+                    .or_else(|| v.get("num").and_then(serde_json::Value::as_u64))
+                    .map(|n| n as u32)
+            }),
         })
     }
 }

--- a/crates/preloop-gha-protocol/src/lib.rs
+++ b/crates/preloop-gha-protocol/src/lib.rs
@@ -459,6 +459,12 @@ pub struct JobPlan {
     /// Executing reusable workflow reference, when this job came from one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub oidc_job_workflow_ref: Option<String>,
+    /// Raw deployment environment configuration (`environment:`), if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environment: Option<serde_json::Value>,
+    /// TemplateToken-encoded defaults (workflow and job level).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub defaults: Vec<serde_json::Value>,
     /// Raw job-level concurrency group expression/string (server-evaluated).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub concurrency_group: Option<String>,
@@ -573,6 +579,9 @@ pub struct StepPlan {
     /// Whether to continue on error.
     #[serde(default)]
     pub continue_on_error: Option<bool>,
+    /// Timeout in minutes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout_in_minutes: Option<u32>,
 }
 
 /// Context material sent to a runner.

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -1664,6 +1664,7 @@ jobs:
   deploy:
     needs: [build]
     runs-on: ubuntu-latest
+    environment: ${{ needs.build.outputs.environment }}
     steps:
       - run: echo deploy
 "#,
@@ -1682,7 +1683,7 @@ jobs:
             "run_id": run_id,
             "job_id": "build",
             "status": "success",
-            "outputs": {"artifact": "dist.tgz"}
+            "outputs": {"artifact": "dist.tgz", "environment": "staging"}
         }),
     )
     .await;
@@ -1694,6 +1695,14 @@ jobs:
         .find(|job| job.job_id.0 == "deploy")
         .expect("deploy job should be promoted");
     let needs = deploy.message.context_data.get("needs").unwrap();
+    assert_eq!(
+        deploy
+            .message
+            .actions_environment
+            .as_ref()
+            .map(|environment| environment.name.as_str()),
+        Some("staging")
+    );
     let azdo::PipelineContextData::Dict(needs) = needs else {
         panic!("needs context should be a dict");
     };

--- a/crates/preloop-runner-server/src/models.rs
+++ b/crates/preloop-runner-server/src/models.rs
@@ -399,6 +399,9 @@ pub(crate) struct QueuedJob {
     /// Explicit runner group from object-valued `runs-on`.
     pub(crate) runner_group: Option<String>,
     pub(crate) message: azdo::AgentJobRequestMessage,
+    /// Original `environment:` value, retained until `needs` is hydrated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) environment: Option<serde_json::Value>,
     /// Raw job-level concurrency (evaluated when the job becomes ready).
     pub(crate) concurrency: Option<preloop_gha_parser::Concurrency>,
     /// Matrix values for this expansion (for concurrency expression eval).

--- a/crates/preloop-runner-server/src/runs.rs
+++ b/crates/preloop-runner-server/src/runs.rs
@@ -1233,6 +1233,7 @@ pub(crate) async fn submit_run_inner(
                 max_parallel: job.max_parallel,
                 runs_on: job.runs_on.clone(),
                 runner_group: job.runner_group.clone(),
+                environment: job.environment.clone(),
                 message: agent_msg,
                 concurrency: concurrency::concurrency_from_plan_fields(
                     job.concurrency_group.as_deref(),

--- a/crates/preloop-runner-server/src/runtime_scheduling.rs
+++ b/crates/preloop-runner-server/src/runtime_scheduling.rs
@@ -1865,6 +1865,11 @@ pub(crate) fn hydrate_needs_context(job: &mut QueuedJob, run: &RunRecord) {
         .context_data
         .insert("needs".to_owned(), azdo::PipelineContextData::Dict(needs));
 
+    // The environment name is the one field the runner never evaluates: it
+    // ships as a plain string, so a name reading `needs.*` was deliberately
+    // left as a template by the job builder and is finished here, now that the
+    // context is complete. Everything else needing `needs` travels as a
+    // template token and is evaluated in-VM against the map installed above.
     let Some(environment) = job.environment.as_ref() else {
         return;
     };
@@ -1875,15 +1880,31 @@ pub(crate) fn hydrate_needs_context(job: &mut QueuedJob, run: &RunRecord) {
     }) else {
         return;
     };
-    let mut context = preloop_gha_expressions::Context::new();
-    for (key, value) in &job.message.context_data {
-        context.insert(key, value.to_json());
+    if !preloop_gha_parser::eval::resolves_after_job_build(name) {
+        // Already resolved at build time against a complete context.
+        return;
     }
     let Some(actions_environment) = job.message.actions_environment.as_mut() else {
         return;
     };
-    actions_environment.name = preloop_gha_parser::eval::resolve_string(name, &context)
-        .unwrap_or_else(|_| name.to_owned());
+    let mut context = preloop_gha_expressions::Context::new();
+    for (key, value) in &job.message.context_data {
+        context.insert(key, value.to_json());
+    }
+    match preloop_gha_parser::eval::resolve_string(name, &context) {
+        Ok(resolved) => actions_environment.name = resolved,
+        Err(error) => {
+            // Nothing downstream re-resolves this, so a raw template would
+            // become the deployment's name in the environment record.
+            tracing::error!(
+                run_id = %job.run_id.0,
+                job = %job.job_id.0,
+                environment = %name,
+                %error,
+                "deployment environment expression failed to evaluate after needs completed"
+            );
+        }
+    }
 }
 pub(crate) fn needs_json_context(run: &RunRecord, needs: &[JobId]) -> serde_json::Value {
     let values = needs

--- a/crates/preloop-runner-server/src/runtime_scheduling.rs
+++ b/crates/preloop-runner-server/src/runtime_scheduling.rs
@@ -1864,6 +1864,26 @@ pub(crate) fn hydrate_needs_context(job: &mut QueuedJob, run: &RunRecord) {
     job.message
         .context_data
         .insert("needs".to_owned(), azdo::PipelineContextData::Dict(needs));
+
+    let Some(environment) = job.environment.as_ref() else {
+        return;
+    };
+    let Some(name) = (match environment {
+        serde_json::Value::String(name) => Some(name.as_str()),
+        serde_json::Value::Object(map) => map.get("name").and_then(serde_json::Value::as_str),
+        _ => None,
+    }) else {
+        return;
+    };
+    let mut context = preloop_gha_expressions::Context::new();
+    for (key, value) in &job.message.context_data {
+        context.insert(key, value.to_json());
+    }
+    let Some(actions_environment) = job.message.actions_environment.as_mut() else {
+        return;
+    };
+    actions_environment.name = preloop_gha_parser::eval::resolve_string(name, &context)
+        .unwrap_or_else(|_| name.to_owned());
 }
 pub(crate) fn needs_json_context(run: &RunRecord, needs: &[JobId]) -> serde_json::Value {
     let values = needs
@@ -2475,6 +2495,7 @@ fn register_expanded_jobs(
             max_parallel: plan.max_parallel,
             runs_on: plan.runs_on.clone(),
             runner_group: plan.runner_group.clone(),
+            environment: plan.environment.clone(),
             message: artifacts.agent_msg,
             concurrency: concurrency::concurrency_from_plan_fields(
                 plan.concurrency_group.as_deref(),
@@ -3037,6 +3058,7 @@ mod assignment_tests {
             max_parallel: None,
             runs_on: vec!["self-hosted".to_owned()],
             runner_group: None,
+            environment: None,
             message: serde_json::from_value(serde_json::json!({
                 "jobId": "00000000-0000-0000-0000-000000000001",
                 "requestId": 1,

--- a/crates/preloop-runner/src/worker/job_extension.rs
+++ b/crates/preloop-runner/src/worker/job_extension.rs
@@ -598,32 +598,6 @@ fn bool_from_template_token(value: &serde_json::Value) -> bool {
     }
 }
 
-/// Read a number out of a TemplateToken.
-///
-/// GitHub never sends `timeoutInMinutes` as a bare JSON number: it is a
-/// number token (`{"type":6,"file":_,"line":_,"col":_,"num":1}`). Reading it
-/// with `as_u64()` silently yields `None`, which drops the step timeout
-/// entirely — the step then runs unbounded until the job timeout. Accept the
-/// bare form too so older/hand-built messages keep working.
-fn num_from_template_token(value: &serde_json::Value) -> Option<u64> {
-    match value {
-        serde_json::Value::Number(_) => value.as_u64(),
-        serde_json::Value::String(s) => s.trim().parse().ok(),
-        serde_json::Value::Object(map) => {
-            if let Some(n) = map.get("num").and_then(serde_json::Value::as_u64) {
-                return Some(n);
-            }
-            if let Some(n) = map.get("number").and_then(serde_json::Value::as_u64) {
-                return Some(n);
-            }
-            map.get("lit")
-                .and_then(serde_json::Value::as_str)
-                .and_then(|lit| lit.trim().parse().ok())
-        }
-        _ => None,
-    }
-}
-
 /// Build the ordered step list from the job message steps.
 pub fn build_step_list(steps: &[serde_json::Value], job_message: &serde_json::Value) -> Vec<Step> {
     let mut result = Vec::new();
@@ -647,7 +621,6 @@ pub fn build_step_list(steps: &[serde_json::Value], job_message: &serde_json::Va
         };
 
         // F029: Split wire ID (GUID) from context name (human-readable key).
-        // Live GitHub sends both `id` (GUID) and `contextName` (__run, __run_2, etc.).
         // aksh-native payloads may only have `id` (which IS the context name).
         let raw_context_name = step.get("contextName").and_then(|v| v.as_str());
         let raw_id = step.get("id").and_then(|v| v.as_str());
@@ -695,7 +668,7 @@ pub fn build_step_list(steps: &[serde_json::Value], job_message: &serde_json::Va
 
         let timeout_minutes = step
             .get("timeoutInMinutes")
-            .and_then(num_from_template_token);
+            .and_then(preloop_gha_protocol::azdo::number_from_template_token);
 
         // Official ActionStep.Background (DTPipelines) — wire `background: true`.
         let is_background = step

--- a/crates/preloop-runner/src/worker/job_extension.rs
+++ b/crates/preloop-runner/src/worker/job_extension.rs
@@ -598,6 +598,32 @@ fn bool_from_template_token(value: &serde_json::Value) -> bool {
     }
 }
 
+/// Read a number out of a TemplateToken.
+///
+/// GitHub never sends `timeoutInMinutes` as a bare JSON number: it is a
+/// number token (`{"type":6,"file":_,"line":_,"col":_,"num":1}`). Reading it
+/// with `as_u64()` silently yields `None`, which drops the step timeout
+/// entirely — the step then runs unbounded until the job timeout. Accept the
+/// bare form too so older/hand-built messages keep working.
+fn num_from_template_token(value: &serde_json::Value) -> Option<u64> {
+    match value {
+        serde_json::Value::Number(_) => value.as_u64(),
+        serde_json::Value::String(s) => s.trim().parse().ok(),
+        serde_json::Value::Object(map) => {
+            if let Some(n) = map.get("num").and_then(serde_json::Value::as_u64) {
+                return Some(n);
+            }
+            if let Some(n) = map.get("number").and_then(serde_json::Value::as_u64) {
+                return Some(n);
+            }
+            map.get("lit")
+                .and_then(serde_json::Value::as_str)
+                .and_then(|lit| lit.trim().parse().ok())
+        }
+        _ => None,
+    }
+}
+
 /// Build the ordered step list from the job message steps.
 pub fn build_step_list(steps: &[serde_json::Value], job_message: &serde_json::Value) -> Vec<Step> {
     let mut result = Vec::new();
@@ -667,7 +693,9 @@ pub fn build_step_list(steps: &[serde_json::Value], job_message: &serde_json::Va
             .map(bool_from_template_token)
             .unwrap_or(false);
 
-        let timeout_minutes = step.get("timeoutInMinutes").and_then(|v| v.as_u64());
+        let timeout_minutes = step
+            .get("timeoutInMinutes")
+            .and_then(num_from_template_token);
 
         // Official ActionStep.Background (DTPipelines) — wire `background: true`.
         let is_background = step
@@ -953,38 +981,46 @@ fn parse_job_defaults(job_message: &serde_json::Value) -> (Option<String>, Optio
         None => return (None, None),
     };
 
-    // defaults can be an array of typed-dict entries or a plain object
-    let run_value = if let Some(arr) = defaults.as_array() {
-        // Walk the array looking for a "run" key in each typed-dict map
-        arr.iter().find_map(|entry| {
-            let map = entry.get("map").and_then(|v| v.as_array())?;
-            map.iter().find_map(|kv| {
+    // `defaults` is an ordered array of typed-dict entries, outermost first:
+    // GitHub sends `[workflow-level, job-level]`. Later entries override
+    // earlier ones per key, so the array must be folded in order — taking the
+    // first match instead silently discards a job-level `defaults.run` that
+    // overrides the workflow-level one. A plain object is the single-scope
+    // form.
+    let mut working_dir = None;
+    let mut shell = None;
+    let mut apply = |run_value: &serde_json::Value| {
+        let run_map = extract_template_map(run_value);
+        if let Some(value) = run_map.get("working-directory") {
+            working_dir = Some(value.clone());
+        }
+        if let Some(value) = run_map.get("shell") {
+            shell = Some(value.clone());
+        }
+    };
+
+    if let Some(entries) = defaults.as_array() {
+        for entry in entries {
+            let Some(map) = entry.get("map").and_then(|v| v.as_array()) else {
+                continue;
+            };
+            for kv in map {
                 let key = kv
                     .get("Key")
                     .or_else(|| kv.get("key"))
-                    .and_then(template_scalar)?;
-                if key == "run" {
-                    kv.get("Value").or_else(|| kv.get("value")).cloned()
-                } else {
-                    None
+                    .and_then(template_scalar);
+                if key.as_deref() != Some("run") {
+                    continue;
                 }
-            })
-        })
-    } else if let Some(obj) = defaults.as_object() {
-        obj.get("run").cloned()
-    } else {
-        None
-    };
+                if let Some(run_value) = kv.get("Value").or_else(|| kv.get("value")) {
+                    apply(run_value);
+                }
+            }
+        }
+    } else if let Some(run_value) = defaults.as_object().and_then(|obj| obj.get("run")) {
+        apply(run_value);
+    }
 
-    let run_value = match run_value {
-        Some(v) => v,
-        None => return (None, None),
-    };
-
-    // Extract working-directory and shell from the run value
-    let run_map = extract_template_map(&run_value);
-    let working_dir = run_map.get("working-directory").cloned();
-    let shell = run_map.get("shell").cloned();
     (working_dir, shell)
 }
 

--- a/crates/preloop-runner/src/worker/job_extension_tests.rs
+++ b/crates/preloop-runner/src/worker/job_extension_tests.rs
@@ -1420,3 +1420,95 @@ fn load_golden_acquirejob(scenario: &str) -> Option<serde_json::Value> {
     }
     None
 }
+
+/// `defaults` arrives as an ordered array, outermost scope first: GitHub
+/// sends `[workflow-level, job-level]` (see the `104-job-defaults-env-cascade`
+/// golden, whose entries carry source lines 8 then 19). Job-level must win.
+///
+/// Reading only the first entry regressed silently against github.com,
+/// because preloop's own server additionally flattens job defaults onto each
+/// step — so a preloop-driven job looked correct while the same runner
+/// ignored job-level defaults when driven by GitHub.
+#[test]
+fn job_level_defaults_override_workflow_level_defaults() {
+    let run_map = |wd: &str, shell: &str| {
+        serde_json::json!({
+            "type": 2,
+            "map": [{
+                "Key": {"type": 0, "lit": "run"},
+                "Value": {"type": 2, "map": [
+                    {"Key": {"type": 0, "lit": "working-directory"},
+                     "Value": {"type": 0, "lit": wd}},
+                    {"Key": {"type": 0, "lit": "shell"},
+                     "Value": {"type": 0, "lit": shell}},
+                ]}
+            }]
+        })
+    };
+    let message = serde_json::json!({
+        "defaults": [run_map("/workflow-dir", "sh"), run_map("/job-dir", "bash")]
+    });
+
+    let (working_dir, shell) = parse_job_defaults(&message);
+
+    assert_eq!(working_dir.as_deref(), Some("/job-dir"));
+    assert_eq!(shell.as_deref(), Some("bash"));
+}
+
+/// A job scope that sets only one key must not erase the workflow-level value
+/// for the other: the scopes merge per key rather than replacing wholesale.
+#[test]
+fn job_defaults_merge_per_key_across_scopes() {
+    let message = serde_json::json!({
+        "defaults": [
+            {"type": 2, "map": [{
+                "Key": {"type": 0, "lit": "run"},
+                "Value": {"type": 2, "map": [
+                    {"Key": {"type": 0, "lit": "working-directory"},
+                     "Value": {"type": 0, "lit": "/workflow-dir"}},
+                    {"Key": {"type": 0, "lit": "shell"},
+                     "Value": {"type": 0, "lit": "bash"}},
+                ]}
+            }]},
+            {"type": 2, "map": [{
+                "Key": {"type": 0, "lit": "run"},
+                "Value": {"type": 2, "map": [
+                    {"Key": {"type": 0, "lit": "working-directory"},
+                     "Value": {"type": 0, "lit": "/job-dir"}},
+                ]}
+            }]},
+        ]
+    });
+
+    let (working_dir, shell) = parse_job_defaults(&message);
+
+    assert_eq!(working_dir.as_deref(), Some("/job-dir"));
+    assert_eq!(
+        shell.as_deref(),
+        Some("bash"),
+        "workflow shell must survive"
+    );
+}
+
+/// GitHub never sends `timeoutInMinutes` as a bare number — it is a number
+/// token. Reading it with `as_u64()` yielded `None`, so `timeout-minutes:`
+/// was silently dropped and the step ran unbounded.
+#[test]
+fn step_timeout_is_read_from_a_number_token() {
+    let steps = vec![serde_json::json!({
+        "type": "action",
+        "reference": {"type": "script"},
+        "id": "00000000-0000-0000-0000-000000000001",
+        "name": "__run",
+        "contextName": "__run",
+        "inputs": {"type": 2, "map": [
+            {"Key": {"type": 0, "lit": "script"}, "Value": {"type": 0, "lit": "sleep 120"}}
+        ]},
+        "timeoutInMinutes": {"type": 6, "file": 1, "line": 8, "col": 26, "num": 1}
+    })];
+
+    let built = build_step_list(&steps, &serde_json::json!({}));
+
+    assert_eq!(built.len(), 1);
+    assert_eq!(built[0].timeout_minutes, Some(1));
+}


### PR DESCRIPTION
Fixes 3 of the 6 divergences in #243. The other 3 are contaminated golden captures, handled separately.

### Real protocol gaps (never implemented, not regressions)

| Field | Evidence it never worked |
|---|---|
| `timeout-minutes` | `git log -S'timeout-minutes' -- crates/preloop-gha-parser/` returns nothing, ever — no field on `Step`, so serde dropped it |
| `actionsEnvironment` | `git log -S'actionsEnvironment' -- crates/` returns nothing, ever |
| `defaults` | hardcoded `Vec::new()` since cdbb34ed (2026-07-16) |

Scenarios 104 / 110 / 114 were unpassable from the moment their captures landed.

### The wire fix was not sufficient

Two of these were *also* mis-read by the runner, in ways that break it against **real github.com**, not just preloop:

- **`timeoutInMinutes`** read with `as_u64()`, which returns `None` for GitHub's number token `{type:6,…,num:1}`. Value arrived and was discarded. Added `num_from_template_token`, mirroring `bool_from_template_token` used one line above for `continueOnError`.
- **`defaults`** is an ordered array, outermost first. `find_map` took the **first** entry, so a job-level override was discarded. Now folded in order, merging per key. Invisible locally because preloop's parser separately flattens job defaults onto each step; GitHub does not flatten, so job-level defaults were silently ignored there.

### Verified by behavior, not just wire shape

`timeout-minutes: 1` on a step running `sleep 120`:

```
before:  14:26:11 start -> 14:28:11 next step   (120s, ran to completion, job Succeeded)
after:   14:37:56 start -> 14:38:56 killed      (60s)
         WARN Step 'Hanging step' timed out after 1 minutes
         Running step: Cleanup      <- if: always() honored
```

Step working directory confirmed for all three defaults cases:

| workflow | step's actual cwd |
|---|---|
| no defaults | `…/_work/default/default` |
| workflow-level only | `/private/tmp/…/wdA` (previously ignored) |
| job overrides workflow | `/private/tmp/…/wdB` |

`actionsEnvironment` now matches GitHub structurally (differs only in source `line`/`col`, which the parser does not track). Note there is **no runner consumer** for it — this is wire fidelity only; environment-secret selection and OIDC `sub` already worked via `oidc_environment`.

### Audit

Swept all 10 token-encoded job-message fields against 124 `acquirejob` captures spanning runner v2.335.1–v2.337.0. Two were broken (both above); the other eight go through token helpers and are correct.

### Tests

Three regression tests in `job_extension_tests.rs`, each confirmed **failing** with its fix stashed:
- `job_level_defaults_override_workflow_level_defaults`
- `job_defaults_merge_per_key_across_scopes`
- `step_timeout_is_read_from_a_number_token`

Second commit fixes two harness defects found while verifying: `runner-e2e` preferred a stale `target/release/preloop-server` on mere existence (three e2e runs reported on a 10-day-old binary), and its readiness probe allowed 3s where RSA keygen needs more — `run.sh` already allows 60s for this. `just conform` was never affected.

fmt + clippy clean; parser 154, protocol 71, runner 560, runner-watch 82 tests green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three acquirejob message fields that were silently dropped, so step `timeout-minutes` now actually kills the step, job-level `defaults.run` overrides workflow-level, and `actionsEnvironment` is sent on the wire.

**Bug Fixes**
- `timeout-minutes` was never a field on `Step` and was read with `as_u64()`, which returns `None` for GitHub's number token; it is now parsed, resolved (including matrix expressions), range-checked to 1–360, and the runner decodes it via the shared `number_from_template_token`. Decimals like `5.0` parse since the schema types the field as a number.
- `defaults` was hardcoded empty and the runner read only the first scope entry; entries now fold in order, merging per key, so job-level overrides work against real github.com.
- `actionsEnvironment` is now built from the job `environment:` key; a `needs`-reading name is left deferred and hydrated by the server once `needs` completes, and an unevaluable expression fails the job.
- Values referencing unpopulated contexts (`needs`, `github.workspace`) now ship as templates instead of resolving to an empty string.
- The e2e harness picks the newer `target/{release,debug}` binary and waits up to 60s for server readiness, reporting the server's exit status if it dies.

<sup>Written for commit 94f2431ad145b83b33f085d99adee5954801bc32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow and job-level run defaults now apply correctly, with job settings taking precedence.
  * Deployment environment details are now preserved and available to job execution.
  * Step timeouts are supported and correctly interpreted, including numeric token formats.
  * Environment variable location metadata is retained for improved diagnostics.

* **Bug Fixes**
  * End-to-end startup checks now detect early server exits and allow up to 60 seconds for readiness.
  * Binary selection now uses the most recently built executable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->