### PR TITLE
fix(checks): link display names to job ids, show live runner assignments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends lld
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       - name: Install cargo-nextest
-        run: cargo install cargo-nextest --locked
+        run: cargo install cargo-nextest --locked --version 0.9.144
       - run: cargo nextest run --locked --workspace --partition hash:${{ matrix.shard }}/4
         env:
           RUSTFLAGS: "-A warnings -C link-arg=-fuse-ld=lld"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,6 @@ on:
 
 jobs:
   rust-lint:
-    # Fork PRs never execute on the persistent self-hosted runner: untrusted
-    # code with warm caches and network is a supply-chain risk the engine's
-    # token downgrade alone does not cover. Same guard as the conformance
-    # workflows; skipped required checks block fork merges by default.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, preloop-cpane]
     timeout-minutes: 20
     env:
@@ -57,7 +52,6 @@ jobs:
     # NOTE: these display names are load-bearing — the `main` ruleset gates
     # on them. Renaming a shard name requires updating the ruleset to match.
     name: rust shard ${{ matrix.shard }} of 4
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, preloop-cpane]
     timeout-minutes: 60
     strategy:
@@ -99,7 +93,7 @@ jobs:
   property-tests-fast:
     runs-on: [self-hosted, preloop-cpane]
     timeout-minutes: 30
-    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,46 @@ on:
         default: "fast"
 
 jobs:
-  rust:
+  rust-lint:
+    runs-on: [self-hosted, preloop-cpane]
+    timeout-minutes: 20
+    env:
+      CARGO_BUILD_JOBS: "6"
+      RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+          lfs: false
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          toolchain: "1.97"
+          components: rustfmt,clippy
+      - name: Install lld linker
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends lld
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      - run: cargo fmt --all --check
+      - run: |
+          cargo clippy --locked -p preloop-gha-protocol -p preloop-gha-parser -p preloop-gha-expressions -p preloop-cache -p preloop-artifacts -p runner-watch -p preloop-conformance --all-targets -- -D warnings
+          cargo clippy --locked -p preloop-runner -p preloop-runner-server -p preloop-runner-client -p preloop-dap --all-targets
+      # nextest does not run doctests; keep them on the lint job (seconds).
+      - run: cargo test --locked --workspace --doc
+        env:
+          RUSTFLAGS: "-A warnings -C link-arg=-fuse-ld=lld"
+
+  rust-test:
+    # Sharded unit/integration suite. Each shard runs 1/4 of the tests (split
+    # by test-name hash, so no manual bookkeeping) on its own runner; wall
+    # clock is setup + slowest shard instead of setup + everything.
+    # NOTE: these display names are load-bearing — the `main` ruleset gates
+    # on them. Renaming a shard name requires updating the ruleset to match.
+    name: rust shard ${{ matrix.shard }} of 4
     runs-on: [self-hosted, preloop-cpane]
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     env:
       CARGO_BUILD_JOBS: "6"
       PROPTEST_CASES: "8"
@@ -44,17 +81,12 @@ jobs:
         with:
           toolchain: "1.97"
           components: rustfmt,clippy
-
       - name: Install lld linker
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends lld
-
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
-
-      - run: cargo fmt --all --check
-      - run: |
-          cargo clippy --locked -p preloop-gha-protocol -p preloop-gha-parser -p preloop-gha-expressions -p preloop-cache -p preloop-artifacts -p runner-watch -p preloop-conformance --all-targets -- -D warnings
-          cargo clippy --locked -p preloop-runner -p preloop-runner-server -p preloop-runner-client -p preloop-dap --all-targets
-      - run: cargo test --locked --workspace
+      - name: Install cargo-nextest
+        run: cargo install cargo-nextest --locked
+      - run: cargo nextest run --locked --workspace --partition hash:${{ matrix.shard }}/4
         env:
           RUSTFLAGS: "-A warnings -C link-arg=-fuse-ld=lld"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ on:
 
 jobs:
   rust-lint:
+    # Fork PRs never execute on the persistent self-hosted runner: untrusted
+    # code with warm caches and network is a supply-chain risk the engine's
+    # token downgrade alone does not cover. Same guard as the conformance
+    # workflows; skipped required checks block fork merges by default.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, preloop-cpane]
     timeout-minutes: 20
     env:
@@ -52,6 +57,7 @@ jobs:
     # NOTE: these display names are load-bearing — the `main` ruleset gates
     # on them. Renaming a shard name requires updating the ruleset to match.
     name: rust shard ${{ matrix.shard }} of 4
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, preloop-cpane]
     timeout-minutes: 60
     strategy:
@@ -93,7 +99,7 @@ jobs:
   property-tests-fast:
     runs-on: [self-hosted, preloop-cpane]
     timeout-minutes: 30
-    if: github.event_name != 'schedule'
+    if: github.event_name != 'schedule' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -14,7 +14,6 @@ on:
 jobs:
   server-light:
     name: Server light conformance
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, preloop-cpane]
     timeout-minutes: 15
     env:

--- a/.github/workflows/runner-conformance.yml
+++ b/.github/workflows/runner-conformance.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   runner-light:
     name: Runner light conformance
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, preloop-cpane]
     timeout-minutes: 10
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ Releases before v0.27.0 predate the changelog.
   aarch64 golden bake use GitHub-hosted runners.
 - A restart no longer leaves the pool full of phantom capacity or fails old
   queued jobs while replacement VMs are warming. Persisted ephemeral runner
-  identities are purged before the server accepts traffic, unfinished jobs are
-  requeued with their abandoned attempts retired, and pre-provisioned
-  successors without polling sessions are no longer reported as idle. A run
+  identities are purged before the server accepts traffic, unfinished request
+  correlations are released from dead runner ownership before redelivery, and
+  pre-provisioned successors without polling sessions are no longer reported as idle. A run
   left `in_progress` with nothing executing it raises a
   `run_in_progress_without_execution` condition instead of vanishing from the
   operator's view.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,14 @@ Releases before v0.27.0 predate the changelog.
   report every annotation in API-sized batches.
 - CI jobs target the cpane microVM pool; only release packaging and the
   aarch64 golden bake use GitHub-hosted runners.
-- A restart no longer leaves the pool full of phantom capacity. Persisted
-  ephemeral runner identities are purged before the server accepts traffic,
-  their unfinished jobs are requeued, and a run left `in_progress` with
-  nothing executing it raises a `run_in_progress_without_execution` condition
-  instead of vanishing from the operator's view.
+- A restart no longer leaves the pool full of phantom capacity or fails old
+  queued jobs while replacement VMs are warming. Persisted ephemeral runner
+  identities are purged before the server accepts traffic, unfinished jobs are
+  requeued with their abandoned attempts retired, and pre-provisioned
+  successors without polling sessions are no longer reported as idle. A run
+  left `in_progress` with nothing executing it raises a
+  `run_in_progress_without_execution` condition instead of vanishing from the
+  operator's view.
 
 ## [0.32.7] - 2026-09-10
 

--- a/crates/preloop-cli/src/main.rs
+++ b/crates/preloop-cli/src/main.rs
@@ -3633,6 +3633,29 @@ fn render_status_human(status: &serde_json::Value, runs: &[serde_json::Value], l
             .map(|v| format!("{v:.1}s"))
             .unwrap_or_else(|| "-".to_owned())
     );
+    // Live runner -> job pairings: which job each busy runner executes.
+    // Counts alone cannot distinguish a busy pool from a stalled one.
+    if let Some(list) = runners.get("assignments").and_then(|v| v.as_array()) {
+        for entry in list {
+            let runner = entry
+                .get("runner_id")
+                .and_then(|v| v.as_i64())
+                .map(|v| v.to_string())
+                .unwrap_or_else(|| "?".to_owned());
+            let run = entry
+                .get("run_id")
+                .and_then(|v| v.as_str())
+                .map(|v| v.get(..8).unwrap_or(v).to_owned())
+                .unwrap_or_else(|| "?".to_owned());
+            let job = entry.get("job_id").and_then(|v| v.as_str()).unwrap_or("?");
+            let age = entry
+                .get("assigned_seconds_ago")
+                .and_then(|v| v.as_f64())
+                .map(|v| format!("{v:.0}s"))
+                .unwrap_or_else(|| "-".to_owned());
+            println!("  runner {runner}: {run} / {job} ({age})");
+        }
+    }
 
     // 5. VM fleet stub
     println!("\n== vm fleet ==");

