### PR TITLE
ci: enforce parser/schema divergence checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
+      - name: Check parser/schema divergence
+        run: python3 benchmarks/conformance/check_schema_contexts.py
       - name: Materialize conformance goldens
         run: |
           git lfs install --local

--- a/benchmarks/conformance/check_schema_contexts.py
+++ b/benchmarks/conformance/check_schema_contexts.py
@@ -1,0 +1,811 @@
+#!/usr/bin/env python3
+"""Diff the vendored GitHub Actions workflow schema against the parser.
+
+The schema is a small DSL rather than JSON Schema: named definitions compose
+through ``mapping``, ``sequence``, and ``one-of`` nodes.  This checker walks
+that DSL from ``workflow-root`` and compares every reachable context-bearing
+field definition with the CTX_* constants in eval.rs.
+
+The schema-to-constant table is deliberately explicit.  The schema names a
+field's contract, while eval.rs chooses which validator is called for that
+field; there is no reliable spelling-only mapping between those two APIs.  The
+constants themselves are parsed from Rust source, including aliases, so a
+changed or malformed constant cannot silently make this check pass.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_DIR = ROOT / "benchmarks" / "conformance" / "schema"
+SCHEMA_PATH = SCHEMA_DIR / "workflow-v1.0.json"
+SOURCE_PATH = SCHEMA_DIR / "SOURCE.json"
+EVAL_PATH = ROOT / "crates" / "preloop-gha-parser" / "src" / "eval.rs"
+MODELS_PATH = ROOT / "crates" / "preloop-gha-parser" / "src" / "models.rs"
+
+# Definition names reachable from the normal (non-strict) workflow root are
+# discovered from the schema.  This table only describes how the parser
+# validates the resulting definitions.  Entries absent here must be written
+# into CONTEXT_ALLOWLIST with a reason before the checker can pass.
+CONTEXT_BINDINGS: dict[str, tuple[str, ...]] = {
+    "run-name": ("CTX_RUN_NAME",),
+    "workflow-env": ("CTX_WORKFLOW_ENV",),
+    "workflow-concurrency": ("CTX_WORKFLOW_CONCURRENCY",),
+    "job-if": ("CTX_JOB_IF",),
+    "strategy": ("CTX_STRATEGY",),
+    "runs-on": ("CTX_JOB_RUNS_ON",),
+    "job-env": ("CTX_JOB_ENV",),
+    "job-concurrency": ("CTX_JOB_CONCURRENCY",),
+    "job-defaults-run": ("CTX_JOB_DEFAULTS_RUN",),
+    "container": ("CTX_JOB_CONTAINER",),
+    "services": ("CTX_JOB_CONTAINER",),
+    "services-container": ("CTX_JOB_CONTAINER",),
+    "container-registry-credentials": ("CTX_CONTAINER_CREDENTIALS",),
+    "boolean-strategy-context": ("CTX_JOB_RUNS_ON",),
+    "string-strategy-context": ("CTX_JOB_RUNS_ON",),
+    "string-runner-context": ("CTX_RUNNER",),
+    "step-continue-on-error": ("CTX_STEP_CONTINUE_ON_ERROR",),
+    "step-if": ("CTX_STEP_IF",),
+    "step-env": ("CTX_STEP_ENV",),
+    "step-name": ("CTX_STEP_NAME",),
+    "step-timeout-minutes": ("CTX_STEP_TIMEOUT",),
+    "step-with": ("CTX_STEP_WITH",),
+    "string-steps-context": ("CTX_STEP_RUN", "CTX_STEP_WORKING_DIR"),
+}
+
+# These are real parser gaps, not expected schema differences.  They remain
+# visible in the report and are required to carry a written reason.  A missing
+# validator is reported as a wrongly-accepts gap because arbitrary contexts
+# are not rejected at that field.
+CONTEXT_ALLOWLIST: dict[str, str] = {
+    "workflow-call-input-default": (
+        "InputDefinition.default is Value (models.rs:360-361) and "
+        "validate_workflow_expressions does not inspect workflow_call definitions "
+        "(eval.rs:358-548)."
+    ),
+    "workflow-output-context": (
+        "OutputDefinition.value is parsed as String (models.rs:420-427), but "
+        "workflow_call output definitions are not visited by the workflow "
+        "expression validator (eval.rs:358-548)."
+    ),
+    "job-environment": (
+        "Job.environment is retained as raw Value (models.rs:665-667) and no "
+        "job environment validation call exists (eval.rs:424-477)."
+    ),
+    "job-environment-name": (
+        "The nested environment name is inside Job.environment Value "
+        "(models.rs:665-667); no validator visits it (eval.rs:424-477)."
+    ),
+    "number-strategy-context": (
+        "The schema's job timeout and cancel-timeout fields have no Job model "
+        "fields (models.rs:637-695), so serde drops them and no context check "
+        "can run."
+    ),
+    "scalar-needs-context": (
+        "Reusable-job with values are stored as Job.with Value "
+        "(models.rs:677-679) and are not visited by eval.rs:378-477."
+    ),
+    "scalar-needs-context-with-secrets": (
+        "Reusable-job secrets are stored as Job.secrets Value "
+        "(models.rs:680-682) and are not visited by eval.rs:378-477."
+    ),
+    "snapshot-if": (
+        "Job has no snapshot field (models.rs:637-695), so snapshot.if is an "
+        "unknown serde key and no context check runs."
+    ),
+    "string-runner-context-no-secrets": (
+        "The environment URL is nested in raw Job.environment Value "
+        "(models.rs:665-667) and is not visited by eval.rs:424-477."
+    ),
+}
+
+# Type checks cover every scalar field represented by the workflow models and
+# every scalar schema definition used by those fields.  The source declaration
+# is located at runtime, so line numbers in the report remain useful after
+# unrelated edits.  Broad Value representations and absent fields are kept in
+# TYPE_ALLOWLIST until a behavior-preserving model cutover is designed.
+TYPE_CHECKS: tuple[dict[str, str], ...] = (
+    {"target": "Workflow.name", "schema": "workflow-name"},
+    {"target": "Workflow.run_name", "schema": "run-name"},
+    {"target": "Workflow.env", "schema": "workflow-env"},
+    {
+        "target": "Workflow.env values",
+        "source_target": "Workflow.env",
+        "model_type": "EnvValue",
+        "schema": "string",
+    },
+    {"target": "Workflow.permissions", "schema": "permissions"},
+    {"target": "Workflow.concurrency", "schema": "workflow-concurrency"},
+    {"target": "Workflow.defaults", "schema": "workflow-defaults"},
+    {"target": "InputDefinition.input_type", "schema": "workflow-call-input-type"},
+    {"target": "InputDefinition.required", "schema": "boolean"},
+    {"target": "InputDefinition.default", "schema": "workflow-call-input-default"},
+    {"target": "InputDefinition.description", "schema": "string"},
+    {"target": "SecretDefinition.required", "schema": "boolean"},
+    {"target": "SecretDefinition.description", "schema": "string"},
+    {"target": "OutputDefinition.value", "schema": "workflow-output-context"},
+    {"target": "OutputDefinition.description", "schema": "string"},
+    {"target": "EnvValue", "schema": "string"},
+    {"target": "Job.name", "schema": "string-strategy-context"},
+    {"target": "Job.if_condition", "schema": "job-if"},
+    {"target": "Job.continue_on_error", "schema": "boolean-strategy-context"},
+    {"target": "Job.timeout_minutes", "schema": "number-strategy-context"},
+    {"target": "Job.cancel_timeout_minutes", "schema": "number-strategy-context"},
+    {"target": "Job.environment", "schema": "job-environment"},
+    {"target": "Job.with", "schema": "workflow-job-with"},
+    {
+        "target": "Job.with values",
+        "source_target": "Job.with",
+        "model_type": "Value",
+        "schema": "scalar-needs-context",
+    },
+    {"target": "Job.secrets", "schema": "workflow-job-secrets"},
+    {
+        "target": "Job.secrets values",
+        "source_target": "Job.secrets",
+        "model_type": "Value",
+        "schema": "scalar-needs-context-with-secrets",
+    },
+    {"target": "Job.outputs", "schema": "job-outputs"},
+    {
+        "target": "Job.outputs values",
+        "source_target": "Job.outputs",
+        "model_type": "Value",
+        "schema": "string-runner-context",
+    },
+    {"target": "Job.uses", "schema": "non-empty-string"},
+    {"target": "Job.permissions", "schema": "permissions"},
+    {"target": "Job.container", "schema": "container"},
+    {
+        "target": "Job.container values",
+        "source_target": "Job.container",
+        "model_type": "Value",
+        "schema": "container",
+    },
+    {"target": "Job.services", "schema": "services"},
+    {
+        "target": "Job.services values",
+        "source_target": "Job.services",
+        "model_type": "Value",
+        "schema": "services",
+    },
+    {"target": "Job.env", "schema": "job-env"},
+    {
+        "target": "Job.env values",
+        "source_target": "Job.env",
+        "model_type": "EnvValue",
+        "schema": "string",
+    },
+    {"target": "Job.defaults", "schema": "job-defaults"},
+    {"target": "DefaultsRun.shell", "schema": "shell"},
+    {"target": "DefaultsRun.working_directory", "schema": "working-directory"},
+    {"target": "RunsOn", "schema": "runs-on"},
+    {"target": "Needs", "schema": "needs"},
+    {"target": "Strategy.fail_fast", "schema": "boolean"},
+    {"target": "Strategy.max_parallel", "schema": "number"},
+    {"target": "DeferredBool", "schema": "boolean"},
+    {"target": "DeferredNumber", "schema": "number"},
+    {"target": "Concurrency.group", "schema": "non-empty-string"},
+    {"target": "Concurrency.cancel_in_progress", "schema": "boolean"},
+    {"target": "Step.id", "schema": "step-id"},
+    {"target": "Step.name", "schema": "step-name"},
+    {"target": "Step.run", "schema": "string-steps-context"},
+    {"target": "Step.uses", "schema": "step-uses"},
+    {"target": "Step.if_condition", "schema": "step-if"},
+    {"target": "Step.working_directory", "schema": "string-steps-context"},
+    {"target": "Step.shell", "schema": "shell"},
+    {"target": "Step.continue_on_error", "schema": "step-continue-on-error"},
+    {"target": "Step.timeout_minutes", "schema": "step-timeout-minutes"},
+    {"target": "Step.env", "schema": "step-env"},
+    {
+        "target": "Step.env values",
+        "source_target": "Step.env",
+        "model_type": "EnvValue",
+        "schema": "string",
+    },
+    {"target": "Step.with", "schema": "step-with"},
+    {
+        "target": "Step.with values",
+        "source_target": "Step.with",
+        "model_type": "Value",
+        "schema": "string",
+    },
+)
+
+# Values accepted by the parser but intentionally broader than the schema are
+# reported with a reason until a typed model cutover can preserve behavior.
+TYPE_ALLOWLIST: dict[str, str] = {
+    "InputDefinition.default": (
+        "Value is intentionally retained until the declared workflow_call input "
+        "type is known; apply_workflow_dispatch_inputs/coerce_value enforce the "
+        "runtime type (models.rs:351-365; expand.rs:682-756)."
+    ),
+    "EnvValue": (
+        "The schema declares environment values as strings, while EnvValue accepts "
+        "YAML scalar bool/number/null and normalizes them to strings "
+        "(models.rs:584-595,609-617); changing this is a coercion-policy decision."
+    ),
+    "Workflow.env values": (
+        "Workflow.env stores scalar values as EnvValue, which accepts YAML "
+        "bool/number/null and normalizes them to strings "
+        "(models.rs:181,587-595,609-617)."
+    ),
+    "Job.env values": (
+        "Job.env stores scalar values as EnvValue, which accepts YAML "
+        "bool/number/null and normalizes them to strings "
+        "(models.rs:664,587-595,609-617)."
+    ),
+    "Step.env values": (
+        "Step.env stores scalar values as EnvValue, which accepts YAML "
+        "bool/number/null and normalizes them to strings "
+        "(models.rs:1018,587-595,609-617)."
+    ),
+    "Step.with values": (
+        "Step.with values remain raw Value because actions commonly accept "
+        "boolean and numeric inputs; narrowing to schema strings is not mechanical "
+        "(models.rs:1021; action input serialization in job_builder.rs)."
+    ),
+    "Job.timeout_minutes": (
+        "The schema declares a numeric job field, but Job has no corresponding field "
+        "(models.rs:637-695); unknown serde keys are dropped."
+    ),
+    "Job.cancel_timeout_minutes": (
+        "The schema declares a numeric job field, but Job has no corresponding field "
+        "(models.rs:637-695); unknown serde keys are dropped."
+    ),
+    "Job.environment": (
+        "Job.environment is raw Value for scalar-or-mapping support "
+        "(models.rs:665-667); narrowing it requires a model and expansion cutover."
+    ),
+    "Job.secrets": (
+        "Reusable-workflow secret values are raw Value (models.rs:680-682); the "
+        "schema-compatible typed cutover is not mechanical."
+    ),
+    "Job.outputs": (
+        "Job output values are raw Value (models.rs:691-694) so expressions and "
+        "wire serialization are preserved; schema says string."
+    ),
+    "RunsOn": (
+        "RunsOn is a deliberate one-of representation of string/list/object input "
+        "(models.rs:716-726), not a scalar type mismatch."
+    ),
+    "Needs": (
+        "Needs is a deliberate one-of representation of string/list input "
+        "(models.rs:768-779), not a scalar type mismatch."
+    ),
+    "Concurrency.cancel_in_progress": (
+        "The schema's boolean may be a deferred expression; the custom deserializer "
+        "accepts bool and string and stores the expression source "
+        "(models.rs:922-984)."
+    ),
+    "Workflow.permissions": (
+        "Permissions are retained as raw Value because the schema accepts several "
+        "mapping and shorthand forms (models.rs:182-184); no scalar-only cutover "
+        "is mechanical."
+    ),
+    "Job.permissions": (
+        "Job permissions are retained as raw Value because the schema accepts "
+        "several mapping and shorthand forms (models.rs:668-670)."
+    ),
+    "Job.container": (
+        "Container accepts string or mapping forms and is evaluated runner-side as "
+        "raw Value (models.rs:683-686); a typed cutover is not mechanical."
+    ),
+    "Job.services": (
+        "Services accept a mapping of raw container values and are evaluated "
+        "runner-side (models.rs:686-687); a typed cutover is not mechanical."
+    ),
+    "Job.with values": (
+        "Reusable-job input values remain raw Value (models.rs:677-679); schema "
+        "scalar enforcement needs a separate typed input contract."
+    ),
+    "Job.secrets values": (
+        "Reusable-job secret values remain raw Value (models.rs:680-682); schema "
+        "scalar enforcement needs a separate typed secret contract."
+    ),
+    "Job.outputs values": (
+        "Job output values remain raw Value to preserve expression/wire handling "
+        "(models.rs:691-694); schema declares strings."
+    ),
+    "Job.container values": (
+        "Container values are raw Value and can be scalar or mapping "
+        "(models.rs:683-686); narrowing nested values is not mechanical."
+    ),
+    "Job.services values": (
+        "Service container values are raw Value (models.rs:686-687); narrowing "
+        "nested values is not mechanical."
+    ),
+}
+
+PRIMITIVE_KINDS = {"string", "number", "boolean", "null", "any", "sequence", "mapping"}
+
+
+class AuditError(Exception):
+    """Malformed input makes the audit fail closed."""
+
+
+def load_json(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text())
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise AuditError(f"cannot read {label} {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise AuditError(f"{label} must contain a JSON object: {path}")
+    return value
+
+
+def verify_schema_source(schema: dict[str, Any], source: dict[str, Any], schema_path: Path) -> None:
+    required = {"repo", "path", "commit", "raw_url", "sha256"}
+    missing = sorted(required - source.keys())
+    if missing:
+        raise AuditError(f"schema source metadata missing keys: {', '.join(missing)}")
+    commit = source["commit"]
+    if not isinstance(commit, str) or not re.fullmatch(r"[0-9a-f]{40}", commit):
+        raise AuditError("schema source commit must be a 40-character lowercase SHA")
+    raw_url = source["raw_url"]
+    expected_fragment = f"{source['repo']}/{commit}/{source['path']}"
+    if not isinstance(raw_url, str) or expected_fragment not in raw_url:
+        raise AuditError("schema source raw_url does not pin the recorded repository/path/SHA")
+    actual_hash = hashlib.sha256(schema_path.read_bytes()).hexdigest()
+    if actual_hash != source["sha256"]:
+        raise AuditError(
+            f"vendored schema sha256 mismatch: metadata={source['sha256']} actual={actual_hash}"
+        )
+    if schema.get("version") != "workflow-v1.0":
+        raise AuditError(f"unexpected schema version: {schema.get('version')!r}")
+
+
+def parse_context_constants(source: str) -> dict[str, dict[str, Any]]:
+    declared = set(re.findall(r"(?m)^\s*const\s+(CTX_[A-Z0-9_]+)\s*:", source))
+    declaration_re = re.compile(
+        r"(?ms)^\s*const\s+(CTX_[A-Z0-9_]+)\s*:\s*&\[&str\]\s*=\s*(.*?);"
+    )
+    parsed: dict[str, dict[str, Any]] = {}
+    for match in declaration_re.finditer(source):
+        name, rhs = match.group(1), match.group(2).strip()
+        line = source.count("\n", 0, match.start()) + 1
+        if rhs.startswith("&[") and rhs.endswith("]"):
+            body = rhs[2:-1]
+            values = re.findall(r'"([^"\\]*(?:\\.[^"\\]*)*)"', body)
+            remainder = re.sub(r'"([^"\\]*(?:\\.[^"\\]*)*)"', "", body)
+            remainder = re.sub(r"[\s,]", "", remainder)
+            if remainder:
+                raise AuditError(f"cannot parse {name} at eval.rs:{line}: {rhs}")
+            parsed[name] = {"values": values, "line": line, "rhs": rhs}
+            continue
+        alias = re.fullmatch(r"(CTX_[A-Z0-9_]+)", rhs)
+        if alias:
+            parsed[name] = {"alias": alias.group(1), "line": line, "rhs": rhs}
+            continue
+        raise AuditError(f"cannot parse {name} at eval.rs:{line}: {rhs}")
+    if declared != set(parsed):
+        missing = sorted(declared - set(parsed))
+        extra = sorted(set(parsed) - declared)
+        raise AuditError(f"CTX declaration parse mismatch: missing={missing} extra={extra}")
+
+    resolving: set[str] = set()
+
+    def resolve(name: str) -> list[str]:
+        if name not in parsed:
+            raise AuditError(f"CTX alias references unknown constant {name}")
+        if name in resolving:
+            raise AuditError(f"CTX alias cycle includes {name}")
+        item = parsed[name]
+        if "values" in item:
+            return list(item["values"])
+        resolving.add(name)
+        values = resolve(item["alias"])
+        resolving.remove(name)
+        return values
+
+    for name in parsed:
+        parsed[name]["values"] = resolve(name)
+    return parsed
+
+
+def named_spec(spec: Any) -> str | None:
+    if isinstance(spec, str):
+        return spec
+    if isinstance(spec, dict) and isinstance(spec.get("type"), str):
+        return spec["type"]
+    return None
+
+
+def schema_kinds(definitions: dict[str, Any], spec: Any, stack: tuple[str, ...] = ()) -> set[str]:
+    name = named_spec(spec)
+    if name is None:
+        raise AuditError(f"schema spec is not a named type: {spec!r}")
+    if name in PRIMITIVE_KINDS:
+        return {name}
+    if name not in definitions:
+        raise AuditError(f"schema references unknown definition {name!r}")
+    if name in stack:
+        return {"recursive"}
+    node = definitions[name]
+    result: set[str] = set()
+    for kind in PRIMITIVE_KINDS:
+        if kind in node:
+            result.add(kind)
+    if "mapping" in node:
+        result.add("mapping")
+    if "sequence" in node:
+        result.add("sequence")
+    if "one-of" in node:
+        for alternative in node["one-of"]:
+            result.update(schema_kinds(definitions, alternative, stack + (name,)))
+    if not result:
+        raise AuditError(f"schema definition {name!r} has no recognized type")
+    return result
+
+
+def walk_schema(definitions: dict[str, Any]) -> dict[str, set[str]]:
+    """Return reachable context definition -> workflow paths."""
+
+    context_paths: dict[str, set[str]] = {}
+
+    def walk(spec: Any, path: str, inherited_context: tuple[str, ...], stack: tuple[str, ...]) -> None:
+        name = named_spec(spec)
+        if name is None:
+            raise AuditError(f"schema spec at {path or '<root>'} is malformed: {spec!r}")
+        if name in PRIMITIVE_KINDS:
+            return
+        if name not in definitions:
+            raise AuditError(f"schema references unknown definition {name!r}")
+        node = definitions[name]
+        context = tuple(node.get("context", inherited_context))
+        if "context" in node:
+            if not isinstance(node["context"], list) or not all(
+                isinstance(value, str) for value in node["context"]
+            ):
+                raise AuditError(f"schema context for {name!r} is not a string list")
+            context_paths.setdefault(name, set()).add(path or "<root>")
+        if name in stack:
+            return
+        next_stack = stack + (name,)
+
+        if "one-of" in node:
+            alternatives = node["one-of"]
+            if not isinstance(alternatives, list) or not alternatives:
+                raise AuditError(f"schema one-of for {name!r} is empty or malformed")
+            for alternative in alternatives:
+                walk(alternative, path, context, next_stack)
+        if "mapping" in node:
+            mapping = node["mapping"]
+            if not isinstance(mapping, dict):
+                raise AuditError(f"schema mapping for {name!r} is malformed")
+            properties = mapping.get("properties", {})
+            if not isinstance(properties, dict):
+                raise AuditError(f"schema properties for {name!r} is malformed")
+            for key, child in properties.items():
+                if not isinstance(key, str):
+                    raise AuditError(f"schema property name for {name!r} is not a string")
+                walk(child, f"{path}.{key}" if path else key, context, next_stack)
+            if "loose-value-type" in mapping:
+                child_path = f"{path}.<*>" if path else "<*>"
+                walk(mapping["loose-value-type"], child_path, context, next_stack)
+        if "sequence" in node:
+            sequence = node["sequence"]
+            if not isinstance(sequence, dict) or "item-type" not in sequence:
+                raise AuditError(f"schema sequence for {name!r} is malformed")
+            walk(sequence["item-type"], f"{path}[*]", context, next_stack)
+
+        # Direct scalar definitions are covered by TYPE_CHECKS below.
+
+    walk("workflow-root", "", (), ())
+    return context_paths
+
+
+def normalize_context(value: str) -> str:
+    return value.split("(", 1)[0].strip().lower()
+
+
+def context_diff(schema_values: list[str], ours: list[str]) -> tuple[list[str], list[str]]:
+    schema_by_name = {normalize_context(value): value for value in schema_values}
+    ours_by_name = {normalize_context(value): value for value in ours}
+    missing = [schema_by_name[key] for key in sorted(schema_by_name.keys() - ours_by_name.keys())]
+    extra = [ours_by_name[key] for key in sorted(ours_by_name.keys() - schema_by_name.keys())]
+    return missing, extra
+
+
+def struct_body(source: str, name: str) -> tuple[str, int] | None:
+    match = re.search(rf"(?m)^pub struct {re.escape(name)}\s*\{{", source)
+    if not match:
+        return None
+    end = re.search(r"(?m)^}\s*$", source[match.end() :])
+    if not end:
+        raise AuditError(f"unterminated struct {name}")
+    body_start = match.end()
+    body_end = match.end() + end.start()
+    return source[body_start:body_end], source.count("\n", 0, body_start) + 1
+
+
+def enum_body(source: str, name: str) -> tuple[str, int] | None:
+    match = re.search(rf"(?m)^pub enum {re.escape(name)}\s*\{{", source)
+    if not match:
+        return None
+    end = re.search(r"(?m)^}\s*$", source[match.end() :])
+    if not end:
+        raise AuditError(f"unterminated enum {name}")
+    body_start = match.end()
+    body_end = match.end() + end.start()
+    return source[body_start:body_end], source.count("\n", 0, body_start) + 1
+
+
+def rust_target_type(source: str, target: str) -> tuple[str | None, int | None]:
+    if "." not in target:
+        enum = enum_body(source, target)
+        if enum is None:
+            return None, None
+        body, start_line = enum
+        if target == "EnvValue":
+            # EnvValue is a deliberate scalar-normalization enum rather than a
+            # single Rust scalar.  The caller classifies it explicitly.
+            return "EnvValue", start_line
+        return target, start_line
+    struct_name, field_name = target.split(".", 1)
+    struct = struct_body(source, struct_name)
+    if struct is None:
+        return None, None
+    body, start_line = struct
+    match = re.search(rf"(?m)^\s*pub {re.escape(field_name)}\s*:\s*", body)
+    if not match:
+        return None, None
+    type_start = match.end()
+    depth = 0
+    for index, character in enumerate(body[type_start:], type_start):
+        if character in "<([{":
+            depth += 1
+        elif character in ">)]}":
+            depth -= 1
+        elif character == "," and depth == 0:
+            line = start_line + body.count("\n", 0, match.start())
+            return body[type_start:index].strip(), line
+        elif character == "\n" and depth == 0:
+            line = start_line + body.count("\n", 0, match.start())
+            return body[type_start:index].strip(), line
+    raise AuditError(f"unterminated field declaration {target}")
+
+
+def rust_kinds(type_name: str | None, target: str) -> set[str]:
+    if type_name is None:
+        return set()
+    if target == "EnvValue" or type_name == "EnvValue":
+        return {"string", "boolean", "number", "null"}
+    type_name = re.sub(r"\s+", "", type_name)
+    while type_name.startswith("Option<") and type_name.endswith(">"):
+        type_name = type_name[7:-1]
+    if type_name.startswith("Vec<"):
+        return {"sequence"}
+    if type_name.startswith("BTreeMap<") or type_name.startswith("IndexMap<"):
+        return {"mapping"}
+    if type_name in {"String", "str"}:
+        return {"string"}
+    if type_name in {"bool"}:
+        return {"boolean"}
+    if type_name in {
+        "u8",
+        "u16",
+        "u32",
+        "u64",
+        "u128",
+        "usize",
+        "i8",
+        "i16",
+        "i32",
+        "i64",
+        "i128",
+        "isize",
+        "f32",
+        "f64",
+        "serde_json::Number",
+    }:
+        return {"number"}
+    if type_name == "Value":
+        return {"any"}
+    custom = {
+        "Env": {"mapping"},
+        "InputType": {"string"},
+        "JobContinueOnError": {"boolean"},
+        "DeferredBool": {"boolean"},
+        "DeferredNumber": {"number"},
+        "RunsOn": {"one-of"},
+        "Needs": {"one-of"},
+        "Concurrency": {"mapping"},
+        "JobDefaults": {"mapping"},
+        "Strategy": {"mapping"},
+        "Value": {"any"},
+    }
+    return custom.get(type_name, {"opaque"})
+
+
+def schema_type_text(kinds: set[str]) -> str:
+    return "{" + ", ".join(sorted(kinds)) + "}"
+
+
+def type_compatible(model: set[str], schema: set[str]) -> bool:
+    if "any" in model:
+        return "any" in schema
+    if "one-of" in model:
+        return "one-of" in schema or "mapping" in schema or len(schema) > 1
+    if "opaque" in model or "recursive" in model:
+        return False
+    return model <= schema
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--schema", type=Path, default=SCHEMA_PATH)
+    parser.add_argument("--source", type=Path, default=SOURCE_PATH)
+    parser.add_argument("--eval", dest="eval_path", type=Path, default=EVAL_PATH)
+    parser.add_argument("--models", type=Path, default=MODELS_PATH)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        schema = load_json(args.schema, "schema")
+        source_metadata = load_json(args.source, "schema source metadata")
+        verify_schema_source(schema, source_metadata, args.schema)
+        definitions = schema.get("definitions")
+        if not isinstance(definitions, dict):
+            raise AuditError("schema definitions must be an object")
+        eval_source = args.eval_path.read_text()
+        models_source = args.models.read_text()
+        constants = parse_context_constants(eval_source)
+        context_paths = walk_schema(definitions)
+    except (AuditError, OSError, UnicodeDecodeError) as error:
+        print(f"schema audit: ERROR: {error}", file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+    bound_constants: set[str] = set()
+    print(
+        f"schema {schema['version']} commit {source_metadata['commit']} "
+        f"sha256 {source_metadata['sha256']}"
+    )
+    print(f"eval.rs CTX constants: {len(constants)}")
+    print("\nContext fields:")
+    for definition in sorted(context_paths):
+        paths = sorted(context_paths[definition])
+        if definition in CONTEXT_BINDINGS:
+            binding = CONTEXT_BINDINGS[definition]
+            bound_constants.update(binding)
+            schema_values = definitions[definition].get("context")
+            if not isinstance(schema_values, list) or not all(
+                isinstance(value, str) for value in schema_values
+            ):
+                errors.append(f"{definition}: malformed schema context")
+                continue
+            # Every constant in a binding is checked.  Shared bindings are
+            # aliases only by convention; comparing each one prevents a stale
+            # secondary validator from being hidden by the primary constant.
+            missing_constants = [name for name in binding if name not in constants]
+            if missing_constants:
+                errors.append(
+                    f"{definition}: binding references missing "
+                    f"{', '.join(missing_constants)}"
+                )
+            mismatches: list[tuple[str, list[str], list[str]]] = []
+            for constant in binding:
+                if constant not in constants:
+                    continue
+                missing, extra = context_diff(schema_values, constants[constant]["values"])
+                if missing or extra:
+                    mismatches.append((constant, missing, extra))
+            location = ", ".join(
+                f"eval.rs:{constants[name]['line']}" for name in binding if name in constants
+            )
+            if missing_constants or mismatches:
+                details = [
+                    f"missing constants={missing_constants}"
+                ] if missing_constants else []
+                classification: set[str] = set()
+                if missing_constants:
+                    classification.add("missing-constant")
+                for constant, missing, extra in mismatches:
+                    details.append(
+                        f"{constant}: missing={missing or '-'} extra={extra or '-'}"
+                    )
+                    if missing:
+                        classification.add("wrongly-rejects")
+                    if extra:
+                        classification.add("wrongly-accepts")
+                detail = "; ".join(details)
+                errors.append(f"{definition}: {detail}")
+                print(
+                    f"DIVERGENCE {definition} paths={paths} {detail} "
+                    f"class={'+'.join(sorted(classification))} source={location}"
+                )
+            else:
+                print(
+                    f"OK {definition} paths={paths} contexts={schema_values} "
+                    f"constant={', '.join(binding)} source={location}"
+                )
+        elif definition in CONTEXT_ALLOWLIST:
+            reason = CONTEXT_ALLOWLIST[definition].strip()
+            if not reason:
+                errors.append(f"{definition}: empty context allowlist reason")
+            schema_values = definitions[definition].get("context", [])
+            print(
+                f"ALLOWLISTED {definition} paths={paths} contexts={schema_values} "
+                f"class=wrongly-accepts reason={reason}"
+            )
+        else:
+            errors.append(f"{definition}: no binding or written allowlist reason")
+            print(f"DIVERGENCE {definition} paths={paths} class=unclassified")
+
+    undeclared = sorted(set(constants) - bound_constants)
+    if undeclared:
+        errors.append("unbound CTX constants: " + ", ".join(undeclared))
+        print("DIVERGENCE unbound constants=" + ", ".join(undeclared))
+
+    print("\nModel scalar types:")
+    for check in TYPE_CHECKS:
+        target, schema_name = check["target"], check["schema"]
+        source_target = check.get("source_target", target)
+        declared, line = rust_target_type(models_source, source_target)
+        if "model_type" in check:
+            declared = check["model_type"]
+        schema_spec: Any = schema_name
+        try:
+            expected = schema_kinds(definitions, schema_spec)
+        except AuditError as error:
+            errors.append(f"{target}: {error}")
+            print(f"TYPE ERROR {target}: {error}")
+            continue
+        observed = rust_kinds(declared, target)
+        source_location = f"models.rs:{line}" if line is not None else "models.rs:<missing>"
+        if not observed:
+            reason = TYPE_ALLOWLIST.get(target)
+            if reason:
+                print(
+                    f"TYPE ALLOWLISTED {target} schema={schema_type_text(expected)} "
+                    f"model=<missing> source={source_location} reason={reason}"
+                )
+            else:
+                errors.append(f"{target}: model declaration missing")
+                print(
+                    f"TYPE DIVERGENCE {target} schema={schema_type_text(expected)} "
+                    f"model=<missing> source={source_location} class=type-mismatch"
+                )
+            continue
+        if type_compatible(observed, expected):
+            print(
+                f"TYPE OK {target} schema={schema_type_text(expected)} "
+                f"model={declared} source={source_location}"
+            )
+        else:
+            reason = TYPE_ALLOWLIST.get(target)
+            if reason:
+                print(
+                    f"TYPE ALLOWLISTED {target} schema={schema_type_text(expected)} "
+                    f"model={declared} source={source_location} reason={reason}"
+                )
+            else:
+                errors.append(
+                    f"{target}: schema={schema_type_text(expected)} model={declared}"
+                )
+                print(
+                    f"TYPE DIVERGENCE {target} schema={schema_type_text(expected)} "
+                    f"model={declared} source={source_location} class=type-mismatch"
+                )
+
+    if errors:
+        print(f"\nFAIL: {len(errors)} unallowlisted divergence(s)", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    print(f"\nPASS: {len(context_paths)} context definitions; {len(TYPE_CHECKS)} model type checks")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/conformance/run.sh
+++ b/benchmarks/conformance/run.sh
@@ -34,6 +34,7 @@ cleanup() {
 trap cleanup EXIT
 
 python3 benchmarks/conformance/check_corpus.py
+python3 benchmarks/conformance/check_schema_contexts.py
 
 # The CI recipe already runs the workspace tests. Standalone conformance builds
 # only the server it executes; runner-watch is told not to repeat the suite.

--- a/benchmarks/conformance/schema/SOURCE.json
+++ b/benchmarks/conformance/schema/SOURCE.json
@@ -1,0 +1,10 @@
+{
+  "description": "Authoritative GitHub Actions workflow schema, vendored so the context diff is reproducible.",
+  "repo": "actions/languageservices",
+  "path": "workflow-parser/src/workflow-v1.0.json",
+  "commit": "880ac43bc39b0fd7b735ff7976044289bbea3724",
+  "committed": "2026-08-04T00:53:44Z",
+  "raw_url": "https://raw.githubusercontent.com/actions/languageservices/880ac43bc39b0fd7b735ff7976044289bbea3724/workflow-parser/src/workflow-v1.0.json",
+  "sha256": "ba07953f8becf1eae45c56efdbc2577b8121db9f57ed065a4c43edbfaf444c66",
+  "vendored": "2026-09-12"
+}

--- a/benchmarks/conformance/schema/workflow-v1.0.json
+++ b/benchmarks/conformance/schema/workflow-v1.0.json
@@ -1,0 +1,2797 @@
+{
+  "version": "workflow-v1.0",
+  "definitions": {
+    "workflow-root": {
+      "description": "A workflow file.",
+      "mapping": {
+        "properties": {
+          "on": "on",
+          "name": "workflow-name",
+          "description": "workflow-description",
+          "run-name": "run-name",
+          "defaults": "workflow-defaults",
+          "env": "workflow-env",
+          "permissions": "permissions",
+          "concurrency": "workflow-concurrency",
+          "jobs": {
+            "type": "jobs",
+            "required": true
+          }
+        }
+      }
+    },
+    "workflow-root-strict": {
+      "description": "Workflow file with strict validation",
+      "mapping": {
+        "properties": {
+          "on": {
+            "type": "on-strict",
+            "required": true
+          },
+          "name": "workflow-name",
+          "description": "workflow-description",
+          "run-name": "run-name",
+          "defaults": "workflow-defaults",
+          "env": "workflow-env",
+          "permissions": "permissions",
+          "concurrency": "workflow-concurrency",
+          "jobs": {
+            "type": "jobs",
+            "required": true
+          }
+        }
+      }
+    },
+    "workflow-name": {
+      "description": "The name of the workflow that GitHub displays on your repository's 'Actions' tab.\n\n[Documentation](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#name)",
+      "string": {}
+    },
+    "workflow-description": {
+      "description": "A description for your workflow or reusable workflow",
+      "string": {}
+    },
+    "run-name": {
+      "context": [
+        "github",
+        "inputs",
+        "vars"
+      ],
+      "string": {},
+      "description": "The name for workflow runs generated from the workflow. GitHub displays the workflow run name in the list of workflow runs on your repository's 'Actions' tab.\n\n[Documentation](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#run-name)"
+    },
+    "on": {
+      "description": "The GitHub event that triggers the workflow. Events can be a single string, array of events, array of event types, or an event configuration map that schedules a workflow or restricts the execution of a workflow to specific files, tags, or branch changes. View a full list of [events that trigger workflows](https://docs.github.com/actions/using-workflows/events-that-trigger-workflows).\n\n[Documentation](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#on)",
+      "one-of": [
+        "string",
+        "sequence",
+        "on-mapping"
+      ]
+    },
+    "on-mapping": {
+      "mapping": {
+        "properties": {
+          "workflow_call": "workflow-call"
+        },
+        "loose-key-type": "non-empty-string",
+        "loose-value-type": "any"
+      }
+    },
+    "on-strict": {
+      "description": "The GitHub event that triggers the workflow.  Events can be a single string, array of events, array of event types, or an event configuration map that schedules a workflow or restricts the execution of a workflow to specific files, tags, or branch changes. View a full list of [events that trigger workflows](https://docs.github.com/actions/using-workflows/events-that-trigger-workflows).\n\n[Documentation](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#on)",
+      "one-of": [
+        "on-string-strict",
+        "on-sequence-strict",
+        "on-mapping-strict"
+      ]
+    },
+    "on-mapping-strict": {
+      "description": "The GitHub event that triggers the workflow.  Events can be a single string, array of events, array of event types, or an event configuration map that schedules a workflow or restricts the execution of a workflow to specific files, tags, or branch changes. View a full list of [events that trigger workflows](https://docs.github.com/actions/using-workflows/events-that-trigger-workflows).\n\n[Documentation](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#on)",
+      "mapping": {
+        "properties": {
+          "branch_protection_rule": "branch-protection-rule",
+          "check_run": "check-run",
+          "check_suite": "check-suite",
+          "create": "create",
+          "delete": "delete",
+          "deployment": "deployment",
+          "deployment_status": "deployment-status",
+          "discussion": "discussion",
+          "discussion_comment": "discussion-comment",
+          "fork": "fork",
+          "gollum": "gollum",
+          "image_version": "image-version",
+          "issue_comment": "issue-comment",
+          "issues": "issues",
+          "label": "label",
+          "merge_group": "merge-group",
+          "milestone": "milestone",
+          "page_build": "page-build",
+          "project": "project",
+          "project_card": "project-card",
+          "project_column": "project-column",
+          "public": "public",
+          "pull_request": "pull-request",
+          "pull_request_comment": "pull-request-comment",
+          "pull_request_review": "pull-request-review",
+          "pull_request_review_comment": "pull-request-review-comment",
+          "pull_request_target": "pull-request-target",
+          "push": "push",
+          "registry_package": "registry-package",
+          "release": "release",
+          "repository_dispatch": "repository-dispatch",
+          "schedule": "schedule",
+          "status": "status",
+          "watch": "watch",
+          "workflow_call": "workflow-call",
+          "workflow_dispatch": "workflow-dispatch",
+          "workflow_run": "workflow-run"
+        }
+      }
+    },
+    "on-string-strict": {
+      "one-of": [
+        "branch-protection-rule-string",
+        "check-run-string",
+        "check-suite-string",
+        "create-string",
+        "delete-string",
+        "deployment-string",
+        "deployment-status-string",
+        "discussion-string",
+        "discussion-comment-string",
+        "fork-string",
+        "gollum-string",
+        "image-version-string",
+        "issue-comment-string",
+        "issues-string",
+        "label-string",
+        "merge-group-string",
+        "milestone-string",
+        "page-build-string",
+        "project-string",
+        "project-card-string",
+        "project-column-string",
+        "public-string",
+        "pull-request-string",
+        "pull-request-comment-string",
+        "pull-request-review-string",
+        "pull-request-review-comment-string",
+        "pull-request-target-string",
+        "push-string",
+        "registry-package-string",
+        "release-string",
+        "repository-dispatch-string",
+        "schedule-string",
+        "status-string",
+        "watch-string",
+        "workflow-call-string",
+        "workflow-dispatch-string",
+        "workflow-run-string"
+      ]
+    },
+    "on-sequence-strict": {
+      "sequence": {
+        "item-type": "on-string-strict"
+      }
+    },
+    "branch-protection-rule-string": {
+      "description": "Runs your workflow when branch protection rules in the workflow repository are changed.",
+      "string": {
+        "constant": "branch_protection_rule"
+      }
+    },
+    "branch-protection-rule": {
+      "description": "Runs your workflow when branch protection rules in the workflow repository are changed.",
+      "one-of": [
+        "null",
+        "branch-protection-rule-mapping"
+      ]
+    },
+    "branch-protection-rule-mapping": {
+      "mapping": {
+        "properties": {
+          "types": "branch-protection-rule-activity"
+        }
+      }
+    },
+    "branch-protection-rule-activity": {
+      "description": "The types of branch protection rule activity that trigger the workflow. Supported activity types: `created`, `edited`, `deleted`.",
+      "one-of": [
+        "branch-protection-rule-activity-type",
+        "branch-protection-rule-activity-types"
+      ]
+    },
+    "branch-protection-rule-activity-types": {
+      "sequence": {
+        "item-type": "branch-protection-rule-activity-type"
+      }
+    },
+    "branch-protection-rule-activity-type": {
+      "allowed-values": [
+        "created",
+        "edited",
+        "deleted"
+      ]
+    },
+    "check-run-string": {
+      "description": "Runs your workflow when activity related to a check run occurs. A check run is an individual test that is part of a check suite.",
+      "string": {
+        "constant": "check_run"
+      }
+    },
+    "check-run": {
+      "description": "Runs your workflow when activity related to a check run occurs. A check run is an individual test that is part of a check suite.",
+      "one-of": [
+        "null",
+        "check-run-mapping"
+      ]
+    },
+    "check-run-mapping": {
+      "mapping": {
+        "properties": {
+          "types": "check-run-activity"
+        }
+      }
+    },
+    "check-run-activity": {
+      "description": "The types of check run activity that trigger the workflow. Supported activity types: `created`, `rerequested`, `completed`, `requested_action`.",
+      "one-of": [
+        "check-run-activity-type",
+        "check-run-activity-types"
+      ]
+    },
+    "check-run-activity-types": {
+      "sequence": {
+        "item-type": "check-run-activity-type"
+      }
+    },
+    "check-run-activity-type": {
+      "allowed-values": [
+        "completed",
+        "created",
+        "rerequested",
+        "requested_action"
+      ]
+    },
+    "check-suite-string": {
+      "description": "Runs your workflow when check suite activity occurs. A check suite is a collection of the check runs created for a specific commit. Check suites summarize the status and conclusion of the check runs that are in the suite.",
+      "string": {
+        "constant": "check_suite"
+      }
+    },
+    "check-suite": {
+      "description": "Runs your workflow when check suite activity occurs. A check suite is a collection of the check runs created for a specific commit. Check suites summarize the status and conclusion of the check runs that are in the suite.",
+      "one-of": [
+        "null",
+        "check-suite-mapping"
+      ]
+    },
+    "check-suite-mapping": {
+      "mapping": {
+        "properties": {
+          "types": "check-suite-activity"
+        }
+      }
+    },
+    "check-suite-activity": {
+      "description": "The types of check suite activity that trigger the workflow. Supported activity types: `completed`.",
+      "one-of": [
+        "check-suite-activity-type",
+        "check-suite-activity-types"
+      ]
+    },
+    "check-suite-activity-types": {
+      "sequence": {
+        "item-type": "check-suite-activity-type"
+      }
+    },
+    "check-suite-activity-type": {
+      "allowed-values": [
+        "completed"
+      ]
+    },
+    "create-string": {
+      "description": "Runs your workflow when someone creates a Git reference (Git branch or tag) in the workflow's repository.",
+      "string": {
+        "constant": "create"
+      }
+    },
+    "create": {
+      "description": "Runs your workflow when someone creates a Git reference (Git branch or tag) in the workflow's repository.",
+      "null": {}
+    },
+    "delete-string": {
+      "description": "Runs your workflow when someone deletes a Git reference (Git branch or tag) in the workflow's repository.",
+      "string": {
+        "constant": "delete"
+      }
+    },
+    "delete": {
+      "description": "Runs your workflow when someone deletes a Git reference (Git branch or tag) in the workflow's repository.",
+      "null": {}
+    },
+    "deployment-string": {
+      "description": "Runs your workflow when someone creates a deployment in the workflow's repository. Deployments created with a commit SHA may not have a Git ref.",
+      "string": {
+        "constant": "deployment"
+      }
+    },
+    "deployment": {
+      "description": "Runs your workflow when someone creates a deployment in the workflow's repository. Deployments created with a commit SHA may not have a Git ref.",
+      "null": {}
+    },
+    "deployment-status-string": {
+      "description": "Runs your workflow when a third party provides a deployment status. Deployments created with a commit SHA may not have a Git ref.",
+      "string": {
+        "constant": "deployment_status"
+      }
+    },
+    "deployment-status": {
+      "description": "Runs your workflow when a third party provides a deployment status. Deployments created with a commit SHA may not have a Git ref.",
+      "null": {}
+    },
+    "discussion-string": {
+      "description": "Runs your workflow when a discussion in the workflow's repository is created or modified. For activity related to comments on a discussion, use the `discussion_comment` event.",
+      "string": {
+        "constant": "discussion"
+      }
+    },
+    "discussion": {
+      "description": "Runs your workflow when a discussion in the workflow's repository is created or modified. For activity related to comments on a discussion, use the `discussion_comment` event.",
+      "one-of": [
+        "null",
+        "discussion-mapping"
+      ]
+    },
+    "discussion-mapping": {
+      "mapping": {
+        "properties": {
+          "types": "discussion-activity"
+        }
+      }
+    },
+    "discussion-activity": {
+      "description": "The types of discussion activity that trigger the workflow. Supported activity types: `created`, `edited`, `deleted`, `transferred`, `pinned`, `unpinned`, `labeled`, `unlabeled`, `locked`, `unlocked`, `category_changed`, `answered`, `unanswered`.",
+      "one-of": [
+        "discussion-activity-type",
+        "discussion-activity-types"
+      ]
+    },
+    "discussion-activity-types": {
+      "sequence": {
+        "item-type": "discussion-activity-type"
+      }
+    },
+    "discussion-activity-type": {
+      "allowed-values": [
+        "created",
+        "edited",
+        "deleted",
+        "transferred",
+        "pinned",
+        "unpinned",
+        "labeled",
+        "unlabeled",
+        "locked",
+        "unlocked",
+        "category_changed",
+        "answered",
+        "unanswered"
+      ]
+    },
+    "discussion-comment-string": {
+      "description": "Runs your workflow when a comment on a discussion in the workflow's repository is created or modified. For activity related to a discussion as opposed to comments on the discussion, use the `discussion` event.",
+      "string": {
+        "constant": "discussion_comment"
+      }
+    },
+    "discussion-comment": {
+      "description": "Runs your workflow when a comment on a discussion in the workflow's repository is created or modified. For activity related to a discussion as opposed to comments on the discussion, use the `discussion` event.",
+      "one-of": [
+        "null",
+        "discussion-comment-mapping"
+      ]
+    },
+    "discussion-comment-mapping": {
+      "mapping": {
+        "properties": {
+          "types": "discussion-comment-activity"
+        }
+      }
+    },
+    "discussion-comment-activity": {
+      "description": "The types of discussion comment activity that trigger the workflow. Supported activity types: `created`, `edited`, `deleted`.",
+      "one-of": [
+        "discussion-comment-activity-type",
+        "discussion-comment-activity-types"
+      ]
+    },
+    "discussion-comment-activity-types": {
+      "sequence": {
+        "item-type": "discussion-comment-activity-type"
+      }
+    },
+    "discussion-comment-activity-type": {
+      "allowed-values": [
+        "created",
+        "edited",
+        "deleted"
+      ]
+    },
+    "fork-string": {
+      "description": "Runs your workflow when someone forks a repository.",
+      "string": {
+        "constant": "fork"
+      }
+    },
+    "fork": {
+      "description": "Runs your workflow when someone forks a repository.",
+      "null": {}
+    },
+    "gollum-string": {
+      "description": "Runs your workflow when someone creates or updates a Wiki page.",
+      "string": {
+        "constant": "gollum"
+      }
+    },
+    "gollum": {
+      "description": "Runs your workflow when someone creates or updates a Wiki page.",
+      "null": {}
+    },
+    "image-version-string": {
+      "description": "Runs your workflow when an image version is created or changes state.",
+      "string": {
+        "constant": "image_version"
+      }
+    },
+    "image-version": {
+      "description": "Runs your workflow when an image version is created or changes state.",
+      "one-of": [
+        "null",
+        "image-version-mapping"
+      ]
+    },
+    "image-version-mapping": {
+      "mapping": {
+        "properties": {
+          "types": "image-version-activity",
+          "names": "event-names",
+          "versions": "event-versions"
+        }
+      }
+    },
+    "image-version-activity": {
+      "description": "The types of image version activity that trigger the workflow. Supported activity types: `created`, `ready`, `deleted`.",
+      "one-of": [
+        "image-version-activity-type",
+        "image-version-activity-types"
+      ]
+    },
+    "image-version-activity-types": {
+      "sequence": {
+        "item-type": "image-version-activity-type"
+      }
+    },
+    "image-version-activity-type": {
+      "allowed-values": [
+        "created",
+        "ready",
+        "deleted"
+      ]
+    },
+    "issue-comment-string": {
+      "description": "Runs your workflow when an issue or pull request comment is created, edited, or deleted.",
+      "string": {
+        "constant": "issue_comment"
+      }
+    },
+    "issue-comment": {
+      "description": "Runs your workflow when an issue or pull request comment is created, edited, or deleted.",
+      "one-of": [
+        "null",
+        "issue-comment-mapping"
+      ]
+    },
+    "issue-comment-mapping": {
+      "mapping": {
+        "properties": {
+          "types": "issue-comment-activity"
+        }
+      }
+    },
+    "issue-comment-activity": {
+      "description": "The types of issue comment activity that trigger the workflow. Supported activity types: `created`, `edited`, `deleted`.",
+      "one-of": [
+        "issue-comment-activity-type",
+        "issue-comment-activity-types"
+      ]
+    },
+    "issue-comment-activity-types": {
+      "sequence": {
+        "item-type": "issue-comment-activity-type"
+      }
+    },
+    "issue-comment-activity-type": {
+      "allowed-values": [
+        "created",
+        "edited",
+        "deleted"
+      ]
+    },
+    "issues-string": {
+      "description": "Runs your workflow when an issue in the workflow's repository is created or modified. For activity related to comments in an issue, use the `issue_comment` event.",
+      "string": {
+        "constant": "issues"
+      }
+    },
+    "issues": {
+      "description": "Runs your workflow when an issue in the workflow's repository is created or modified. For activity related to comments in an issue, use the `issue_comment` event.",
+      "one-of": [
+        "null",
+        "issues-mapping"
+      ]
+    },
+    "issues-mapping": {
+      "mapping": {
+        "properties": {
+          "types": "issues-activity"
+        }
+      }
+    },
+    "issues-activity": {
+      "description": "The types of issue activity that trigger the workflow. Supported activity types: `opened`, `edited`, `deleted`, `transferred`, `pinned`, `unpinned`, `closed`, `reopened`, `assigned`, `unassigned`, `labeled`, `unlabeled`, `locked`, `unlocked`, `milestoned`, `demilestoned`, `field_added`, `field_removed`, `typed`, `untyped`.",
+      "one-of": [
+        "issues-activity-type",
+        "issues-activity-types"
+      ]
+    },
+    "issues-activity-types": {
+      "sequence": {
+        "item-type": "issues-activity-type"
+      }
+    },
+    "issues-activity-type": {
+      "allowed-values": [
+        "opened",
+        "edited",
+        "deleted",
+        "transferred",
+        "pinned",
+        "unpinned",
+        "closed",
+        "reopened",
+        "assigned",
+        "unassigned",
+        "labeled",
+        "unlabeled",
+        "locked",
+        "unlocked",
+        "milestoned",
+        "demilestoned",
+        "field_added",
+        "field_removed",
+        "typed",
+        "untyped"
+      ]
+    },
+    "label-string": {
+      "description": "Runs your workflow when a label in your workflow's repository is created or modified.",
+      "string": {
+        "constant": "label"
+      }
+    },
+    "label": {
+      "description": "Runs your workflow when a label in your workflow's repository is created or modified.",
+      "one-of": [
+        "null",
+        "label-mapping"
+      ]
+    },
+    "label-mapping": {
+      "mapping": {
+        "properties": {
+          "types": "label-activity"
+        }
+      }
+    },
+    "label-activity": {
+      "description": "The types of label activity that trigger the workflow. Supported activity types: `created`, `edited`, `deleted`.",
+      "one-of": [
+        "label-activity-type",
+        "label-activity-types"
+      ]
+    },
+    "label-activity-types": {
+      "sequence": {
+        "item-type": "label-activity-type"
+      }
+    },
+    "label-activity-type": {
+      "allowed-values": [
+        "created",
+        "edited",
+        "deleted"
+      ]
+    },
+    "merge-group-string": {
+      "description": "Runs your workflow when a pull request is added to a merge queue, which adds the pull request to a merge group.",
+      "string": {
+        "constant": "merge_group"
+      }
+    },
+    "merge-group": {
+      "description": "Runs your workflow when a pull request is added to a merge queue, which adds the pull request to a merge group.",
+      "one-of": [
+        "null",
+        "merge-group-mapping"
+      ]
+    },
+    "merge-group-mapping": {
+      "mapping": {
+        "properties": {
+          "types": "merge-group-activity",
+          "branches": "event-branches",
+          "branches-ignore": "event-branches-ignore"
+        }
+      }
+    },
+    "merge-group-activity": {
+      "description": "The types of merge group activity that trigger the workflow. Supported activity types: `checks_requested`.",
+      "one-of": [
+        "merge-group-activity-type",
+        "merge-group-activity-types"
+      ]
+    },
+    "merge-group-activity-types": {
+      "sequence": {
+        "item-type": "merge-group-activity-type"
+      }
+    },
+    "merge-group-activity-type": {
+      "allowed-values": [
+        "checks_requested"
+      ]
+    },
+    "milestone-string": {
+      "description": "Runs your workflow when a milestone in the workflow's repository is created or modified.",
+      "string": {
+        "constant": "milestone"
+      }
+    },
+    "milestone": {
+      "description": "Runs your workflow when a milestone in the workflow's repository is created or modified.",
+      "one-of": [
+        "null",
+        "milestone-mapping"
+      ]
+    },
+    "milestone-mapping": {
+      "mapping": {
+        "properties": {
+          "types": "milestone-activity"
+        }
+      }
+    },
+    "milestone-activity": {
+      "description": "The types of milestone activity that trigger the workflow. Supported activity types: `created`, `closed`, `opened`, `edited`, `deleted`.",
+      "one-of": [
+        "milestone-activity-type",
+        "milestone-activity-types"
+      ]
+    },
+    "milestone-activity-types": {
+      "sequence": {
+        "item-type": "milestone-activity-type"
+      }
+    },
+    "milestone-activity-type": {
+      "allowed-values": [
+        "created",
+        "closed",
+        "opened",
+        "edited",
+        "deleted"
+      ]
+    },
+    "page-build-string": {
+      "description": "Runs your workflow when someone pushes to a branch that is the publishing source for GitHub Pages, if GitHub Pages is enabled for the repository.",
+      "string": {
+        "constant": "page_build"
+      }
+    },
+    "page-build": {
+      "description": "Runs your workflow when someone pushes to a branch that is the publishing source for GitHub Pages, if GitHub Pages is enabled for the repository.",
+      "null": {}
+    },
+    "project-string": {
+      "description": "Runs your workflow when a project board is created or modified. For activity related to cards or columns in a project board, use the `project_card` or `project_column` events instead.",
+      "string": {
+        "constant": "project"
+      }
+    },
+    "project": {
+      "description": "Runs your workflow when a project board is created or modified. For activity related to cards or columns in a project board, use the `project_card` or `project_column` events instead.",
+      "one-of": [
+        "null",
+        "project-mapping"
+      ]
+    },
+    "project-mapping": {
+      "mapping": {
+        "properties": {
+          "types": "project-activity"
+        }
+      }
+    },
+    "project-activity": {
+      "description": "The types of project activity that trigger the workflow. Supported activity types: `created`, `closed`, `reopened`, `edited`, `deleted`.",
+      "one-of": [
+        "project-activity-type",
+        "project-activity-types"
+      ]
+    },
+    "project-activity-types": {
+      "sequence": {
+        "item-type": "project-activity-type"
+      }
+    },
+    "project-activity-type": {
+      "allowed-values": [
+        "created",
+        "closed",
+        "reopened",
+        "edited",
+        "deleted"
+      ]
+    },
+    "project-card-string": {
+      "description": "Runs your workflow when a card on a project board is created or modified. For activity related to project boards or columns in a project board, use the `project` or `project_column` event instead.",
+      "string": {
+        "constant": "project_card"
+      }
+    },
+    "project-card": {
+      "description": "Runs your workflow when a card on a project board is created or modified. For activity related to project boards or columns in a project board, use the `project` or `project_column` event instead.",
+      "one-of": [
+        "null",
+        "project-card-mapping"
+      ]
+    },
+    "project-card-mapping": {
+      "mapping": {
+        "properties": {
+          "types": "project-card-activity"
+        }
+      }
+    },
+    "project-card-activity": {
+      "description": "The types of project card activity that trigger the workflow. Supported activity types: `created`, `moved`, `converted`, `edited`, `deleted`.",
+      "one-of": [
+        "project-card-activity-type",
+        "project-card-activity-types"
+      ]
+    },
+    "project-card-activity-types": {
+      "sequence": {
+        "item-type": "project-card-activity-type"
+      }
+    },
+    "project-card-activity-type": {
+      "allowed-values": [
+        "created",
+        "moved",
+        "converted",
+        "edited",
+        "deleted"
+      ]
+    },
+    "project-column-string": {
+      "description": "Runs your workflow when a column on a project board is created or modified. For activity related to project boards or cards in a project board, use the `project` or `project_card` event instead.",
+      "string": {
+        "constant": "project_column"
+      }
+    },
+    "project-column": {
+      "description": "Runs your workflow when a column on a project board is created or modified. For activity related to project boards or cards in a project board, use the `project` or `project_card` event instead.",
+      "one-of": [
+        "null",
+        "project-column-mapping"
+      ]
+    },
+    "project-column-mapping": {
+      "mapping": {
+        "properties": {
+          "types": "project-column-activity"
+        }
+      }
+    },
+    "project-column-activity": {
+      "description": "The types of project column activity that trigger the workflow. Supported activity types: `created`, `updated`, `moved`, `deleted`.",
+      "one-of": [
+        "project-column-activity-type",
+        "project-column-activity-types"
+      ]
+    },
+    "project-column-activity-types": {
+      "sequence": {
+        "item-type": "project-column-activity-type"
+      }
+    },
+    "project-column-activity-type": {
+      "allowed-values": [
+        "created",
+        "updated",
+        "moved",
+        "deleted"
+      ]
+    },
+    "public-string": {
+      "description": "Runs your workflow when your workflow's repository changes from private to public.",
+      "string": {
+        "constant": "public"
+      }
+    },
+    "public": {
+      "description": "Runs your workflow when your workflow's repository changes from private to public.",
+      "null": {}
+    },
+    "pull-request-string": {
+      "description": "Runs your workflow when activity on a pull request in the workflow's repository occurs. If no activity types are specified, the workflow runs when a pull request is opened, reopened, or when the head branch of the pull request is updated.",
+      "string": {
+        "constant": "pull_request"
+      }
+    },
+    "pull-request": {
+      "description": "Runs your workflow when activity on a pull request in the workflow's repository occurs. If no activity types are specified, the workflow runs when a pull request is opened, reopened, or when the head branch of the pull request is updated.",
+      "one-of": [
+        "null",
+        "pull-request-mapping"
+      ]
+    },
+    "pull-request-mapping": {
+      "mapping": {
+        "properties": {
+          "types": "pull-request-activity",
+          "branches": "event-branches",
+          "branches-ignore": "event-branches-ignore",
+          "paths": "event-paths",
+          "paths-ignore": "event-paths-ignore"
+        }
+      }
+    },
+    "pull-request-activity": {
+      "description": "The types of pull request activity that trigger the workflow. Supported activity types: `assigned`, `unassigned`, `labeled`, `unlabeled`, `opened`, `edited`, `closed`, `reopened`, `synchronize`, `converted_to_draft`, `locked`, `unlocked`, `enqueued`, `dequeued`, `milestoned`, `demilestoned`, `ready_for_review`, `review_requested`, `review_request_removed`, `auto_merge_enabled`, `auto_merge_disabled`, `stacked`.",
+      "one-of": [
+        "pull-request-activity-type",
+        "pull-request-activity-types"
+      ]
+    },
+    "pull-request-activity-types": {
+      "sequence": {
+        "item-type": "pull-request-activity-type"
+      }
+    },
+    "pull-request-activity-type": {
+      "allowed-values": [
+        "assigned",
+        "unassigned",
+        "labeled",
+        "unlabeled",
+        "opened",
+        "edited",
+        "closed",
+        "reopened",
+        "synchronize",
+        "converted_to_draft",
+        "locked",
+        "unlocked",
+        "enqueued",
+        "dequeued",
+        "milestoned",
+        "demilestoned",
+        "ready_for_review",
+        "review_requested",
+        "review_request_removed",
+        "auto_merge_enabled",
+        "auto_merge_disabled",
+        "stacked"
+      ]
+    },
+    "pull-request-comment-string": {
+      "description": "Please use the `issue_comment` event instead.",
+      "string": {
+        "constant": "pull_request_comment"
+      }
+    },
+    "pull-request-comment": {
+      "description": "Please use the `issue_comment` event instead.",
+      "one-of": [
+        "null",
+        "issue-comment-mapping"
+      ]
+    },
+    "pull-request-review-string": {
+      "description": "Runs your workflow when a pull request review is submitted, edited, or dismissed. A pull request review is a group of pull request review comments in addition to a body comment and a state. For activity related to pull request review comments or pull request comments, use the `pull_request_review_comment` or `issue_comment` events instead.",
+      "string": {
+        "constant": "pull_request_review"
+      }
+    },
+    "pull-request-review": {
+      "description": "Runs your workflow when a pull request review is submitted, edited, or dismissed. A pull request review is a group of pull request review comments in addition to a body comment and a state. For activity related to pull request review comments or pull request comments, use the `pull_request_review_comment` or `issue_comment` events instead.",
+      "one-of": [
+        "null",
+        "pull-request-review-mapping"
+      ]
+    },
+    "pull-request-review-mapping": {
+      "mapping": {
+        "properties": {
+          "types": "pull-request-review-activity"
+        }
+      }
+    },
+    "pull-request-review-activity": {
+      "description": "The types of pull request review activity that trigger the workflow. Supported activity types: `submitted`, `edited`, `dismissed`.",
+      "one-of": [
+        "pull-request-review-activity-type",
+        "pull-request-review-activity-types"
+      ]
+    },
+    "pull-request-review-activity-types": {
+      "sequence": {
+        "item-type": "pull-request-review-activity-type"
+      }
+    },
+    "pull-request-review-activity-type": {
+      "allowed-values": [
+        "submitted",
+        "edited",
+        "dismissed"
+      ]
+    },
+    "pull-request-review-comment-string": {
+      "description": "",
+      "string": {
+        "constant": "pull_request_review_comment"
+      }
+    },
+    "pull-request-review-comment": {
+      "description": "",
+      "one-of": [
+        "null",
+        "pull-request-review-comment-mapping"
+      ]
+    },
+    "pull-request-review-comment-mapping": {
+      "mapping": {
+        "properties": {
+          "types": "pull-request-review-comment-activity"
+        }
+      }
+    },
+    "pull-request-review-comment-activity": {
+      "description": "The types of pull request review comment activity that trigger the workflow. Supported activity types: `created`, `edited`, `deleted`.",
+      "one-of": [
+        "pull-request-review-comment-activity-type",
+        "pull-request-review-comment-activity-types"
+      ]
+    },
+    "pull-request-review-comment-activity-types": {
+      "sequence": {
+        "item-type": "pull-request-review-comment-activity-type"
+      }
+    },
+    "pull-request-review-comment-activity-type": {
+      "allowed-values": [
+        "created",
+        "edited",
+        "deleted"
+      ]
+    },
+    "pull-request-target-string": {
+      "description": "Runs your workflow when activity on a pull request in the workflow's repository occurs. If no activity types are specified, the workflow runs when a pull request is opened, reopened, or when the head branch of the pull request is updated.\n\nThis event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the `pull_request` event does. This prevents execution of unsafe code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow. This event allows your workflow to do things like label or comment on pull requests from forks. Avoid using this event if you need to build or run code from the pull request.",
+      "string": {
+        "constant": "pull_request_target"
+      }
+    },
+    "pull-request-target": {
+      "description": "Runs your workflow when activity on a pull request in the workflow's repository occurs. If no activity types are specified, the workflow runs when a pull request is opened, reopened, or when the head branch of the pull request is updated.\n\nThis event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the `pull_request` event does. This prevents execution of unsafe code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow. This event allows your workflow to do things like label or comment on pull requests from forks. Avoid using this event if you need to build or run code from the pull request.",
+      "one-of": [
+        "null",
+        "pull-request-target-mapping"
+      ]
+    },
+    "pull-request-target-mapping": {
+      "mapping": {
+        "properties": {
+          "types": "pull-request-target-activity",
+          "branches": "event-branches",
+          "branches-ignore": "event-branches-ignore",
+          "paths": "event-paths",
+          "paths-ignore": "event-paths-ignore"
+        }
+      }
+    },
+    "pull-request-target-activity": {
+      "description": "The types of pull request activity that trigger the workflow. Supported activity types: `assigned`, `unassigned`, `labeled`, `unlabeled`, `opened`, `edited`, `closed`, `reopened`, `synchronize`, `converted_to_draft`, `locked`, `unlocked`, `enqueued`, `dequeued`, `milestoned`, `demilestoned`, `ready_for_review`, `review_requested`, `review_request_removed`, `auto_merge_enabled`, `auto_merge_disabled`, `stacked`.",
+      "one-of": [
+        "pull-request-target-activity-type",
+        "pull-request-target-activity-types"
+      ]
+    },
+    "pull-request-target-activity-types": {
+      "sequence": {
+        "item-type": "pull-request-target-activity-type"
+      }
+    },
+    "pull-request-target-activity-type": {
+      "allowed-values": [
+        "assigned",
+        "unassigned",
+        "labeled",
+        "unlabeled",
+        "opened",
+        "edited",
+        "closed",
+        "reopened",
+        "synchronize",
+        "converted_to_draft",
+        "locked",
+        "unlocked",
+        "enqueued",
+        "dequeued",
+        "milestoned",
+        "demilestoned",
+        "ready_for_review",
+        "review_requested",
+        "review_request_removed",
+        "auto_merge_enabled",
+        "auto_merge_disabled",
+        "stacked"
+      ]
+    },
+    "push-string": {
+      "description": "Runs your workflow when you push a commit or tag.",
+      "string": {
+        "constant": "push"
+      }
+    },
+    "push": {
+      "description": "Runs your workflow when you push a commit or tag.",
+      "one-of": [
+        "null",
+        "push-mapping"
+      ]
+    },
+    "push-mapping": {
+      "mapping": {
+        "properties": {
+          "branches": "event-branches",
+          "branches-ignore": "event-branches-ignore",
+          "tags": "event-tags",
+          "tags-ignore": "event-tags-ignore",
+          "paths": "event-paths",
+          "paths-ignore": "event-paths-ignore"
+        }
+      }
+    },
+    "registry-package-string": {
+      "description": "Runs your workflow when activity related to GitHub Packages occurs in your repository.",
+      "string": {
+        "constant": "registry_package"
+      }
+    },
+    "registry-package": {
+      "description": "Runs your workflow when activity related to GitHub Packages occurs in your repository.",
+      "one-of": [
+        "null",
+        "registry-package-mapping"
+      ]
+    },
+    "registry-package-mapping": {
+      "mapping": {
+        "properties": {
+          "types": "registry-package-activity"
+        }
+      }
+    },
+    "registry-package-activity": {
+      "description": "The types of registry package activity that trigger the workflow. Supported activity types: `published`, `updated`.",
+      "one-of": [
+        "registry-package-activity-type",
+        "registry-package-activity-types"
+      ]
+    },
+    "registry-package-activity-types": {
+      "sequence": {
+        "item-type": "registry-package-activity-type"
+      }
+    },
+    "registry-package-activity-type": {
+      "allowed-values": [
+        "published",
+        "updated"
+      ]
+    },
+    "release-string": {
+      "description": "Runs your workflow when release activity in your repository occurs.",
+      "string": {
+        "constant": "release"
+      }
+    },
+    "release": {
+      "description": "Runs your workflow when release activity in your repository occurs.",
+      "one-of": [
+        "null",
+        "release-mapping"
+      ]
+    },
+    "release-mapping": {
+      "mapping": {
+        "properties": {
+          "types": "release-activity"
+        }
+      }
+    },
+    "release-activity": {
+      "description": "The types of release activity that trigger the workflow. Supported activity types: `published`, `unpublished`, `created`, `edited`, `deleted`, `prereleased`, `released`.",
+      "one-of": [
+        "release-activity-type",
+        "release-activity-types"
+      ]
+    },
+    "release-activity-types": {
+      "sequence": {
+        "item-type": "release-activity-type"
+      }
+    },
+    "release-activity-type": {
+      "allowed-values": [
+        "published",
+        "unpublished",
+        "created",
+        "edited",
+        "deleted",
+        "prereleased",
+        "released"
+      ]
+    },
+    "schedule-string": {
+      "description": "The `schedule` event allows you to trigger a workflow at a scheduled time.\n\nYou can schedule a workflow to run at specific UTC times using POSIX cron syntax. Scheduled workflows run on the latest commit on the default or base branch. The shortest interval you can run scheduled workflows is once every 5 minutes. GitHub Actions does not support the non-standard syntax `@yearly`, `@monthly`, `@weekly`, `@daily`, `@hourly`, and `@reboot`.",
+      "string": {
+        "constant": "schedule"
+      }
+    },
+    "schedule": {
+      "description": "The `schedule` event allows you to trigger a workflow at a scheduled time.\n\nYou can schedule a workflow to run at specific UTC times using POSIX cron syntax. Scheduled workflows run on the latest commit on the default or base branch. The shortest interval you can run scheduled workflows is once every 5 minutes. GitHub Actions does not support the non-standard syntax `@yearly`, `@monthly`, `@weekly`, `@daily`, `@hourly`, and `@reboot`.",
+      "sequence": {
+        "item-type": "cron-mapping"
+      }
+    },
+    "status-string": {
+      "description": "Runs your workflow when the status of a Git commit changes. For example, commits can be marked as `error`, `failure`, `pending`, or `success`. If you want to provide more details about the status change, you may want to use the `check_run` event.",
+      "string": {
+        "constant": "status"
+      }
+    },
+    "status": {
+      "description": "Runs your workflow when the status of a Git commit changes. For example, commits can be marked as `error`, `failure`, `pending`, or `success`. If you want to provide more details about the status change, you may want to use the `check_run` event.",
+      "null": {}
+    },
+    "watch-string": {
+      "description": "Runs your workflow when the workflow's repository is starred.",
+      "string": {
+        "constant": "watch"
+      }
+    },
+    "watch": {
+      "description": "Runs your workflow when the workflow's repository is starred.",
+      "one-of": [
+        "null",
+        "watch-mapping"
+      ]
+    },
+    "watch-mapping": {
+      "mapping": {
+        "properties": {
+          "types": "watch-activity"
+        }
+      }
+    },
+    "watch-activity": {
+      "description": "The types of watch activity that trigger the workflow. Supported activity types: `started`.",
+      "one-of": [
+        "watch-activity-type",
+        "watch-activity-types"
+      ]
+    },
+    "watch-activity-types": {
+      "sequence": {
+        "item-type": "watch-activity-type"
+      }
+    },
+    "watch-activity-type": {
+      "allowed-values": [
+        "started"
+      ]
+    },
+    "workflow-run-string": {
+      "description": "This event occurs when a workflow run is requested or completed. It allows you to execute a workflow based on execution or completion of another workflow. The workflow started by the `workflow_run` event is able to access secrets and write tokens, even if the previous workflow was not. This is useful in cases where the previous workflow is intentionally not privileged, but you need to take a privileged action in a later workflow.",
+      "string": {
+        "constant": "workflow_run"
+      }
+    },
+    "workflow-run": {
+      "description": "This event occurs when a workflow run is requested or completed. It allows you to execute a workflow based on execution or completion of another workflow. The workflow started by the `workflow_run` event is able to access secrets and write tokens, even if the previous workflow was not. This is useful in cases where the previous workflow is intentionally not privileged, but you need to take a privileged action in a later workflow.",
+      "one-of": [
+        "null",
+        "workflow-run-mapping"
+      ]
+    },
+    "workflow-run-mapping": {
+      "mapping": {
+        "properties": {
+          "types": "workflow-run-activity",
+          "workflows": "workflow-run-workflows",
+          "branches": "event-branches",
+          "branches-ignore": "event-branches-ignore"
+        }
+      }
+    },
+    "workflow-run-workflows": {
+      "description": "The name of the workflow that triggers the `workflow_run` event. The workflow must be in the same repository as the workflow that uses the `workflow_run` event.",
+      "one-of": [
+        "non-empty-string",
+        "sequence-of-non-empty-string"
+      ]
+    },
+    "workflow-run-activity": {
+      "description": "The types of workflow run activity that trigger the workflow. Supported activity types: `completed`, `requested`, `in_progress`.",
+      "one-of": [
+        "workflow-run-activity-type",
+        "workflow-run-activity-types"
+      ]
+    },
+    "workflow-run-activity-types": {
+      "sequence": {
+        "item-type": "workflow-run-activity-type"
+      }
+    },
+    "workflow-run-activity-type": {
+      "allowed-values": [
+        "requested",
+        "completed",
+        "in_progress"
+      ]
+    },
+    "event-branches": {
+      "description": "Use the `branches` filter when you want to include branch name patterns or when you want to both include and exclude branch name patterns. You cannot use both the `branches` and `branches-ignore` filters for the same event in a workflow.",
+      "one-of": [
+        "non-empty-string",
+        "sequence-of-non-empty-string"
+      ]
+    },
+    "event-branches-ignore": {
+      "description": "Use the `branches-ignore` filter when you only want to exclude branch name patterns. You cannot use both the `branches` and `branches-ignore` filters for the same event in a workflow.",
+      "one-of": [
+        "non-empty-string",
+        "sequence-of-non-empty-string"
+      ]
+    },
+    "event-names": {
+      "description": "Use the `names` filter when you want to include names via patterns or when you want to both include and exclude names using patterns. ",
+      "one-of": [
+        "non-empty-string",
+        "sequence-of-non-empty-string"
+      ]
+    },
+    "event-tags": {
+      "description": "Use the `tags` filter when you want to include tag name patterns or when you want to both include and exclude tag names patterns. You cannot use both the `tags` and `tags-ignore` filters for the same event in a workflow.",
+      "one-of": [
+        "non-empty-string",
+        "sequence-of-non-empty-string"
+      ]
+    },
+    "event-tags-ignore": {
+      "description": "Use the `tags-ignore` filter when you only want to exclude tag name patterns. You cannot use both the `tags` and `tags-ignore` filters for the same event in a workflow.",
+      "one-of": [
+        "non-empty-string",
+        "sequence-of-non-empty-string"
+      ]
+    },
+    "event-paths": {
+      "description": "Use the `paths` filter when you want to include file path patterns or when you want to both include and exclude file path patterns. You cannot use both the `paths` and `paths-ignore` filters for the same event in a workflow.",
+      "one-of": [
+        "non-empty-string",
+        "sequence-of-non-empty-string"
+      ]
+    },
+    "event-paths-ignore": {
+      "description": "Use the `paths-ignore` filter when you only want to exclude file path patterns. You cannot use both the `paths` and `paths-ignore` filters for the same event in a workflow.",
+      "one-of": [
+        "non-empty-string",
+        "sequence-of-non-empty-string"
+      ]
+    },
+    "event-versions": {
+      "description": "Use the `versions` filter when you want to include versions via patterns or when you want to both include and exclude versions using patterns. ",
+      "one-of": [
+        "non-empty-string",
+        "sequence-of-non-empty-string"
+      ]
+    },
+    "repository-dispatch-string": {
+      "description": "You can use the GitHub API to trigger a webhook event called `repository_dispatch` when you want to trigger a workflow for activity that happens outside of GitHub.",
+      "string": {
+        "constant": "branch_protection_rule"
+      }
+    },
+    "repository-dispatch": {
+      "description": "You can use the GitHub API to trigger a webhook event called `repository_dispatch` when you want to trigger a workflow for activity that happens outside of GitHub.",
+      "one-of": [
+        "null",
+        "repository-dispatch-mapping"
+      ]
+    },
+    "repository-dispatch-mapping": {
+      "mapping": {
+        "properties": {
+          "types": "sequence-of-non-empty-string"
+        }
+      }
+    },
+    "workflow-call-string": {
+      "description": "The `workflow_call` event is used to indicate that a workflow can be called by another workflow. When a workflow is triggered with the `workflow_call` event, the event payload in the called workflow is the same event payload from the calling workflow.",
+      "string": {
+        "constant": "workflow_call"
+      }
+    },
+    "workflow-call": {
+      "description": "The `workflow_call` event is used to indicate that a workflow can be called by another workflow. When a workflow is triggered with the `workflow_call` event, the event payload in the called workflow is the same event payload from the calling workflow.",
+      "one-of": [
+        "null",
+        "workflow-call-mapping"
+      ]
+    },
+    "workflow-call-mapping": {
+      "mapping": {
+        "properties": {
+          "inputs": "workflow-call-inputs",
+          "secrets": "workflow-call-secrets",
+          "outputs": "workflow-call-outputs"
+        }
+      }
+    },
+    "workflow-call-inputs": {
+      "description": "Inputs that are passed to the called workflow from the caller workflow.",
+      "mapping": {
+        "loose-key-type": "non-empty-string",
+        "loose-value-type": "workflow-call-input-definition"
+      }
+    },
+    "workflow-call-input-definition": {
+      "mapping": {
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "A string description of the input parameter."
+          },
+          "type": {
+            "type": "workflow-call-input-type",
+            "required": true
+          },
+          "required": {
+            "type": "boolean",
+            "description": "A boolean to indicate whether the action requires the input parameter. Set to `true` when the parameter is required."
+          },
+          "default": "workflow-call-input-default"
+        }
+      }
+    },
+    "workflow-call-input-type": {
+      "description": "Required if input is defined for the `on.workflow_call` keyword. The value of this parameter is a string specifying the data type of the input. This must be one of: `boolean`, `number`, or `string`.",
+      "one-of": [
+        "input-type-string",
+        "input-type-boolean",
+        "input-type-number"
+      ]
+    },
+    "input-type-string": {
+      "string": {
+        "constant": "string"
+      }
+    },
+    "input-type-boolean": {
+      "string": {
+        "constant": "boolean"
+      }
+    },
+    "input-type-number": {
+      "string": {
+        "constant": "number"
+      }
+    },
+    "input-type-choice": {
+      "string": {
+        "constant": "choice"
+      }
+    },
+    "input-type-environment": {
+      "string": {
+        "constant": "environment"
+      }
+    },
+    "workflow-call-input-default": {
+      "description": "If a `default` parameter is not set, the default value of the input is `false` for boolean, `0` for a number, and `\"\"` for a string.",
+      "context": [
+        "github",
+        "inputs",
+        "vars"
+      ],
+      "one-of": [
+        "string",
+        "boolean",
+        "number"
+      ]
+    },
+    "workflow-call-secrets": {
+      "description": "A map of the secrets that can be used in the called workflow. Within the called workflow, you can use the `secrets` context to refer to a secret.",
+      "mapping": {
+        "loose-key-type": "workflow-call-secret-name",
+        "loose-value-type": "workflow-call-secret-definition"
+      }
+    },
+    "workflow-call-secret-name": {
+      "string": {
+        "require-non-empty": true
+      },
+      "description": "A string identifier to associate with the secret."
+    },
+    "workflow-call-secret-definition": {
+      "one-of": [
+        "null",
+        "workflow-call-secret-mapping-definition"
+      ]
+    },
+    "workflow-call-secret-mapping-definition": {
+      "mapping": {
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "A string description of the secret parameter."
+          },
+          "required": {
+            "type": "boolean",
+            "description": "A boolean specifying whether the secret must be supplied."
+          }
+        }
+      }
+    },
+    "workflow-call-outputs": {
+      "description": "A reusable workflow may generate data that you want to use in the caller workflow. To use these outputs, you must specify them as the outputs of the reusable workflow.",
+      "mapping": {
+        "loose-key-type": "workflow-call-output-name",
+        "loose-value-type": "workflow-call-output-definition"
+      }
+    },
+    "workflow-call-output-name": {
+      "string": {
+        "require-non-empty": true
+      },
+      "description": "A string identifier to associate with the output. The value of `<output_id>` is a map of the input's metadata. The `<output_id>` must be a unique identifier within the outputs object and must start with a letter or _ and contain only alphanumeric characters, -, or _."
+    },
+    "workflow-call-output-definition": {
+      "mapping": {
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "A string description of the output parameter."
+          },
+          "value": {
+            "type": "workflow-output-context",
+            "required": true
+          }
+        }
+      }
+    },
+    "workflow-output-context": {
+      "description": "The value to assign to the output parameter.",
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "jobs"
+      ],
+      "string": {}
+    },
+    "workflow-dispatch-string": {
+      "description": "The `workflow_dispatch` event allows you to manually trigger a workflow run. A workflow can be manually triggered using the GitHub API, GitHub CLI, or GitHub browser interface.",
+      "string": {
+        "constant": "workflow_dispatch"
+      }
+    },
+    "workflow-dispatch": {
+      "description": "The `workflow_dispatch` event allows you to manually trigger a workflow run. A workflow can be manually triggered using the GitHub API, GitHub CLI, or GitHub browser interface.",
+      "one-of": [
+        "null",
+        "workflow-dispatch-mapping"
+      ]
+    },
+    "workflow-dispatch-mapping": {
+      "mapping": {
+        "properties": {
+          "inputs": "workflow-dispatch-inputs"
+        }
+      }
+    },
+    "workflow-dispatch-inputs": {
+      "description": "You can configure custom-defined input properties, default input values, and required inputs for the event directly in your workflow. When you trigger the event, you can provide the `ref` and any `inputs`. When the workflow runs, you can access the input values in the `inputs` context.",
+      "mapping": {
+        "loose-key-type": "workflow-dispatch-input-name",
+        "loose-value-type": "workflow-dispatch-input"
+      }
+    },
+    "workflow-dispatch-input-name": {
+      "string": {
+        "require-non-empty": true
+      },
+      "description": "A string identifier to associate with the input. The value of <input_id> is a map of the input's metadata. The <input_id> must be a unique identifier within the inputs object. The <input_id> must start with a letter or _ and contain only alphanumeric characters, -, or _."
+    },
+    "workflow-dispatch-input": {
+      "mapping": {
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "A string description of the input parameter."
+          },
+          "type": {
+            "type": "workflow-dispatch-input-type"
+          },
+          "required": {
+            "type": "boolean",
+            "description": "A boolean to indicate whether the workflow requires the input parameter. Set to true when the parameter is required."
+          },
+          "default": "workflow-dispatch-input-default",
+          "options": {
+            "type": "sequence-of-string",
+            "description": "The options of the dropdown list, if the type is a choice."
+          }
+        }
+      }
+    },
+    "workflow-dispatch-input-type": {
+      "description": "A string representing the type of the input. This must be one of: `boolean`, `number`, `string`, `choice`, or `environment`.",
+      "one-of": [
+        "input-type-string",
+        "input-type-boolean",
+        "input-type-number",
+        "input-type-environment",
+        "input-type-choice"
+      ]
+    },
+    "workflow-dispatch-input-default": {
+      "description": "The default value is used when an input parameter isn't specified in a workflow file.",
+      "one-of": [
+        "string",
+        "boolean",
+        "number"
+      ]
+    },
+    "permissions": {
+      "description": "You can use `permissions` to modify the default permissions granted to the `GITHUB_TOKEN`, adding or removing access as required, so that you only allow the minimum required access.\n\n[Documentation](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#permissions)",
+      "one-of": [
+        "permissions-mapping",
+        "permission-level-shorthand-read-all",
+        "permission-level-shorthand-write-all"
+      ]
+    },
+    "permissions-mapping": {
+      "mapping": {
+        "properties": {
+          "actions": {
+            "type": "permission-level-any",
+            "description": "Actions workflows, workflow runs, and artifacts."
+          },
+          "artifact-metadata": {
+            "type": "permission-level-any",
+            "description": "Storage and deployment records for build artifacts."
+          },
+          "attestations": {
+            "type": "permission-level-any",
+            "description": "Artifact attestations."
+          },
+          "checks": {
+            "type": "permission-level-any",
+            "description": "Check runs and check suites."
+          },
+          "code-quality": {
+            "type": "permission-level-any",
+            "description": "Code quality data."
+          },
+          "contents": {
+            "type": "permission-level-any",
+            "description": "Repository contents, commits, branches, downloads, releases, and merges."
+          },
+          "copilot-requests": {
+            "type": "permission-level-write-or-no-access",
+            "description": "GitHub Copilot requests."
+          },
+          "deployments": {
+            "type": "permission-level-any",
+            "description": "Deployments and deployment statuses."
+          },
+          "discussions": {
+            "type": "permission-level-any",
+            "description": "Discussions and related comments and labels."
+          },
+          "drives": {
+            "type": "permission-level-any",
+            "description": "GitHub Drives persistent workspace storage. Use `read` for checkout and `write` to commit changes."
+          },
+          "id-token": {
+            "type": "permission-level-write-or-no-access",
+            "description": "Token to request an OpenID Connect token."
+          },
+          "issues": {
+            "type": "permission-level-any",
+            "description": "Issues and related comments, assignees, labels, and milestones."
+          },
+          "models": {
+            "type": "permission-level-read-or-no-access",
+            "description": "Call AI models with GitHub Models."
+          },
+          "packages": {
+            "type": "permission-level-any",
+            "description": "Packages published to the GitHub Package Platform."
+          },
+          "pages": {
+            "type": "permission-level-any",
+            "description": "Retrieve Pages statuses, configuration, and builds, as well as create new builds."
+          },
+          "pull-requests": {
+            "type": "permission-level-any",
+            "description": "Pull requests and related comments, assignees, labels, milestones, and merges."
+          },
+          "repository-projects": {
+            "type": "permission-level-any",
+            "description": "Classic projects within a repository."
+          },
+          "security-events": {
+            "type": "permission-level-any",
+            "description": "Code scanning alerts."
+          },
+          "statuses": {
+            "type": "permission-level-any",
+            "description": "Commit statuses."
+          },
+          "vulnerability-alerts": {
+            "type": "permission-level-read-or-no-access",
+            "description": "Dependabot alerts."
+          }
+        }
+      }
+    },
+    "permission-level-any": {
+      "description": "The permission level for the `GITHUB_TOKEN`.",
+      "one-of": [
+        "permission-level-read",
+        "permission-level-write",
+        "permission-level-no-access"
+      ]
+    },
+    "permission-level-read-or-no-access": {
+      "one-of": [
+        "permission-level-read",
+        "permission-level-no-access"
+      ]
+    },
+    "permission-level-write-or-no-access": {
+      "one-of": [
+        "permission-level-write",
+        "permission-level-no-access"
+      ]
+    },
+    "permission-level-read": {
+      "description": "The permission level for the `GITHUB_TOKEN`. Grants `read` permission for the specified scope.",
+      "string": {
+        "constant": "read"
+      }
+    },
+    "permission-level-write": {
+      "description": "The permission level for the `GITHUB_TOKEN`. Grants `write` permission for the specified scope.",
+      "string": {
+        "constant": "write"
+      }
+    },
+    "permission-level-no-access": {
+      "description": "The permission level for the `GITHUB_TOKEN`. Restricts all access for the specified scope.",
+      "string": {
+        "constant": "none"
+      }
+    },
+    "permission-level-shorthand-read-all": {
+      "description": "The permission level for the `GITHUB_TOKEN`. Grants `read` access for all scopes.",
+      "string": {
+        "constant": "read-all"
+      }
+    },
+    "permission-level-shorthand-write-all": {
+      "description": "The permission level for the `GITHUB_TOKEN`. Grants `write` access for all scopes.",
+      "string": {
+        "constant": "write-all"
+      }
+    },
+    "workflow-defaults": {
+      "description": "Use `defaults` to create a map of default settings that will apply to all jobs in the workflow. You can also set default settings that are only available to a job.\n\n[Documentation](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#defaults)",
+      "mapping": {
+        "properties": {
+          "run": "workflow-defaults-run"
+        }
+      }
+    },
+    "workflow-defaults-run": {
+      "mapping": {
+        "properties": {
+          "shell": "shell",
+          "working-directory": "working-directory"
+        }
+      }
+    },
+    "workflow-env": {
+      "description": "A map of environment variables that are available to the steps of all jobs in the workflow. You can also set environment variables that are only available to the steps of a single job or to a single step.\n\n[Documentation](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#env)",
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "secrets"
+      ],
+      "mapping": {
+        "loose-key-type": "non-empty-string",
+        "loose-value-type": "string"
+      }
+    },
+    "jobs": {
+      "description": "A workflow run is made up of one or more `jobs`, which run in parallel by default. To run jobs sequentially, you can define dependencies on other jobs using the `jobs.<job_id>.needs` keyword. Each job runs in a runner environment specified by `runs-on`.\n\n[Documentation](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#jobs)",
+      "mapping": {
+        "loose-key-type": "job-id",
+        "loose-value-type": "job"
+      }
+    },
+    "job-id": {
+      "string": {
+        "require-non-empty": true
+      },
+      "description": "A unique identifier for the job. The identifier must start with a letter or _ and contain only alphanumeric characters, -, or _."
+    },
+    "job": {
+      "description": "Each job must have an id to associate with the job. The key `job_id` is a string and its value is a map of the job's configuration data. You must replace `<job_id>` with a string that is unique to the jobs object. The `<job_id>` must start with a letter or _ and contain only alphanumeric characters, -, or _.",
+      "one-of": [
+        "job-factory",
+        "workflow-job"
+      ]
+    },
+    "job-factory": {
+      "mapping": {
+        "properties": {
+          "needs": "needs",
+          "if": "job-if",
+          "strategy": "strategy",
+          "name": {
+            "type": "string-strategy-context",
+            "description": "The name of the job displayed on GitHub."
+          },
+          "runs-on": {
+            "type": "runs-on",
+            "required": true
+          },
+          "timeout-minutes": {
+            "type": "number-strategy-context",
+            "description": "The maximum number of minutes to let a workflow run before GitHub automatically cancels it. Default: 360"
+          },
+          "cancel-timeout-minutes": "number-strategy-context",
+          "continue-on-error": {
+            "type": "boolean-strategy-context",
+            "description": "Prevents a workflow run from failing when a job fails. Set to true to allow a workflow run to pass when this job fails."
+          },
+          "container": "container",
+          "services": "services",
+          "env": "job-env",
+          "environment": "job-environment",
+          "permissions": "permissions",
+          "concurrency": "job-concurrency",
+          "outputs": "job-outputs",
+          "defaults": "job-defaults",
+          "steps": "steps",
+          "snapshot": "snapshot"
+        }
+      }
+    },
+    "workflow-job": {
+      "mapping": {
+        "properties": {
+          "name": {
+            "type": "string-strategy-context",
+            "description": "The name of the job displayed on GitHub."
+          },
+          "uses": {
+            "description": "The location and version of a reusable workflow file to run as a job. Use one of the following formats:\n\n* `{owner}/{repo}/.github/workflows/{filename}@{ref}` for reusable workflows in public and private repositories.\n* `./.github/workflows/{filename}` for reusable workflows in the same repository.\n\n{ref} can be a SHA, a release tag, or a branch name. Using the commit SHA is the safest for stability and security.",
+            "type": "non-empty-string",
+            "required": true
+          },
+          "with": "workflow-job-with",
+          "secrets": "workflow-job-secrets",
+          "needs": "needs",
+          "if": "job-if",
+          "permissions": "permissions",
+          "concurrency": "job-concurrency",
+          "strategy": "strategy"
+        }
+      }
+    },
+    "workflow-job-with": {
+      "description": "When a job is used to call a reusable workflow, you can use `with` to provide a map of inputs that are passed to the called workflow.\n\nAny inputs that you pass must match the input specifications defined in the called workflow.",
+      "mapping": {
+        "loose-key-type": "non-empty-string",
+        "loose-value-type": "scalar-needs-context"
+      }
+    },
+    "workflow-job-secrets": {
+      "description": "When a job is used to call a reusable workflow, you can use `secrets` to provide a map of secrets that are passed to the called workflow.\n\nAny secrets that you pass must match the names defined in the called workflow.",
+      "one-of": [
+        "workflow-job-secrets-mapping",
+        "workflow-job-secrets-inherit"
+      ]
+    },
+    "workflow-job-secrets-mapping": {
+      "mapping": {
+        "loose-key-type": "non-empty-string",
+        "loose-value-type": "scalar-needs-context-with-secrets"
+      }
+    },
+    "workflow-job-secrets-inherit": {
+      "string": {
+        "constant": "inherit"
+      }
+    },
+    "needs": {
+      "description": "Use `needs` to identify any jobs that must complete successfully before this job will run. It can be a string or array of strings. If a job fails, all jobs that need it are skipped unless the jobs use a conditional expression that causes the job to continue. If a run contains a series of jobs that need each other, a failure applies to all jobs in the dependency chain from the point of failure onwards.",
+      "one-of": [
+        "sequence-of-non-empty-string",
+        "non-empty-string"
+      ]
+    },
+    "job-if": {
+      "description": "You can use the `if` conditional to prevent a job from running unless a condition is met. You can use any supported context and expression to create a conditional.",
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "always(0,0)",
+        "failure(0,MAX)",
+        "cancelled(0,0)",
+        "success(0,MAX)"
+      ],
+      "string": {}
+    },
+    "job-if-result": {
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "always(0,0)",
+        "failure(0,MAX)",
+        "cancelled(0,0)",
+        "success(0,MAX)"
+      ],
+      "one-of": [
+        "null",
+        "boolean",
+        "number",
+        "string",
+        "sequence",
+        "mapping"
+      ]
+    },
+    "strategy": {
+      "description": "Use `strategy` to use a matrix strategy for your jobs. A matrix strategy lets you use variables in a single job definition to automatically create multiple job runs that are based on the combinations of the variables. ",
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs"
+      ],
+      "mapping": {
+        "properties": {
+          "fail-fast": {
+            "type": "boolean",
+            "description": "Setting `fail-fast` to `false` prevents GitHub from canceling all in-progress jobs if any matrix job fails. Default: `true`"
+          },
+          "max-parallel": {
+            "type": "number",
+            "description": "The maximum number of jobs that can run simultaneously when using a matrix job strategy. By default, GitHub will maximize the number of jobs run in parallel depending on runner availability."
+          },
+          "matrix": "matrix"
+        }
+      }
+    },
+    "matrix": {
+      "description": "Use `matrix` to define a matrix of different job configurations. Within your matrix, define one or more variables followed by an array of values.",
+      "mapping": {
+        "properties": {
+          "include": {
+            "type": "matrix-filter",
+            "description": "Use `include` to expand existing matrix configurations or to add new configurations. The value of `include` is a list of objects.\n\nFor each object in the `include` list, the key:value pairs in the object will be added to each of the matrix combinations if none of the key:value pairs overwrite any of the original matrix values. If the object cannot be added to any of the matrix combinations, a new matrix combination will be created instead. Note that the original matrix values will not be overwritten, but added matrix values can be overwritten."
+          },
+          "exclude": {
+            "type": "matrix-filter",
+            "description": "To remove specific configurations defined in the matrix, use `exclude`. An excluded configuration only has to be a partial match for it to be excluded."
+          }
+        },
+        "loose-key-type": "non-empty-string",
+        "loose-value-type": "sequence"
+      }
+    },
+    "matrix-filter": {
+      "sequence": {
+        "item-type": "matrix-filter-item"
+      }
+    },
+    "matrix-filter-item": {
+      "mapping": {
+        "loose-key-type": "non-empty-string",
+        "loose-value-type": "any"
+      }
+    },
+    "snapshot": {
+      "description": "Use `snapshot` to define a custom image you want to create or update after your job succeeds by taking a snapshot of your runner.",
+      "one-of": [
+        "non-empty-string",
+        "snapshot-mapping"
+      ]
+    },
+    "snapshot-mapping": {
+      "mapping": {
+        "properties": {
+          "image-name": {
+            "description": "The desired name of the custom image you want to create or update.",
+            "type": "non-empty-string",
+            "required": true
+          },
+          "if": "snapshot-if",
+          "version": {
+            "description": "The desired major version updates upon a new custom image version creation.",
+            "type": "non-empty-string"
+          }
+        }
+      }
+    },
+    "snapshot-if": {
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix"
+      ],
+      "description": "Use the if conditional to prevent a snapshot from being taken unless a condition is met. Any supported context and expression can be used to create a conditional. Expressions in an `if` conditional do not require the bracketed expression syntax. When you use expressions in an `if` conditional, you may omit the expression syntax because GitHub automatically evaluates the `if` conditional as an expression.",
+      "string": {}
+    },
+    "runs-on": {
+      "description": "Use `runs-on` to define the type of machine to run the job on.\n* The destination machine can be either a GitHub-hosted runner, larger runner, or a self-hosted runner.\n* You can target runners based on the labels assigned to them, or their group membership, or a combination of these.\n* You can provide `runs-on` as a single string or as an array of strings.\n* If you specify an array of strings, your workflow will execute on any runner that matches all of the specified `runs-on` values.\n* If you would like to run your workflow on multiple machines, use `jobs.<job_id>.strategy`.",
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix"
+      ],
+      "one-of": [
+        "non-empty-string",
+        "sequence-of-non-empty-string",
+        "runs-on-mapping"
+      ]
+    },
+    "runs-on-mapping": {
+      "mapping": {
+        "properties": {
+          "group": {
+            "description": "The group from which to select a runner.",
+            "type": "non-empty-string"
+          },
+          "labels": "runs-on-labels"
+        }
+      }
+    },
+    "runs-on-labels": {
+      "description": "The label by which to filter for available runners.",
+      "one-of": [
+        "non-empty-string",
+        "sequence-of-non-empty-string"
+      ]
+    },
+    "job-env": {
+      "description": "A map of variables that are available to all steps in the job.",
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix",
+        "secrets"
+      ],
+      "mapping": {
+        "loose-key-type": "non-empty-string",
+        "loose-value-type": "string"
+      }
+    },
+    "workflow-concurrency": {
+      "description": "Concurrency ensures that only a single job or workflow using the same concurrency group will run at a time. A concurrency group can be any string or expression.\n\nYou can also specify `concurrency` at the job level.\n\n[Documentation](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#concurrency)",
+      "context": [
+        "github",
+        "inputs",
+        "vars"
+      ],
+      "one-of": [
+        "string",
+        "concurrency-mapping"
+      ]
+    },
+    "job-concurrency": {
+      "description": "Concurrency ensures that only a single job using the same concurrency group will run at a time. A concurrency group can be any string or expression. The expression can use any context except for the `secrets` context.\n\nYou can also specify `concurrency` at the workflow level.",
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix"
+      ],
+      "one-of": [
+        "non-empty-string",
+        "concurrency-mapping"
+      ]
+    },
+    "concurrency-mapping": {
+      "description": "Concurrency ensures that only a single job or workflow using the same concurrency group will run at a time. A concurrency group can be any string or expression.\n\nYou can also specify `concurrency` at the job level.\n\n[Documentation](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#concurrency)",
+      "mapping": {
+        "properties": {
+          "group": {
+            "type": "non-empty-string",
+            "required": true,
+            "description": "When a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be `pending`. Any previously pending job or workflow in the concurrency group will be canceled. To also cancel any currently running job or workflow in the same concurrency group, specify `cancel-in-progress: true`."
+          },
+          "cancel-in-progress": {
+            "type": "boolean",
+            "description": "To cancel any currently running job or workflow in the same concurrency group, specify cancel-in-progress: true."
+          },
+          "queue": {
+            "type": "concurrency-queue",
+            "description": "The queuing mode for the concurrency group. When set to `max`, workflows or jobs will wait in a queue for the concurrency group up to the maximum queue length. Default: `single` meaning at most one item can be pending."
+          }
+        }
+      }
+    },
+    "concurrency-queue": {
+      "allowed-values": [
+        "single",
+        "max"
+      ]
+    },
+    "job-environment": {
+      "description": "The environment that the job references. All environment protection rules must pass before a job referencing the environment is sent to a runner.",
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix"
+      ],
+      "one-of": [
+        "string",
+        "job-environment-mapping"
+      ]
+    },
+    "job-environment-mapping": {
+      "mapping": {
+        "properties": {
+          "name": {
+            "type": "job-environment-name",
+            "required": true
+          },
+          "url": {
+            "type": "string-runner-context-no-secrets",
+            "description": "The environment URL, which maps to `environment_url` in the deployments API."
+          },
+          "deployment": {
+            "type": "boolean",
+            "description": "Whether to create a deployment record for this environment. Defaults to true."
+          }
+        }
+      }
+    },
+    "job-environment-name": {
+      "description": "The name of the environment used by the job.",
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix"
+      ],
+      "string": {}
+    },
+    "job-defaults": {
+      "description": "A map of default settings that will apply to all steps in the job. You can also set default settings for the entire workflow.",
+      "mapping": {
+        "properties": {
+          "run": "job-defaults-run"
+        }
+      }
+    },
+    "job-defaults-run": {
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "strategy",
+        "matrix",
+        "needs",
+        "env"
+      ],
+      "mapping": {
+        "properties": {
+          "shell": "shell",
+          "working-directory": "working-directory"
+        }
+      }
+    },
+    "job-outputs": {
+      "description": "A map of outputs for a called workflow. Called workflow outputs are available to all downstream jobs in the caller workflow. Each output has an identifier, an optional `description,` and a `value`. The `value` must be set to the value of an output from a job within the called workflow.",
+      "mapping": {
+        "loose-key-type": "non-empty-string",
+        "loose-value-type": "string-runner-context"
+      }
+    },
+    "steps": {
+      "description": "A job contains a sequence of tasks called `steps`. Steps can run commands, run setup tasks, run an action in your repository, a public repository, or an action published in a Docker registry, wait for background steps to complete, or cancel a background step. Not all steps run actions, but all actions run as a step. Each step runs in its own process in the runner environment and has access to the workspace and filesystem. Because steps run in their own process, changes to environment variables are not preserved between steps. GitHub provides built-in steps to set up and complete a job.",
+      "sequence": {
+        "item-type": "steps-item"
+      }
+    },
+    "steps-item": {
+      "one-of": [
+        "run-step",
+        "regular-step",
+        "wait-step",
+        "wait-all-step",
+        "cancel-step",
+        "parallel-step"
+      ]
+    },
+    "run-step": {
+      "mapping": {
+        "properties": {
+          "name": "step-name",
+          "id": "step-id",
+          "if": "step-if",
+          "timeout-minutes": "step-timeout-minutes",
+          "run": {
+            "type": "string-steps-context",
+            "description": "Runs command-line programs using the operating system's shell. If you do not provide a `name`, the step name will default to the text specified in the `run` command. Commands run using non-login shells by default. You can choose a different shell and customize the shell used to run commands. Each `run` keyword represents a new process and shell in the virtual environment. When you provide multi-line commands, each line runs in the same shell.",
+            "required": true
+          },
+          "continue-on-error": "step-continue-on-error",
+          "env": "step-env",
+          "working-directory": "string-steps-context",
+          "shell": "shell",
+          "background": "step-background"
+        }
+      }
+    },
+    "regular-step": {
+      "mapping": {
+        "properties": {
+          "name": "step-name",
+          "id": "step-id",
+          "if": "step-if",
+          "continue-on-error": "step-continue-on-error",
+          "timeout-minutes": "step-timeout-minutes",
+          "uses": {
+            "type": "step-uses",
+            "required": true
+          },
+          "with": "step-with",
+          "env": "step-env",
+          "background": "step-background"
+        }
+      }
+    },
+    "wait-step": {
+      "mapping": {
+        "properties": {
+          "name": "step-name",
+          "id": "step-id",
+          "continue-on-error": "step-continue-on-error",
+          "wait": {
+            "type": "step-wait-target",
+            "required": true
+          }
+        }
+      }
+    },
+    "wait-all-step": {
+      "mapping": {
+        "properties": {
+          "name": "step-name",
+          "id": "step-id",
+          "continue-on-error": "step-continue-on-error",
+          "wait-all": {
+            "type": "step-wait-all-value",
+            "required": true
+          }
+        }
+      }
+    },
+    "cancel-step": {
+      "mapping": {
+        "properties": {
+          "name": "step-name",
+          "id": "step-id",
+          "continue-on-error": "step-continue-on-error",
+          "cancel": {
+            "type": "step-cancel-target",
+            "required": true
+          }
+        }
+      }
+    },
+    "parallel-step": {
+      "mapping": {
+        "properties": {
+          "parallel": {
+            "type": "parallel-steps",
+            "required": true,
+            "description": "Run a group of steps concurrently. All steps in the parallel block run as background steps and the workflow waits for all of them to complete before continuing."
+          }
+        }
+      }
+    },
+    "parallel-steps": {
+      "sequence": {
+        "item-type": "steps-item"
+      }
+    },
+    "step-uses": {
+      "description": "Selects an action to run as part of a step in your job. An action is a reusable unit of code. You can use an action defined in the same repository as the workflow, a public repository, a [private repository with access enabled](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#allowing-access-to-components-in-a-private-repository), or in a published Docker container image.",
+      "string": {
+        "require-non-empty": true
+      }
+    },
+    "step-background": {
+      "boolean": {},
+      "description": "When set to true, runs this step in the background. The workflow continues to the next step immediately without waiting for the background step to finish."
+    },
+    "step-wait-target": {
+      "description": "The step ID or IDs of background steps to wait for.",
+      "one-of": [
+        "non-empty-string",
+        "sequence-of-non-empty-string"
+      ]
+    },
+    "step-wait-all-value": {
+      "description": "Wait for all prior background steps to complete. Use as a bare key (`wait-all:`) or with a boolean value.",
+      "one-of": [
+        "null",
+        "boolean"
+      ]
+    },
+    "step-cancel-target": {
+      "description": "The step ID of a background step to cancel.",
+      "string": {
+        "require-non-empty": true
+      }
+    },
+    "step-continue-on-error": {
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix",
+        "secrets",
+        "steps",
+        "job",
+        "runner",
+        "env",
+        "hashFiles(1,255)"
+      ],
+      "boolean": {},
+      "description": "Prevents a job from failing when a step fails. Set to `true` to allow a job to pass when this step fails."
+    },
+    "step-id": {
+      "string": {
+        "require-non-empty": true
+      },
+      "description": "A unique identifier for the step. You can use the `id` to reference the step in contexts."
+    },
+    "step-if": {
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix",
+        "steps",
+        "job",
+        "runner",
+        "env",
+        "always(0,0)",
+        "failure(0,0)",
+        "cancelled(0,0)",
+        "success(0,0)",
+        "hashFiles(1,255)"
+      ],
+      "description": "Use the `if` conditional to prevent a step from running unless a condition is met. Any supported context and expression can be used to create a conditional. Expressions in an `if` conditional do not require the bracketed expression syntax. When you use expressions in an `if` conditional, you may omit the expression syntax because GitHub automatically evaluates the `if` conditional as an expression.",
+      "string": {}
+    },
+    "step-if-result": {
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "strategy",
+        "matrix",
+        "steps",
+        "job",
+        "runner",
+        "env",
+        "always(0,0)",
+        "failure(0,0)",
+        "cancelled(0,0)",
+        "success(0,0)",
+        "hashFiles(1,255)"
+      ],
+      "one-of": [
+        "null",
+        "boolean",
+        "number",
+        "string",
+        "sequence",
+        "mapping"
+      ]
+    },
+    "step-env": {
+      "description": "Sets variables for steps to use in the runner environment. You can also set variables for the entire workflow or a job.",
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix",
+        "secrets",
+        "steps",
+        "job",
+        "runner",
+        "env",
+        "hashFiles(1,255)"
+      ],
+      "mapping": {
+        "loose-key-type": "non-empty-string",
+        "loose-value-type": "string"
+      }
+    },
+    "step-name": {
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix",
+        "secrets",
+        "steps",
+        "job",
+        "runner",
+        "env",
+        "hashFiles(1,255)"
+      ],
+      "string": {},
+      "description": "A name for your step to display on GitHub."
+    },
+    "step-timeout-minutes": {
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix",
+        "secrets",
+        "steps",
+        "job",
+        "runner",
+        "env",
+        "hashFiles(1,255)"
+      ],
+      "number": {},
+      "description": "The maximum number of minutes to run the step before killing the process."
+    },
+    "step-with": {
+      "description": "A map of the input parameters defined by the action. Each input parameter is a key/value pair. Input parameters are set as variables. When you specify an input in a workflow file or use a default input value, GitHub creates a variable for the input with the name `INPUT_<VARIABLE_NAME>`. The variable created converts input names to uppercase letters and replaces spaces with `_`.",
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix",
+        "secrets",
+        "steps",
+        "job",
+        "runner",
+        "env",
+        "hashFiles(1,255)"
+      ],
+      "mapping": {
+        "loose-key-type": "non-empty-string",
+        "loose-value-type": "string"
+      }
+    },
+    "container": {
+      "description": "A container to run any steps in a job that don't already specify a container. If you have steps that use both script and container actions, the container actions will run as sibling containers on the same network with the same volume mounts.\n\nIf you do not set a container, all steps will run directly on the host specified by runs-on unless a step refers to an action configured to run in a container.",
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix"
+      ],
+      "one-of": [
+        "string",
+        "container-mapping"
+      ]
+    },
+    "container-mapping": {
+      "mapping": {
+        "properties": {
+          "image": {
+            "type": "non-empty-string",
+            "description": "Use `jobs.<job_id>.container.image` to define the Docker image to use as the container to run the action. The value can be the Docker Hub image or a registry name."
+          },
+          "options": {
+            "type": "string",
+            "description": "Use `jobs.<job_id>.container.options` to configure additional Docker container resource options."
+          },
+          "env": "container-env",
+          "ports": {
+            "type": "sequence-of-non-empty-string",
+            "description": "Use `jobs.<job_id>.container.ports` to set an array of ports to expose on the container."
+          },
+          "volumes": {
+            "type": "sequence-of-non-empty-string",
+            "description": "Use `jobs.<job_id>.container.volumes` to set an array of volumes for the container to use. You can use volumes to share data between services or other steps in a job. You can specify named Docker volumes, anonymous Docker volumes, or bind mounts on the host."
+          },
+          "credentials": "container-registry-credentials"
+        }
+      }
+    },
+    "services": {
+      "description": "Additional containers to host services for a job in a workflow. These are useful for creating databases or cache services like redis. The runner on the virtual machine will automatically create a network and manage the life cycle of the service containers. When you use a service container for a job or your step uses container actions, you don't need to set port information to access the service. Docker automatically exposes all ports between containers on the same network. When both the job and the action run in a container, you can directly reference the container by its hostname. The hostname is automatically mapped to the service name. When a step does not use a container action, you must access the service using localhost and bind the ports.",
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix"
+      ],
+      "mapping": {
+        "loose-key-type": "non-empty-string",
+        "loose-value-type": "services-container"
+      }
+    },
+    "services-container": {
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix"
+      ],
+      "one-of": [
+        "non-empty-string",
+        "service-container-mapping"
+      ]
+    },
+    "container-registry-credentials": {
+      "description": "If the image's container registry requires authentication to pull the image, you can use `jobs.<job_id>.container.credentials` to set a map of the username and password. The credentials are the same values that you would provide to the `docker login` command.",
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "secrets",
+        "env"
+      ],
+      "mapping": {
+        "properties": {
+          "username": "non-empty-string",
+          "password": "non-empty-string"
+        }
+      }
+    },
+    "container-env": {
+      "description": "Use `jobs.<job_id>.container.env` to set a map of variables in the container.",
+      "mapping": {
+        "loose-key-type": "non-empty-string",
+        "loose-value-type": "string-runner-context"
+      }
+    },
+    "non-empty-string": {
+      "string": {
+        "require-non-empty": true
+      }
+    },
+    "sequence-of-non-empty-string": {
+      "sequence": {
+        "item-type": "non-empty-string"
+      }
+    },
+    "sequence-of-string": {
+      "sequence": {
+        "item-type": "string"
+      }
+    },
+    "boolean-needs-context": {
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs"
+      ],
+      "boolean": {}
+    },
+    "number-needs-context": {
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs"
+      ],
+      "number": {}
+    },
+    "string-needs-context": {
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs"
+      ],
+      "string": {}
+    },
+    "scalar-needs-context": {
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix"
+      ],
+      "one-of": [
+        "string",
+        "boolean",
+        "number"
+      ]
+    },
+    "scalar-needs-context-with-secrets": {
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "secrets",
+        "strategy",
+        "matrix"
+      ],
+      "one-of": [
+        "string",
+        "boolean",
+        "number"
+      ]
+    },
+    "boolean-strategy-context": {
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix"
+      ],
+      "boolean": {}
+    },
+    "number-strategy-context": {
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix"
+      ],
+      "number": {}
+    },
+    "string-strategy-context": {
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix"
+      ],
+      "string": {}
+    },
+    "boolean-steps-context": {
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix",
+        "secrets",
+        "steps",
+        "job",
+        "runner",
+        "env",
+        "hashFiles(1,255)"
+      ],
+      "boolean": {}
+    },
+    "number-steps-context": {
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix",
+        "secrets",
+        "steps",
+        "job",
+        "runner",
+        "env",
+        "hashFiles(1,255)"
+      ],
+      "number": {}
+    },
+    "string-runner-context": {
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix",
+        "secrets",
+        "steps",
+        "job",
+        "runner",
+        "env"
+      ],
+      "string": {}
+    },
+    "string-runner-context-no-secrets": {
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix",
+        "steps",
+        "job",
+        "runner",
+        "env"
+      ],
+      "string": {}
+    },
+    "string-steps-context": {
+      "context": [
+        "github",
+        "inputs",
+        "vars",
+        "needs",
+        "strategy",
+        "matrix",
+        "secrets",
+        "steps",
+        "job",
+        "runner",
+        "env",
+        "hashFiles(1,255)"
+      ],
+      "string": {}
+    },
+    "shell": {
+      "string": {
+        "require-non-empty": true
+      },
+      "description": "Use `shell` to override the default shell settings in the runner's operating system. You can use built-in shell keywords, or you can define a custom set of shell options. The shell command that is run internally executes a temporary file that contains the commands specified in `run`."
+    },
+    "working-directory": {
+      "string": {
+        "require-non-empty": true
+      },
+      "description": "The `working-directory` keyword specifies the working directory where the command is run."
+    },
+    "cron-mapping": {
+      "mapping": {
+        "properties": {
+          "cron": {
+            "type": "cron-pattern",
+            "required": true
+          },
+          "timezone": "timezone-string"
+        }
+      }
+    },
+    "cron-pattern": {
+      "description": "A cron expression that represents a schedule. A scheduled workflow will run at most once every 5 minutes.",
+      "string": {
+        "require-non-empty": true
+      }
+    },
+    "timezone-string": {
+      "description": "A string that represents the time zone a scheduled workflow will run relative to in IANA format (e.g. 'America/New_York' or 'Europe/London'). If omitted, the workflow will run relative to midnight UTC.",
+      "string": {
+        "require-non-empty": true
+      }
+    },
+    "service-container-mapping": {
+      "mapping": {
+        "properties": {
+          "image": {
+            "type": "non-empty-string",
+            "description": "The Docker image to use as the container. The value can be the Docker Hub image or a registry name."
+          },
+          "options": {
+            "type": "string",
+            "description": "Additional Docker container resource options."
+          },
+          "env": "container-env",
+          "ports": {
+            "type": "sequence-of-non-empty-string",
+            "description": "An array of ports to expose on the container."
+          },
+          "volumes": {
+            "type": "sequence-of-non-empty-string",
+            "description": "An array of volumes for the container to use. You can use volumes to share data between services or other steps in a job. You can specify named Docker volumes, anonymous Docker volumes, or bind mounts on the host."
+          },
+          "credentials": "container-registry-credentials",
+          "entrypoint": {
+            "type": "string",
+            "description": "Override the default ENTRYPOINT in the service container image."
+          },
+          "command": {
+            "type": "string",
+            "description": "Override the default CMD in the service container image."
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/preloop-gha-expressions/src/evaluator.rs
+++ b/crates/preloop-gha-expressions/src/evaluator.rs
@@ -47,7 +47,7 @@ pub(super) fn validate_function_calls(expr: &Expr) -> Result<(), ExpressionError
     }
 }
 
-/// Collect all top-level context names referenced in an expression AST.
+/// Collect top-level data contexts and context-sensitive function names.
 pub(super) fn collect_contexts_from_expr(expr: &Expr, out: &mut std::collections::HashSet<String>) {
     match expr {
         Expr::Path(path) => {
@@ -63,7 +63,13 @@ pub(super) fn collect_contexts_from_expr(expr: &Expr, out: &mut std::collections
             collect_contexts_from_expr(left, out);
             collect_contexts_from_expr(right, out);
         }
-        Expr::Call { args, .. } => {
+        Expr::Call { name, args } => {
+            if matches!(
+                name.to_ascii_lowercase().as_str(),
+                "always" | "success" | "failure" | "cancelled" | "hashfiles"
+            ) {
+                out.insert(name.to_ascii_lowercase());
+            }
             for arg in args {
                 collect_contexts_from_expr(arg, out);
             }

--- a/crates/preloop-gha-expressions/src/lib.rs
+++ b/crates/preloop-gha-expressions/src/lib.rs
@@ -114,7 +114,8 @@ pub fn validate_expression(input: &str) -> Result<(), ExpressionError> {
     validate_function_calls(&expr)
 }
 
-/// Collect top-level context names (e.g. "github", "matrix") from an expression string.
+/// Collect top-level data contexts and context-sensitive functions (e.g.
+/// `github`, `matrix`, `success`, and `hashFiles`) from an expression string.
 pub fn collect_contexts(input: &str) -> Result<std::collections::HashSet<String>, ExpressionError> {
     let trimmed = trim_expression_markers(input);
     let expr = parse_cached(trimmed)?;

--- a/crates/preloop-gha-parser/src/eval.rs
+++ b/crates/preloop-gha-parser/src/eval.rs
@@ -249,16 +249,19 @@ const CTX_JOB_IF: &[&str] = &[
     "success",
 ];
 const CTX_JOB_RUNS_ON: &[&str] = &["github", "inputs", "vars", "needs", "matrix", "strategy"];
-const CTX_STRATEGY: &[&str] = &["github", "inputs", "vars", "needs", "matrix", "strategy"];
+const CTX_STRATEGY: &[&str] = &["github", "inputs", "vars", "needs"];
 const CTX_JOB_ENV: &[&str] = &[
-    "github", "inputs", "vars", "needs", "strategy", "matrix", "secrets", "env",
+    "github", "inputs", "vars", "needs", "strategy", "matrix", "secrets",
 ];
 const CTX_JOB_CONCURRENCY: &[&str] = &["github", "inputs", "vars", "needs", "strategy", "matrix"];
-const CTX_JOB_DEFAULTS_RUN: &[&str] = &["github", "strategy", "matrix", "needs", "env", "vars"];
-const CTX_JOB_CONTAINER: &[&str] = &["github", "inputs", "needs", "strategy", "matrix", "vars"];
-const CTX_CONTAINER_CREDENTIALS: &[&str] = &["secrets", "env", "github", "vars"];
+const CTX_JOB_DEFAULTS_RUN: &[&str] = &[
+    "github", "inputs", "vars", "strategy", "matrix", "needs", "env",
+];
+const CTX_JOB_CONTAINER: &[&str] = &["github", "inputs", "vars", "needs", "strategy", "matrix"];
+const CTX_CONTAINER_CREDENTIALS: &[&str] = &["github", "inputs", "vars", "secrets", "env"];
 const CTX_RUNNER: &[&str] = &[
-    "github", "needs", "strategy", "matrix", "secrets", "steps", "job", "runner", "env", "vars",
+    "github", "inputs", "vars", "needs", "strategy", "matrix", "secrets", "steps", "job", "runner",
+    "env",
 ];
 const CTX_STEP_IF: &[&str] = &[
     "github",
@@ -267,7 +270,6 @@ const CTX_STEP_IF: &[&str] = &[
     "needs",
     "strategy",
     "matrix",
-    "secrets",
     "steps",
     "job",
     "runner",
@@ -279,7 +281,18 @@ const CTX_STEP_IF: &[&str] = &[
     "hashfiles",
 ];
 const CTX_STEP_TIMEOUT: &[&str] = &[
-    "github", "inputs", "vars", "needs", "strategy", "matrix", "env",
+    "github",
+    "inputs",
+    "vars",
+    "needs",
+    "strategy",
+    "matrix",
+    "secrets",
+    "steps",
+    "job",
+    "runner",
+    "env",
+    "hashfiles",
 ];
 const CTX_STEP_ENV: &[&str] = &[
     "github",
@@ -295,6 +308,7 @@ const CTX_STEP_ENV: &[&str] = &[
     "env",
     "hashfiles",
 ];
+const CTX_STEP_CONTINUE_ON_ERROR: &[&str] = CTX_STEP_ENV;
 const CTX_STEP_WITH: &[&str] = CTX_STEP_ENV;
 const CTX_STEP_RUN: &[&str] = CTX_STEP_ENV;
 const CTX_STEP_NAME: &[&str] = CTX_STEP_ENV;
@@ -482,13 +496,12 @@ pub fn validate_workflow_expressions(workflow: &Workflow) -> Result<(), ParserEr
             if let Some(crate::models::DeferredBool::Expression(expression)) =
                 &step.continue_on_error
             {
-                validate_expressions_in_string(expression, false, Some(CTX_STEP_IF)).map_err(
-                    |e| {
+                validate_expressions_in_string(expression, false, Some(CTX_STEP_CONTINUE_ON_ERROR))
+                    .map_err(|e| {
                         ParserError::InvalidExpression(format!(
                             "job `{job_id}` {step_ref} continue-on-error: {e}"
                         ))
-                    },
-                )?;
+                    })?;
             }
             if let Some(crate::models::DeferredNumber::Expression(expression)) =
                 &step.timeout_minutes

--- a/crates/preloop-gha-parser/src/job_builder.rs
+++ b/crates/preloop-gha-parser/src/job_builder.rs
@@ -1383,7 +1383,7 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
-      - if: ${{ secrets['system.preloop.debug_worker_token'] != '' }}
+      - if: ${{ github.ref == 'refs/heads/main' }}
         run: exit 23
 "#,
         )
@@ -1404,7 +1404,7 @@ jobs:
         );
         assert_eq!(
             message.steps[0].condition.as_deref(),
-            Some("secrets['system.preloop.debug_worker_token'] != ''")
+            Some("github.ref == 'refs/heads/main'")
         );
     }
 

--- a/crates/preloop-gha-parser/src/lib_tests.rs
+++ b/crates/preloop-gha-parser/src/lib_tests.rs
@@ -2009,6 +2009,212 @@ jobs:
 }
 
 #[test]
+fn step_timeout_accepts_schema_contexts() {
+    for expression in [
+        "${{ secrets.TIMEOUT }}",
+        "${{ steps.previous.outputs.timeout }}",
+        "${{ job.status }}",
+        "${{ runner.os }}",
+        "${{ hashFiles('*.rs') }}",
+    ] {
+        let workflow = r#"on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - id: previous
+        run: echo ok
+      - run: echo ok
+        timeout-minutes: "TIMEOUT_EXPRESSION"
+"#
+        .replace("TIMEOUT_EXPRESSION", expression);
+        parse_workflow(&workflow).unwrap_or_else(|error| {
+            panic!("timeout expression {expression:?} was rejected: {error}")
+        });
+    }
+}
+
+#[test]
+fn container_and_service_credentials_accept_inputs_context() {
+    let workflow = parse_workflow(
+        r#"on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:latest
+      credentials:
+        username: "${{ inputs.registry_user }}"
+    services:
+      redis:
+        image: redis:latest
+        credentials:
+          username: "${{ inputs.registry_user }}"
+    steps:
+      - run: echo ok
+"#,
+    )
+    .expect("inputs context is allowed in container credentials");
+    assert!(workflow.jobs["build"].container.is_some());
+    assert!(workflow.jobs["build"].services.is_some());
+}
+
+#[test]
+fn runner_context_fields_accept_inputs_context() {
+    let workflow = parse_workflow(
+        r#"on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:latest
+      env:
+        FROM_INPUT: "${{ inputs.container_value }}"
+    services:
+      redis:
+        image: redis:latest
+        env:
+          FROM_INPUT: "${{ inputs.service_value }}"
+    outputs:
+      value: "${{ inputs.output_value }}"
+    steps:
+      - run: echo ok
+"#,
+    )
+    .expect("inputs context is allowed in runner-context fields");
+    assert_eq!(
+        workflow.jobs["build"].outputs["value"],
+        "${{ inputs.output_value }}"
+    );
+}
+
+#[test]
+fn job_defaults_run_accepts_inputs_context() {
+    let workflow = parse_workflow(
+        r#"on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: "${{ inputs.shell }}"
+    steps:
+      - run: echo ok
+"#,
+    )
+    .expect("inputs context is allowed in job defaults.run");
+    assert_eq!(
+        workflow.jobs["build"]
+            .defaults
+            .as_ref()
+            .and_then(|defaults| defaults.run.as_ref())
+            .and_then(|run| run.shell.as_deref()),
+        Some("${{ inputs.shell }}")
+    );
+}
+
+#[test]
+fn job_env_rejects_env_context() {
+    let result = parse_workflow(
+        r#"on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      LOOP: "${{ env.LOOP }}"
+    steps:
+      - run: echo ok
+"#,
+    );
+
+    match result {
+        Err(ParserError::InvalidExpression(message)) => {
+            assert!(message.contains("job `build` env"));
+            assert!(message.contains("context \"env\""));
+        }
+        other => panic!("expected job env context rejection, got {other:?}"),
+    }
+}
+
+#[test]
+fn strategy_fields_reject_strategy_and_matrix_contexts() {
+    for (field, expression) in [
+        ("fail-fast", "${{ matrix.fast }}"),
+        ("max-parallel", "${{ strategy.limit }}"),
+    ] {
+        let workflow = r#"on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      FIELD: "EXPRESSION"
+    steps:
+      - run: echo ok
+"#
+        .replace("FIELD", field)
+        .replace("EXPRESSION", expression);
+        match parse_workflow(&workflow) {
+            Err(ParserError::InvalidExpression(message)) => {
+                assert!(message.contains("strategy"));
+                assert!(message.contains("context"));
+            }
+            other => panic!("expected strategy context rejection, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn step_if_rejects_secrets_but_continue_on_error_uses_its_schema_contexts() {
+    let invalid = parse_workflow(
+        r#"on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - if: "${{ secrets.SKIP }}"
+        run: echo ok
+"#,
+    );
+    match invalid {
+        Err(ParserError::InvalidExpression(message)) => {
+            assert!(message.contains("if condition"));
+            assert!(message.contains("context \"secrets\""));
+        }
+        other => panic!("expected step if context rejection, got {other:?}"),
+    }
+
+    let invalid_function = parse_workflow(
+        r#"on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - continue-on-error: "${{ success() }}"
+        run: echo ok
+"#,
+    );
+    match invalid_function {
+        Err(ParserError::InvalidExpression(message)) => {
+            assert!(message.contains("continue-on-error"));
+            assert!(message.contains("context \"success\""));
+        }
+        other => panic!("expected continue-on-error function rejection, got {other:?}"),
+    }
+
+    parse_workflow(
+        r#"on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - continue-on-error: "${{ secrets.ALLOW }}"
+        run: echo ok
+"#,
+    )
+    .expect("secrets context is allowed for step continue-on-error");
+}
+
+#[test]
 fn job_defaults_run_working_directory_rejects_secrets_and_accepts_matrix() {
     let invalid = parse_workflow(
         r#"on: push
@@ -2315,7 +2521,7 @@ jobs:
   test:
     strategy:
       matrix: ${{ fromJSON(inputs.test-matrix) }}
-      fail-fast: ${{ matrix.os == 'ubuntu-latest' }}
+      fail-fast: true
     runs-on: ${{ matrix.os }}
     steps:
       - run: echo ${{ matrix.os }}
@@ -2331,32 +2537,6 @@ jobs:
             .jobs;
     assert_eq!(jobs.len(), 2);
     assert!(jobs.iter().all(|job| job.matrix.get("os").is_some()));
-}
-
-#[test]
-fn strategy_expression_scalars_are_preserved_and_resolved() {
-    let workflow = parse_workflow(
-        r#"
-on: push
-jobs:
-  build:
-    strategy:
-      fail-fast: ${{ matrix.experimental }}
-      max-parallel: ${{ matrix.parallelism }}
-      matrix:
-        include:
-          - experimental: true
-            parallelism: 3
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo ok
-"#,
-    )
-    .unwrap();
-    let plans = expand_jobs(&workflow).unwrap();
-    assert_eq!(plans.len(), 1);
-    assert!(plans[0].fail_fast);
-    assert_eq!(plans[0].max_parallel, Some(3));
 }
 
 #[test]
@@ -2680,13 +2860,12 @@ jobs:
 }
 
 /// A needs-deferred matrix leaves a single un-suffixed placeholder node whose
-/// matrix is intentionally empty. Matrix-dependent `fail-fast`, `max-parallel`
-/// and `continue-on-error` expressions cannot be evaluated against that empty
-/// placeholder — they resolve to null and are rejected at parse time — so the
-/// placeholder defers them: defaults apply until the runtime fan-out builds
-/// the concrete combinations and re-resolves them per cell.
+/// matrix is intentionally empty. The matrix-dependent `continue-on-error`
+/// expression cannot be evaluated against that empty placeholder — it resolves
+/// to null and is rejected at parse time — so the placeholder defers it until
+/// runtime fan-out builds the concrete combinations and re-resolves it per cell.
 #[test]
-fn deferred_matrix_placeholder_defers_strategy_scalars() {
+fn deferred_matrix_placeholder_defers_continue_on_error() {
     let workflow = parse_workflow(
         r#"
 on: push
@@ -2700,8 +2879,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
-      fail-fast: ${{ matrix.experimental }}
-      max-parallel: ${{ matrix.parallelism }}
     continue-on-error: ${{ matrix.experimental }}
     steps:
       - run: echo ${{ matrix.os }}
@@ -2715,7 +2892,6 @@ jobs:
         build.fail_fast,
         "placeholder keeps the default until fan-out"
     );
-    assert_eq!(build.max_parallel, None);
     assert!(!build.continue_on_error);
 
     // The runtime fan-out resolves the scalars per concrete combination.
@@ -2723,7 +2899,7 @@ jobs:
     let mut setup_outputs = BTreeMap::new();
     setup_outputs.insert(
         "matrix".to_string(),
-        json!("{\"include\": [{\"os\": \"ubuntu-latest\", \"experimental\": true, \"parallelism\": 3}]}"),
+        json!("{\"include\": [{\"os\": \"ubuntu-latest\", \"experimental\": true}]}"),
     );
     needs_outputs.insert("setup".to_string(), setup_outputs);
     let plans = crate::expand_deferred_matrix_job(
@@ -2736,7 +2912,6 @@ jobs:
     .unwrap();
     assert_eq!(plans.len(), 1);
     assert!(plans[0].fail_fast);
-    assert_eq!(plans[0].max_parallel, Some(3));
 }
 
 /// A needs-deferred matrix reusable caller nested inside another reusable


### PR DESCRIPTION
## What & why

Audits the vendored GitHub Actions workflow schema against Preloop's parser and closes the resulting expression-context, function-arity, model-kind, and runner-watch comparison gaps. The audit pins the exact upstream schema bytes and verifies real parser call sites so declared constants cannot mask incorrect wiring.

## Protocol surface

- [x] I confirm this change touches the runner protocol interface: **NO**

## Required gates

- [x] `just test-ci` passes locally (fmt-check + clippy `-D` + full test suite + runner-watch conformance)
- [x] Protocol/wire-shape validation: **N/A** — no runner wire DTO or serialized payload changed
- [x] Property-test extension: **N/A** — no scheduling/concurrency invariant changed; existing full property suite passed
- [x] Additive/defaulted wire fields: **N/A** — no wire field or event added
- [x] No secrets, credentials, or internal/deployment-specific paths are introduced

## Verification performed

- `python3 benchmarks/conformance/check_schema_contexts.py` — PASS: 32 context definitions; 60 model type checks
- `cargo test --locked -p preloop-gha-expressions -p preloop-gha-parser -p runner-watch` — 305 tests passed across 9 suites
- `just test-ci` — passed, including fmt-check, workspace Clippy with `-D warnings`, full workspace tests, and official-runner conformance replay

## Checklist

- [x] Tests added/updated for changed observable expression-validation and comparison contracts
- [x] Docs updated where behavior changed: **N/A** — no user-facing workflow or CLI contract changed
- [x] Changelog-worthy user-facing change described here; no separate changelog entry required