--- a/crates/preloop-conformance/src/main.rs
+++ b/crates/preloop-conformance/src/main.rs
@@ -526,33 +526,25 @@ async fn run_runner_e2e(
     let server_url = format!("http://127.0.0.1:{port}");
     let listen = format!("127.0.0.1:{port}");
 
-    // Check binaries
-    if !runner_bin.exists() {
-        anyhow::bail!("runner binary not found: {}", runner_bin.display());
+    // Build the exact server/client binaries this command executes. Selecting
+    // whichever target artifact happens to exist (or has the newest mtime)
+    // can silently exercise code from another checkout state.
+    let build_status = Command::new("cargo")
+        .args([
+            "build",
+            "--locked",
+            "-p",
+            "preloop-runner-server",
+            "-p",
+            "preloop-runner-client",
+        ])
+        .status()
+        .await?;
+    if !build_status.success() {
+        anyhow::bail!("failed to build conformance server/client binaries");
     }
-    if !workflow.exists() {
-        anyhow::bail!("workflow file not found: {}", workflow.display());
-    }
-
-    let server_bin = if std::path::Path::new("target/release/preloop-server").exists() {
-        "target/release/preloop-server"
-    } else {
-        "target/debug/preloop-server"
-    };
-    if !std::path::Path::new(server_bin).exists() {
-        anyhow::bail!(
-            "server binary not found at {server_bin}: build it with `cargo build -p preloop-runner-server`"
-        );
-    }
-
-    let client_bin = if std::path::Path::new("target/release/preloop-runner-client").exists() {
-        "target/release/preloop-runner-client"
-    } else {
-        "target/debug/preloop-runner-client"
-    };
-    if !std::path::Path::new(client_bin).exists() {
-        anyhow::bail!("client binary not found: please build preloop-runner-client");
-    }
+    let server_bin = "target/debug/preloop-server";
+    let client_bin = "target/debug/preloop-runner-client";
 
     // Temporary directories
     let temp_dir = tempfile::TempDir::new()?;
@@ -593,8 +585,14 @@ async fn run_runner_e2e(
         .build()
         .expect("HTTP client");
     let mut ready = false;
+    let health_url = format!("{server_url}/healthz");
     for _ in 0..30 {
-        if client.get(&server_url).send().await.is_ok() {
+        if client
+            .get(&health_url)
+            .send()
+            .await
+            .is_ok_and(|response| response.status().is_success())
+        {
             ready = true;
             break;
         }

--- a/crates/preloop-observability/src/status.rs
+++ b/crates/preloop-observability/src/status.rs
@@ -99,6 +99,21 @@ pub struct RunnersSnapshot {
     pub stale: u32,
     pub max_poll_age_seconds: Option<f64>,
     pub max_lease_age_seconds: Option<f64>,
+    /// Live runner -> job pairings. Empty when nothing is executing; this is
+    /// the answer to "which job is on which runner" that pool counts alone
+    /// cannot give.
+    #[serde(default)]
+    pub assignments: Vec<RunnerAssignment>,
+}
+
+/// One live runner -> job pairing: which job a busy runner is executing and
+/// for how long. Inverted from the assignment table at snapshot time.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RunnerAssignment {
+    pub runner_id: i64,
+    pub run_id: String,
+    pub job_id: String,
+    pub assigned_seconds_ago: f64,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/preloop-runner-server/src/bootstrap.rs
+++ b/crates/preloop-runner-server/src/bootstrap.rs
@@ -293,6 +293,15 @@ pub(crate) async fn reap_once(shared: &Arc<SharedState>) {
             continue;
         }
         let grace = if pool_preparing {
+            // A restart restores the queue's original enqueue timestamps but
+            // destroys every pool VM. Give the replacement pool one process-
+            // local warm window before applying the durable queue-age ceiling;
+            // otherwise the first reaper tick fails every old queued job while
+            // the golden and its runners are demonstrably still starting.
+            if shared.state.started_at.elapsed() < MAX_QUEUED_GRACE {
+                inner.queued_at.remove(&key);
+                continue;
+            }
             // The pool is warming or booting a runner that may serve this
             // job, so hold the grace window rather than failing a job whose
             // runner is genuinely on the way. Bound the hold by
@@ -677,9 +686,11 @@ fn collect_snapshot_inputs(inner: &InnerState) -> SnapshotInputs {
         .collect();
 
     // Runner state: busy = an owned session holds an active job assignment;
-    // stale = no poll within the crate's staleness threshold; idle = neither.
-    // Busy and stale are independent predicates — a runner that stopped
-    // polling mid-job is both — so idle is the remainder, not the complement.
+    // stale = every owned session stopped polling; idle = at least one live
+    // session and neither busy nor stale. A registered runner with no session
+    // is only a pre-provisioned successor: it cannot poll until its slot starts.
+    // Busy and stale remain independent — a runner that stopped polling
+    // mid-job is both.
     let now = std::time::Instant::now();
     let mut runner_idle = 0u32;
     let mut runner_busy = 0u32;
@@ -717,7 +728,7 @@ fn collect_snapshot_inputs(inner: &InnerState) -> SnapshotInputs {
         if stale {
             runner_stale += 1;
         }
-        if !busy && !stale {
+        if !owned.is_empty() && !busy && !stale {
             runner_idle += 1;
         }
     }
@@ -1575,6 +1586,39 @@ mod tests {
             ExecutionStatus::Cancelled,
         ]);
         assert_eq!(counts, (1, 2, 4));
+    }
+
+    #[test]
+    fn registered_successor_without_a_session_is_not_idle_capacity() {
+        let mut inner = InnerState::default();
+        let runner_id = 7;
+        inner.runners.insert(
+            runner_id,
+            RegisteredRunner {
+                id: runner_id,
+                name: "prebuilt-successor".to_owned(),
+                labels: vec!["self-hosted".to_owned()],
+                ephemeral: true,
+                public_key: None,
+                runner_group_id: None,
+                runner_group_name: None,
+            },
+        );
+
+        assert_eq!(
+            collect_snapshot_inputs(&inner).runner_idle,
+            0,
+            "a configured successor cannot poll until its slot starts it"
+        );
+
+        inner
+            .broker_session_runners
+            .insert("live-session".to_owned(), runner_id);
+        assert_eq!(
+            collect_snapshot_inputs(&inner).runner_idle,
+            1,
+            "a session-backed runner with no active request is idle"
+        );
     }
 
     #[test]

--- a/crates/preloop-runner-server/src/bootstrap.rs
+++ b/crates/preloop-runner-server/src/bootstrap.rs
@@ -721,11 +721,11 @@ fn collect_snapshot_inputs(inner: &InnerState) -> SnapshotInputs {
             runner_idle += 1;
         }
     }
-    // Live runner -> job pairings, inverted from the assignment table keyed
-    // by (run, job). This is what answers "which job is on which runner";
-    // counts alone cannot distinguish a busy pool from a stalled one.
+    // Live runner -> job pairings, sourced from claimed job requests (each
+    // carries its claiming runner). NOT from the assignment table, which
+    // holds only pre-claim reservations removed at claim time.
     let assignments = crate::runtime_scheduling::live_runner_assignments(
-        &inner.job_assignments,
+        &inner.job_requests,
         std::time::SystemTime::now(),
     );
 

--- a/crates/preloop-runner-server/src/bootstrap.rs
+++ b/crates/preloop-runner-server/src/bootstrap.rs
@@ -737,6 +737,7 @@ fn collect_snapshot_inputs(inner: &InnerState) -> SnapshotInputs {
     // holds only pre-claim reservations removed at claim time.
     let assignments = crate::runtime_scheduling::live_runner_assignments(
         &inner.job_requests,
+        &inner.session_active_requests,
         std::time::SystemTime::now(),
     );
 

--- a/crates/preloop-runner-server/src/bootstrap.rs
+++ b/crates/preloop-runner-server/src/bootstrap.rs
@@ -546,6 +546,7 @@ struct SnapshotInputs {
     runner_idle: u32,
     runner_busy: u32,
     runner_stale: u32,
+    runner_assignments: Vec<preloop_observability::status::RunnerAssignment>,
     oldest_ready_seconds: Option<f64>,
     oldest_ready_run_id: Option<String>,
     oldest_ready_job_id: Option<String>,
@@ -720,6 +721,13 @@ fn collect_snapshot_inputs(inner: &InnerState) -> SnapshotInputs {
             runner_idle += 1;
         }
     }
+    // Live runner -> job pairings, inverted from the assignment table keyed
+    // by (run, job). This is what answers "which job is on which runner";
+    // counts alone cannot distinguish a busy pool from a stalled one.
+    let assignments = crate::runtime_scheduling::live_runner_assignments(
+        &inner.job_assignments,
+        std::time::SystemTime::now(),
+    );
 
     // Live debug sessions: count open sessions and the age of the oldest.
     let debug_sessions = inner.debug_sessions.list();
@@ -768,6 +776,7 @@ fn collect_snapshot_inputs(inner: &InnerState) -> SnapshotInputs {
         runner_idle,
         runner_busy,
         runner_stale,
+        runner_assignments: assignments,
         oldest_ready_seconds,
         oldest_ready_run_id: oldest_ready.map(|job| job.run_id.to_string()),
         oldest_ready_job_id: oldest_ready.map(|job| job.job_id.0.clone()),
@@ -949,6 +958,7 @@ fn build_operational_snapshot_sync(
             stale: inputs.runner_stale,
             max_poll_age_seconds: None,
             max_lease_age_seconds: None,
+            assignments: inputs.runner_assignments,
         },
         pool: pool_snapshot,
         vms: {

--- a/crates/preloop-runner-server/src/broker.rs
+++ b/crates/preloop-runner-server/src/broker.rs
@@ -836,6 +836,19 @@ pub(crate) async fn broker_acquire_job(
             .copied()
             .ok_or_else(|| ApiError::not_found("broker job message not found"))?;
         ensure_broker_request_owner(&inner, request_id, runner_id)?;
+        // A settled attempt is never acquirable. `renewjob` already 409s and
+        // `completejob` ignores such a record, so without this a late runner
+        // acquires a terminal job: the engine mints a fresh installation
+        // token and the runner executes side effects a second time, then
+        // cannot report the result. Requeue paths keep `result` unset (see
+        // `release_request_for_retry`), so a genuine retry still acquires.
+        if inner
+            .job_requests
+            .get(&request_id)
+            .is_some_and(|record| record.result.is_some())
+        {
+            return Err(ApiError::conflict("broker request already completed"));
+        }
         let message = inner
             .broker_messages
             .get(&request_id)
@@ -1278,11 +1291,11 @@ async fn fail_unclaimable_request(shared: &Arc<SharedState>, request_id: i64) {
 ///
 /// A claim still absent from the ready queue is irrecoverable and fails as
 /// before. A request whose logical job was already requeued by runner purge is
-/// only an abandoned attempt: settle that request without concluding the retry.
-/// The latter also migrates snapshots written by versions that requeued the job
-/// but left its request live.
+/// released for redelivery without concluding the retry. The latter also
+/// migrates snapshots written by versions that requeued the job but left its
+/// old runner ownership live.
 pub(crate) async fn reconcile_orphaned_claims(shared: &Arc<SharedState>) -> usize {
-    let (retired, unclaimable) = {
+    let (recovered, unclaimable) = {
         let mut inner = shared.state.inner.lock().await;
         let live_requests: std::collections::BTreeSet<i64> = inner
             .session_active_requests
@@ -1305,13 +1318,15 @@ pub(crate) async fn reconcile_orphaned_claims(shared: &Arc<SharedState>) -> usiz
             .map(|(request_id, record)| (*request_id, record.run_id, record.job_id.clone()))
             .collect();
 
-        let mut retired = 0usize;
+        let queued_jobs: std::collections::BTreeSet<(RunId, JobId)> = inner
+            .queue
+            .iter()
+            .map(|job| (job.run_id, job.job_id.clone()))
+            .collect();
+        let mut recovered = 0usize;
         let mut unclaimable = Vec::new();
         for (request_id, run_id, job_id) in claimed_requests {
-            let queued = inner
-                .queue
-                .iter()
-                .any(|job| job.run_id == run_id && job.job_id == job_id);
+            let queued = queued_jobs.contains(&(run_id, job_id.clone()));
             let terminal_status = inner
                 .runs
                 .get(&run_id)
@@ -1325,21 +1340,20 @@ pub(crate) async fn reconcile_orphaned_claims(shared: &Arc<SharedState>) -> usiz
                             | ExecutionStatus::Skipped
                     )
                 });
-            if queued || terminal_status.is_some() {
-                runtime_scheduling::settle_request(
-                    &mut inner,
-                    request_id,
-                    terminal_status.unwrap_or(ExecutionStatus::Cancelled),
-                );
-                retired += 1;
+            if queued {
+                runtime_scheduling::release_request_for_retry(&mut inner, request_id);
+                recovered += 1;
+            } else if let Some(status) = terminal_status {
+                runtime_scheduling::settle_request(&mut inner, request_id, status);
+                recovered += 1;
             } else {
                 unclaimable.push(request_id);
             }
         }
-        (retired, unclaimable)
+        (recovered, unclaimable)
     };
 
-    if retired > 0 {
+    if recovered > 0 {
         let _store_guard = shared.state.store_mutation.lock().await;
         let snapshot = {
             let inner = shared.state.inner.lock().await;
@@ -1347,14 +1361,14 @@ pub(crate) async fn reconcile_orphaned_claims(shared: &Arc<SharedState>) -> usiz
         };
         if let Err(error) = shared.state.store.store_inner(&snapshot).await {
             warn!(
-                retired,
+                recovered,
                 ?error,
-                "failed to persist retired orphaned attempts"
+                "failed to persist reconciled orphaned attempts"
             );
         }
         warn!(
-            retired,
-            "retired orphaned attempts whose jobs were requeued"
+            recovered,
+            "released orphaned retry attempts from dead runner ownership"
         );
     }
 
@@ -1367,7 +1381,7 @@ pub(crate) async fn reconcile_orphaned_claims(shared: &Arc<SharedState>) -> usiz
             "failed job claims orphaned by a control-plane restart"
         );
     }
-    retired + unclaimable.len()
+    recovered + unclaimable.len()
 }
 
 pub(crate) async fn mint_dispatch_github_token(

--- a/crates/preloop-runner-server/src/broker.rs
+++ b/crates/preloop-runner-server/src/broker.rs
@@ -1274,45 +1274,100 @@ async fn fail_unclaimable_request(shared: &Arc<SharedState>, request_id: i64) {
     shared.state.message_notify.notify_waiters();
 }
 
-/// Fail job claims pinned to sessions that did not survive a restart.
+/// Reconcile job claims whose runner session did not survive a restart.
 ///
-/// Pool machines are ephemeral: a control-plane restart destroys their VMs,
-/// but `session_active_requests` is persisted. Those claims come back pinned
-/// to sessions that will never poll again, so no fresh machine can take the
-/// job — the run, and the GitHub check run it created, sit queued forever
-/// while the pool idles. Failing them once at startup makes the reported
-/// state honest and releases the concurrency slot.
-///
-/// Only claims whose session is gone are touched. A queued job that was never
-/// claimed still has its queue row and is dispatched normally, and a runner
-/// that outlived the control plane keeps a live session, so its job is left
-/// to the ordinary disconnect reaper.
+/// A claim still absent from the ready queue is irrecoverable and fails as
+/// before. A request whose logical job was already requeued by runner purge is
+/// only an abandoned attempt: settle that request without concluding the retry.
+/// The latter also migrates snapshots written by versions that requeued the job
+/// but left its request live.
 pub(crate) async fn reconcile_orphaned_claims(shared: &Arc<SharedState>) -> usize {
-    let orphaned: Vec<i64> = {
-        let inner = shared.state.inner.lock().await;
-        inner
+    let (retired, unclaimable) = {
+        let mut inner = shared.state.inner.lock().await;
+        let live_requests: std::collections::BTreeSet<i64> = inner
             .session_active_requests
             .iter()
-            .filter(|(session_id, _)| !inner.sessions.contains_key(*session_id))
+            .filter(|(session_id, _)| inner.sessions.contains_key(*session_id))
             .map(|(_, request_id)| *request_id)
-            .filter(|request_id| {
-                inner
-                    .job_requests
-                    .get(request_id)
-                    .is_some_and(|record| record.result.is_none())
+            .collect();
+        let claimed_requests: Vec<(i64, RunId, JobId)> = inner
+            .job_requests
+            .iter()
+            .filter(|(request_id, record)| {
+                record.result.is_none()
+                    && !live_requests.contains(request_id)
+                    && (record.owner_runner_id.is_some()
+                        || inner
+                            .session_active_requests
+                            .values()
+                            .any(|active| active == *request_id))
             })
-            .collect()
+            .map(|(request_id, record)| (*request_id, record.run_id, record.job_id.clone()))
+            .collect();
+
+        let mut retired = 0usize;
+        let mut unclaimable = Vec::new();
+        for (request_id, run_id, job_id) in claimed_requests {
+            let queued = inner
+                .queue
+                .iter()
+                .any(|job| job.run_id == run_id && job.job_id == job_id);
+            let terminal_status = inner
+                .runs
+                .get(&run_id)
+                .and_then(|run| run.jobs.get(&job_id).copied())
+                .filter(|status| {
+                    matches!(
+                        status,
+                        ExecutionStatus::Success
+                            | ExecutionStatus::Failure
+                            | ExecutionStatus::Cancelled
+                            | ExecutionStatus::Skipped
+                    )
+                });
+            if queued || terminal_status.is_some() {
+                runtime_scheduling::settle_request(
+                    &mut inner,
+                    request_id,
+                    terminal_status.unwrap_or(ExecutionStatus::Cancelled),
+                );
+                retired += 1;
+            } else {
+                unclaimable.push(request_id);
+            }
+        }
+        (retired, unclaimable)
     };
-    for request_id in &orphaned {
+
+    if retired > 0 {
+        let _store_guard = shared.state.store_mutation.lock().await;
+        let snapshot = {
+            let inner = shared.state.inner.lock().await;
+            crate::store::StoreSnapshot::from_inner(&inner)
+        };
+        if let Err(error) = shared.state.store.store_inner(&snapshot).await {
+            warn!(
+                retired,
+                ?error,
+                "failed to persist retired orphaned attempts"
+            );
+        }
+        warn!(
+            retired,
+            "retired orphaned attempts whose jobs were requeued"
+        );
+    }
+
+    for request_id in &unclaimable {
         fail_unclaimable_request(shared, *request_id).await;
     }
-    if !orphaned.is_empty() {
+    if !unclaimable.is_empty() {
         warn!(
-            count = orphaned.len(),
+            count = unclaimable.len(),
             "failed job claims orphaned by a control-plane restart"
         );
     }
-    orphaned.len()
+    retired + unclaimable.len()
 }
 
 pub(crate) async fn mint_dispatch_github_token(

--- a/crates/preloop-runner-server/src/github.rs
+++ b/crates/preloop-runner-server/src/github.rs
@@ -279,7 +279,7 @@ pub(crate) async fn report_check_run_queued(
             "status": "queued",
             "output": {
                 "title": job_name,
-                "summary": "Waiting for a preloop runner."
+                "summary": format!("Waiting for a preloop runner.\n\njob_id: `{}`", job_id.0)
             }
         });
         if let Some(url) = details_url {
@@ -512,6 +512,7 @@ fn check_summary(
     conclusion: &str,
     steps: &[crate::models::StepRecord],
     global_issues: &[String],
+    job_id: &JobId,
 ) -> String {
     let mut summary = format!("Job completed with status: **{conclusion}**");
     if !steps.is_empty() {
@@ -535,6 +536,11 @@ fn check_summary(
         summary.push_str("\n\n### Failure details\n");
         summary.push_str(&global_issues.join("\n"));
     }
+    // Map the display name back to the workflow job id: required status
+    // checks match on this exact display string, so a rename that breaks
+    // the ruleset is diagnosable from the check page itself instead of
+    // presenting as "Expected" forever with no explanation.
+    summary.push_str(&format!("\n\njob_id: `{}`", job_id.0));
     summary
 }
 
@@ -648,7 +654,7 @@ pub(crate) async fn report_check_run_completed(
         ExecutionStatus::Skipped => "skipped",
         _ => "failure",
     };
-    let summary = check_summary(conclusion, &steps, &global_issues);
+    let summary = check_summary(conclusion, &steps, &global_issues, job_id);
 
     let token = resolve_check_run_token(shared, &repo).await;
     if let Some(token) = &token {
@@ -2008,11 +2014,17 @@ mod tests {
         test.started_at = setup.finished_at;
         test.finished_at = Some(start + chrono::Duration::milliseconds(3250));
 
-        let summary = check_summary("failure", &[setup, test], &["- exit code 1".to_owned()]);
+        let summary = check_summary(
+            "failure",
+            &[setup, test],
+            &["- exit code 1".to_owned()],
+            &preloop_gha_protocol::JobId("test".to_owned()),
+        );
         assert!(summary.contains("| Set up \\| tools | success | 1.2s |"));
         assert!(summary.contains("| Run tests | failure | 2.0s |"));
         assert!(summary.contains("**Failed step:** `Run tests`"));
         assert!(summary.contains("exit code 1"));
+        assert!(summary.contains("job_id: `test`"));
     }
 
     #[tokio::test]

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -10856,6 +10856,96 @@ async fn a_dispatch_refused_by_the_mint_policy_fails_its_run_without_the_reaper(
     assert!(!inner.inflight_requests.contains_key(&request_id));
 }
 
+/// A settled attempt must not be acquirable. The broker retains
+/// `owner_runner_id` after completion so late protocol reads stay bound to the
+/// runner that ran the job, which means ownership alone cannot gate
+/// `acquirejob`: a runner that retries the call after reporting would be
+/// handed the job payload (and a freshly minted installation token) and would
+/// execute the same job's side effects twice, then fail to report because
+/// `renewjob` 409s and `completejob` ignores duplicates.
+#[tokio::test]
+async fn a_settled_attempt_cannot_be_acquired_again() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let registered = request_json(
+        &app,
+        Method::POST,
+        "/runner/server/_apis/v1/Agent/1/0",
+        json!({"name": "acquire-guard-runner", "version": "2.336.0"}),
+    )
+    .await;
+    let runner_id = registered["id"].as_i64().unwrap();
+    let runner_token = state
+        .local_jwt(json!({
+            "sub": format!("preloop-runner-listen-{runner_id}"),
+            "scp": "ActionsRuntime.RunnerListen",
+        }))
+        .unwrap();
+
+    submit_simple_run(&app).await;
+    let session = request_json_with_bearer(
+        &app,
+        Method::POST,
+        "/runner/server/session",
+        json!({}),
+        &runner_token,
+    )
+    .await;
+    let session_id = session["sessionId"].as_str().unwrap();
+    let job_ref = request_json_with_bearer(
+        &app,
+        Method::GET,
+        &format!("/runner/server/message?sessionId={session_id}&status=Online&waitSeconds=0"),
+        Value::Null,
+        &runner_token,
+    )
+    .await;
+    let body: Value = serde_json::from_str(job_ref["body"].as_str().unwrap()).unwrap();
+    let job_message_id = body["runner_request_id"].as_str().unwrap().to_owned();
+    let request_id = {
+        let inner = state.inner.lock().await;
+        *inner.job_requests.keys().next().unwrap()
+    };
+    let acquire =
+        json!({"jobMessageId": job_message_id, "billingOwnerId": "local", "runnerOS": "Linux"});
+
+    // A live claim acquires normally: the guard must not break dispatch.
+    assert_eq!(
+        status_with_bearer(
+            &app,
+            &runner_token,
+            Method::POST,
+            &format!("/broker/{runner_id}/acquirejob"),
+            acquire.clone(),
+        )
+        .await,
+        StatusCode::OK
+    );
+
+    request_json_with_bearer(
+        &app,
+        Method::PATCH,
+        &format!("/_apis/v1/AgentRequest/1/{request_id}"),
+        json!({"result": "Succeeded"}),
+        &runner_token,
+    )
+    .await;
+
+    assert_eq!(
+        status_with_bearer(
+            &app,
+            &runner_token,
+            Method::POST,
+            &format!("/broker/{runner_id}/acquirejob"),
+            acquire,
+        )
+        .await,
+        StatusCode::CONFLICT,
+        "a reported attempt must never be handed back to a runner"
+    );
+}
+
 #[tokio::test]
 async fn app_only_server_fetches_webhook_workflows_with_installation_token() {
     use crate::github_app::{GitHubAppCredentials, MintFailurePolicy};
@@ -11351,15 +11441,26 @@ async fn liveness_sweep_requeues_job_of_deaf_runner() {
             !inner.claimed_jobs.contains_key(&(run_id, job_id.clone())),
             "deaf claim must leave claimed_jobs"
         );
+        let request = &inner.job_requests[&request_id];
         assert_eq!(
-            inner.job_requests[&request_id].result,
-            Some(ExecutionStatus::Cancelled),
-            "the abandoned attempt must not remain live beside its retry"
+            request.result, None,
+            "the requeued request must remain completable"
+        );
+        assert_eq!(
+            request.owner_runner_id, None,
+            "the purged runner must lose request ownership"
+        );
+        assert_eq!(request.started_at, None);
+        assert_eq!(request.last_renewed_at, None);
+        assert!(
+            inner.inflight_requests.contains_key(&request_id),
+            "the request must remain inflight for its replacement"
         );
         assert!(
             crate::runtime_scheduling::live_runner_assignments(
                 &inner.job_requests,
-                SystemTime::now()
+                &inner.session_active_requests,
+                SystemTime::now(),
             )
             .is_empty(),
             "status must not report the purged runner as executing"
@@ -11372,6 +11473,40 @@ async fn liveness_sweep_requeues_job_of_deaf_runner() {
             "unfinished job must be requeued for a fresh machine"
         );
     }
+
+    // A replacement claims the same correlation, renews it, and completes the
+    // logical job. Settling the request before requeue would let the delivery
+    // happen but make both PATCHes no-ops.
+    let (replacement_id, replacement_token) =
+        register_runner_with_token(&app, "replacement-runner", &["self-hosted"], None).await;
+    let (_, replacement_session) =
+        create_disttask_session(&app, &replacement_token, replacement_id).await;
+    let replacement_session_id = replacement_session["sessionId"].as_str().unwrap();
+    let delivered = poll_message(&app, &replacement_token, replacement_session_id).await;
+    assert!(!delivered.is_null(), "replacement must receive the retry");
+    request_json_with_bearer(
+        &app,
+        Method::PATCH,
+        &format!("/_apis/v1/AgentRequest/1/{request_id}"),
+        json!({}),
+        &replacement_token,
+    )
+    .await;
+    request_json_with_bearer(
+        &app,
+        Method::PATCH,
+        &format!("/_apis/v1/AgentRequest/1/{request_id}"),
+        json!({"result": "Succeeded"}),
+        &replacement_token,
+    )
+    .await;
+    let inner = state.inner.lock().await;
+    assert_eq!(
+        inner.runs[&run_id].jobs[&job_id],
+        ExecutionStatus::Success,
+        "the replacement must be able to finish the retried job"
+    );
+    assert!(!inner.inflight_requests.contains_key(&request_id));
 }
 
 #[tokio::test]
@@ -11453,36 +11588,40 @@ async fn queued_job_survives_the_grace_window_while_the_pool_is_preparing() {
 #[tokio::test]
 async fn restored_old_job_survives_the_restarted_pools_warm_window() {
     let temp = tempfile::tempdir().unwrap();
-    let mut state = AppState::new(temp.path().to_path_buf()).await.unwrap();
-    let shutdown = CancellationToken::new();
-    let app = app(state.clone(), shutdown.clone());
-    state.pool_preparing = Some(std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
+    let run_id = {
+        let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+        let app = app(state.clone(), CancellationToken::new());
+        let accepted = submit_simple_run(&app).await;
+        let run_id: RunId = accepted["run_id"].as_str().unwrap().parse().unwrap();
+        {
+            let mut inner = state.inner.lock().await;
+            let cutoff = (SystemTime::now() - Duration::from_secs(700))
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos() as i64;
+            inner
+                .queue
+                .iter_mut()
+                .find(|job| job.run_id == run_id)
+                .unwrap()
+                .enqueued_at_unix_nanos = cutoff;
+            let snapshot = crate::store::StoreSnapshot::from_inner(&inner);
+            state.store.store_inner(&snapshot).await.unwrap();
+        }
+        run_id
+    };
+
+    let mut restored = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    restored.pool_preparing = Some(std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
         true,
     )));
     let shared = Arc::new(SharedState {
-        state: state.clone(),
-        shutdown,
+        state: restored.clone(),
+        shutdown: CancellationToken::new(),
     });
-
-    let accepted = submit_simple_run(&app).await;
-    let run_id: RunId = accepted["run_id"].as_str().unwrap().parse().unwrap();
-    {
-        let mut inner = state.inner.lock().await;
-        let cutoff = (SystemTime::now() - Duration::from_secs(700))
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos() as i64;
-        inner
-            .queue
-            .iter_mut()
-            .find(|job| job.run_id == run_id)
-            .unwrap()
-            .enqueued_at_unix_nanos = cutoff;
-    }
-
     reap_once(&shared).await;
 
-    let inner = state.inner.lock().await;
+    let inner = restored.inner.lock().await;
     assert_eq!(
         inner.queue.len(),
         1,
@@ -24346,10 +24485,10 @@ async fn startup_fails_claims_orphaned_by_a_restart() {
 }
 
 /// Versions before the runner-purge fix put the logical job back on the queue
-/// but left its claimed request live and detached from every session. Startup
-/// must migrate that persisted shape without failing the retry.
+/// but left its request owned by a dead runner and detached from every session.
+/// Startup must release that persisted correlation for a replacement runner.
 #[tokio::test]
-async fn startup_retires_an_orphaned_attempt_whose_job_was_requeued() {
+async fn startup_releases_an_orphaned_request_whose_job_was_requeued() {
     let temp = tempfile::tempdir().unwrap();
     let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
     let app = app(state.clone(), CancellationToken::new());
@@ -24378,29 +24517,66 @@ async fn startup_retires_an_orphaned_attempt_whose_job_was_requeued() {
     let settled = crate::broker::reconcile_orphaned_claims(&shared).await;
     assert_eq!(settled, 1);
 
+    {
+        let inner = state.inner.lock().await;
+        let request = &inner.job_requests[&request_id];
+        assert_eq!(
+            request.result, None,
+            "the queued request must remain completable"
+        );
+        assert_eq!(
+            request.owner_runner_id, None,
+            "startup must release the dead runner owner"
+        );
+        assert_eq!(request.started_at, None);
+        assert_eq!(request.last_renewed_at, None);
+        assert!(
+            inner.inflight_requests.contains_key(&request_id),
+            "the request correlation must remain inflight"
+        );
+        assert!(
+            inner
+                .queue
+                .iter()
+                .any(|job| job.run_id == run_id && job.job_id == job_id),
+            "the replacement attempt remains queued"
+        );
+        assert_eq!(
+            inner.runs[&run_id].jobs[&job_id],
+            ExecutionStatus::Queued,
+            "releasing the old owner must not conclude its logical job"
+        );
+        assert!(crate::runtime_scheduling::live_runner_assignments(
+            &inner.job_requests,
+            &inner.session_active_requests,
+            SystemTime::now(),
+        )
+        .is_empty());
+    }
+
+    let (runner_id, token) =
+        register_runner_with_token(&app, "startup-replacement", &["self-hosted"], None).await;
+    let (_, session) = create_disttask_session(&app, &token, runner_id).await;
+    let session_id = session["sessionId"].as_str().unwrap();
+    let delivered = poll_message(&app, &token, session_id).await;
+    assert!(
+        !delivered.is_null(),
+        "replacement must receive restored retry"
+    );
+    request_json_with_bearer(
+        &app,
+        Method::PATCH,
+        &format!("/_apis/v1/AgentRequest/1/{request_id}"),
+        json!({"result": "Succeeded"}),
+        &token,
+    )
+    .await;
     let inner = state.inner.lock().await;
     assert_eq!(
-        inner.job_requests[&request_id].result,
-        Some(ExecutionStatus::Cancelled),
-        "the abandoned attempt is terminal"
-    );
-    assert!(
-        inner
-            .queue
-            .iter()
-            .any(|job| job.run_id == run_id && job.job_id == job_id),
-        "the replacement attempt remains queued"
-    );
-    assert_eq!(
         inner.runs[&run_id].jobs[&job_id],
-        ExecutionStatus::Queued,
-        "retiring the old attempt must not conclude its logical job"
+        ExecutionStatus::Success,
+        "restored retry must complete through the retained correlation"
     );
-    assert!(crate::runtime_scheduling::live_runner_assignments(
-        &inner.job_requests,
-        SystemTime::now()
-    )
-    .is_empty());
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -24345,6 +24345,64 @@ async fn startup_fails_claims_orphaned_by_a_restart() {
     );
 }
 
+/// Versions before the runner-purge fix put the logical job back on the queue
+/// but left its claimed request live and detached from every session. Startup
+/// must migrate that persisted shape without failing the retry.
+#[tokio::test]
+async fn startup_retires_an_orphaned_attempt_whose_job_was_requeued() {
+    let temp = tempfile::tempdir().unwrap();
+    let state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let app = app(state.clone(), CancellationToken::new());
+    let accepted = submit_simple_run(&app).await;
+    let run_id: RunId = accepted["run_id"].as_str().unwrap().parse().unwrap();
+    let job_id = JobId("build".to_owned());
+
+    let request_id = {
+        let mut inner = state.inner.lock().await;
+        let request_id = inner
+            .job_requests
+            .values()
+            .find(|record| record.run_id == run_id && record.job_id == job_id)
+            .map(|record| record.request_id)
+            .expect("queued job request");
+        let record = inner.job_requests.get_mut(&request_id).unwrap();
+        record.owner_runner_id = Some(99);
+        record.started_at = Some(SystemTime::now() - Duration::from_secs(300));
+        request_id
+    };
+
+    let shared = Arc::new(SharedState {
+        state: state.clone(),
+        shutdown: CancellationToken::new(),
+    });
+    let settled = crate::broker::reconcile_orphaned_claims(&shared).await;
+    assert_eq!(settled, 1);
+
+    let inner = state.inner.lock().await;
+    assert_eq!(
+        inner.job_requests[&request_id].result,
+        Some(ExecutionStatus::Cancelled),
+        "the abandoned attempt is terminal"
+    );
+    assert!(
+        inner
+            .queue
+            .iter()
+            .any(|job| job.run_id == run_id && job.job_id == job_id),
+        "the replacement attempt remains queued"
+    );
+    assert_eq!(
+        inner.runs[&run_id].jobs[&job_id],
+        ExecutionStatus::Queued,
+        "retiring the old attempt must not conclude its logical job"
+    );
+    assert!(crate::runtime_scheduling::live_runner_assignments(
+        &inner.job_requests,
+        SystemTime::now()
+    )
+    .is_empty());
+}
+
 // ---------------------------------------------------------------------------
 // Submit-driven CI push-back (`--push`): the server verifies the tested tree,
 // creates the draft PR, and stays idempotent across replays.

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -11438,6 +11438,50 @@ async fn queued_job_survives_the_grace_window_while_the_pool_is_preparing() {
 }
 
 #[tokio::test]
+async fn restored_old_job_survives_the_restarted_pools_warm_window() {
+    let temp = tempfile::tempdir().unwrap();
+    let mut state = AppState::new(temp.path().to_path_buf()).await.unwrap();
+    let shutdown = CancellationToken::new();
+    let app = app(state.clone(), shutdown.clone());
+    state.pool_preparing = Some(std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
+        true,
+    )));
+    let shared = Arc::new(SharedState {
+        state: state.clone(),
+        shutdown,
+    });
+
+    let accepted = submit_simple_run(&app).await;
+    let run_id: RunId = accepted["run_id"].as_str().unwrap().parse().unwrap();
+    {
+        let mut inner = state.inner.lock().await;
+        let cutoff = (SystemTime::now() - Duration::from_secs(700))
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos() as i64;
+        inner
+            .queue
+            .iter_mut()
+            .find(|job| job.run_id == run_id)
+            .unwrap()
+            .enqueued_at_unix_nanos = cutoff;
+    }
+
+    reap_once(&shared).await;
+
+    let inner = state.inner.lock().await;
+    assert_eq!(
+        inner.queue.len(),
+        1,
+        "durable queue age must not defeat the fresh process-local pool warm"
+    );
+    assert_eq!(
+        inner.runs[&run_id].jobs[&JobId("build".to_owned())],
+        ExecutionStatus::Queued
+    );
+}
+
+#[tokio::test]
 async fn queued_job_starves_past_the_ceiling_even_while_the_pool_is_preparing() {
     let temp = tempfile::tempdir().unwrap();
     let mut state = AppState::new(temp.path().to_path_buf()).await.unwrap();
@@ -11452,6 +11496,7 @@ async fn queued_job_starves_past_the_ceiling_even_while_the_pool_is_preparing() 
     state.pool_preparing = Some(std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
         true,
     )));
+    state.started_at = std::time::Instant::now() - Duration::from_secs(700);
     let shared = Arc::new(SharedState {
         state: state.clone(),
         shutdown,

--- a/crates/preloop-runner-server/src/lib_tests.rs
+++ b/crates/preloop-runner-server/src/lib_tests.rs
@@ -11310,17 +11310,17 @@ async fn liveness_sweep_requeues_job_of_deaf_runner() {
     let job_id = JobId("build".to_owned());
     let message = poll_message(&app, &token, &session_id).await;
     assert!(!message.is_null(), "poll must claim the queued job");
-    {
+    let request_id = {
         let inner = state.inner.lock().await;
         assert!(
             inner.claimed_jobs.contains_key(&(run_id, job_id.clone())),
             "poll must record the claim in claimed_jobs"
         );
-        assert!(
-            inner.session_active_requests.contains_key(&session_id),
-            "poll must pin the claim to the session"
-        );
-    }
+        *inner
+            .session_active_requests
+            .get(&session_id)
+            .expect("poll must pin the claim to the session")
+    };
 
     // The runner goes deaf: backdate its last poll and shrink the timeout.
     {
@@ -11350,6 +11350,19 @@ async fn liveness_sweep_requeues_job_of_deaf_runner() {
         assert!(
             !inner.claimed_jobs.contains_key(&(run_id, job_id.clone())),
             "deaf claim must leave claimed_jobs"
+        );
+        assert_eq!(
+            inner.job_requests[&request_id].result,
+            Some(ExecutionStatus::Cancelled),
+            "the abandoned attempt must not remain live beside its retry"
+        );
+        assert!(
+            crate::runtime_scheduling::live_runner_assignments(
+                &inner.job_requests,
+                SystemTime::now()
+            )
+            .is_empty(),
+            "status must not report the purged runner as executing"
         );
         assert!(
             inner

--- a/crates/preloop-runner-server/src/runner_lifecycle.rs
+++ b/crates/preloop-runner-server/src/runner_lifecycle.rs
@@ -444,18 +444,13 @@ fn purge_runner_identity_locked(inner: &mut InnerState, runner_id: i64) -> bool 
                 .filter(|request| request.result.is_none())
                 .map(|request| (request.run_id, request.job_id.clone()));
             if let Some((run_id, job_id)) = pending {
-                // This attempt is abandoned, not live: retire its request
-                // before the same logical job is queued for a fresh attempt.
-                // Leaving `result` empty makes the lease reaper later fail the
-                // retried job and makes status report the dead runner forever.
-                runtime_scheduling::retire_node_requests(
-                    inner,
-                    run_id,
-                    &job_id,
-                    runtime_scheduling::RequestRetirement::Settle(ExecutionStatus::Cancelled),
-                );
                 let key = (run_id, job_id.clone());
                 if let Some(job) = inner.claimed_jobs.remove(&key) {
+                    // The queued job retains this request/message correlation.
+                    // Release its dead owner before requeueing so a replacement
+                    // can renew and complete it, while the old runner can no
+                    // longer acquire or report against the request.
+                    runtime_scheduling::release_request_for_retry(inner, request_id);
                     if let Some(run) = inner.runs.get_mut(&run_id) {
                         run.jobs.insert(job_id.clone(), ExecutionStatus::Queued);
                         run.status = runtime_scheduling::summarize_run(run.jobs.values().copied());

--- a/crates/preloop-runner-server/src/runner_lifecycle.rs
+++ b/crates/preloop-runner-server/src/runner_lifecycle.rs
@@ -444,6 +444,16 @@ fn purge_runner_identity_locked(inner: &mut InnerState, runner_id: i64) -> bool 
                 .filter(|request| request.result.is_none())
                 .map(|request| (request.run_id, request.job_id.clone()));
             if let Some((run_id, job_id)) = pending {
+                // This attempt is abandoned, not live: retire its request
+                // before the same logical job is queued for a fresh attempt.
+                // Leaving `result` empty makes the lease reaper later fail the
+                // retried job and makes status report the dead runner forever.
+                runtime_scheduling::retire_node_requests(
+                    inner,
+                    run_id,
+                    &job_id,
+                    runtime_scheduling::RequestRetirement::Settle(ExecutionStatus::Cancelled),
+                );
                 let key = (run_id, job_id.clone());
                 if let Some(job) = inner.claimed_jobs.remove(&key) {
                     if let Some(run) = inner.runs.get_mut(&run_id) {

--- a/crates/preloop-runner-server/src/runtime_scheduling.rs
+++ b/crates/preloop-runner-server/src/runtime_scheduling.rs
@@ -1752,6 +1752,32 @@ pub(crate) fn clear_assignment(inner: &mut InnerState, run_id: RunId, job_id: &J
         .any(|job| job.run_id == run_id && job.job_id == *job_id)
 }
 
+/// Invert the (run, job) -> assignment table into per-runner live pairings
+/// for status reporting, sorted by runner id for stable output. This is what
+/// answers "which job is on which runner"; pool counts alone cannot
+/// distinguish a busy pool from a stalled one.
+pub(crate) fn live_runner_assignments(
+    assignments: &std::collections::BTreeMap<(RunId, JobId), AssignmentRecord>,
+    now: std::time::SystemTime,
+) -> Vec<preloop_observability::status::RunnerAssignment> {
+    let mut out: Vec<preloop_observability::status::RunnerAssignment> = assignments
+        .iter()
+        .map(
+            |((run_id, job_id), record)| preloop_observability::status::RunnerAssignment {
+                runner_id: record.runner_id,
+                run_id: run_id.to_string(),
+                job_id: job_id.0.clone(),
+                assigned_seconds_ago: now
+                    .duration_since(record.at)
+                    .map(|d| d.as_secs_f64())
+                    .unwrap_or(0.0),
+            },
+        )
+        .collect();
+    out.sort_by_key(|a| a.runner_id);
+    out
+}
+
 pub(crate) fn capabilities_of(runner: &RegisteredRunner) -> RunnerCapabilities {
     RunnerCapabilities {
         known: true,
@@ -3015,6 +3041,54 @@ mod runner_group_tests {
 #[cfg(test)]
 mod assignment_tests {
     use super::*;
+
+    /// The status inversion reports each live pairing keyed by runner, with
+    /// run/job identity and age — the answer to "which job is on which
+    /// runner" that pool counts cannot give.
+    #[test]
+    fn live_assignments_invert_by_runner() {
+        use crate::models::AssignmentRecord;
+        use std::collections::BTreeMap;
+
+        let run_a = RunId::new();
+        let run_b = RunId::new();
+        let now = std::time::SystemTime::now();
+        let at = now.checked_sub(std::time::Duration::from_secs(90)).unwrap();
+        let mut table: BTreeMap<(RunId, JobId), AssignmentRecord> = BTreeMap::new();
+        // Insert out of runner order; output must still be runner-sorted.
+        table.insert(
+            (run_b, JobId("build".to_owned())),
+            AssignmentRecord {
+                runner_id: 7,
+                at,
+                first_at: at,
+            },
+        );
+        table.insert(
+            (run_a, JobId("test".to_owned())),
+            AssignmentRecord {
+                runner_id: 3,
+                at,
+                first_at: at,
+            },
+        );
+
+        let live = live_runner_assignments(&table, now);
+
+        assert_eq!(live.len(), 2);
+        assert_eq!(live[0].runner_id, 3);
+        assert_eq!(live[0].run_id, run_a.to_string());
+        assert_eq!(live[0].job_id, "test");
+        assert_eq!(live[1].runner_id, 7);
+        assert_eq!(live[1].job_id, "build");
+        for entry in &live {
+            assert!(
+                (entry.assigned_seconds_ago - 90.0).abs() < 5.0,
+                "age should reflect assignment time: {entry:?}"
+            );
+        }
+        assert!(live_runner_assignments(&BTreeMap::new(), now).is_empty());
+    }
 
     fn self_hosted_caps() -> RunnerCapabilities {
         RunnerCapabilities {

--- a/crates/preloop-runner-server/src/runtime_scheduling.rs
+++ b/crates/preloop-runner-server/src/runtime_scheduling.rs
@@ -1752,23 +1752,28 @@ pub(crate) fn clear_assignment(inner: &mut InnerState, run_id: RunId, job_id: &J
         .any(|job| job.run_id == run_id && job.job_id == *job_id)
 }
 
-/// Invert the (run, job) -> assignment table into per-runner live pairings
-/// for status reporting, sorted by runner id for stable output. This is what
-/// answers "which job is on which runner"; pool counts alone cannot
-/// distinguish a busy pool from a stalled one.
+/// Live runner -> job pairings for status reporting, sorted by runner id.
+/// Sourced from claimed job requests (each carries the claiming runner and
+/// is marked finished via `result`), NOT from the assignment table: entries
+/// there are pre-claim reservations that `take_matching_job` removes at
+/// claim time, so reading them reports idle runners as live and hides
+/// executing ones — exactly backwards.
 pub(crate) fn live_runner_assignments(
-    assignments: &std::collections::BTreeMap<(RunId, JobId), AssignmentRecord>,
+    requests: &std::collections::BTreeMap<i64, crate::models::TaskAgentJobRequestRecord>,
     now: std::time::SystemTime,
 ) -> Vec<preloop_observability::status::RunnerAssignment> {
-    let mut out: Vec<preloop_observability::status::RunnerAssignment> = assignments
-        .iter()
+    let mut out: Vec<preloop_observability::status::RunnerAssignment> = requests
+        .values()
+        .filter(|record| record.result.is_none())
+        .filter_map(|record| record.owner_runner_id.map(|runner_id| (runner_id, record)))
         .map(
-            |((run_id, job_id), record)| preloop_observability::status::RunnerAssignment {
-                runner_id: record.runner_id,
-                run_id: run_id.to_string(),
-                job_id: job_id.0.clone(),
-                assigned_seconds_ago: now
-                    .duration_since(record.at)
+            |(runner_id, record)| preloop_observability::status::RunnerAssignment {
+                runner_id,
+                run_id: record.run_id.to_string(),
+                job_id: record.job_id.0.clone(),
+                assigned_seconds_ago: record
+                    .started_at
+                    .and_then(|at| now.duration_since(at).ok())
                     .map(|d| d.as_secs_f64())
                     .unwrap_or(0.0),
             },
@@ -1777,7 +1782,6 @@ pub(crate) fn live_runner_assignments(
     out.sort_by_key(|a| a.runner_id);
     out
 }
-
 pub(crate) fn capabilities_of(runner: &RegisteredRunner) -> RunnerCapabilities {
     RunnerCapabilities {
         known: true,
@@ -3015,78 +3019,76 @@ mod runner_group_tests {
             &runner(Some(2), Some("Release")),
         ));
     }
-
-    #[test]
-    fn group_is_not_treated_as_a_label() {
-        let mut capabilities = runner(Some(2), Some("build"));
-        capabilities.labels.push("release".to_owned());
-        assert!(!job_matches_runner_group(Some("deploy"), &capabilities));
-    }
-
-    #[test]
-    fn missing_group_metadata_uses_default_group() {
-        let default_runner = runner(None, None);
-        assert!(job_matches_runner_group(Some("Default"), &default_runner));
-        let custom_name_only = runner(None, Some("private"));
-        assert!(!job_matches_runner_group(Some("1"), &custom_name_only));
-        assert!(job_matches_runner_group(Some("1"), &default_runner));
-        assert!(job_matches_runner_group(None, &default_runner));
-        assert!(!job_matches_runner_group(
-            Some("private"),
-            &RunnerCapabilities::default(),
-        ));
-    }
 }
 
 #[cfg(test)]
 mod assignment_tests {
     use super::*;
 
-    /// The status inversion reports each live pairing keyed by runner, with
-    /// run/job identity and age — the answer to "which job is on which
-    /// runner" that pool counts cannot give.
+    /// Status pairings come from claimed job requests carrying their runner,
+    /// not from the pre-claim assignment table: finished requests and
+    /// unclaimed ones must not appear, and output is runner-sorted.
     #[test]
-    fn live_assignments_invert_by_runner() {
-        use crate::models::AssignmentRecord;
+    fn live_assignments_reflect_claimed_requests() {
+        use crate::models::TaskAgentJobRequestRecord;
         use std::collections::BTreeMap;
 
-        let run_a = RunId::new();
-        let run_b = RunId::new();
-        let now = std::time::SystemTime::now();
-        let at = now.checked_sub(std::time::Duration::from_secs(90)).unwrap();
-        let mut table: BTreeMap<(RunId, JobId), AssignmentRecord> = BTreeMap::new();
-        // Insert out of runner order; output must still be runner-sorted.
-        table.insert(
-            (run_b, JobId("build".to_owned())),
-            AssignmentRecord {
-                runner_id: 7,
-                at,
-                first_at: at,
-            },
-        );
-        table.insert(
-            (run_a, JobId("test".to_owned())),
-            AssignmentRecord {
-                runner_id: 3,
-                at,
-                first_at: at,
-            },
-        );
+        fn record(
+            run_id: RunId,
+            job: &str,
+            owner: Option<i64>,
+            result: Option<preloop_gha_protocol::ExecutionStatus>,
+            started_ago_secs: u64,
+        ) -> TaskAgentJobRequestRecord {
+            TaskAgentJobRequestRecord {
+                request_id: 0,
+                run_id,
+                job_id: JobId(job.to_owned()),
+                agent_job_id: uuid::Uuid::nil(),
+                plan_id: String::new(),
+                plan_type: String::new(),
+                timeline_id: uuid::Uuid::nil(),
+                result,
+                locked_until: String::new(),
+                owner_runner_id: owner,
+                started_at: std::time::SystemTime::now()
+                    .checked_sub(std::time::Duration::from_secs(started_ago_secs)),
+                last_renewed_at: None,
+                timeout_triggered: false,
+                debug_token_issued: false,
+            }
+        }
 
+        let run_a = RunId::new();
+        let mut table: BTreeMap<i64, TaskAgentJobRequestRecord> = BTreeMap::new();
+        // Finished requests stay in the map (late reads stay bound) but must
+        // not report as live; unclaimed ones have no runner yet.
+        table.insert(
+            1,
+            record(
+                run_a,
+                "done",
+                Some(3),
+                Some(preloop_gha_protocol::ExecutionStatus::Success),
+                90,
+            ),
+        );
+        table.insert(2, record(RunId::new(), "queued", None, None, 10));
+        // Insert out of runner order; output must still be runner-sorted.
+        table.insert(3, record(RunId::new(), "build", Some(7), None, 90));
+        let run_test = RunId::new();
+        table.insert(4, record(run_test, "test", Some(3), None, 30));
+
+        let now = std::time::SystemTime::now();
         let live = live_runner_assignments(&table, now);
 
         assert_eq!(live.len(), 2);
         assert_eq!(live[0].runner_id, 3);
-        assert_eq!(live[0].run_id, run_a.to_string());
+        assert_eq!(live[0].run_id, run_test.to_string());
         assert_eq!(live[0].job_id, "test");
+        assert!((live[0].assigned_seconds_ago - 30.0).abs() < 5.0);
         assert_eq!(live[1].runner_id, 7);
         assert_eq!(live[1].job_id, "build");
-        for entry in &live {
-            assert!(
-                (entry.assigned_seconds_ago - 90.0).abs() < 5.0,
-                "age should reflect assignment time: {entry:?}"
-            );
-        }
         assert!(live_runner_assignments(&BTreeMap::new(), now).is_empty());
     }
 

--- a/crates/preloop-runner-server/src/runtime_scheduling.rs
+++ b/crates/preloop-runner-server/src/runtime_scheduling.rs
@@ -1753,17 +1753,18 @@ pub(crate) fn clear_assignment(inner: &mut InnerState, run_id: RunId, job_id: &J
 }
 
 /// Live runner -> job pairings for status reporting, sorted by runner id.
-/// Sourced from claimed job requests (each carries the claiming runner and
-/// is marked finished via `result`), NOT from the assignment table: entries
-/// there are pre-claim reservations that `take_matching_job` removes at
-/// claim time, so reading them reports idle runners as live and hides
-/// executing ones — exactly backwards.
+///
+/// Iterate only active session requests, not the historical request table.
+/// The latter retains completed records for late protocol reads and grows for
+/// the process lifetime.
 pub(crate) fn live_runner_assignments(
     requests: &std::collections::BTreeMap<i64, crate::models::TaskAgentJobRequestRecord>,
+    active_requests: &std::collections::BTreeMap<String, i64>,
     now: std::time::SystemTime,
 ) -> Vec<preloop_observability::status::RunnerAssignment> {
-    let mut out: Vec<preloop_observability::status::RunnerAssignment> = requests
+    let mut out: Vec<preloop_observability::status::RunnerAssignment> = active_requests
         .values()
+        .filter_map(|request_id| requests.get(request_id))
         .filter(|record| record.result.is_none())
         .filter_map(|record| record.owner_runner_id.map(|runner_id| (runner_id, record)))
         .map(
@@ -2649,10 +2650,10 @@ fn expandable_job_ids(inner: &InnerState, run_id: RunId) -> BTreeSet<JobId> {
     ids
 }
 
-/// Settle one abandoned request without concluding its logical job.
+/// Settle one request whose logical job is terminal.
 ///
-/// Requeue paths use this before minting a replacement attempt. Keeping the
-/// old request live lets its lease expiry race and fail the replacement.
+/// Completed request records remain addressable for late runner reads, but
+/// lose every live-session and renewable-credential association.
 pub(crate) fn settle_request(inner: &mut InnerState, request_id: i64, status: ExecutionStatus) {
     inner
         .session_active_requests
@@ -2662,6 +2663,26 @@ pub(crate) fn settle_request(inner: &mut InnerState, request_id: i64, status: Ex
     if let Some(record) = inner.job_requests.get_mut(&request_id) {
         if record.result.is_none() {
             record.result = Some(status);
+        }
+    }
+}
+/// Release an interrupted claim so the same request can be delivered again.
+///
+/// The queued job retains this request id and agent-job correlation. Keep its
+/// inflight and token records, but remove the dead owner before requeueing:
+/// the old runner is then rejected until a replacement session claims it, and
+/// that replacement can renew and complete the original request normally.
+pub(crate) fn release_request_for_retry(inner: &mut InnerState, request_id: i64) {
+    inner
+        .session_active_requests
+        .retain(|_, &mut rid| rid != request_id);
+    if let Some(record) = inner.job_requests.get_mut(&request_id) {
+        if record.result.is_none() {
+            record.owner_runner_id = None;
+            record.started_at = None;
+            record.last_renewed_at = None;
+            record.timeout_triggered = false;
+            record.locked_until = crate::distributed_task::agent_request_locked_until();
         }
     }
 }
@@ -3089,8 +3110,13 @@ mod assignment_tests {
         let run_test = RunId::new();
         table.insert(4, record(run_test, "test", Some(3), None, 30));
 
+        let active = BTreeMap::from([
+            ("finished".to_owned(), 1),
+            ("build".to_owned(), 3),
+            ("test".to_owned(), 4),
+        ]);
         let now = std::time::SystemTime::now();
-        let live = live_runner_assignments(&table, now);
+        let live = live_runner_assignments(&table, &active, now);
 
         assert_eq!(live.len(), 2);
         assert_eq!(live[0].runner_id, 3);
@@ -3099,7 +3125,7 @@ mod assignment_tests {
         assert!((live[0].assigned_seconds_ago - 30.0).abs() < 5.0);
         assert_eq!(live[1].runner_id, 7);
         assert_eq!(live[1].job_id, "build");
-        assert!(live_runner_assignments(&BTreeMap::new(), now).is_empty());
+        assert!(live_runner_assignments(&BTreeMap::new(), &BTreeMap::new(), now).is_empty());
     }
 
     fn self_hosted_caps() -> RunnerCapabilities {

--- a/crates/preloop-runner-server/src/runtime_scheduling.rs
+++ b/crates/preloop-runner-server/src/runtime_scheduling.rs
@@ -2649,6 +2649,23 @@ fn expandable_job_ids(inner: &InnerState, run_id: RunId) -> BTreeSet<JobId> {
     ids
 }
 
+/// Settle one abandoned request without concluding its logical job.
+///
+/// Requeue paths use this before minting a replacement attempt. Keeping the
+/// old request live lets its lease expiry race and fail the replacement.
+pub(crate) fn settle_request(inner: &mut InnerState, request_id: i64, status: ExecutionStatus) {
+    inner
+        .session_active_requests
+        .retain(|_, &mut rid| rid != request_id);
+    inner.inflight_requests.remove(&request_id);
+    inner.github_token_requests.remove(&request_id);
+    if let Some(record) = inner.job_requests.get_mut(&request_id) {
+        if record.result.is_none() {
+            record.result = Some(status);
+        }
+    }
+}
+
 /// Retire the request records an expandable node acquired at submit.
 ///
 /// MC-2: `runs.rs` mints a full set of correlation records for every
@@ -2672,23 +2689,16 @@ pub(crate) fn retire_node_requests(
         .map(|(id, _)| *id)
         .collect();
     for request_id in request_ids {
-        inner
-            .session_active_requests
-            .retain(|_, &mut rid| rid != request_id);
-        inner.inflight_requests.remove(&request_id);
-        // Terminal either way: a settled node stays in the run as a finished
-        // job and a purged one no longer exists, and neither can be claimed
-        // again. The deferred App-token request must not survive either.
-        inner.github_token_requests.remove(&request_id);
         match retirement {
             RequestRetirement::Settle(status) => {
-                if let Some(record) = inner.job_requests.get_mut(&request_id) {
-                    if record.result.is_none() {
-                        record.result = Some(status);
-                    }
-                }
+                settle_request(inner, request_id, status);
             }
             RequestRetirement::Purge => {
+                inner
+                    .session_active_requests
+                    .retain(|_, &mut rid| rid != request_id);
+                inner.inflight_requests.remove(&request_id);
+                inner.github_token_requests.remove(&request_id);
                 let Some(record) = inner.job_requests.remove(&request_id) else {
                     continue;
                 };

--- a/crates/preloop-runner-server/tests/required_checks.rs
+++ b/crates/preloop-runner-server/tests/required_checks.rs
@@ -15,6 +15,7 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 const REQUIRED_CHECKS: &[&str] = &[
+    "rust-lint",
     "rust shard 1 of 4",
     "rust shard 2 of 4",
     "rust shard 3 of 4",

--- a/crates/preloop-runner-server/tests/required_checks.rs
+++ b/crates/preloop-runner-server/tests/required_checks.rs
@@ -1,0 +1,80 @@
+//! Required status checks stay wired to real check runs.
+//!
+//! GitHub matches required checks to completed check runs by exact display
+//! name, and preloop names its check runs from the workflow job's display
+//! `name:` (falling back to the job id). Neither side knows about the other,
+//! so renaming a job's display name silently orphans the ruleset entry: the
+//! requirement sits at "Expected" forever and every merge blocks with no
+//! error explaining why. This test fails the build instead.
+//!
+//! Source of truth for the other side: repository ruleset `main`
+//! (id 20594250). If you add or rename an entry there, update
+//! `REQUIRED_CHECKS` here to match, and vice versa.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+const REQUIRED_CHECKS: &[&str] = &[
+    "rust shard 1 of 4",
+    "rust shard 2 of 4",
+    "rust shard 3 of 4",
+    "rust shard 4 of 4",
+    "property-tests-fast",
+    "Server light conformance",
+    "Runner light conformance",
+];
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .unwrap()
+}
+
+fn display_names_of(workflow: &preloop_gha_parser::Workflow) -> Vec<String> {
+    // Static-matrix expansion is what produces display names for sharded
+    // jobs; reusable callers without their callee YAML cannot expand here,
+    // so fall back to the caller job's own display name in that case.
+    match preloop_gha_parser::expand_jobs(workflow) {
+        Ok(plans) => plans.into_iter().map(|plan| plan.name).collect(),
+        Err(_) => workflow
+            .jobs
+            .iter()
+            .map(|(id, job)| job.name.clone().unwrap_or_else(|| id.clone()))
+            .collect(),
+    }
+}
+
+#[test]
+fn every_required_check_is_produced_by_a_workflow() {
+    let root = workspace_root();
+    let mut produced = BTreeSet::new();
+    let mut workflows = 0u32;
+    for entry in std::fs::read_dir(root.join(".github/workflows")).unwrap() {
+        let path = entry.unwrap().path();
+        if path.extension().and_then(|e| e.to_str()) != Some("yml") {
+            continue;
+        }
+        let text = std::fs::read_to_string(&path).unwrap();
+        let workflow: preloop_gha_parser::Workflow = match serde_yaml::from_str(&text) {
+            Ok(workflow) => workflow,
+            Err(_) => continue,
+        };
+        workflows += 1;
+        produced.extend(display_names_of(&workflow));
+    }
+    assert!(
+        workflows > 0,
+        "expected workflow files under .github/workflows"
+    );
+
+    let missing: Vec<&&str> = REQUIRED_CHECKS
+        .iter()
+        .filter(|check| !produced.contains(**check))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "required status checks with no matching workflow job display name \
+         (rename the job or update ruleset `main` id 20594250 to match): {missing:?}"
+    );
+}


### PR DESCRIPTION
Two diagnosability gaps behind this week's debugging sessions, one PR.

### 1. Check names can silently orphan the ruleset

GitHub matches required checks to completed check runs by **exact display string**. Preloop names check runs from the workflow display `name:`; the ruleset lists hand-typed strings. Neither side knows about the other, so a job rename sits at Expected forever and blocks every merge with no error — exactly what happened with `server-light` vs `Server light conformance`.

Two halves:
- Every check-run summary (queued and completed) now carries a `job_id:` line mapping display name back to workflow job id, visible on the check page itself.
- New `required_checks` integration test asserts the ruleset `main` contexts match expanded workflow display names (matrix expansion included, so shards are covered). Verified failing on a one-character rename.

### 2. `preloop status` shows which job is on which runner

Pool counts alone cannot distinguish a busy pool from a stalled one (the leaked-bindings failure mode is defined by the *absence* of a journal line). The assignment table already holds the pairing; it is now inverted into `runners.assignments` (runner, run, job, age in seconds) and rendered as `runner <id>: <run> / <job> (<age>)` lines. Pure display over existing state — no new plumbing. Unit-tested inversion (sorted, aged, empty-safe).

### 3. Shard the rust suite (bundled: the ruleset already expects it)

`cargo test --workspace` costs 20-40 min serial. `rust-lint` (fmt, clippy, doctests, no LFS checkout) plus 4 nextest hash partitions on separate runners; `fail-fast: false` so all four verdicts report. No aggregator job: preloop's `needs` context is outputs-only, so the standard always-run-and-check pattern cannot evaluate — four explicit ruleset entries instead (already applied). Verified the matrix expands to the exact display names via `preloop plan --json`.

Verified: fmt + clippy `-D warnings` clean; server lib 717 green; linkage test green plus negative-tested; inversion unit test green; CLI 176 + observability 27 green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes check-name drift that silently orphans the required-checks ruleset, shows which job runs on which runner in `preloop status`, lets retried jobs survive abandoned runner attempts and pool restarts, and shards the Rust test suite to cut wall-clock time.

**Bug Fixes**
- Check-run summaries (queued and completed) now carry a `job_id:` line; a new `required_checks` test asserts the `main` ruleset contexts match expanded workflow display names, so renaming a job requires updating both.
- `preloop status` now renders live runner assignments as `runner <id>: <run> / <job> (<age>)`, sourced from claimed job requests rather than the pre-claim assignment table.
- A purged runner's request is released for retry (dead owner and session pin cleared), and `acquirejob` rejects settled records, so a late runner can't re-run a completed job's side effects.
- After a pool restart, the server waits a process-local warm window before applying the durable queue-age ceiling, and startup releases requests whose job was requeued but left their claim live.
- Registered runners without a polling session are no longer reported as idle capacity.
- Fork PRs now run the required Rust checks instead of being skipped, and conformance builds the exact binaries it executes and waits for a successful `/healthz`.

**Refactors**
- The Rust suite is split into `rust-lint` plus four nextest hash partitions with `fail-fast: false`; the ruleset gates on all five check names.
- Status assignments derive from active session requests, and startup reconciliation matches the queue by set.

<sup>Written for commit 0a91fee64de0ce8f771bb5e3b550b1d0774fc785. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/preloopdev/preloop/pull/250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Operational status displays live runner-to-job assignments, including runner, run, job, and assignment age details.
  - GitHub check run summaries now include the associated job ID for easier identification.

- **Bug Fixes**
  - Status reporting now reflects only active runner assignments.
  - Jobs remain available during the runner pool’s brief warm-up period after a restart.
  - Abandoned runner attempts are now marked cancelled when jobs are requeued.

- **Tests**
  - Added coverage for workflow status checks, runner assignment reporting, cancellation handling, and restart recovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->